### PR TITLE
fix(alert): MQTT ALT- signal updates Alert + records state change

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "ef750bdb-505b-4d5b-807b-431bf87ab6f2",
+          "id": "ffa65845-071b-44fe-a416-79a51555a73e",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "d2785efd-7ca3-4285-adb1-bf81707d909a",
+              "id": "2d2c8eb2-377b-4148-b7b4-175225320e52",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "c05b4763-9d9f-4ddf-9181-161fff38aefe",
+          "id": "4c8a7df7-efa2-4651-93e1-235044485da0",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "39cd276d-c188-4147-a9b2-a43d1eb9b658",
+              "id": "f3c2cedb-ede4-4297-a591-4acc67e2b231",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "b4669d37-9671-4a1c-a49e-08dee13a4010",
+          "id": "a11d804c-abae-48e2-9873-9a6ee46dfe8e",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "98dee0bb-283a-4dc6-afa7-35a57956b21d",
+              "id": "45bbc89c-d30c-42cd-8d31-1fb629932334",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "502db693-307b-432e-a2fa-19f62d00ab34",
+          "id": "eb6ae662-c098-475b-a387-2b49dfad77f6",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "0a296334-eb0f-4c4f-86c4-94976799eaf8",
+              "id": "f7849dd4-94e7-41fe-afa3-ceaa4b17eeb0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "f22af647-6b04-4987-9a1b-0278f4a00434",
+          "id": "8f756983-0906-487b-a4c7-15cc61b06fb9",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "a3e31eff-6658-4970-8cbd-f62e11179e5c",
+              "id": "8c3d4e29-48b6-4267-8306-0c087802c84e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "a976caf9-4aee-4230-8879-add0c6ff21cf",
+          "id": "126fe735-4bfc-4f77-8d73-1437175d3335",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "9a522a9e-a192-4b7d-baaf-7695d4c573a4",
+              "id": "34eb52d6-b5db-424f-a418-8278b6ef97a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "4bcb252d-e50b-46a5-9dc0-0751878bb0de",
+          "id": "bfb8b7e7-f3b6-4da7-adbf-274256c5d5ac",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "073546a5-34b4-47ec-a6b8-9c36c9e8d2f6",
+              "id": "68aa0237-368b-49f2-9460-0d34863bf358",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "64e4e48f-63eb-4d98-be35-42c6dd3d0d31",
+          "id": "647bb155-8a7b-4703-ac05-da210b38c069",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "64f70aef-dce4-4aa0-ad61-1a7762fde17b",
+              "id": "554aa122-acf5-43c0-be89-9cf88e20e5b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "a408dd2d-2483-400e-adb7-5ab041eafc8e",
+          "id": "60fcc452-3fff-4759-bc5d-5c6ec3f2b999",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "3c7ec5d5-587f-420b-8649-f1209b07888a",
+              "id": "7d78d952-a3be-4ecb-9036-c8423a55443e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "b9196511-541f-4a85-99fe-a4b533705952",
+          "id": "0d404b82-98b9-4c85-a6ea-df964b653b1b",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "641dcfac-aaaf-4db8-9014-3bbed441b144",
+              "id": "0c91372a-d38c-4160-abbe-e7326d316b83",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "e3d54f71-4474-4c2a-816d-6fa23868292b",
+          "id": "a2f5a62b-dab6-4934-8e18-05d5c1801629",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "61268054-d53c-4bbd-bdb9-1160ce82cbc0",
+              "id": "2d7bf884-8c8c-4f5f-8bed-f6fcbb654c5d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "304b9518-9334-4549-9a30-b46bf8c27b51",
+          "id": "2fdc45d4-6d17-4876-a6fe-61409c84bac3",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "eb61c325-340b-4c84-a3e8-b6e24e57e9b3",
+              "id": "e538bdc1-b106-43e9-ab2b-c0456d478822",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "5a746c01-098d-4ac3-8660-07e3a30f71cc",
+          "id": "3418c995-56b6-407b-8394-048bd89a86e1",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "f5af208d-7e4d-42b5-a30e-c7d9ab5492fc",
+              "id": "5073f4d2-5a2e-474c-8b54-f4b4078a276e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "3557a1aa-624b-41ce-8384-145375d9f8ad",
+          "id": "b8fe2e81-cc17-4a39-9976-a6988ddaf39a",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "bfe2b82d-baf9-4ed1-8e1c-688404c9dee6",
+              "id": "880e501e-d14d-4ae0-9763-9ba3cc724ade",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "fb13d5ca-2bc4-40dc-aadb-f1cb70678fb4",
+          "id": "91c32a77-e5e7-4d66-940b-211daf274e6b",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "a273df24-acff-4524-9ad6-a86c6a5876ef",
+              "id": "8403afb6-e723-4370-8856-e0cc39a3d57c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "ccb66d0d-efa4-489d-938f-99ab22382b49",
+          "id": "6a424634-db99-4929-8457-28f0bbcb3c49",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "0985c028-e4c1-42e9-b0e6-3fb723da417c",
+              "id": "490d87db-aedd-40d1-b8b5-8d6e05db0999",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "65f8c9b2-d88c-4cc5-b815-f914e13c7836",
+          "id": "89a76586-9f22-43cf-823c-b5a9b5009a13",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "cb56f1d0-105c-4ea3-bda2-a22eb642484f",
+              "id": "9f10d3f4-b72a-464f-87bc-2844a78e4472",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "2376cb3a-6b94-4f22-87be-a9b53ed1969b",
+          "id": "286879b3-21a6-4c1b-b68e-c179fe83c848",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "30bdea2a-2151-4e33-ac4c-43f36cb5fffd",
+              "id": "5d0a443e-da74-48e8-bc6f-869301bcbd8d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "85fdb4b0-ccae-455d-b442-7f60db6fa187",
+          "id": "7d05d7ce-fa18-442d-aca0-a106663290df",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "96a8063f-03f3-48e9-a1ae-09069a1db91f",
+              "id": "a155eef1-56f4-44b2-b26e-6cabe0af6fb5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "8b6073fc-9c7b-4a70-8086-ac8a2c7f0dc5",
+          "id": "8d83da75-48f2-4eb3-bba0-a4fc18a579ba",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "a040d0e8-7bc2-4b95-9194-9d0f818cb1bd",
+              "id": "65720d27-ae10-4bac-a187-6535a2d4d9da",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "508f51ab-d059-4347-85a3-d77a9d3b45f6",
+          "id": "ede71244-6e03-4eb5-a0f2-3216ea28a746",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "54d9ca0e-5493-4a95-b327-d8482de3fb81",
+              "id": "fa91dfc3-5da7-4cc4-88c3-52007d9d14b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "3d26fc4c-7feb-4d6c-bb90-0cef8bcde93e",
+          "id": "6ae1d61f-897f-433c-af59-b0d59a2202f4",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "17ec141e-df02-4660-b254-1bc65673b6a0",
+              "id": "e4785b0c-9a2a-4305-b19f-bd4c7ca66b77",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "26612dda-fe04-40b6-b107-189ae9490dff",
+          "id": "c2e318dd-d3a4-4e32-8434-fe61cc113532",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "c64cd4b0-0375-436d-8da8-5e753b891115",
+              "id": "ef156921-935e-4236-8088-206eb47ae029",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "32a18cfc-e39c-4a1e-a54a-114017e90de6",
+          "id": "39af073b-17b5-46de-954a-0cce9c51ebd0",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A1Bf11\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6c5B6e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "a43cc517-24e1-452f-a9ec-901e60b3535e",
+              "id": "0f1d8ea0-32bc-458f-ae39-cc91290c1b9c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A1Bf11\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6c5B6e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "bcaa03b1-5ff9-4fee-b2f3-519639f82791",
+          "id": "c2563f80-67c2-4eb7-8062-bc613ad82fbb",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "c1891b0d-6907-4fb1-95c2-6239363c9b81",
+              "id": "b6994f59-6d19-4a99-9cd5-502652e58aa2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "ddcf5865-1803-45d4-b4a6-9497ab72e67b",
+          "id": "ac0f8bba-03cb-48cd-96ba-fabe20a143a9",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "6ae7f338-f64e-43c9-92a0-d77bdcab5251",
+              "id": "66a5ce46-a584-4bc0-a983-7572066e5b97",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "68116b1e-058b-49b6-9346-6ee0b9c8ca80",
+          "id": "d5e1206e-58b6-4502-bba1-526c3ad02a35",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FBb90B\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FEe5c0\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "db19cef6-06c6-4a77-8948-692e96104e28",
+              "id": "882fab05-8f50-4430-988e-0b36710e0f6c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FBb90B\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FEe5c0\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "f62a88d5-17cc-4db2-8365-c68a4be23e13",
+          "id": "64935cba-36f0-42e1-ac02-c304c7a06c0b",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "d5261032-51bf-41bc-a779-650064d27684",
+              "id": "9890867e-1718-473c-bebd-9a4bbf600ed2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "ded077a6-8510-456a-80c4-7cff55d71ea3",
+          "id": "53f04efc-c576-4273-9b63-f07b290e7fc7",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "c09f30cf-0a5e-4563-b8fc-00a3508235d4",
+              "id": "f0bfa0f3-be94-448b-b89b-203950826d20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "815804d2-dab6-482e-8b4a-5e16fb68a32b",
+          "id": "84b0aeee-4ad7-42e0-954a-2a9f70ed2397",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "6efb8633-67f0-42dc-997b-5505e08e8139",
+              "id": "b54fbbf8-aa81-4010-9343-81a7e2a6dae9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "a0afa531-0288-4991-a1cf-07f669f08be2",
+          "id": "e3373c12-5cc7-4396-9b79-594b7304eb80",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "f1bbc039-8431-4ee2-80e0-d32277d2a270",
+              "id": "f5fc464b-1546-47bf-8c52-398c778c8ad7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "79b126ba-4878-49ef-9c7a-7358c84bc7fe",
+          "id": "65845abf-89a9-4936-99ac-43cde22bd6dd",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "88bbe8bb-8d54-44b2-adc8-e29e504f7bda",
+              "id": "1c45d15a-69e7-4210-9b64-157d91f2ff0a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "898d9774-adb9-4d05-b8a1-d9f95436d626",
+          "id": "0e91993b-22bb-4a85-9a24-6976d1df4583",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "86ac38cf-c558-4d81-ab3c-b5e16a8dff6f",
+              "id": "458ad67a-5bc5-4100-9f8a-562ffee793f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "75cf4887-a39b-498d-b3c0-e8f01bf1fc37",
+          "id": "56c32e95-fc92-43c7-bce2-caf1f5a818fa",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "38baf862-6504-40d1-bc21-7ed4f4e51ef5",
+              "id": "bc2d789f-4e23-4d9e-ab6a-560a512bbc80",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "94c99f40-3094-4f44-80a2-13283474ae4e",
+          "id": "4d55c4f1-7c2e-4c74-9cd2-419e7798d7d2",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "33bcb4d1-c3ed-4b17-bc4a-bcb31ad0d457",
+              "id": "cfb7570d-843b-4b11-8d65-8ce69c9534d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "70acd853-6668-488b-876f-88823c546c1b",
+          "id": "2cd47878-f49a-48e9-b1c3-ec5a6dc4f99b",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "c31c8ce3-d594-46c1-bc70-768bd2e63436",
+              "id": "f61f7386-ed8f-404c-9b1e-40fe70564826",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "5afa5002-27c6-40ca-8fe7-9285bd975787",
+          "id": "6ebf5f9d-51af-47e3-b353-5e078a202bca",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "1af7c578-cc56-4934-a04d-17aa041ded67",
+              "id": "f743eb4c-1015-460f-a244-e824f08b491f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "b8f7d799-16a8-466a-ac38-be47398b4414",
+          "id": "06a8ca40-4e56-4b72-9615-616b16624689",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "44a7ebd7-b658-4276-88a6-b1a0b6d7e86f",
+              "id": "e38e740d-0d62-4d74-a34a-1d9549d0a7fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "eb5a67f4-d558-4e02-a59d-4c8f20458cab",
+          "id": "81e58981-0e30-497b-8e66-782b6f4d6719",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "2c86798c-9fac-42e8-8bae-3183b574ad35",
+              "id": "65e5064e-7fa1-4b46-9b58-347b5fc982eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "27b1575e-c1f0-465c-9cbf-60df194068cc",
+          "id": "f54e03c2-519d-4024-b81e-bfcd0ab9f62f",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "ca0aee9a-e2dd-4daa-a489-4b90c5e4e09b",
+              "id": "498f970b-922c-4ac5-b4f2-dc1e4b443677",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "24c88048-4a68-40c2-944a-9f77ea2b5008",
+          "id": "27d41e7b-c2c4-4f6a-b1a2-74d94ba1c031",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "193ef6cc-4eff-48ed-9aa7-c42359c6434f",
+              "id": "01f94e55-c89d-4a92-9134-86d7c6c4ae5e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "e07f04dd-c611-473c-b7cb-7f32e660ca09",
+          "id": "d8ddf66f-4bd5-4709-8a4f-1077614b63e6",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "8efd8f89-6785-444f-8b91-2aa33fade688",
+              "id": "c6c0a1c6-a0a1-49cb-a228-066f7b0ee306",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "6acdf510-8b9d-4991-b746-200c84e64e75",
+          "id": "b7bac859-b65b-454c-8554-338aeaedb18b",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "0e2fae31-490d-4391-a194-28c5be4f32f9",
+              "id": "1d46659e-50e1-4976-bb56-0762f53cf712",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "e83a5328-55e0-4462-98a0-98c29f714c12",
+          "id": "2521326c-1eb1-4fbe-a32a-1849d2fa6690",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "2f827777-2a17-41f1-bef0-c94c3a94aeaa",
+              "id": "24c29f38-f690-40a6-a1f2-f2587b52d15d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "b4edc40b-3ce1-440b-821a-56c72e4b0f5b",
+          "id": "a3f7ff31-acfe-4ee4-9850-2f7ff6f1c5d7",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "95b90923-1eb6-4f59-94c6-7b5309632bda",
+              "id": "c5f2ce7e-4154-4810-ba16-ec7deebccd67",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "12a78975-1485-4a8c-99b7-ea6d6c11a4e6",
+          "id": "9074f46d-969e-4ff6-9c66-e934d8c88543",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "04eb71ee-d0f4-446d-b8a7-061cbff0ec9b",
+              "id": "eaebf510-a8cd-4c53-831d-9f4da7fee153",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "6ae73f17-69d0-4796-84cc-5fcb66aedc98",
+          "id": "b397f2df-a18c-4d8c-8fcb-0c1ca428fa0b",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "c6c7bfdc-411f-4487-b6cf-8612b59acca8",
+              "id": "c4f81b7b-42d9-45d1-bd4e-d0aa37cc3c21",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "693b10fd-0075-417f-8b53-52d1540da80d",
+          "id": "61fbff2d-58d5-4dbc-9dc6-43ce324fd932",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "5a02683e-5105-4097-a025-0717768a1a10",
+              "id": "1fbb2613-c1c6-4fd4-824f-9328d2a8be5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "bb1c3635-fd1c-48bc-bd80-4078e413ae25",
+          "id": "8eb6b60c-d6fe-404c-9fd3-b3b014fbf0a4",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "c986c1a7-5af0-4add-ba1d-d2aa124f2522",
+              "id": "2f60d47e-5971-4fb3-9f82-0df8b7fcf836",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "19b44b81-7b67-48f9-8d7a-4aea02b67955",
+          "id": "1de1f2e6-7ad0-4a75-9d2a-937b99988bc6",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "043ba2f5-f2f9-445f-bc7d-cf12ff642bab",
+              "id": "e8c2736e-287c-4aad-b659-e54bf76c805d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "e9520d6e-edaa-4f6e-9cd2-9e0490027fa4",
+          "id": "f7ed23e4-a5d8-4280-8eec-0378e0c71a33",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "e8f9b891-0319-4a66-a490-597f0970468b",
+              "id": "c3443f31-5bb9-4c74-8257-e1fe0281c4ff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "c85be0a9-457b-424b-bc8e-4279b561c2b6",
+          "id": "ebc23deb-8b1c-4538-bd1a-29187328a958",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "1e7a5fa4-6f73-4124-8e49-c72777de3be5",
+              "id": "0fb2c3e8-1966-42d4-8734-5cbcec29e2bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "824de862-0d26-4c3a-8033-91c32a18e757",
+          "id": "d143c7ed-d68f-4e71-ae35-8f6007514883",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "5dad2e57-8187-4494-9e1f-6e39186d2a2e",
+              "id": "15f5caba-d30d-4b99-8d47-8a460a1acb14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "77245112-90df-4344-8264-a5712e3a8647",
+          "id": "7b19d224-3d61-48e8-9364-b3859d346f2d",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "e4908602-b576-4cb7-8541-b03290d472b4",
+              "id": "87d4309a-8170-4811-83e7-73d748d1ecef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "690c62e0-3610-4e19-9e39-578ffcf4db18",
+          "id": "be8def4d-d381-4f11-b4da-a98cb44d436b",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "72b74979-c29f-40d9-81eb-b39ec84ee964",
+              "id": "39cbcbaf-7c99-47d0-ae01-7c76cfd2a85e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "6836372f-08fb-45bc-a1c8-ae0800762e9d",
+          "id": "7ed88fe4-de3b-48f5-8502-ffa1b4a77f18",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "eb0acaf1-1ec0-411b-a60d-23ea91792e4d",
+              "id": "02bc9a6d-c6d0-4d39-a1f2-ee45636739cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "3b980ac4-6527-4f6b-9f97-f7aebba87af5",
+          "id": "2bd96fb2-b704-4188-9105-8ae19ad8a5a1",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "e27b4a6a-a772-4b4e-a106-2f8c81650edf",
+              "id": "b9e838ee-c937-4ad4-9eb5-ab19e77c8496",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "f24e8aba-c043-4123-a57f-a63500df5265",
+          "id": "a0299d11-7fc8-4155-9065-acbf9d416cba",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "c84c9eff-d866-4b13-bff8-cbabfd0753bc",
+              "id": "1f4b3f57-cae3-4285-83a9-a5754cc94859",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "c43c2764-11bd-4f28-aca7-b11ab00512c1",
+          "id": "5671c7bf-e274-49e2-a0b6-d653ef3b9356",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "82e4e86a-1046-4851-b946-faa031b3efbb",
+              "id": "1c741e26-02e2-494b-9259-9ea7d69918da",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "72c7e803-bd36-4912-a92c-a4e3fbcee13a",
+          "id": "5b791678-19e8-48cd-ad08-be29b0de31ec",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "02b37059-dd14-48a1-801e-5eb165c5f93f",
+              "id": "e1347b0c-94d2-4a15-a3d3-a20746d1a8aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "22fa0967-297b-4da4-8bbb-16c1d09d7f7c",
+          "id": "f55327b7-27e9-489f-b126-5fdbfc0720d4",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "686e6a96-fdba-461b-a217-1646c358e4bb",
+              "id": "b376612f-6dab-49f7-b737-e87ccbd625f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "0dc08f95-ceb9-4b0d-9f30-5185c7fdf0fa",
+          "id": "c457c711-51c6-453b-8bdc-76612582bfe6",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "b04283bb-2f54-4327-9164-18ef74a224a9",
+              "id": "67d45f91-933a-4b07-9288-cf8e3b5e8ff2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "f3f52684-934f-479a-9daa-b6ddf13c7a5d",
+          "id": "06d75a11-1c9a-42e0-82ff-a1aedf5ede34",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "51de8ea8-a70f-4e66-822e-779363c598b4",
+              "id": "cd4dd6ea-8a47-4a96-a721-aa7c5e6f1f38",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "ecc57c4b-6f00-4f4f-9f6a-88d71798f63a",
+          "id": "b30a964c-b226-4b6b-93a2-b282ec62f30f",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "4d7a006c-d1fd-4099-b653-7c66b07edc10",
+              "id": "5443e95a-6c5e-4b36-bf18-6c0c9fdd6aeb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "6b3de6dc-3a27-4eb5-9b7c-bfd00ba81be7",
+          "id": "11a4e05d-5976-4340-8acd-fd0e86188ba5",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "5f97b37d-c167-4460-a818-e9621822f264",
+              "id": "52c47dc8-d52b-4210-b041-dc7c7871d0ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "9b06a113-3bac-4517-9319-cc1c56c936c3",
+          "id": "4d17d37b-a5d3-42c7-886a-77a4d449f2c8",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "6425826d-7fb3-49c7-ab08-f99fe72db9a3",
+              "id": "e34011bf-fa25-4e1b-b7bc-4a933256fee8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "bd0b99f1-8140-4145-9985-56d37e561b19",
+          "id": "27cad949-5ea4-4d82-98b9-38a891b13509",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "a7f5bd8b-2e36-4597-8753-51817a2d8d58",
+              "id": "11fc299f-a0fe-4190-a6b8-c72caf3f29bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "ef0c10b3-5f06-4a90-8e59-3acf31682f6f",
+          "id": "87fb2ba2-e7ec-45ea-94ae-2d20cf49b956",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "2eeb071a-5fec-47d4-8e7c-12ade25db020",
+              "id": "0bd622b0-4432-4cdc-92a9-48c5429461a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "27cec7b7-9034-4d6a-994f-dcd70a6d1fa1",
+          "id": "278b3308-817d-493c-af8e-f7a138ae3db8",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "1cd6b45d-7b3a-48b9-ac6f-ff8bf9a5e8a9",
+              "id": "61080265-ce00-45e5-9ce4-c4d4423e51a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "9c2f730f-d5df-4ef5-85eb-c3bdc0fc4680",
+          "id": "d9a431fe-0f96-4890-883a-204d7009f683",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "6883162d-b864-4808-a0ee-2607d36c627a",
+              "id": "d2bda795-8e51-4928-abb8-3d5aa03b4bb7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "3184b188-bef7-4a40-af28-60386a01b765",
+          "id": "f18ca754-f57e-479d-89d9-65b07105200a",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "2bd80af5-5eeb-4db5-a06d-b48c63c0478f",
+              "id": "66fb5280-4993-4719-bf24-9eb4dc0709b9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "5ce20d2a-0d5c-4459-921d-2197dc253355",
+          "id": "5f696c55-70c5-4ca1-b640-486ac0802831",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "5d2ccebf-e495-430f-b737-25a41483eb69",
+              "id": "afbd4cab-bf3c-4173-add2-e623484eae85",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "d53346c2-018c-464b-a1c5-044f059b9966",
+          "id": "5366da98-6b86-45e8-babd-c565f8e18e7b",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "6c679cad-b6cc-4a80-be4c-96e30ba90d56",
+              "id": "a766dffa-ffd2-4c42-8dc5-72f169656c50",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "29f86bb6-b7d2-4d10-813a-8b3d769e9f96",
+          "id": "3abde498-c523-4fba-befe-370c6cb6f5f7",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "211ce27f-e802-434b-88c6-5070dd11db12",
+              "id": "a155288c-9f09-44d7-baaf-6d7c3c131689",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "355ccd98-db43-41ac-81e8-cb6e65ef25a0",
+          "id": "8a43bc43-0d2a-469d-ba0e-b34d2efcb198",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "a3e11b42-c904-426d-aa78-202d97cfb6f2",
+              "id": "ce3a1a58-3f8b-4e9f-8d65-7ab83828feb8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "55531f8d-01d9-47b9-b537-bfd626f7e364",
+          "id": "ec588992-3454-4654-92c2-ab762a15fa3e",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "933eb5c7-9b79-40d5-b31d-d33fbd4eca7f",
+              "id": "5cc984c0-b3e0-4dcb-96eb-36789816e943",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "85b58f07-19aa-4a27-b404-cc311cbd94ab",
+          "id": "2dd1d731-a5b9-4dc0-af4e-09d7ec3b1e1d",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "de5d7c5c-ed87-4a15-b19b-b749b4aab624",
+              "id": "d7210a6b-7bd1-453e-a2e1-70062d2a8e73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "6ae49632-3ae0-4d00-b211-42b76d5c5b61",
+          "id": "c7b6150b-3f26-4830-bfe3-3b0fe7449f18",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "2e1ec342-b2a4-4a4c-b4ca-6e3282c02a11",
+              "id": "001253ac-bff0-431d-8402-5200292612db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0be8c8cc-86b0-4a16-8866-ae00809cd982",
+              "id": "3fd57281-9769-4b85-a5f6-b67d5ee5e983",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "e7184c48-20d2-47e7-ba97-03e58fdc9d2b",
+          "id": "91ba44fa-5a74-4923-a68a-606fe410c024",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "14997772-3cc7-43e3-bab1-0d1942840244",
+              "id": "077aea56-29ae-4d15-8d2f-eb1419712fef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1364726d-38ba-41c4-a5db-d94a72cccecb",
+              "id": "f8872cf2-a95d-40bd-a1dd-d405324118d0",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "70f3362f-7e7c-4a56-aaba-78fada5f4ab9",
+              "id": "d4d7dc3a-0271-4957-b89f-c82a6b69761b",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "e92db82b-19a0-4db2-badb-39edca1abb31",
+          "id": "cc52b961-23b2-4c10-b7e1-2773e8919920",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "788308f0-44a6-444d-a896-76b05f0852db",
+              "id": "adbb9460-5d0d-4a38-9131-4ca461ef9cd0",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "23b9df67-44e2-4b45-afc1-984921c218dd",
+              "id": "9bb4429e-230e-4cb1-a1b7-8355c590f14a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "852fb652-b46a-4088-bc97-75f93cd89930",
+              "id": "eb053861-01eb-43c7-8840-5d7bc1309cb7",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "9829e95d-c6a7-4355-b406-cd563df4bf73",
+          "id": "d6c3e3e0-3a04-4298-bf70-a46065d225ce",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "5ecc3d70-d165-4380-84b3-fa248ef951f1",
+              "id": "07ffeb68-4992-4ba0-9002-423f8b1be33a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "142a15aa-f3a5-405a-85f9-1dc213186231",
+          "id": "aa04e5b1-3dac-4eba-a285-d835df6cae7c",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "86e1992c-0d36-40ef-a3fc-42bb274394c8",
+              "id": "f40cc6f9-cedd-4811-a297-0a0f2a4c7319",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b28d620e-4496-4813-a9f6-525544c02cff",
+              "id": "a1765131-83ee-4da6-a8b6-40a98e494b09",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "f2fbcb90-9b3b-4075-b9b0-7bd968fa9dce",
+          "id": "6645c9b9-a351-401d-9ac6-29ac8c520196",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "6de085d8-602d-4225-9501-ccfefda7339f",
+              "id": "6736e0a4-1b56-4e5e-aaf8-39efbeef6bbb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "cb37e17d-db2d-4a5a-82f5-ffb5625ff441",
+          "id": "d29f0e15-85f6-4121-b6a6-527b20f947da",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "4a095289-0f22-47b6-8249-ccce2514d4bb",
+              "id": "1d72cc5f-3e81-49eb-a8e5-b29b74a29513",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "14252080-d0cd-441c-8b8e-aefc45e4672b",
+          "id": "aa82317e-aa5f-406f-b424-4c82abab5c86",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "efb7e504-5d46-4a9c-86c5-2c993df5f649",
+              "id": "22f3b037-3c81-4ec0-a71c-bc4d959dca2c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "efedcf50-362c-43d4-8ed6-fb6bb0cdbae9",
+          "id": "d9a6c93e-b4be-4996-b4bf-9115414523f3",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#407c1C\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#EC37d8\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "5cab4629-26fd-482c-8a2b-23d3271582ab",
+              "id": "3e103bfb-394b-489d-845f-0406ebb1cf1e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#407c1C\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#EC37d8\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "d12e24d3-f66d-4572-b2ad-42780c17670a",
+          "id": "bd83308d-2627-4655-a5c0-9ee3d884f79e",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "dc1f68ff-1faf-474b-bf9d-005eb1557f9d",
+              "id": "c3ea296a-0a3a-481c-b1b8-0b0378f32c7a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "d94bb021-b017-42e9-aa83-8bb84dbb6e68",
+          "id": "9111a186-0969-410d-bdee-caffd8f7e449",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "a8fcad39-3a6e-4886-b681-c7286d4b5598",
+              "id": "80b85943-3f83-4951-8237-973d63828341",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "e03a6755-ad68-44c2-85d7-3791dd822483",
+          "id": "19ae2e8a-7015-4569-88dd-b5901767790c",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cFFdFd\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#16ffc8\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "dc15ccbc-44f8-446d-8ed7-dfcfc6d4391d",
+              "id": "894c148f-4ad5-4fce-afc5-f3da9dadecc7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cFFdFd\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#16ffc8\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "7f873435-ce20-48bf-a1db-1b4cc6edb584",
+          "id": "3f2bc065-3bf6-45be-b401-b97816b7e688",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "e2c6664d-502f-4873-b98d-5d7727cd529c",
+              "id": "aa65c53c-11bf-41fb-9cfe-2b6e50fabd9a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "1e358fcf-1d14-4124-9f2d-98a00a2854ea",
+          "id": "38c63d74-b0fe-4fd7-b33b-6e9904202cee",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "f1afb992-7727-4eb0-97bf-376ca8f3d760",
+              "id": "d31b88f6-20c5-4c82-b6da-78be57f008e9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "160f470c-f0b4-43b9-bbdf-f10e616a648a",
+          "id": "6ba0b0de-3462-4bff-8232-aae7d0fce1e4",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "b2460dd6-5d0c-40ee-8d00-c29250c5b423",
+              "id": "60ef3ed2-7ccb-4bbe-82e1-47a3ffda36a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "482aa700-fe80-4ead-a320-1e5e57b44cfd",
+          "id": "7e0f8aeb-b980-4b1e-be0c-1462936849a4",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "eecbf307-cd76-43a3-933e-1b90f191de8b",
+              "id": "89088bf6-36e2-4027-9ea5-a1eb3652b245",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "c357569b-38f8-49a5-94d8-90fcc40d637f",
+          "id": "d9b65465-d709-448e-9464-f04a7e2a7497",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "15a47cb2-6dc3-478e-afe3-eab93841fb69",
+              "id": "0a487d12-5d6c-4dc9-a14a-16beff553748",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "616030ae-c345-4697-97b7-d9aa2a8164d5",
+          "id": "73f1db1b-5dec-4d32-83a5-60540481fea5",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "de85709b-d154-4780-9f81-a2e186928eca",
+              "id": "eb267794-73a4-47c2-91d1-367d554d7b4f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "fe09c0d2-e4bb-46ba-859b-572aacd7ecb4",
+          "id": "47a27ed7-95bf-41b5-97f6-4600fdabf40e",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "a67f438a-4fd8-41fc-895c-815c3c14313b",
+              "id": "50287a10-8030-42a8-8409-2017ad12c5f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "644b8614-b428-47bb-9341-37d0afa64987",
+          "id": "cb47fd12-6c00-4a10-a53c-8b21ae47776c",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "025b9967-9e5e-4c29-9945-99ca74066edd",
+              "id": "4d292eae-eed5-4731-9a4a-e6a8cd1ba0f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "ecefa0f0-f9e4-4a74-ad1d-7bb0fcba6f5f",
+          "id": "d58b31ee-7ecd-463a-8859-c482deeff69a",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "48630df5-bb4c-4399-a398-6b74d81c19ab",
+              "id": "f3da4629-8df1-4054-82d3-36924e1d1863",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "f3fca491-4ee6-4731-8dc0-3e4b0f25f08a",
+          "id": "d1e96641-801b-4258-90a9-f60b66c6aea3",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "5022ab22-9f0a-49c2-9dd9-eb059579278c",
+              "id": "0eb3cc9b-3e7f-488f-99bc-6ec32b549baf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "d747def4-40aa-4c33-a92c-aa0a3e4a6d0d",
+          "id": "e27726fc-0668-493a-b0a3-2affd7ebb8cd",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "88b943c8-47b6-4e9f-8e66-9dfc4d91a4db",
+              "id": "ef552d20-e4db-44a7-9bf3-1d9c9b830627",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "9f3ff84c-e73a-4e3c-8d8e-aaa68b619782",
+          "id": "bf3e97f8-1729-4df7-856f-dec60cd3a180",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "8903840b-a7df-439b-bb32-824cdd0f0d2e",
+              "id": "df36c33b-06fb-4fe2-afe3-69c86918095a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "d1d3405a-8f2c-471b-a507-4380232ad27c",
+          "id": "b8c51678-36c3-47aa-bac2-cdbfd2989ba3",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "178e5fea-9946-49ab-a20b-53c896d793c7",
+              "id": "a9b29d3f-f145-4a5f-9c8d-64ec6ca434d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "55570ab6-d381-4c4b-b734-84aba956713e",
+          "id": "95782d79-c361-4088-88c6-c422b18ce35e",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "7621f0a2-9f54-4c79-911f-577ec67bba71",
+              "id": "a3afafde-6444-4d1a-8c54-f17bc0a7fd47",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "6489a75d-3bb5-43dc-845d-52116673f943",
+          "id": "57f2049b-f11b-4fd0-9904-fbda4297bb88",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "db8893a9-17b3-404d-8fdc-d839e608b355",
+              "id": "76f053df-6f39-4411-ac44-04d61561b302",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "b8daf2b3-3273-4663-8a7c-829c5f675149",
+          "id": "03d9a909-6a07-4abc-8cba-050e04e25777",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "551b8435-5598-4e44-b3fc-176d7ae515bd",
+              "id": "35871f49-9458-4e33-80f4-eb15d34c67a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "086cc0c2-8641-4b9f-8a19-fcced3854190",
+          "id": "c9c78e0a-7fbb-481a-abf7-fa9765f81284",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "937e98db-7046-4628-8fe3-c5453092069f",
+              "id": "0d0cebe6-aade-45a2-9309-0c37c3b60466",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "d58ef9c4-8c3f-458e-81a3-d2c84a2362bc",
+          "id": "490e5ce1-68f9-4f3e-91a0-be665cbb6477",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "29e02cc4-4df1-4cf4-89a8-a5c184c34276",
+              "id": "bd2d9cc9-25ac-4346-9bfe-11d53eb0f1c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "78ca4fff-d0d3-41bf-abbd-8a6781877aac",
+          "id": "823e927c-6ee5-4d00-b722-36495f643fa9",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "ff2f2866-a89a-4d5e-8eea-f7d395929ce0",
+              "id": "60cc883c-575e-4401-9fd8-51f631f208fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "1b38dfa3-17a0-4341-ab7b-7ba32aefab93",
+          "id": "c82c198f-adbd-4a79-9c16-b7733c02c656",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "57796a05-9cfe-4dd5-8169-f854cdb0a13e",
+              "id": "f39bdf52-7951-4e5d-8aee-33921dbbd36a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "ff2a399d-1778-4def-945e-ac4fc9f92249",
+          "id": "50a10940-e092-4273-9e08-da6fcd308de4",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "bcfa72ed-a5d6-44f6-b298-8fa672a6f99d",
+              "id": "10def026-b5ba-4cf8-a5e3-5f49d7182077",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "0a816613-a306-40cf-8b1c-eb55e40573ae",
+          "id": "3852022f-098b-4a34-92e7-2f7806314042",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "1d51a98f-b0b7-4174-a5af-f97d3c971860",
+              "id": "f0cf2d13-bd9d-4836-8906-9990c543ccfc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "683e6ce6-5ff7-4f79-af12-d53f29c77ceb",
+          "id": "3dea392b-f0fa-4864-8d4a-c6a3bafdb2d0",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "56a2c177-5a9e-4cf6-abd8-ca687c7c2c2f",
+              "id": "09b41843-d670-4d28-a4f8-37e82e24da46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "75976a2f-e821-461a-b87c-79e7688bc028",
+          "id": "bfb6e005-b5b1-4139-bd3e-aaa125e7981b",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "277a7465-8b10-498b-b9c1-db201a489dbe",
+              "id": "621e17a7-2241-4cc0-bb0c-8b6aba65e893",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13520,7 +13520,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "c4edaf51-360d-4749-8b4d-8ef6f23915a7",
+          "id": "110fd217-592a-48e1-8555-71bcd71234d0",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "29bb6eb9-0b9b-43cd-9662-02c7e8afe558",
+              "id": "574edd6c-05ad-421a-9f27-b70d33c4fb7b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13630,7 +13630,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "82202771-5ee4-439e-b463-19765e5617c9",
+          "id": "1e7b2a1d-e094-46c6-a420-c293b62d67b4",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "4e63ef98-1132-41ba-a4b6-1946bbf0aab5",
+              "id": "0159cc13-1e50-48e3-a935-0021bc68faa1",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0b6514d7-e248-42a2-94eb-838955d72ce6",
+              "id": "ce99b33a-9020-4612-abdc-9e58604c5e16",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "adb53ef9-a83a-40a5-9379-63b970bb6844",
+          "id": "eb6cd6ba-27ed-497f-906e-34eba5a6cd6d",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "0161dc58-5143-4cbc-80a3-13f533ac8298",
+              "id": "2fae0d98-f581-4de4-8d1d-e21d70335af2",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3043268f-d62e-4b54-b186-5023e3c569fe",
+              "id": "8c3e9016-c3dc-4f09-a9c1-dfe08f6981d8",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "81336107-e409-444d-97bb-39570784815f",
+          "id": "0d045f09-19b7-4a21-ab0d-bf8f0a22734d",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "6a88ace3-6e17-42d5-8279-945e75f933f1",
+              "id": "33c4c998-70cf-45aa-9ff4-1c1e92e9f836",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "14036f36-bdc7-467e-aa34-735b8f978eb1",
+              "id": "fd4a2b68-c22f-4a71-9402-36f984a27e16",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "de9eee43-5c92-491f-93e5-b0a5194cc6f8",
+          "id": "264f54d4-49b3-4370-80b5-8c6497d477d0",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "5bba69ac-b7c9-49dc-8c5a-7a1cdaf908b7",
+              "id": "ef1aad57-1cc6-40b9-adb1-7822f131e0fe",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "bf9babe4-2b87-488b-b408-b7667f9e24bf",
+          "id": "39632efe-1c0c-4679-9340-681304638eb3",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "0b83e34a-2b0c-4e6e-a8c1-6d7c710442ef",
+              "id": "3195cea9-67e0-457a-9f25-b2c9480107fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "c677cd04-bbe0-492b-9265-15617b99e39b",
+          "id": "0988ca62-88bb-4c48-9683-98abb54d25e7",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "9cdde4b5-f855-4ec9-84c6-8a8008d44fee",
+              "id": "3b54c988-be97-4e6f-b69e-7f66e69c5ca2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "6f755304-66c2-4b28-b423-65908fec4099",
+          "id": "3222df66-358f-4cb3-9601-84427f2722f8",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "496da6f8-1153-46d1-9314-dec732009436",
+              "id": "6bab25d4-4d8a-4769-af56-20ac010b0659",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "5e12243c-4b37-450d-8f93-b48dff88f9c6",
+          "id": "5a2b3e30-02bd-40bd-bb28-dc8fe835b544",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "32d2b112-1790-4cf2-b75b-cff8bed3e929",
+              "id": "1dc83eba-902d-46a5-be1f-820806358729",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "346f838b-a776-42de-8105-f8b372e83971",
+          "id": "43748f8f-33b3-4d20-9ba9-15c68e902b66",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "7df19d07-5c36-4717-957b-f5fff84581c1",
+              "id": "383b1aa3-cdd3-4046-9422-ba28d24f7164",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "b3557e2c-585a-43c5-b227-f001cb32f1a6",
+          "id": "883603e6-9328-407c-9f66-da9bb38def0c",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "08112636-c502-4b8f-b9c2-cd2d84ee8ba0",
+              "id": "b018100a-dc32-4f93-a5e6-7e696b1c0eed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "0e851c47-1287-46ad-8ce5-a806a4f6b85e",
+          "id": "3eff6fba-3255-403c-867c-c7b670ceb04e",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "2f372d75-9c70-424a-a9e8-842b6e19fd67",
+              "id": "7686e9f2-677f-43df-8d8b-32c55c789c78",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "a8f0ae64-da1f-4a42-a13e-b98390bc97fc",
+          "id": "8552881e-276a-478e-8e3c-8a7b2ba1f6cc",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "1038f4df-2eca-4bcb-8d23-1d98fecef499",
+              "id": "51699e5c-c3fb-402f-80d9-29221f3d2812",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "37e18fce-6bc6-4afb-b71a-6bb2e030b14b",
+          "id": "8fec6f2b-2a87-4e32-b8a5-a9a33e4468d2",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "22c92356-6c28-4b4e-b6ae-370ef0ee6fd4",
+              "id": "c99bc930-34cc-4920-9330-4022a45594e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "58f7978c-fb7d-4a62-9568-62fcd8a34b95",
+          "id": "586742d0-476c-49b3-8a24-74279393f59b",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "004fe5be-adcb-430d-b963-61f2b54ddb57",
+              "id": "eee8c16b-9ee7-4c27-9201-7d116ca5ad6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "64f79f1c-2007-4e25-bf5e-a87836eff5ef",
+          "id": "62fbd0fc-b169-4dce-acaa-6c0748c9eaa3",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "41ef09aa-7d83-4ef0-b581-02db3e1f0211",
+              "id": "a93265e2-7e60-462c-b4a6-36396ceb4a93",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "e052dc65-13b8-4806-8858-f175cd52722b",
+          "id": "e491c164-1b16-4103-a73b-bebc11be3c0b",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "8c0bc92a-208f-4f5d-a191-9ccadcefee49",
+              "id": "fd229e91-7e50-475e-a21f-64b50b529d3e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "5437c14e-21c3-4f0b-b9de-5ef8570293a7",
+          "id": "6df7155b-2f7c-426b-b81f-9c08e6b98952",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "b090049b-c153-462d-8297-5434d1851edf",
+              "id": "601ba7b3-ae21-4cda-9b40-2f7b52cbbde9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "8b64b802-fd8b-4221-bb56-3f40e3b53261",
+    "_postman_id": "f0742945-eb0a-47c9-87cd-da30a1a6007f",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-27 19:21 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-27 19:23 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "1c6abbc1-757f-42b3-90e3-618d68123ba6",
+          "id": "ef750bdb-505b-4d5b-807b-431bf87ab6f2",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "0bc83580-ee32-48dc-868c-115960e06a0a",
+              "id": "d2785efd-7ca3-4285-adb1-bf81707d909a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "4e18f838-e509-4ed5-9192-fad2c6a760ff",
+          "id": "c05b4763-9d9f-4ddf-9181-161fff38aefe",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "2e43b483-b563-4f99-86a2-92ae20139578",
+              "id": "39cd276d-c188-4147-a9b2-a43d1eb9b658",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "8c916dc9-c1c6-46d2-9e2a-adde44c4550a",
+          "id": "b4669d37-9671-4a1c-a49e-08dee13a4010",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "afd71d9c-7c3b-48d4-9d23-b0f63f4986d2",
+              "id": "98dee0bb-283a-4dc6-afa7-35a57956b21d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "709e0b48-4e39-46fe-a445-96b7fe1015a6",
+          "id": "502db693-307b-432e-a2fa-19f62d00ab34",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "f258cf75-3b87-406c-b523-b44529294f91",
+              "id": "0a296334-eb0f-4c4f-86c4-94976799eaf8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "fc75ff9e-4406-4867-94cd-32d248a9ac32",
+          "id": "f22af647-6b04-4987-9a1b-0278f4a00434",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "c82277d0-ebba-4304-b4e0-75159253ef19",
+              "id": "a3e31eff-6658-4970-8cbd-f62e11179e5c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "790b6926-a130-46c7-82e5-7ce589dd7fed",
+          "id": "a976caf9-4aee-4230-8879-add0c6ff21cf",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "6e075af2-e4e1-4bcb-a531-c1f8d62e0ed8",
+              "id": "9a522a9e-a192-4b7d-baaf-7695d4c573a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "cb9bbf1c-56ae-4de3-82b7-7b135192ff7a",
+          "id": "4bcb252d-e50b-46a5-9dc0-0751878bb0de",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "1be8a82c-b40a-4e09-b30f-bef395d79002",
+              "id": "073546a5-34b4-47ec-a6b8-9c36c9e8d2f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "afc991eb-df55-4652-bd25-c4472e6c7825",
+          "id": "64e4e48f-63eb-4d98-be35-42c6dd3d0d31",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "b157f6ae-4de6-4cf2-913b-05e75c310c41",
+              "id": "64f70aef-dce4-4aa0-ad61-1a7762fde17b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "b0e0ce0f-ce75-442a-b57b-cdba6f8eeecf",
+          "id": "a408dd2d-2483-400e-adb7-5ab041eafc8e",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "5a7dd957-dbd0-4d73-b9cc-411f3c6c044c",
+              "id": "3c7ec5d5-587f-420b-8649-f1209b07888a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "60507ba4-386a-44ff-a9d8-c8fc6cabaf50",
+          "id": "b9196511-541f-4a85-99fe-a4b533705952",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "0f8a0b94-0286-4d17-b548-2ec8ef76cef1",
+              "id": "641dcfac-aaaf-4db8-9014-3bbed441b144",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "b7b5fb7e-1ead-403b-85b1-24b575c0347d",
+          "id": "e3d54f71-4474-4c2a-816d-6fa23868292b",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "16104a38-825d-4999-a06e-fddd4c78682f",
+              "id": "61268054-d53c-4bbd-bdb9-1160ce82cbc0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "ab690fce-53d3-404f-a5be-8953d6f701ef",
+          "id": "304b9518-9334-4549-9a30-b46bf8c27b51",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "8acf8cb9-aa7a-45d3-aacc-4c47cc3d7726",
+              "id": "eb61c325-340b-4c84-a3e8-b6e24e57e9b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "4304a398-637b-4828-90aa-68fc2103956b",
+          "id": "5a746c01-098d-4ac3-8660-07e3a30f71cc",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "f6812a11-d0bf-4fcd-ae35-3d803a1fcb50",
+              "id": "f5af208d-7e4d-42b5-a30e-c7d9ab5492fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "004d8e63-12dc-4928-8b7b-eaa76db4f63a",
+          "id": "3557a1aa-624b-41ce-8384-145375d9f8ad",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "0c0df32e-cd25-40d1-bd55-4ba469eb8e01",
+              "id": "bfe2b82d-baf9-4ed1-8e1c-688404c9dee6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "fc914014-5339-4aca-8479-a09319a7e58e",
+          "id": "fb13d5ca-2bc4-40dc-aadb-f1cb70678fb4",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "91a19c15-d641-4d11-aa0a-640a1e1d559d",
+              "id": "a273df24-acff-4524-9ad6-a86c6a5876ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "84688dec-8f19-4aa1-9d26-660293c8a856",
+          "id": "ccb66d0d-efa4-489d-938f-99ab22382b49",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "8849ba2e-d9f4-480c-8a84-ebd88c0b1dec",
+              "id": "0985c028-e4c1-42e9-b0e6-3fb723da417c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "5884d678-4d96-478d-bbbc-950a2b42d8e9",
+          "id": "65f8c9b2-d88c-4cc5-b815-f914e13c7836",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "4cf20b48-3425-44b6-aa7b-51e91ad9c7cc",
+              "id": "cb56f1d0-105c-4ea3-bda2-a22eb642484f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "e0504145-0f46-439a-b52f-31e185bbaf6b",
+          "id": "2376cb3a-6b94-4f22-87be-a9b53ed1969b",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "333bf025-7af4-4bd0-8b89-c473358c23b4",
+              "id": "30bdea2a-2151-4e33-ac4c-43f36cb5fffd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "519c083f-79e4-4037-bc96-505916e4c358",
+          "id": "85fdb4b0-ccae-455d-b442-7f60db6fa187",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "310972c9-6bee-41ee-b0cc-99ac43f5a74f",
+              "id": "96a8063f-03f3-48e9-a1ae-09069a1db91f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "12fdeedb-132b-4874-bc51-95f46c6aca93",
+          "id": "8b6073fc-9c7b-4a70-8086-ac8a2c7f0dc5",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "7d6d5da2-ad8b-467e-a656-6994a35433ed",
+              "id": "a040d0e8-7bc2-4b95-9194-9d0f818cb1bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "78f2a694-26af-4695-a09c-e646e449b9cd",
+          "id": "508f51ab-d059-4347-85a3-d77a9d3b45f6",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "80882b98-b846-4710-9e56-f53e381e7f53",
+              "id": "54d9ca0e-5493-4a95-b327-d8482de3fb81",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "c9376801-c844-41cf-89c0-e7f641642a01",
+          "id": "3d26fc4c-7feb-4d6c-bb90-0cef8bcde93e",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "b6d1e64c-b272-4066-8974-9e31a46ce92d",
+              "id": "17ec141e-df02-4660-b254-1bc65673b6a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "7f8b9bf3-0444-4c10-83be-8e5d8ff7b1da",
+          "id": "26612dda-fe04-40b6-b107-189ae9490dff",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "164cc1b2-fc20-4b7b-97a1-c84859428881",
+              "id": "c64cd4b0-0375-436d-8da8-5e753b891115",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "a0f0b365-c6b9-4444-a307-43f112e78f4f",
+          "id": "32a18cfc-e39c-4a1e-a54a-114017e90de6",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#c9DF3A\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A1Bf11\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "88549322-ebf4-478d-82ed-f86f524a59b7",
+              "id": "a43cc517-24e1-452f-a9ec-901e60b3535e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#c9DF3A\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A1Bf11\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "b6735af0-1975-4d98-81ab-c041b63743e7",
+          "id": "bcaa03b1-5ff9-4fee-b2f3-519639f82791",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "0cb24058-739a-4b6f-9e30-9525b129f46b",
+              "id": "c1891b0d-6907-4fb1-95c2-6239363c9b81",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "8400f5dd-5246-43e7-a2f8-d2ea5cd468ef",
+          "id": "ddcf5865-1803-45d4-b4a6-9497ab72e67b",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "be198ee4-ce4a-4442-a136-570f59dbddb5",
+              "id": "6ae7f338-f64e-43c9-92a0-d77bdcab5251",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "4832ba61-7a3e-4cbc-b662-3d86857c8b99",
+          "id": "68116b1e-058b-49b6-9346-6ee0b9c8ca80",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#7fBFAa\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FBb90B\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "8489ed4d-b1b9-4d15-bf71-9b415b52687b",
+              "id": "db19cef6-06c6-4a77-8948-692e96104e28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#7fBFAa\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FBb90B\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "57688754-0ba7-457a-a7c3-8bb96f73385c",
+          "id": "f62a88d5-17cc-4db2-8365-c68a4be23e13",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "071477b6-6fe6-47c8-931a-d4b3e931a344",
+              "id": "d5261032-51bf-41bc-a779-650064d27684",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "50196343-e745-4e35-8a90-a95e2ba897f3",
+          "id": "ded077a6-8510-456a-80c4-7cff55d71ea3",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "b0d64f85-ebe4-4730-b2a3-8f0c8084a0fc",
+              "id": "c09f30cf-0a5e-4563-b8fc-00a3508235d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "0f24851a-8a90-4c35-8af6-68667c749dd4",
+          "id": "815804d2-dab6-482e-8b4a-5e16fb68a32b",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "f7b3b5f1-96bd-4702-9c8a-9811491dca23",
+              "id": "6efb8633-67f0-42dc-997b-5505e08e8139",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "477454a7-ef84-4d00-b887-a2c5e1d1546f",
+          "id": "a0afa531-0288-4991-a1cf-07f669f08be2",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "956e0023-fd7d-4a60-9b85-5da1f1867c50",
+              "id": "f1bbc039-8431-4ee2-80e0-d32277d2a270",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "72357417-8263-4da8-bf96-d9954aa2c346",
+          "id": "79b126ba-4878-49ef-9c7a-7358c84bc7fe",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "aaf2eddd-30b9-4324-bfa2-047e0fd542e6",
+              "id": "88bbe8bb-8d54-44b2-adc8-e29e504f7bda",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "a3267350-c94e-4045-924b-9c4cbe485ddb",
+          "id": "898d9774-adb9-4d05-b8a1-d9f95436d626",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "9160852b-052a-4e4c-84ef-09280b3c0851",
+              "id": "86ac38cf-c558-4d81-ab3c-b5e16a8dff6f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "8728d27f-62d0-4bc0-8479-7990232f8cde",
+          "id": "75cf4887-a39b-498d-b3c0-e8f01bf1fc37",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "2adf1146-874c-4ccb-a281-6b0690143a49",
+              "id": "38baf862-6504-40d1-bc21-7ed4f4e51ef5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7552,\n  \"key_1\": 4905,\n  \"key_2\": 6875\n}",
+              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "d427b3e6-3aab-4304-becb-3781dcd795bd",
+          "id": "94c99f40-3094-4f44-80a2-13283474ae4e",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "28582680-8a87-48af-93d5-3e22a3a9d69d",
+              "id": "33bcb4d1-c3ed-4b17-bc4a-bcb31ad0d457",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "82227bcf-8053-4c00-83dd-dc62da287ab3",
+          "id": "70acd853-6668-488b-876f-88823c546c1b",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "ecf877fc-88da-4e72-acd6-a59049d25005",
+              "id": "c31c8ce3-d594-46c1-bc70-768bd2e63436",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "ca9da745-a2c6-4f00-b6e7-5d742f8d2c63",
+          "id": "5afa5002-27c6-40ca-8fe7-9285bd975787",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "00591468-7e40-4ac1-ae50-81a81e57f266",
+              "id": "1af7c578-cc56-4934-a04d-17aa041ded67",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "36cd0700-ff4e-4883-b74f-f45134e055f3",
+          "id": "b8f7d799-16a8-466a-ac38-be47398b4414",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "f401d341-f760-41e9-8875-2c5516577b21",
+              "id": "44a7ebd7-b658-4276-88a6-b1a0b6d7e86f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "9917e917-a80d-4975-b0d2-2a832c4ce3d2",
+          "id": "eb5a67f4-d558-4e02-a59d-4c8f20458cab",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "3d7b0d21-ab53-4439-8772-9dcb44728bbe",
+              "id": "2c86798c-9fac-42e8-8bae-3183b574ad35",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "926aad63-3578-463c-8d3b-54040b1aef40",
+          "id": "27b1575e-c1f0-465c-9cbf-60df194068cc",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "6df5d69a-5524-46e9-bd7d-a64b23e5f4d4",
+              "id": "ca0aee9a-e2dd-4daa-a489-4b90c5e4e09b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "a9c2a162-e182-4655-b125-e6d1eec5c985",
+          "id": "24c88048-4a68-40c2-944a-9f77ea2b5008",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "5fdf451e-d029-4c1f-a759-3ed8a147cd1c",
+              "id": "193ef6cc-4eff-48ed-9aa7-c42359c6434f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "6070c794-e741-46f2-b327-54a3558b1e60",
+          "id": "e07f04dd-c611-473c-b7cb-7f32e660ca09",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "8191eab7-5d57-4e35-b730-dc354e989fd8",
+              "id": "8efd8f89-6785-444f-8b91-2aa33fade688",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "ccc82445-667d-47d2-9c87-58d364128551",
+          "id": "6acdf510-8b9d-4991-b746-200c84e64e75",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "33489a70-78bc-4e54-88d8-fab766ea61d3",
+              "id": "0e2fae31-490d-4391-a194-28c5be4f32f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "60eb9aa6-c57a-4969-bf88-ab1cb4e1a1d4",
+          "id": "e83a5328-55e0-4462-98a0-98c29f714c12",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "528993d2-1368-4d94-bf64-8fad4f8ced77",
+              "id": "2f827777-2a17-41f1-bef0-c94c3a94aeaa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "2f29be9b-670d-48f4-9a5b-3c41c1479eb6",
+          "id": "b4edc40b-3ce1-440b-821a-56c72e4b0f5b",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "eda2812c-dcab-4ee8-a22f-bd7c58c206cc",
+              "id": "95b90923-1eb6-4f59-94c6-7b5309632bda",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "ef77cba7-8734-4bd3-b229-d4f63cf95703",
+          "id": "12a78975-1485-4a8c-99b7-ea6d6c11a4e6",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "9481addf-a6c6-4829-9e34-1a9c79501ea7",
+              "id": "04eb71ee-d0f4-446d-b8a7-061cbff0ec9b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "aaaa7996-ade3-4920-959e-899056cec709",
+          "id": "6ae73f17-69d0-4796-84cc-5fcb66aedc98",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "ee1d46f1-37b2-4f5c-ad96-c93098e3c8a4",
+              "id": "c6c7bfdc-411f-4487-b6cf-8612b59acca8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "331d204a-57f8-4dc2-84a3-40dfb3af0168",
+          "id": "693b10fd-0075-417f-8b53-52d1540da80d",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "834c8a96-a93e-4515-b716-9ce57a438e36",
+              "id": "5a02683e-5105-4097-a025-0717768a1a10",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "b45cc72c-eef0-4be0-8bc4-54224222e1a1",
+          "id": "bb1c3635-fd1c-48bc-bd80-4078e413ae25",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "0af4c06e-e36f-484d-a615-e8898be02625",
+              "id": "c986c1a7-5af0-4add-ba1d-d2aa124f2522",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "64f755be-792b-4317-bd38-4e5ca98f6052",
+          "id": "19b44b81-7b67-48f9-8d7a-4aea02b67955",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "3a5e03c6-2f54-4b7c-b9ec-b7577eaae91d",
+              "id": "043ba2f5-f2f9-445f-bc7d-cf12ff642bab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "af934544-1342-4b1a-92c0-040a16dac6ed",
+          "id": "e9520d6e-edaa-4f6e-9cd2-9e0490027fa4",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "6d4824d8-ef71-428b-b9ad-1f094bbdc0ba",
+              "id": "e8f9b891-0319-4a66-a490-597f0970468b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "67e0fe43-87b4-4b27-a92f-e24f66a0ab82",
+          "id": "c85be0a9-457b-424b-bc8e-4279b561c2b6",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "7d7df179-a51c-42f8-a47b-2afba8a1b3b8",
+              "id": "1e7a5fa4-6f73-4124-8e49-c72777de3be5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "cf81c3ed-b84a-4ccc-9129-005697ef4b49",
+          "id": "824de862-0d26-4c3a-8033-91c32a18e757",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "92e6a46b-cc34-40c6-adb9-40e665ca495d",
+              "id": "5dad2e57-8187-4494-9e1f-6e39186d2a2e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "6118e890-3cdf-48b1-b675-b88f2f3dfb44",
+          "id": "77245112-90df-4344-8264-a5712e3a8647",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "bff651a6-9114-4092-9588-5606d8b7008f",
+              "id": "e4908602-b576-4cb7-8541-b03290d472b4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "e0154015-636b-4a8e-a4f7-2e0a5ab3adb3",
+          "id": "690c62e0-3610-4e19-9e39-578ffcf4db18",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "3ab49252-2b99-49df-a974-dd88f81c30a7",
+              "id": "72b74979-c29f-40d9-81eb-b39ec84ee964",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "6e7af192-8fc1-4205-a0b9-a1fcf2b904f3",
+          "id": "6836372f-08fb-45bc-a1c8-ae0800762e9d",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "cf98d3fa-570e-4048-bf63-06533d87ec3e",
+              "id": "eb0acaf1-1ec0-411b-a60d-23ea91792e4d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "ae8a6673-e6ff-488e-be28-8c3f7540e826",
+          "id": "3b980ac4-6527-4f6b-9f97-f7aebba87af5",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "70964f01-28bf-456c-b745-e7155c46e348",
+              "id": "e27b4a6a-a772-4b4e-a106-2f8c81650edf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "0bf405ec-617e-4f9f-8589-bdbee3c01fa3",
+          "id": "f24e8aba-c043-4123-a57f-a63500df5265",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "3132ef41-0944-474a-8421-84defa266a50",
+              "id": "c84c9eff-d866-4b13-bff8-cbabfd0753bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "8dc8641d-ba26-4ba5-9fdf-524fe84954ae",
+          "id": "c43c2764-11bd-4f28-aca7-b11ab00512c1",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "d377ea00-fbb8-426c-8977-8c26b6490f22",
+              "id": "82e4e86a-1046-4851-b946-faa031b3efbb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "34558232-0a6d-49b7-8ab3-dd993dea2167",
+          "id": "72c7e803-bd36-4912-a92c-a4e3fbcee13a",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "b49c43a0-587e-405d-af61-8e236d1f49b4",
+              "id": "02b37059-dd14-48a1-801e-5eb165c5f93f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "360db49d-8320-4eb3-a863-3ac5631f05db",
+          "id": "22fa0967-297b-4da4-8bbb-16c1d09d7f7c",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "ceda5981-672b-48f9-87af-19623bda96cd",
+              "id": "686e6a96-fdba-461b-a217-1646c358e4bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "3ec9db69-345f-45bd-8bfd-c90b95fbafce",
+          "id": "0dc08f95-ceb9-4b0d-9f30-5185c7fdf0fa",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "cd238488-8346-4586-9ab8-b35f577db554",
+              "id": "b04283bb-2f54-4327-9164-18ef74a224a9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "bd5d396c-9252-4b1e-829e-68aad52c44f8",
+          "id": "f3f52684-934f-479a-9daa-b6ddf13c7a5d",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "28d05e91-a19a-41b0-af29-b4cf4b533caf",
+              "id": "51de8ea8-a70f-4e66-822e-779363c598b4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "b597aace-c263-4b64-b1f9-2bea8d63e4e8",
+          "id": "ecc57c4b-6f00-4f4f-9f6a-88d71798f63a",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "b24abe0d-95e6-46b9-b192-1c58f8c39438",
+              "id": "4d7a006c-d1fd-4099-b653-7c66b07edc10",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "360caf6e-9839-4543-8f92-407dc671b53f",
+          "id": "6b3de6dc-3a27-4eb5-9b7c-bfd00ba81be7",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "68e42734-6c04-4148-97c7-2d98e1bbc1a2",
+              "id": "5f97b37d-c167-4460-a818-e9621822f264",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "eaf506e4-3d48-4a5b-a18a-c9026f99f935",
+          "id": "9b06a113-3bac-4517-9319-cc1c56c936c3",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "872aab4a-8d54-4bea-ae9a-cb6da2bb42ec",
+              "id": "6425826d-7fb3-49c7-ab08-f99fe72db9a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "c2648f94-c714-4ace-96bc-0ff36fdb70bf",
+          "id": "bd0b99f1-8140-4145-9985-56d37e561b19",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "fe0b5f89-a5e5-4221-bea8-773091c8b785",
+              "id": "a7f5bd8b-2e36-4597-8753-51817a2d8d58",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "7e1a9e1a-5f88-403a-8364-30e36c18648b",
+          "id": "ef0c10b3-5f06-4a90-8e59-3acf31682f6f",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "d7c200d6-c7cc-4d95-95d9-bc654f98a0bf",
+              "id": "2eeb071a-5fec-47d4-8e7c-12ade25db020",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "16f9ee50-7dfa-4e69-abec-a1c9a6a3d121",
+          "id": "27cec7b7-9034-4d6a-994f-dcd70a6d1fa1",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "1a314907-08cc-4a19-811b-3f65cd2cf0a2",
+              "id": "1cd6b45d-7b3a-48b9-ac6f-ff8bf9a5e8a9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "c4ffd8a8-e53c-4a8a-acde-81c7084967bc",
+          "id": "9c2f730f-d5df-4ef5-85eb-c3bdc0fc4680",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "601373f7-5d72-4cb2-836e-e342fd0133f1",
+              "id": "6883162d-b864-4808-a0ee-2607d36c627a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "5dc3a52e-5c78-4818-b569-7f2fe22323ff",
+          "id": "3184b188-bef7-4a40-af28-60386a01b765",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "b8f9439d-43dc-4719-9f6c-0224854b34cd",
+              "id": "2bd80af5-5eeb-4db5-a06d-b48c63c0478f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "45d0d1bf-59d6-44c7-9c61-3f652b979daa",
+          "id": "5ce20d2a-0d5c-4459-921d-2197dc253355",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "b2e2d8f3-4db8-4f83-8514-061381da45c9",
+              "id": "5d2ccebf-e495-430f-b737-25a41483eb69",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "293b99f3-8a5e-42d7-9025-e0af4a3075bf",
+          "id": "d53346c2-018c-464b-a1c5-044f059b9966",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "33965ed2-43df-4c1c-a5d3-eb36e1855a17",
+              "id": "6c679cad-b6cc-4a80-be4c-96e30ba90d56",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "1f2b9061-4dc7-4b2e-ab0f-19ed6e0671a5",
+          "id": "29f86bb6-b7d2-4d10-813a-8b3d769e9f96",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "3f9d4599-66db-4450-975b-1348bb994090",
+              "id": "211ce27f-e802-434b-88c6-5070dd11db12",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "e98a8370-c7d3-427d-ae08-c788336f24a6",
+          "id": "355ccd98-db43-41ac-81e8-cb6e65ef25a0",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "8619b61a-a27c-4e09-8d24-b0760e7a5e95",
+              "id": "a3e11b42-c904-426d-aa78-202d97cfb6f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "5ee9bae5-32e6-43cd-af11-b7198e3e5c11",
+          "id": "55531f8d-01d9-47b9-b537-bfd626f7e364",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "16b0abe6-e324-4694-be9c-83b905a5f68b",
+              "id": "933eb5c7-9b79-40d5-b31d-d33fbd4eca7f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "e14b4100-e3a2-455f-af10-abe556faa76a",
+          "id": "85b58f07-19aa-4a27-b404-cc311cbd94ab",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "559649be-a0e6-46c0-adfe-e9ea09a40739",
+              "id": "de5d7c5c-ed87-4a15-b19b-b749b4aab624",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "8ed32df0-3a05-4889-b844-ff937ad54b7b",
+          "id": "6ae49632-3ae0-4d00-b211-42b76d5c5b61",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "4d553107-135c-441b-9d62-bfb270618ee1",
+              "id": "2e1ec342-b2a4-4a4c-b4ca-6e3282c02a11",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0b3b1677-0ed4-47e6-96f5-5a489931d311",
+              "id": "0be8c8cc-86b0-4a16-8866-ae00809cd982",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "4071356f-9ac6-4583-bea2-14d278e9e340",
+          "id": "e7184c48-20d2-47e7-ba97-03e58fdc9d2b",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "4be08680-74d5-42c3-9593-d3d0ba7d26c9",
+              "id": "14997772-3cc7-43e3-bab1-0d1942840244",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "fd639192-db5b-4176-899e-a09ee2928c5c",
+              "id": "1364726d-38ba-41c4-a5db-d94a72cccecb",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "fff7da4c-ac91-4ec2-85e5-ca1531c29618",
+              "id": "70f3362f-7e7c-4a56-aaba-78fada5f4ab9",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "cd38206e-1221-4dec-9437-e9f0e9633261",
+          "id": "e92db82b-19a0-4db2-badb-39edca1abb31",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "58a1e345-207c-4bea-abff-15430c40dc82",
+              "id": "788308f0-44a6-444d-a896-76b05f0852db",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "62c42b53-e2c3-4461-a08e-25981d7f031f",
+              "id": "23b9df67-44e2-4b45-afc1-984921c218dd",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ed67fab3-e650-42b6-a205-54ad87c5a101",
+              "id": "852fb652-b46a-4088-bc97-75f93cd89930",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "674cfe3d-88d0-4135-a7f9-3ec384dfd47a",
+          "id": "9829e95d-c6a7-4355-b406-cd563df4bf73",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "2aead118-c554-4c5f-a43d-c4c0f874b2a0",
+              "id": "5ecc3d70-d165-4380-84b3-fa248ef951f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "eb1d7f3c-a240-4f49-aac3-da434b75a4e7",
+          "id": "142a15aa-f3a5-405a-85f9-1dc213186231",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "088d4509-638b-4b93-80c2-732ca0d7e239",
+              "id": "86e1992c-0d36-40ef-a3fc-42bb274394c8",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "50d34321-16b5-40bd-88d2-07a180ffe515",
+              "id": "b28d620e-4496-4813-a9f6-525544c02cff",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "964e2343-aa52-4f90-8a29-d81c718d6b10",
+          "id": "f2fbcb90-9b3b-4075-b9b0-7bd968fa9dce",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "c2c4b6de-fe70-4829-9a86-da0f011c9fb4",
+              "id": "6de085d8-602d-4225-9501-ccfefda7339f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7552,\n  \"key_1\": 4905,\n  \"key_2\": 6875\n}",
+              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "76310a83-7ad3-4730-b9bd-06c2a1351c3a",
+          "id": "cb37e17d-db2d-4a5a-82f5-ffb5625ff441",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "73ceecde-e140-4fae-80f2-7a5d21493024",
+              "id": "4a095289-0f22-47b6-8249-ccce2514d4bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "ceffd9c9-c2a9-43d4-925b-aa1ed4c9235d",
+          "id": "14252080-d0cd-441c-8b8e-aefc45e4672b",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "52a3fc91-5ae6-45a3-9b3a-8a7577882d71",
+              "id": "efb7e504-5d46-4a9c-86c5-2c993df5f649",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "32dc42cf-e361-4a75-9fd1-948b2bad18b8",
+          "id": "efedcf50-362c-43d4-8ed6-fb6bb0cdbae9",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#A2C179\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#407c1C\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "9fe9ff31-de7d-4215-9207-8234387ef079",
+              "id": "5cab4629-26fd-482c-8a2b-23d3271582ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#A2C179\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#407c1C\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "90b41640-cf6f-4ce3-99b1-02f62c162f60",
+          "id": "d12e24d3-f66d-4572-b2ad-42780c17670a",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "dae7b4f3-a42b-463c-aa41-cf5b326202d6",
+              "id": "dc1f68ff-1faf-474b-bf9d-005eb1557f9d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "c71f683e-3357-413c-9c3b-1693ac1acb5c",
+          "id": "d94bb021-b017-42e9-aa83-8bb84dbb6e68",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "f440fcbb-7ece-4897-a80b-b4eb8a237453",
+              "id": "a8fcad39-3a6e-4886-b681-c7286d4b5598",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "4ac100e2-ad9c-4970-8c58-0091600adf8a",
+          "id": "e03a6755-ad68-44c2-85d7-3791dd822483",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4e3e3d\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cFFdFd\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "18956e3e-65ed-4c0d-8f8b-662ea68f008f",
+              "id": "dc15ccbc-44f8-446d-8ed7-dfcfc6d4391d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4e3e3d\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cFFdFd\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "1517bf44-e31a-4656-8702-c4ad370c83ef",
+          "id": "7f873435-ce20-48bf-a1db-1b4cc6edb584",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "1d937bfa-3b0d-4faf-ad21-0c2269ee65ec",
+              "id": "e2c6664d-502f-4873-b98d-5d7727cd529c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "56241e80-7a2c-432c-9195-f2e494193cf6",
+          "id": "1e358fcf-1d14-4124-9f2d-98a00a2854ea",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "193df8f7-f0f4-4006-b059-8b96d2cee4f4",
+              "id": "f1afb992-7727-4eb0-97bf-376ca8f3d760",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "32873273-d20c-4067-9b16-a2255153913f",
+          "id": "160f470c-f0b4-43b9-bbdf-f10e616a648a",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "e4da767f-70ee-4680-b7e8-fb02c311ecba",
+              "id": "b2460dd6-5d0c-40ee-8d00-c29250c5b423",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "27c196f4-8d46-4d2b-a269-60944a6e9083",
+          "id": "482aa700-fe80-4ead-a320-1e5e57b44cfd",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "04f854aa-35a1-4293-8cf9-2011ee485afd",
+              "id": "eecbf307-cd76-43a3-933e-1b90f191de8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "4c312ec1-0477-4f05-a2c4-c5d87655c43d",
+          "id": "c357569b-38f8-49a5-94d8-90fcc40d637f",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "86e89fa2-8a38-48f6-b8a6-5c93d10ac549",
+              "id": "15a47cb2-6dc3-478e-afe3-eab93841fb69",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "a77b1e39-4c73-4486-bec1-ee65bcd15012",
+          "id": "616030ae-c345-4697-97b7-d9aa2a8164d5",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "23551140-3bef-4697-8d27-f0d3752a22c6",
+              "id": "de85709b-d154-4780-9f81-a2e186928eca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "50668cab-06e8-467e-826f-fa39ae485bc4",
+          "id": "fe09c0d2-e4bb-46ba-859b-572aacd7ecb4",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "f3dcbb91-9c93-4c2c-b4b6-c896cb0aa4a7",
+              "id": "a67f438a-4fd8-41fc-895c-815c3c14313b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "146a6111-3542-4709-92e6-105fb8d5d0a5",
+          "id": "644b8614-b428-47bb-9341-37d0afa64987",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "33813270-5cec-4205-a862-d39ab95c34b9",
+              "id": "025b9967-9e5e-4c29-9945-99ca74066edd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "1d1e86e7-79dc-4cbc-9ed2-a793765acb0d",
+          "id": "ecefa0f0-f9e4-4a74-ad1d-7bb0fcba6f5f",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "8f97c502-8f41-4de5-b26f-34aaa72a62cc",
+              "id": "48630df5-bb4c-4399-a398-6b74d81c19ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "239f00a0-a6b3-4f8a-ae8a-e04d91302353",
+          "id": "f3fca491-4ee6-4731-8dc0-3e4b0f25f08a",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "e1641ba5-7935-43da-b5ad-15f86fc0b29e",
+              "id": "5022ab22-9f0a-49c2-9dd9-eb059579278c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "17611424-525c-4548-9cee-d588defab4cf",
+          "id": "d747def4-40aa-4c33-a92c-aa0a3e4a6d0d",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "a942ad9a-d654-410b-8175-a3f53fd62645",
+              "id": "88b943c8-47b6-4e9f-8e66-9dfc4d91a4db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "857940af-7abe-400b-aa55-e8d97255942c",
+          "id": "9f3ff84c-e73a-4e3c-8d8e-aaa68b619782",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "e0b112fd-0d85-42b1-a0d1-b10976d23229",
+              "id": "8903840b-a7df-439b-bb32-824cdd0f0d2e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "3657d8ba-eb76-4f07-944d-7eeb365c9ad1",
+          "id": "d1d3405a-8f2c-471b-a507-4380232ad27c",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "f9b0ef06-2187-4560-8726-ee10a2671ecf",
+              "id": "178e5fea-9946-49ab-a20b-53c896d793c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "dec94ee5-b918-4050-a6c6-efe9791b1452",
+          "id": "55570ab6-d381-4c4b-b734-84aba956713e",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "bf662657-590a-4440-8525-703399084e0b",
+              "id": "7621f0a2-9f54-4c79-911f-577ec67bba71",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "80bb2578-1ba2-44a0-9c58-9ebb2aa2cb91",
+          "id": "6489a75d-3bb5-43dc-845d-52116673f943",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "eb75efa9-e026-49de-8a35-098f23ad05f0",
+              "id": "db8893a9-17b3-404d-8fdc-d839e608b355",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "0d50db8c-2fd9-45f6-ab39-d6f6eaa5c72c",
+          "id": "b8daf2b3-3273-4663-8a7c-829c5f675149",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "e1947a9d-748f-4af1-98d4-3b012cff0449",
+              "id": "551b8435-5598-4e44-b3fc-176d7ae515bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "ff3a4f51-69f6-4cb1-a404-2b9077069cc6",
+          "id": "086cc0c2-8641-4b9f-8a19-fcced3854190",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "33047339-2e56-41ed-809d-b6c84227fce0",
+              "id": "937e98db-7046-4628-8fe3-c5453092069f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "206ab814-984d-4a02-b482-b93c9e7fe7d3",
+          "id": "d58ef9c4-8c3f-458e-81a3-d2c84a2362bc",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "b0a7e882-77fd-46c2-bc1d-1d3e8d652c70",
+              "id": "29e02cc4-4df1-4cf4-89a8-a5c184c34276",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "f0193984-7c1b-4499-bf8a-08a86e355f78",
+          "id": "78ca4fff-d0d3-41bf-abbd-8a6781877aac",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "4238c09c-5423-4b47-9014-63e93465bab2",
+              "id": "ff2f2866-a89a-4d5e-8eea-f7d395929ce0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "9551892d-6bed-4fc4-ae9e-0c434c14edc2",
+          "id": "1b38dfa3-17a0-4341-ab7b-7ba32aefab93",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "d7b20e27-b399-415b-af84-c2f7453e9a34",
+              "id": "57796a05-9cfe-4dd5-8169-f854cdb0a13e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "f5c91ec4-4190-4cc1-8ec9-98e0be0af30f",
+          "id": "ff2a399d-1778-4def-945e-ac4fc9f92249",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "d6e908b7-317c-4eb4-8ffe-8570bb6f8044",
+              "id": "bcfa72ed-a5d6-44f6-b298-8fa672a6f99d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "57a3bf1b-f9ec-43ef-83b3-658e2465287e",
+          "id": "0a816613-a306-40cf-8b1c-eb55e40573ae",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "ba48a3a1-c51c-4340-91a7-db2335ea52e5",
+              "id": "1d51a98f-b0b7-4174-a5af-f97d3c971860",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "95c2b525-5fa0-4a37-a87f-f0520c460eb5",
+          "id": "683e6ce6-5ff7-4f79-af12-d53f29c77ceb",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "62f9889e-9d0b-415d-9948-722a5ec359a6",
+              "id": "56a2c177-5a9e-4cf6-abd8-ca687c7c2c2f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "8d78f467-e8fc-4cd2-87dd-f5bff5cf6b0c",
+          "id": "75976a2f-e821-461a-b87c-79e7688bc028",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "1f88a753-779e-4942-9b76-1d9a2bb9144e",
+              "id": "277a7465-8b10-498b-b9c1-db201a489dbe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13520,7 +13520,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "cf643553-9df9-4c5b-acf3-a88e1c9fd3a8",
+          "id": "c4edaf51-360d-4749-8b4d-8ef6f23915a7",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "c3a88e3e-e9a4-4ed6-a7f0-b672e5e2789d",
+              "id": "29bb6eb9-0b9b-43cd-9662-02c7e8afe558",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13630,7 +13630,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "0b29e0c4-8318-46fa-8ffb-b94c14ee5890",
+          "id": "82202771-5ee4-439e-b463-19765e5617c9",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "34e5fa7a-8507-456b-9ec6-8cfa7267d769",
+              "id": "4e63ef98-1132-41ba-a4b6-1946bbf0aab5",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "83b5bf33-9142-4225-84e1-08353939d4e9",
+              "id": "0b6514d7-e248-42a2-94eb-838955d72ce6",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "837c183a-6929-40e6-aa37-c49ba4d8809a",
+          "id": "adb53ef9-a83a-40a5-9379-63b970bb6844",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "f36dfe6f-80c9-4b9d-ba4e-d287a2931952",
+              "id": "0161dc58-5143-4cbc-80a3-13f533ac8298",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "db18b73f-1ce9-4683-977a-fb9d5e805735",
+              "id": "3043268f-d62e-4b54-b186-5023e3c569fe",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "936e3f6e-c3bc-4dd9-994d-7faf02d5d61a",
+          "id": "81336107-e409-444d-97bb-39570784815f",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "37a631f4-436a-4128-92f8-5804bab23192",
+              "id": "6a88ace3-6e17-42d5-8279-945e75f933f1",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "aa036ba8-e63c-4ae2-b173-28affda92cf1",
+              "id": "14036f36-bdc7-467e-aa34-735b8f978eb1",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "f050e1f3-11eb-4118-8491-7053506da399",
+          "id": "de9eee43-5c92-491f-93e5-b0a5194cc6f8",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "bdfdbd51-b199-4c44-ac75-3f8fd11a5f0b",
+              "id": "5bba69ac-b7c9-49dc-8c5a-7a1cdaf908b7",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "8d7227ca-4fbe-4982-afc9-73379a3ccaad",
+          "id": "bf9babe4-2b87-488b-b408-b7667f9e24bf",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "8bda6e70-002e-48bf-be3b-43cf103057ef",
+              "id": "0b83e34a-2b0c-4e6e-a8c1-6d7c710442ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7552,\n  \"key_1\": 4905,\n  \"key_2\": 6875\n}",
+              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "d241f132-24b1-490e-823e-77d27df392f6",
+          "id": "c677cd04-bbe0-492b-9265-15617b99e39b",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "4a94b03c-b1ec-484a-a3b4-f9f1c8505b87",
+              "id": "9cdde4b5-f855-4ec9-84c6-8a8008d44fee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "e294c78a-45bc-4d62-812b-ea2c5e90bf9c",
+          "id": "6f755304-66c2-4b28-b423-65908fec4099",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "753bd4e2-3d01-4d3c-bc55-399c251295e7",
+              "id": "496da6f8-1153-46d1-9314-dec732009436",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14585,7 +14585,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"avgValue\": \"<double>\",\n  \"chartData\": [\n    {\n      \"timestamp\": \"<string>\",\n      \"value\": \"<double>\",\n      \"minValue\": \"<double>\",\n      \"maxValue\": \"<double>\"\n    },\n    {\n      \"timestamp\": \"<string>\",\n      \"value\": \"<double>\",\n      \"minValue\": \"<double>\",\n      \"maxValue\": \"<double>\"\n    }\n  ],\n  \"code\": \"<string>\",\n  \"currentValue\": \"<double>\",\n  \"currentValueTimestamp\": \"<string>\",\n  \"endTime\": \"<string>\",\n  \"maxValue\": \"<double>\",\n  \"minValue\": \"<double>\",\n  \"period\": \"<string>\",\n  \"startTime\": \"<string>\",\n  \"trendDirection\": \"<string>\",\n  \"trendPercent\": \"<double>\",\n  \"unit\": \"<string>\"\n}",
+              "body": "{\n  \"avgValue\": \"<double>\",\n  \"chartData\": [\n    {\n      \"timestamp\": \"<string>\",\n      \"value\": \"<double>\",\n      \"minValue\": \"<double>\",\n      \"maxValue\": \"<double>\"\n    },\n    {\n      \"timestamp\": \"<string>\",\n      \"value\": \"<double>\",\n      \"minValue\": \"<double>\",\n      \"maxValue\": \"<double>\"\n    }\n  ],\n  \"code\": \"<string>\",\n  \"currentValue\": \"<double>\",\n  \"currentValueTimestamp\": \"<string>\",\n  \"endTime\": \"<string>\",\n  \"isBooleanDevice\": \"<boolean>\",\n  \"maxValue\": \"<double>\",\n  \"minValue\": \"<double>\",\n  \"period\": \"<string>\",\n  \"pointCount\": \"<integer>\",\n  \"resolution\": \"<string>\",\n  \"startTime\": \"<string>\",\n  \"trendDirection\": \"<string>\",\n  \"trendPercent\": \"<double>\",\n  \"unit\": \"<string>\",\n  \"transitions\": [\n    {\n      \"newState\": \"<boolean>\",\n      \"timestamp\": \"<string>\"\n    },\n    {\n      \"newState\": \"<boolean>\",\n      \"timestamp\": \"<string>\"\n    }\n  ],\n  \"booleanStats\": {\n    \"offPercentage\": \"<double>\",\n    \"onPercentage\": \"<double>\",\n    \"transitionCount\": \"<integer>\"\n  }\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "7eb614f4-08e0-4a06-9e90-bd7b76829301",
+          "id": "5e12243c-4b37-450d-8f93-b48dff88f9c6",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "214928a5-b85b-429f-913a-6d5604fe6483",
+              "id": "32d2b112-1790-4cf2-b75b-cff8bed3e929",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "6599694f-37a3-47ac-9f0f-3d992c1d8934",
+          "id": "346f838b-a776-42de-8105-f8b372e83971",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "7c30e5c0-6a9f-495e-a153-6b7ba928ccc6",
+              "id": "7df19d07-5c36-4717-957b-f5fff84581c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "117b58fb-3d97-4e47-910d-1e3adcc73301",
+          "id": "b3557e2c-585a-43c5-b227-f001cb32f1a6",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "aee51826-86a4-4ec3-9ad4-ddd917b607aa",
+              "id": "08112636-c502-4b8f-b9c2-cd2d84ee8ba0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7552,\n  \"key_1\": 4905,\n  \"key_2\": 6875\n}",
+              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "017fbdf3-b7a1-48c4-9e1f-a60dc4ace41d",
+          "id": "0e851c47-1287-46ad-8ce5-a806a4f6b85e",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "303ee635-2134-47bf-877d-994cdee879dc",
+              "id": "2f372d75-9c70-424a-a9e8-842b6e19fd67",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "91c17f71-fadd-4a8d-9116-1b591c1e9d19",
+          "id": "a8f0ae64-da1f-4a42-a13e-b98390bc97fc",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "29eb1743-a5a4-4296-a068-f0db967b7ef3",
+              "id": "1038f4df-2eca-4bcb-8d23-1d98fecef499",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "e9400fb9-893e-4d60-a9be-2d2128ce3ad8",
+          "id": "37e18fce-6bc6-4afb-b71a-6bb2e030b14b",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "6684c9a5-7063-4cfe-bd13-51a1c55fb1bb",
+              "id": "22c92356-6c28-4b4e-b6ae-370ef0ee6fd4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "b788d25d-902c-477e-94c7-6f8647a28301",
+          "id": "58f7978c-fb7d-4a62-9568-62fcd8a34b95",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "aa01c3bb-d399-4a96-8c5a-196465916769",
+              "id": "004fe5be-adcb-430d-b963-61f2b54ddb57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7552,\n  \"key_1\": 4905,\n  \"key_2\": 6875\n}",
+              "body": "{\n  \"key_0\": 9613.52977993713,\n  \"key_1\": 6914\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "3c801966-db01-449f-a068-913c89ae227c",
+          "id": "64f79f1c-2007-4e25-bf5e-a87836eff5ef",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "7fb3395b-cf1b-4593-a8af-533129fb457b",
+              "id": "41ef09aa-7d83-4ef0-b581-02db3e1f0211",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "ccb44fe2-389f-4034-8f03-664794d571a3",
+          "id": "e052dc65-13b8-4806-8858-f175cd52722b",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "31441250-9ca3-438f-88e8-a37e23d9955e",
+              "id": "8c0bc92a-208f-4f5d-a191-9ccadcefee49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15533,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_3\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "dc653ae1-0cef-4ada-9b1c-38e65c7c7804",
+          "id": "5437c14e-21c3-4f0b-b9de-5ef8570293a7",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "bad38467-32eb-4647-afda-cbd3d8ea0848",
+              "id": "b090049b-c153-462d-8297-5434d1851edf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15615,7 +15615,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "c6d49c21-5f51-4695-8346-b45764a0ad4e",
+    "_postman_id": "8b64b802-fd8b-4221-bb56-3f40e3b53261",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-03-26 11:57 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-27 19:21 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "b0651f40-fe9c-4075-a7a8-68e853692687",
+          "id": "960b62ea-f950-406c-a172-0e104c2eb21a",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "9507546a-0a37-4361-9481-c2fd5fb111b8",
+              "id": "473d481e-d606-4f43-940b-02b512247b98",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "8f89f708-e4f7-4237-8df3-fefa41bd18e5",
+          "id": "e483eca7-386b-487d-90c6-0e514ac63592",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "a7659e1c-d804-4e76-9e15-2967efd08c02",
+              "id": "cb9b0f93-2e6a-47eb-9724-c6b950fce997",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "02fb712d-43a5-4726-ae5b-4c573ffe4506",
+          "id": "147c26d6-61ef-496e-922e-3f65511232da",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "fa118389-e2bf-40e4-837b-3fb998a24351",
+              "id": "015670ab-6163-4b38-8886-b522ac2b381f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "35ea69c0-661e-40b6-b926-b681360ac124",
+          "id": "ace774b0-32fe-4813-971d-5575738bd59d",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "bbc973d5-9a19-42fa-8dd4-a3330f4a296a",
+              "id": "3191be66-7720-464f-927a-62ef0af264d2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "ccd3fc31-dd8c-489f-bd8c-10644d33ff33",
+          "id": "0e8dbd0d-1c82-4832-9cf0-189b0acf4bdf",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "8bd5cfd7-77cc-442b-8fc6-ee15470a98e9",
+              "id": "e1d507c5-9d4e-4701-b173-ce71fa1b296b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "e42044a6-33cf-463f-a99b-9f534276d4e6",
+          "id": "989931aa-6052-45a1-86e9-27903ec4c9ca",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "c01ea756-13d6-4e9f-afbc-b85bfe2f006a",
+              "id": "2477af8b-a691-40f2-9533-732810223251",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "938374b0-b74c-4ed7-8098-9b3527eff14a",
+          "id": "7ca97103-0319-4707-9cac-007ef71217df",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "0a414a67-36b8-4568-9ca2-6a255d9db380",
+              "id": "1869cba8-4080-4c0a-8e8b-89b315f4f673",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "47b787b2-420d-4f83-b78f-b793b623fff0",
+          "id": "6ea533de-63d7-4763-b15b-f54baf2ce665",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "6c2018f3-5894-4e6b-b692-0be4b78dfe3e",
+              "id": "5eb195eb-c7f1-48b5-86e5-b82f7225520b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "40e9d78e-fb8a-45b1-a853-9b77d6b2a550",
+          "id": "acc4f513-8075-4a12-87f0-1164ecb646b7",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "25989fe4-20e5-46dd-8414-c2e37ace5e46",
+              "id": "0fc7a96b-58c2-4994-95a7-b9c50e580d20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "a79da597-a516-46c3-a93d-ec38f13879e1",
+          "id": "d24dbac1-cc09-452e-80b2-88a73ff7f8d1",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "fab1f14d-bc49-4d16-a3ef-189806e99240",
+              "id": "382cc988-762d-4ea9-949e-a9ac0ee0b837",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "75ac8886-ce4a-4120-bd20-a5f18642385f",
+          "id": "48476540-1545-4d99-85ce-e1855d416e86",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "94303e8f-6a59-47c5-b22b-b88555ab6399",
+              "id": "e494f4a5-8540-4e74-9489-b951bc0225e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "7c1afd99-17f5-436b-8440-b3a9003105ab",
+          "id": "ef8b0e2a-e916-44ad-8d81-2f3e31bf1368",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "8a010004-54e7-4be6-bd0a-38b32581c59c",
+              "id": "3f0ee90f-665a-44db-9962-ea238df60d66",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "cd436a36-a94f-4885-9d8a-af62de39483f",
+          "id": "e2b72689-df13-4d51-bd03-ded67db086a1",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "01cbd532-4e09-4a15-8569-243a013ac889",
+              "id": "55f42fce-9ff8-4d7d-bbb3-a20313257f7f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "1696d4d1-0def-4029-92d5-14c4ae38d92e",
+          "id": "325ad206-0471-43d2-9765-e124f7cdb672",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "1aaf1b56-3e5e-419b-8db0-828ac1e6aebb",
+              "id": "265f2a9b-b3d0-4cc0-a373-eda690ea5715",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "4714db17-494c-4d32-868a-c0be0cf40769",
+          "id": "4c4f39ed-2829-40e6-9b58-d93617e7ae20",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "763ed49f-5e84-4ee7-b997-d411382185ff",
+              "id": "fd98114d-b79b-4422-8222-63af54e3ab46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "8178c03f-868d-4a73-b29b-63a2adcf6638",
+          "id": "cee362b5-299d-4d43-a5f7-bc664a15bbbd",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "95b759dd-5e89-436f-a6b8-aab4a3402bad",
+              "id": "374d4c84-f345-4938-b088-c943e26f5f68",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "035437a2-ba9a-4ebc-a674-98ebac4cbbbe",
+          "id": "ccd32814-aeef-4f8e-ad1f-7954cfad9715",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "eba93219-f710-43fa-b9f5-c9e1d8a99998",
+              "id": "4007e925-f1ab-473b-ae44-6e4abca27c90",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "f7112420-56e3-4cb2-a36c-1a6a111f4b0f",
+          "id": "8f1b2105-93e6-4a1f-b655-7a32314f7038",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "636e94b3-6cd6-40ff-9788-915dcb0ed549",
+              "id": "45ae4da3-94a1-4e5d-88a8-1d5970ed5eec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "1c8a68fb-81ad-43dc-b110-4a38c3f43cfd",
+          "id": "8fc69cd4-81c6-469f-8845-746fa208dfa3",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "f6adaa28-40d0-41f4-b27f-a5a89d1ea0ac",
+              "id": "d3a9aee2-ad24-4397-8316-35e54d7543c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "35931a83-7157-442e-ad5f-bce852fd6a34",
+          "id": "6e90c5c6-5163-4d6e-81bb-abb2d9e7187a",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "8758276c-44c3-4e74-8e10-68d16a6399e0",
+              "id": "93b07871-4701-447f-81d9-e6d594143631",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "519481ff-6e3b-4883-8ab2-d8d84ef17a23",
+          "id": "66f94a6a-fae5-433d-9b10-7cd0e01a5cf0",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "3ec26aa4-c62e-42c9-be2d-b50bf8f307f0",
+              "id": "106584a7-e533-43b3-bcc3-bedfd79abb52",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "39c55837-8bb9-4a69-bdbd-3c10724dcbe7",
+          "id": "6b55f150-1fca-4479-8b28-fe89bc6d1cd6",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "8048bbfe-6830-43fa-80c9-0648dcc86fde",
+              "id": "38c35ba5-65b2-43cb-8c21-18d535e87463",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "327a92ca-13b6-4231-9a5d-aca214173135",
+          "id": "9bb90a36-a6e5-4dce-a239-6a9318011e5a",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "3da95845-143a-4e98-9df3-872b3fa5819e",
+              "id": "8e6bdb6a-d0b3-4a52-bf8d-84145ee26dc3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "a01b21ae-5696-44b0-8758-577bd8f86d21",
+          "id": "14e5561e-e782-46ee-a60e-db78c98feac4",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1Dd48e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#239A3E\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "d5352006-b619-482c-a9af-9d7f25d6ef8b",
+              "id": "047367e4-8193-4459-aa90-8aef9dde5201",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1Dd48e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#239A3E\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "4205c6da-fe62-439a-acb2-78ab83fcba9b",
+          "id": "d47cfe2b-b6a1-4eeb-b424-f3c0f743f67b",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "f6d95bd6-ab34-48c4-b8ab-20fe88e09258",
+              "id": "23bc05e4-bc74-4f50-92d3-7ac45d40204d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "fbe6c40e-3a7a-46e9-8c3e-7efc7774a0fb",
+          "id": "136033d7-181e-4f43-b48c-090b63d35f49",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "9af29e4c-6735-492b-883b-91d52b76bcc1",
+              "id": "e2d5355b-11e9-4411-983d-6da3238619d6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "2dc3b886-6768-447c-a9af-f9a1b5bd358e",
+          "id": "d5d432e9-952c-4fd5-88ae-ffb41a199ddd",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#5B9828\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#7feeBC\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "489002fb-c9f9-47b3-8634-e77c0ca5e035",
+              "id": "c46d93d3-7adf-4351-b9cc-c2aca54d536e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#5B9828\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#7feeBC\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "badfd1ff-f487-4615-8e7e-51b6ca75bfd8",
+          "id": "9d030bd5-540b-426e-b56d-194fb1275071",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "b022f778-60a2-4f8d-bff0-9813f30dccc2",
+              "id": "372463d1-88c0-4687-94a9-5f173b5164fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "786c66db-74fe-444a-80c0-b78c5b737017",
+          "id": "fcd0ffe0-1eb3-4d5d-aad5-d0eafa5db678",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "c310f534-4155-4ac2-bd5f-79b398e50dc9",
+              "id": "0c67ff5e-de1d-4cf8-be39-4cffafc085a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "08998a72-7c22-417c-a8e9-096295adc580",
+          "id": "5bc93c8d-8113-457e-a40e-c9cb8a7fb364",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "894ae0fd-e25d-4c74-85ac-78ccfb51351f",
+              "id": "7847622a-9add-4a33-a6e1-a4ae75527c30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "9ca141f5-4e04-4b4c-91e4-3c721b868a78",
+          "id": "e5571235-cee6-423b-9572-06c1fadd319a",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "e7e152ee-9bea-49e3-a672-0c7499460258",
+              "id": "c6a76486-2c46-426d-9bec-ed2a2ee7d2c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "696a89c2-261f-4001-bd18-955969627820",
+          "id": "395ab193-e472-48fe-9a8b-a6c75f43e925",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "c10b9adf-82dc-4e92-8d2e-46c0c6b7d3c5",
+              "id": "81ee3c3c-d5f9-4e85-af22-36a7e9364255",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "df5169b2-d76a-4b61-bc07-d54c7a587e9e",
+          "id": "ac181bd6-2641-4754-b840-191140f1ff1e",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "8a0a8395-1060-40f8-9f10-586377a7280d",
+              "id": "f29a436e-f492-4cd1-9161-22a731e32f51",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "a3fcda0c-2118-4b01-b6a2-757de25ee812",
+          "id": "2b5d1409-dd97-4c7d-86a5-c21ab9a1647e",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "c1f3e786-0f49-4b06-97a5-d6c33f27c9f5",
+              "id": "81b28cf4-fecd-469c-8883-7f9902c73b3f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "3e07778a-e273-4589-83a4-1bb35242a7d6",
+          "id": "dbf69d96-096b-40d7-af92-b833e39f6961",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "1489ba6f-8975-469d-a87a-44704aa4c445",
+              "id": "fdad7347-43e3-4451-965c-845067089769",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "3daf55d2-2563-465b-8148-819182063d39",
+          "id": "9461e721-3313-486d-aa61-b542208e2d7d",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "83cb2531-1065-4a96-9f73-79ede40e70c2",
+              "id": "ef328fcb-3512-45f5-a379-a5adbb9d3bb1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "1255c2e8-28c2-4b0e-ada9-d019b4e325cd",
+          "id": "8eee801b-c8b0-440c-862d-b4a98235349c",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "aebeea46-5351-45fe-b3a5-ede8f3beae6c",
+              "id": "3356f1e9-9cca-4599-a7f8-2cd57fb13961",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "4a2fe917-66a5-4205-be83-62951a2c4c85",
+          "id": "77c2d8fa-1e50-4fba-8998-713d67bde2ef",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "6ee58466-47cb-40fc-bdfd-4e5a87fbba01",
+              "id": "c40eefae-48de-4e38-ac27-cb735459a849",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "273d77a9-4e56-4321-a7b6-db39d7b96c60",
+          "id": "0054c414-c657-4235-9c29-d36e43b93d0b",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "3dd89df8-8fe1-4549-afd2-b8a7f7756c06",
+              "id": "13424960-de39-4e6a-955b-8b1bf00f3a68",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "b5ba06fa-31bb-45ea-a998-512aebb313c5",
+          "id": "a8f48d59-cd70-438c-acae-17706b63f8a9",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "a528eb27-4260-4d4c-b249-a6d07906372b",
+              "id": "76197803-62c2-4c06-890b-5b0e1f849238",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "6e5c0a97-3290-451e-82ac-cecac3b723b7",
+          "id": "dd2e8956-35a3-4951-ab77-d1659f3f038b",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "ad0c9b81-1043-494f-bec0-4f57dbab51e3",
+              "id": "8d602bb2-644b-4eef-9c08-229aa10fd7a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "22eba4d8-acf4-4180-be60-d6b7985bf551",
+          "id": "bd6a9c85-01cf-413f-aa00-427c136c8fff",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "06483cfd-072e-43e1-8942-2d6eb850b0aa",
+              "id": "4ad287ba-a683-44a3-9977-e8d6a821ae72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "a7dc8ab7-6a6c-4bf5-bd2d-0b5de00ea124",
+          "id": "d933e61e-0ff6-46ee-905f-64288602ca07",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "ce671eb7-d347-4d67-b25c-c41c3ce73e06",
+              "id": "8981e4ab-1f26-4923-8430-1d97c9fafb73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "c903d293-2ad3-4542-9097-3a374982f8f7",
+          "id": "73e141cd-5f0c-43b0-bba2-484ad90999f9",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "dd1020fc-b646-46e2-8836-b7c93ce0108f",
+              "id": "850359a0-dc14-43c5-8f03-4efc97bee4f7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "587bb135-a8e8-4570-a237-373df36ebaa4",
+          "id": "8d03339c-e24d-439b-b2a1-fe4e8952d931",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "4d671aa8-62c3-458c-b4a9-61e7fc19c464",
+              "id": "af75e2f4-d7f7-4ae0-9121-ddcd4e284e64",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "65a00566-2eb3-47ae-b80d-aa2f46a1d0fb",
+          "id": "256bda34-68c1-4c2e-8c8a-0d6b46ca670c",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "200cc205-b578-4b9d-a39e-17cc9fbd19b2",
+              "id": "44b4a539-60e6-4ba4-a054-3cd6542c05f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "5669f3e5-da8b-4ef1-8f3e-a4a514fe9a57",
+          "id": "f98e8caf-3cfb-496d-91eb-e773ac54a3e5",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "536894dc-6209-4f60-b377-abc946244137",
+              "id": "7c6474c8-cb2d-4463-830c-5850ed57c87d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "017b1a20-beba-4f8d-9df5-43fe3ffee242",
+          "id": "10c00ac7-7df7-4106-98f1-374963474a45",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "b173715b-53f7-4255-8c15-fd8ba2b00093",
+              "id": "37d963dd-3a9d-489f-b04b-596dcf538886",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "cc4e7a5a-6a44-42df-a5df-4156e07c4aa3",
+          "id": "b2b5153f-8a52-4e63-8ea8-bc415b204883",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "db4daf05-e40b-4d46-9266-1fe0362a5863",
+              "id": "9a8a1a08-c060-4cc5-8a52-700e85593ed3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "81cad46a-0e7f-4847-91dc-f85162f8bf5b",
+          "id": "7c9bca1a-b01d-4ef0-94b5-67c76c77287c",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "21480fe7-53c0-474e-8eee-cc91b73fc02a",
+              "id": "77da0ec2-ee1e-47c1-8d9b-ce4a8b277475",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "2c0d7945-3a6f-4642-b7c4-0b6a471e6541",
+          "id": "498f6375-ee6f-4b4b-8317-cbf6e5039743",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "e6d22a83-cb40-4ca4-a86c-63fb73c38a90",
+              "id": "e25565cf-6e86-4cff-a1e7-a66a41f3422c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "853c9e1f-4a4e-4811-b57e-3e07b257afde",
+          "id": "e5e3708f-4c9a-420d-b29e-71843f740ca4",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "ea83bc22-ce71-418a-b71d-cde979c74a7d",
+              "id": "706aeaeb-11b9-443a-bdac-39cf1301b978",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "edaa275a-228a-4bd0-bd0f-c754abf684c6",
+          "id": "161c3714-625f-482b-aeec-47d8e7056c51",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "361532db-324c-4701-9b2c-2d9cbd30d3c9",
+              "id": "2a660e76-ac9b-4ba4-8b9e-8731204dcac8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "a5db5a1c-c6c9-4df0-a9cb-606c8a004ddd",
+          "id": "01a94240-f951-4f32-996a-c515fef46142",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "5e81234e-393c-4a98-b1df-21106a88e334",
+              "id": "8b7e14b6-b19b-4c8e-a655-9e2337023b90",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "aa5e31cf-d703-4a33-9209-8a5b46268a88",
+          "id": "f112f683-df16-4a1b-a62d-f17d0825a8ef",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "4bf5fb48-2633-47ee-9178-fbd2a2f10683",
+              "id": "6dcc9e3e-1cae-4534-a0bf-3bb933c6d077",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "b2f4c667-8ed7-465a-92d1-fcb6dadd5161",
+          "id": "ddcf2986-0481-4079-9f3b-79d1be6f6f52",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "4ea8a51f-d325-44bc-b659-de57d7d9c061",
+              "id": "8edeae5a-43d3-4b6d-94d5-3f755af77be1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "e8255d10-d2b1-4ddc-84c1-e0ea8f3df051",
+          "id": "45acee1c-a9ee-47e7-ad0b-897256cb820e",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "2a814006-2f4d-42c4-b7ca-a79db0f55666",
+              "id": "d200802f-11e1-4913-be14-3ff18fce02d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "9f035858-00ef-47df-83eb-7afb4ab845f5",
+          "id": "b50e0503-53c6-4809-80b5-2c8af375097d",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "152297b6-7df6-4732-b799-8595e3212fb5",
+              "id": "3f274fc9-a310-4e49-897d-45e420ea45b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "c7885979-0b3f-4d29-a4a2-5defb2b10f22",
+          "id": "2968dc45-d016-4f44-b4c2-c6dcce531668",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "c175c25d-a07e-44c3-bf18-d6b77605c20c",
+              "id": "78358444-5534-4dc2-a38c-20089e100b75",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "69d46127-0d2b-48bc-9cd2-5558fb289285",
+          "id": "9bd45c0c-8ebb-4c16-ab9a-ebc41c9b33ef",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "b1695e37-eba3-4cdd-89ee-5b9bfd569dac",
+              "id": "888c760d-a4b5-440d-abea-241c775992e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "45055ad2-d514-44ce-b2cc-4758c6c5e99e",
+          "id": "72f6b7e7-1004-49f7-9e77-9a3d09896f2e",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "7bc79c93-0322-48e2-8eda-99cff3f436ca",
+              "id": "8fb82e76-b58e-4eec-a233-3cd2024e80dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "3aed791c-f7a5-4764-8f94-d8eb0639246f",
+          "id": "8f706b46-f710-4502-bcce-4c1b0f95b643",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "9497cfb8-8e0a-44a4-b2a9-bded053dfc75",
+              "id": "32651073-e812-448a-a9dd-85168b390fea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "296ace4d-4c68-4ec2-a39c-1a7ed28925fb",
+          "id": "b9f1ec8f-478b-4562-bb00-b2ea0b15f7b8",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "db8a5ec9-14d9-421f-a245-9fecad52670c",
+              "id": "7c50fbf2-0117-4f27-807d-ef57026c3934",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "8360c190-91dc-4653-a691-2bf807fdd118",
+          "id": "e7fcee75-c501-4bcd-a506-ba103d23594e",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "ba402b6f-c436-4353-b837-ebe5136c0fbc",
+              "id": "922fd441-f0fa-4fef-9de7-24aa699bae28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "279ec6cd-89e9-4fdc-b309-584a8b6ae8d0",
+          "id": "a4738259-d11c-4b7c-82d9-2de764de6948",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "babefe12-ec75-447b-ad6c-4c9091efe5db",
+              "id": "5ec06ea6-6c22-4a67-9c41-2e8076ff6e4c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "c5c9ccef-05df-4d12-9270-6e5e0378e3b4",
+          "id": "4d305893-012c-48a3-9fd0-d0180c145289",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "279935c1-dd6a-4f4d-a98d-51309d63ab30",
+              "id": "ecde92fe-d127-4e61-acba-e357cf2f1dfd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "e76da962-396c-41ee-930f-8a69f4ab49bc",
+          "id": "a85ff1d8-7eb8-470e-993a-00f74a0112fe",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "b3128807-0e1d-405a-837c-20f95b8c2278",
+              "id": "0fe32b27-3f26-47c8-ad1e-970e791bcfea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "97b6ceee-d4ee-4305-a918-bfdd4cbcec1f",
+          "id": "fe5ba0c7-022b-423c-ae04-be31aea5ab2f",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "ed2c6396-7177-4c80-a30d-2b022f2402e1",
+              "id": "2e4de499-1ac0-4712-8818-b132297b75cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "3d2d8926-2f4f-4af1-af77-2165ff3fa25a",
+          "id": "32c884cc-1d89-4b2d-b56f-faab3fee571c",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "723fb3b2-2ed5-4cd3-b0e2-8e79c8a431a1",
+              "id": "dd6e2040-cbd2-4a04-b89e-7ca83ef10b89",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "f95eff58-a3be-4e7c-905a-c866837e852f",
+          "id": "3f769655-d23c-4515-93c6-329c4e249484",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "058e16c1-87d6-42db-b99f-9bea72a4ef27",
+              "id": "a994dcf5-4f6f-435d-b83f-045105e65b46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "8d46c2b3-fbad-4c22-a20a-75fa2498a1b7",
+          "id": "26d45a3b-747a-4a0b-a299-9b353f131ea2",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "afc86a44-1710-49f5-a48d-6a4b2c4af2b3",
+              "id": "d59a5123-4774-41b1-8688-a6a71c545d84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "b82ef100-a3a1-428c-9384-624315fecf27",
+          "id": "ea3af132-42c6-48bf-9586-316ea4985128",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "a4084a4b-99dd-4d4e-abfa-578569118fbc",
+              "id": "48e4103d-c7fe-4757-8b14-e8e520bfd95d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "a89b5314-158a-4616-8093-6504a5b16c8e",
+          "id": "298dd049-262b-4b9f-af97-ac9b8fa2dcf1",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "03b13420-5b61-489a-9da3-5fd3c741e4a0",
+              "id": "61ea9528-016c-4153-a80b-c635792bab28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "f7af06ce-1d16-47f7-96d2-ff06723dfe0f",
+          "id": "1dde10a9-3699-43dc-879e-77b4101a2f02",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "728bfe8d-e732-4ec4-aa9f-e904188b5cdf",
+              "id": "ae92a421-6d64-48a5-b37a-db884871dd50",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "433f90f7-52c1-4d78-a77b-dab7235d64c7",
+          "id": "63ffa1c8-f580-4c5d-af06-44c5389d47b4",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "ecbdfe07-14a1-4be5-82e3-4b583c4ec1e9",
+              "id": "b06bc320-5aa4-4852-9909-28eff02563b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "04f1fb14-fc33-4c79-b41c-a5e6df77efe1",
+          "id": "82dd33e4-6178-42c4-b667-b16cc34891dc",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "45ba6de1-72d1-4e0b-a9e9-bd0b2f62ef09",
+              "id": "156cec2d-43d2-4173-9d43-ab9ec805e5c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "4607f069-080a-4eab-8a42-2682693006cc",
+          "id": "c8cf74f3-eee7-4893-877d-e2899d89d14f",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "4c313865-261b-4bb2-8361-3d67a1f1d036",
+              "id": "802a6c95-4bc3-4110-b8c6-dd1716335478",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "7c886fbd-f78c-4e0b-955b-2333d383e2e0",
+          "id": "a7f8e302-a935-4b46-8f34-b9b43362c5bf",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "679789cf-7fc3-49d0-9459-0da9e8c597b8",
+              "id": "97368ed0-ff97-4a28-8472-7d442640021d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "faf3383a-0da5-4e40-9f93-6403d95a820b",
+              "id": "fe9814e2-e9fe-4f86-a55d-b1a00658b6a3",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "4c664bc9-10d4-4f2e-8bee-9b7d61c363ec",
+          "id": "143cb71f-ceef-4051-91f4-6941d72cf235",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "c88e9c6d-0059-444d-a067-fbbd0a4cd56c",
+              "id": "47fc8cee-cd81-4fe1-93d0-bd89bdc55373",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "166e3f0c-f4df-497f-9c7b-8612484c2ab2",
+              "id": "1e179aa2-d4e8-4290-8ac2-a9984139cb60",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "2f97ed41-c642-4516-a553-15b736ae06b5",
+              "id": "1ccb5afc-c434-47ce-a33e-f01a7eccac69",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "a4803808-ebd6-4876-80cf-4ad9fecab890",
+          "id": "cd1a8635-5c14-4bd1-adb3-13bd3ca376d8",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "93297876-2849-4e16-9aed-04d9397b218e",
+              "id": "2012b187-bc99-4df2-951d-8f60e6822d7c",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "625d23e0-30ef-43ef-90e3-2e33f13787e7",
+              "id": "ef92ff6f-b184-4843-8448-8057775b7e3c",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e0325aa6-0249-4c83-b98b-922421c855bf",
+              "id": "4e4b1e61-a366-4574-8b79-c78e4ee38e2d",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "c3c92484-843c-499a-b1bf-d4ef3fd9a6e4",
+          "id": "a681c94f-2e8d-4613-bd81-8ee3c8d8cf98",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "e4a3dea6-28fe-41ee-a7a2-1dbec320a42b",
+              "id": "b450eb64-08e9-4575-a07a-bf52246c469d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "c71a1a93-1127-4a98-923b-e8d82408b7fc",
+          "id": "262081c1-f398-440a-919d-95d28d499608",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "204a81d9-e8d0-42dd-b97e-3292d0d1c258",
+              "id": "ceab3f3f-0770-4df5-afc0-8afcd7516ce3",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1e5e2fe3-92e4-4227-9ab7-344c9db7f567",
+              "id": "5ae2bc53-39dc-4495-a845-14a9626e1c42",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "081015d6-d682-404a-8b1f-91f31e314483",
+          "id": "c0d812c2-87f9-49d5-bba6-c56cf4654624",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "d02dfcd9-a9a9-4c9a-931a-d772400f19d1",
+              "id": "94d37fec-00fb-4a03-90d2-1358c86b70b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "2bf42ac2-cd73-44fb-aef1-77884dd319f2",
+          "id": "8d514651-a64c-4d42-9edb-21be133dfaa9",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "3214e10f-0527-4210-8cdf-326361ecc572",
+              "id": "d85b55a6-67ef-48b3-a18f-6a375d56143a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "c9131f1d-4ace-4619-9bd1-3bb17f7aed89",
+          "id": "7edd8a62-8319-4b01-a245-e0d342233e2e",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "eab654b1-9739-4ec0-8708-0f6b4592510d",
+              "id": "814fd53b-9a18-49bf-8ba3-34cf725c61c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "ad87907c-7140-4c73-b365-0158da29ffbf",
+          "id": "f8129546-9e0e-46ce-8f47-ae63ecca7452",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#fFfF96\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2ec0eA\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "42093e97-fef8-4680-b501-e8bb823e4cf5",
+              "id": "91f0687c-4cf9-4abb-a7b4-7c67fac4aa30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#fFfF96\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2ec0eA\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "58110a10-408a-4c0b-b3b6-415be60cf10e",
+          "id": "159a3a73-5256-406a-b1db-c90d7191cfef",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "6633d603-bec9-479a-b919-b26d535ab226",
+              "id": "a5385562-0400-4d39-a058-508a203afe58",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "f81cdf70-475a-47a0-896d-53a7cd8e0038",
+          "id": "6e0b2348-f153-4feb-adc9-cd0706b47fd0",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "033058ec-f1ae-409f-b6db-7d6868689036",
+              "id": "b32bfaeb-b5db-4564-94e8-73b49c0b309b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "4555b659-7f8c-4f91-922f-0e9b9c65731d",
+          "id": "d7d3c863-8e49-46cb-bfd9-4833e6892898",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#D1E05d\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#54c282\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "198263d0-3745-4bb0-bb65-0cd51c0385ed",
+              "id": "3535eb70-83ef-4943-a93b-c05311c0a5d3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#D1E05d\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#54c282\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "272c0320-cd39-4f8e-8dbe-c1306a0b8112",
+          "id": "91f30e55-2f20-40dd-9b4b-01519fa9574f",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "525ddc8b-1b55-464f-b640-ef9d442718e4",
+              "id": "0193c585-2f52-4a72-8f12-8e43184fe801",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "92cc2e91-d126-41c1-a0e5-933562528bc4",
+          "id": "7074643a-df3c-492b-b1a2-d4c4a08deaaf",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "0f1c7f9d-6a42-4adb-9709-0cfbc9ed844f",
+              "id": "550ddfe0-bbd9-4f96-98a6-dc7be316e4a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "95ba0678-5aad-4469-a057-fb7fc89b06cc",
+          "id": "8bb415d0-7b4a-4663-9488-244227ee27c7",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "970bf949-1c8d-488a-a4b0-5ae60b2d8783",
+              "id": "e7212186-5d0c-44e3-bedb-7106822bd116",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "7c05e898-00cc-40ca-824c-1fedf40e9a6c",
+          "id": "d02c07ca-83c8-40ec-a7e2-0af781d018f3",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "20e7bc20-501d-4abd-97fd-28941f9d86b7",
+              "id": "fa7e6921-7efc-4614-ae27-d9adf4894718",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "c59d2472-1540-4398-9a5f-3e5c80d75f53",
+          "id": "f4adcbbe-274f-4838-9c7b-24a991861717",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "4316fb5a-b8d9-4fac-84dd-0d65efca400b",
+              "id": "f85298d2-3048-4ac1-a69e-3efe5174ff72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "0e73e79f-c323-4269-80a7-2c09c052c8f4",
+          "id": "f98d91f6-6a91-4717-8974-6f335c3fa772",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "46b0d88f-a157-4d35-a932-fb903f7da61e",
+              "id": "b6afd0fe-ab3e-4a0d-8d64-4ebdf3b877c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "69acb300-eae1-474f-b39f-b60cc3b3a362",
+          "id": "84a3e113-3884-4433-b8a5-63cbd48aa699",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "3b70dc94-1f97-4a61-ac9f-46cfabe3593c",
+              "id": "ab1faab4-2375-4c73-b18f-f9741ddf0b0c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "4a8d1f67-bdf4-40d3-9e54-e0d51264f669",
+          "id": "c957b581-8ddd-4a20-bea2-ed4190904d6b",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "e15b1d51-7740-4ae2-90a2-06101ce1b748",
+              "id": "ef8539c4-5c8f-4dd0-97c8-eac84bb39765",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "82eb482b-408e-49b5-97de-30a883619bdf",
+          "id": "ddb1f819-c463-4ac9-b883-cfa0412f4543",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "20fea139-6c3e-4a4c-8e4a-91cc702ccbdc",
+              "id": "6e2265d7-1657-4ed6-aba0-dc0d51a184f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "c7ffcb34-d234-4bab-9661-04a4d9f3cebc",
+          "id": "5483a4d0-3718-458c-bdb0-8ce66293f72d",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "ff04f38d-af64-4089-8edc-d31c1cc6cc14",
+              "id": "f66b7389-d7e9-4589-a2f9-dbae928a575f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "fa6c8418-e466-48ec-9c0d-e0e68c404739",
+          "id": "d33cb8a6-3ab9-4b02-ad42-c65126c21990",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "921a1ab2-bf43-4598-be5a-d219dca59d89",
+              "id": "b6d47b81-dc0d-41a4-8c14-951a2ffeb971",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "0604151d-4bd7-414e-b789-eceb8708ea52",
+          "id": "056fe9ba-73e9-4d61-9b63-4eff3031dfa1",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "96cd4e50-5e0a-4138-b92a-cde2f83c2a6f",
+              "id": "de21f22f-1ef6-4f3e-ab5f-2993df3c3c30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "3bc9ce80-c5b2-49f3-b0b6-192c4c12713d",
+          "id": "af5af880-dade-4fd8-afe0-5f6fe252e789",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "412d9d51-0632-4141-a20e-e129975d4ee7",
+              "id": "475ae6e9-06e0-4903-b775-8daebf4cb32f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "fcdf889b-39b2-47cf-b355-31448966b10f",
+          "id": "7d662f66-16d1-413c-9568-4de26fdfc3bf",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "eaed7e53-ac35-435b-9b0a-f0ffce5e8dc9",
+              "id": "bb2acbf1-a3c9-4a4c-8246-9850359f2b8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "770c3c8e-9003-4fb7-b6db-d156f2543aef",
+          "id": "be0c75a6-7240-4326-9873-3530f71d713b",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "73958c25-2cc6-4788-98c2-fdb9154579f3",
+              "id": "89f05eb9-f084-4a54-a048-e83931ae89ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "88d4eb44-fbec-487d-ab89-89ccf5d52272",
+          "id": "de35a167-35bb-4c46-9acc-48df7bae7391",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "96bfae78-7597-4486-a9ff-21a04c72c2e1",
+              "id": "79afb542-eb71-4ae4-9d55-c3590b73e1eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "08edca8d-e22c-482d-92f4-c0d3c456acbe",
+          "id": "45c8c65e-2d80-476c-89b4-d529c0d33653",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "910d8cf3-a7e5-461b-b6ca-9d891aee9bb9",
+              "id": "5a650a95-454d-4f35-8060-702b461b4731",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "1fb3caec-4761-45a0-9347-50dd8c15d125",
+          "id": "a0802426-5f35-4476-b7ae-6909b43ec2ab",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "db084146-2101-442c-a7fc-c3a59b21ca6e",
+              "id": "41b090f8-248d-4301-9cef-52f77e27fd16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "88d010d0-72c9-418c-b6dc-47a108a2bcad",
+          "id": "1fe47d94-ce38-4dd0-9383-c9929e392fec",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "8bd4f624-53a0-4d07-9732-810669e5fd1c",
+              "id": "48965461-5a28-422f-98c6-83334664aeaa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "3c4a0fa5-b9a7-4c21-a131-9de7aa4995b4",
+          "id": "8adb3ee5-46a5-4c6d-a310-37e90f0ab8c0",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "79c3c3bd-b86f-43be-8c8e-ec50987c93f9",
+              "id": "737ed5dc-92cf-4f1a-bc16-801b7cc106f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "72655dc3-9db1-488d-a0b5-bbb028789c34",
+          "id": "12e76c6f-d5cc-471a-9e05-26a5aad4567d",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "0f08bc12-ae7e-48de-9246-093b0ac9ba70",
+              "id": "25cb1d99-9aad-4a75-a227-29102c7a1a7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "e9640688-9429-4c87-9cd9-3cbafaf3a338",
+          "id": "0cb8a47e-963d-4194-a693-14c1126e4aa0",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "7f0948cd-dad8-4e7a-b150-b804f1e4b783",
+              "id": "34778c4d-cfc9-4207-964b-3f022b6901a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "60a17eef-3ca8-4d64-9f1e-c7a6596ba225",
+          "id": "fc6c5dc0-9de4-47a0-ba47-451e74b8e79d",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "ced6f540-4d0e-48be-ae64-a98354e1f04a",
+              "id": "c724bfdb-3ccb-42b4-a5c5-bf1ec175fc3a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "695af2ea-8c1f-459d-ab4a-953c821fbeff",
+          "id": "0f6e7402-948c-4f06-90c6-dfb0caf0397c",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "a90833d6-969e-4a6e-8fe3-35e1483d033d",
+              "id": "13e3696c-49ba-432a-af0b-4d44f02383e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13520,7 +13520,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "4aa6ec35-73f2-45ea-8ead-9283e8fdb40a",
+          "id": "51b231f1-4db8-475b-a1ef-45703e80387f",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "96cab73b-b5a2-4108-920c-d952cf9be609",
+              "id": "88aea6c1-642b-43c2-acbc-417fa0d8b0c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13630,7 +13630,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "6db19230-4ee8-4b0a-b8e2-9d96f43ba381",
+          "id": "3f297bf9-68d8-449c-8180-befa6b1037a2",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "e1e6f068-c4e1-40a0-a4f0-7090d8bd4b85",
+              "id": "14aaa10c-c495-4134-98f9-5543813de518",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e24d0bf6-da45-431e-90c1-b708d5b3c2ce",
+              "id": "64fc8ff3-1738-4141-905c-449405d13643",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "bd51d6e3-edf0-4513-b3bd-fbbb03c85ee1",
+          "id": "f33854a0-c08b-40be-b772-75403f4b2a70",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "c9ba5935-6c72-4863-b46d-614c2fe4fc73",
+              "id": "3a88fbb8-1c15-4409-9e4c-5765c71c620a",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "166c0f26-bee9-4f07-9acc-f05d37aaeb61",
+              "id": "19aaaeea-0df4-4ada-8a66-09c90935000a",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "0e6e1a2c-0d67-4170-b64b-c5346f82dbe2",
+          "id": "51506053-0558-4d73-af4a-609f462a11c4",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "e6e104bd-aa2d-4c90-8b09-985f56d53857",
+              "id": "52fea758-6baa-482f-bf2e-891531d1d958",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "321cf1e8-c024-4308-8c2b-024a076ca399",
+              "id": "54f0ca7e-8276-4169-8c01-dce2aa082171",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "1af8bec7-2251-42f0-99bb-e2b053ba2f2a",
+          "id": "dff242de-3ae7-4494-b55e-a6b1deaddf43",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "e8ac6bf4-05fc-4ae7-8f2b-b64a433e0ff8",
+              "id": "f0c16100-1315-4f49-92ee-46df51a5d767",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "ad01bb0c-45a3-4984-af64-d911dc8e92ab",
+          "id": "71ef6952-f9fc-4171-b233-517c26ef1e2f",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "0b4a86e1-7f63-45b9-992c-926ca517624f",
+              "id": "0212e53d-daa3-4e86-8e6d-42b6ef92cdf1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "5cd72933-d29d-45f4-b135-20bbe8d0af24",
+          "id": "16b45a1d-510b-4103-b77d-1bfdc8218446",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "389d579b-3ff0-4115-8ea6-4b31a4c93ce1",
+              "id": "1b1fc845-85f5-429a-9a4d-5ae95c19f960",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "3a52df16-8563-481e-ade2-72f004b7722f",
+          "id": "dec26d4d-9b59-480e-a771-f7b2265c8167",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "daa9c122-8a58-497b-9469-c3ad78d459ee",
+              "id": "15bf3be6-799c-4fe1-a053-b113b245fc7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "e75783da-d8d1-4a84-8f7f-aa94c6ed58a5",
+          "id": "74c905e2-52bc-4403-adbc-441d91aa8baf",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "c2d61701-98bc-4a33-9950-17ee5cde8509",
+              "id": "5a3792ad-7c94-4a93-9262-f74a52037c51",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "63f90a4d-895c-46d3-b0d9-d839d3800634",
+          "id": "4759923a-21d1-4637-99f1-805d1a594dfd",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "b300209e-f14e-4568-b151-69a5c52479ef",
+              "id": "188edbb5-fdfe-4e68-8852-4ac86969fd9c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "34290de3-299f-4fbf-a299-06404dac8762",
+          "id": "01f92079-6586-4a51-a700-e78ca6a01270",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "68bbb01b-12e8-467c-830d-9730fb5ff932",
+              "id": "7e2e1843-8332-4631-a757-87e0d0d77798",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "891e3ede-2368-46c7-9b0f-ce8bf4e80237",
+          "id": "44e1fc52-e86e-4b39-b1d9-45391b310f54",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "eee1d73e-0e98-484f-a5c3-7e31f87b4b85",
+              "id": "0f0a3cf1-b083-4a1d-be61-c720dd7f73c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "d6682fcf-2ebd-4b48-a732-781d5f1512ed",
+          "id": "0f9baa53-3ae3-4222-ae00-eea3eca61b37",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "9a62230f-8481-4f77-a3e3-c89d48290e19",
+              "id": "82594788-6d29-487a-8eea-3115434d10c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "f6842333-da3d-423a-a38c-4601ee5b97f0",
+          "id": "a7833415-86b0-408f-bbce-5dbb8369f488",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "e9c4eb4b-3241-451e-ade9-46e79bbe203f",
+              "id": "003aa4a4-eb80-46d8-add1-fc721ebb827f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "0d67056a-6fb5-4887-b4c9-845243a41186",
+          "id": "fbf226b1-0978-4cdd-90b9-bffebee046ae",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "11a84608-4325-4db1-a588-d242ecea39d4",
+              "id": "33a1e779-61dd-4564-9245-41114d031bea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "9617bc84-ba28-4fc6-ab0f-d88912d73910",
+          "id": "4ae7c978-b1e3-42c9-ac6d-a36f0f3865c8",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "a4d5be94-2405-4db8-ace6-a4c2599f0701",
+              "id": "cb5425b9-c796-47cf-8c57-a153deaccb58",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "8278f8d1-0dc7-4649-8784-fd754c739bc7",
+          "id": "e0257007-0b99-4f11-9a92-122a806b737c",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "0ee9e630-8cff-4a09-b642-dddc4e31f02f",
+              "id": "ddeb8462-d9d3-4c35-86eb-ee7bfa9e1d74",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15533,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "6e8a0982-6e4c-44e5-adb5-22da048b717d",
+          "id": "67b117f1-24d7-46a7-89dd-bed035ebcd16",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "2b91028e-0e6e-4bbc-b72a-bfbe9a814161",
+              "id": "dbd87fc7-4ba4-4caa-a8eb-a9dd0f78c241",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15615,7 +15615,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "4f54effb-5e17-42ea-914f-1d8f5aca0005",
+    "_postman_id": "4479dc77-6373-49c4-90d7-b5b2b33fd557",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-27 19:29 UTC\nRama: main\nEntorno: prod\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 11:56 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "ffa65845-071b-44fe-a416-79a51555a73e",
+          "id": "7149ae9e-b49a-4fdd-a31e-9f84fa2a0cda",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "2d2c8eb2-377b-4148-b7b4-175225320e52",
+              "id": "4510d483-4de2-45b7-b9c8-89920bc553a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "4c8a7df7-efa2-4651-93e1-235044485da0",
+          "id": "f9f7d94b-8039-4e01-a273-76e2b4b65959",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "f3c2cedb-ede4-4297-a591-4acc67e2b231",
+              "id": "984aa807-7fd9-44d7-9898-56e069cb0797",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "a11d804c-abae-48e2-9873-9a6ee46dfe8e",
+          "id": "15d65ea0-d7f6-4025-9ec4-ef4a2e57efc3",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "45bbc89c-d30c-42cd-8d31-1fb629932334",
+              "id": "4389dd74-231e-4264-a17d-80745bc0c9cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "eb6ae662-c098-475b-a387-2b49dfad77f6",
+          "id": "bdad6300-454e-4457-bc15-61a2cc7c9ad0",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "f7849dd4-94e7-41fe-afa3-ceaa4b17eeb0",
+              "id": "3e1ed325-7de3-4bcf-a3df-f3fe4bbf2aa4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "8f756983-0906-487b-a4c7-15cc61b06fb9",
+          "id": "4780daf3-c69b-436a-bbf5-75fc943b5589",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "8c3d4e29-48b6-4267-8306-0c087802c84e",
+              "id": "2b8695aa-a0df-4103-9343-47256b8e0d8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "126fe735-4bfc-4f77-8d73-1437175d3335",
+          "id": "ac35cf80-e665-4ef0-a991-e9868a7eb8c2",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "34eb52d6-b5db-424f-a418-8278b6ef97a0",
+              "id": "3d74dcbd-96e0-46e6-98a2-c8b7dcc52f68",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "bfb8b7e7-f3b6-4da7-adbf-274256c5d5ac",
+          "id": "977ca74e-6ec1-4862-b6f2-5b00fd5b8e41",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "68aa0237-368b-49f2-9460-0d34863bf358",
+              "id": "7a6e10af-9e05-4928-a453-157caccef007",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "647bb155-8a7b-4703-ac05-da210b38c069",
+          "id": "b391b4c7-4b91-4718-a37a-051b29cb1a59",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "554aa122-acf5-43c0-be89-9cf88e20e5b2",
+              "id": "d0a9ca96-220f-4bdd-bc4c-44ca0e391851",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "60fcc452-3fff-4759-bc5d-5c6ec3f2b999",
+          "id": "0cd92bde-cf18-4e3d-b2e9-9bd51b744d75",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "7d78d952-a3be-4ecb-9036-c8423a55443e",
+              "id": "5fe726cb-1974-4aaa-8d79-8480e57b852f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "0d404b82-98b9-4c85-a6ea-df964b653b1b",
+          "id": "efa44aa2-5031-4ba7-8b96-29b943b9b9d5",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "0c91372a-d38c-4160-abbe-e7326d316b83",
+              "id": "89a49f76-42d0-4573-899c-d56c6a6d5853",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "a2f5a62b-dab6-4934-8e18-05d5c1801629",
+          "id": "da4ad257-df84-4bdb-8ee0-67e087e7ef70",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "2d7bf884-8c8c-4f5f-8bed-f6fcbb654c5d",
+              "id": "0b256f36-cfd7-4790-a648-1bb0245ad0e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "2fdc45d4-6d17-4876-a6fe-61409c84bac3",
+          "id": "a64a2c7a-cb0b-4b88-a356-abcdf1d08696",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "e538bdc1-b106-43e9-ab2b-c0456d478822",
+              "id": "79383fab-ef0d-423d-86ce-0efed9c67b5e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "3418c995-56b6-407b-8394-048bd89a86e1",
+          "id": "244815e9-4cfe-417d-a99c-90139c1d1ebd",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "5073f4d2-5a2e-474c-8b54-f4b4078a276e",
+              "id": "c7c22078-1844-4ba3-ae8c-d88e329b38cd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "b8fe2e81-cc17-4a39-9976-a6988ddaf39a",
+          "id": "876d6581-e2ec-4eae-bdaa-641791222c14",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "880e501e-d14d-4ae0-9763-9ba3cc724ade",
+              "id": "b9e668b6-286a-4a83-ba46-286bd3264c7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "91c32a77-e5e7-4d66-940b-211daf274e6b",
+          "id": "9064708b-f98c-46e5-bbf3-7ce8b2776423",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "8403afb6-e723-4370-8856-e0cc39a3d57c",
+              "id": "b877f51c-751f-4061-83ff-51c4a93de033",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "6a424634-db99-4929-8457-28f0bbcb3c49",
+          "id": "5da5409c-8617-4da3-a0a1-eada9eb2fbb1",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "490d87db-aedd-40d1-b8b5-8d6e05db0999",
+              "id": "67b64350-2edd-4176-af89-15cb1c939e65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "89a76586-9f22-43cf-823c-b5a9b5009a13",
+          "id": "64de19cc-bf40-4add-a7a6-b47e93e77a99",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "9f10d3f4-b72a-464f-87bc-2844a78e4472",
+              "id": "a522fc57-cde2-4e32-b4bd-f00f8747b9a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "286879b3-21a6-4c1b-b68e-c179fe83c848",
+          "id": "09d22f48-126d-412f-a1fe-2f85934d3520",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "5d0a443e-da74-48e8-bc6f-869301bcbd8d",
+              "id": "e9ed93ad-dd12-41f9-a157-e8b6777ed629",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "7d05d7ce-fa18-442d-aca0-a106663290df",
+          "id": "b5301b3f-d11d-4f7b-92b1-fb8333f2828f",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "a155eef1-56f4-44b2-b26e-6cabe0af6fb5",
+              "id": "bfcf399a-27f6-4790-b5dc-97f12efe327b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "8d83da75-48f2-4eb3-bba0-a4fc18a579ba",
+          "id": "5956dde0-d46d-4121-a018-8f6816c3b88d",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "65720d27-ae10-4bac-a187-6535a2d4d9da",
+              "id": "4d1f2f83-4bce-4b54-b405-08bf32e12d18",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "ede71244-6e03-4eb5-a0f2-3216ea28a746",
+          "id": "95cf9b07-4b90-4a43-a427-155c2df8ff59",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "fa91dfc3-5da7-4cc4-88c3-52007d9d14b6",
+              "id": "5c4dad0f-efbb-4724-80ac-0ca806421093",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "6ae1d61f-897f-433c-af59-b0d59a2202f4",
+          "id": "dba0dc04-4447-45ce-a911-5ead516db7f3",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "e4785b0c-9a2a-4305-b19f-bd4c7ca66b77",
+              "id": "1a2ab614-6a5d-4f83-93aa-490b86efbfa6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "c2e318dd-d3a4-4e32-8434-fe61cc113532",
+          "id": "75be2281-5d99-4ad1-ace8-f99d7f4f79d9",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "ef156921-935e-4236-8088-206eb47ae029",
+              "id": "3ddb5973-7b2d-411e-8b09-690cdc2e7683",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "39af073b-17b5-46de-954a-0cce9c51ebd0",
+          "id": "de189872-5954-4eab-8a99-7b96607380df",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6c5B6e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6ECDcd\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "0f1d8ea0-32bc-458f-ae39-cc91290c1b9c",
+              "id": "2bdcb722-4981-4be2-8402-2d5b2df7d972",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6c5B6e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6ECDcd\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "c2563f80-67c2-4eb7-8062-bc613ad82fbb",
+          "id": "da18b967-3dd1-4ce5-ae5d-c92c07df0804",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "b6994f59-6d19-4a99-9cd5-502652e58aa2",
+              "id": "a2f6b742-d954-4e7a-ba90-d4530e9683c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "ac0f8bba-03cb-48cd-96ba-fabe20a143a9",
+          "id": "d9477f8b-e25e-4e52-9d74-df56399ed4b8",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "66a5ce46-a584-4bc0-a983-7572066e5b97",
+              "id": "e39a4520-606f-42ce-b5e8-9168723b88f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "d5e1206e-58b6-4502-bba1-526c3ad02a35",
+          "id": "1e16712c-ac45-4b10-9600-509be8cd91f7",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FEe5c0\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#dfEcFF\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "882fab05-8f50-4430-988e-0b36710e0f6c",
+              "id": "91b4cbf7-65c3-4971-ae16-f4a894b919b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FEe5c0\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#dfEcFF\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "64935cba-36f0-42e1-ac02-c304c7a06c0b",
+          "id": "474f1d54-f196-4a15-9212-5e97cd900e1c",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "9890867e-1718-473c-bebd-9a4bbf600ed2",
+              "id": "a5d68804-c804-4e2f-8595-b2b0a3eec1db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "53f04efc-c576-4273-9b63-f07b290e7fc7",
+          "id": "52d1f6d8-b52d-4a23-99ee-ccb1fbc3e493",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "f0bfa0f3-be94-448b-b89b-203950826d20",
+              "id": "c53b3c27-72b8-4259-91d1-477cc4ab9643",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "84b0aeee-4ad7-42e0-954a-2a9f70ed2397",
+          "id": "9a693842-e713-408a-a100-02cb251af8c6",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "b54fbbf8-aa81-4010-9343-81a7e2a6dae9",
+              "id": "2c220754-7ee9-4886-b33c-df3809c0c99e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "e3373c12-5cc7-4396-9b79-594b7304eb80",
+          "id": "d691d658-b5d0-4182-9ef9-eb961a1e6ff3",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "f5fc464b-1546-47bf-8c52-398c778c8ad7",
+              "id": "9ae394ad-b0ba-400a-a0c9-7a11de35e3c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "65845abf-89a9-4936-99ac-43cde22bd6dd",
+          "id": "9140c733-2d98-4250-b6dd-172e89fd4cb0",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "1c45d15a-69e7-4210-9b64-157d91f2ff0a",
+              "id": "f36edd52-f3bb-4bb6-b9e7-84087600628e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "0e91993b-22bb-4a85-9a24-6976d1df4583",
+          "id": "59d39634-ca43-4995-84cc-28e134234e42",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "458ad67a-5bc5-4100-9f8a-562ffee793f1",
+              "id": "0097ec78-a9f5-4645-96f2-fcc6811b6239",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "56c32e95-fc92-43c7-bce2-caf1f5a818fa",
+          "id": "f48b3c31-3331-4d2a-990b-a4adb23a8e48",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "bc2d789f-4e23-4d9e-ab6a-560a512bbc80",
+              "id": "a3ccbd16-b8aa-4361-bd3a-b8acbfed6660",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "4d55c4f1-7c2e-4c74-9cd2-419e7798d7d2",
+          "id": "d6a14ae6-e560-434b-ab5a-128f139cd630",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "cfb7570d-843b-4b11-8d65-8ce69c9534d9",
+              "id": "cf9a9cf2-8d74-4861-8ad4-560b015ef03e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "2cd47878-f49a-48e9-b1c3-ec5a6dc4f99b",
+          "id": "8fe631e7-8c87-4275-b7d5-c2cf446d0de2",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "f61f7386-ed8f-404c-9b1e-40fe70564826",
+              "id": "ba1fdcda-0b4c-4d79-a8bc-f8dfd227d60d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "6ebf5f9d-51af-47e3-b353-5e078a202bca",
+          "id": "f3ee4012-a725-45e6-aa0b-3002bd892e1c",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "f743eb4c-1015-460f-a244-e824f08b491f",
+              "id": "8a9bb9cc-5da2-489d-ba9d-4f608cfcc3f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "06a8ca40-4e56-4b72-9615-616b16624689",
+          "id": "bbc90f79-8a1b-4dea-832e-a5fc87df0f7d",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "e38e740d-0d62-4d74-a34a-1d9549d0a7fa",
+              "id": "192879b7-6bd8-450b-9740-942b4c5c848a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "81e58981-0e30-497b-8e66-782b6f4d6719",
+          "id": "b8ab0490-d8ee-4b48-8bbc-ca6b91edc092",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "65e5064e-7fa1-4b46-9b58-347b5fc982eb",
+              "id": "bd9119e5-e828-4ea1-8b65-5e893b92c3a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "f54e03c2-519d-4024-b81e-bfcd0ab9f62f",
+          "id": "2ba1e352-9daa-4047-8216-8b0e83658d71",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "498f970b-922c-4ac5-b4f2-dc1e4b443677",
+              "id": "9cadfee3-2c1f-4c4c-8b47-e18ac464b79d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "27d41e7b-c2c4-4f6a-b1a2-74d94ba1c031",
+          "id": "3f1c6090-a3da-4778-a010-54753975432c",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "01f94e55-c89d-4a92-9134-86d7c6c4ae5e",
+              "id": "ec048ce2-64b0-4395-be92-f5b90fe75bb5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "d8ddf66f-4bd5-4709-8a4f-1077614b63e6",
+          "id": "9b98e103-3456-476e-b360-90d7e1fbabf7",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "c6c0a1c6-a0a1-49cb-a228-066f7b0ee306",
+              "id": "bc1126f8-aac2-4a65-9235-9caa0ccd19ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "b7bac859-b65b-454c-8554-338aeaedb18b",
+          "id": "b0aab4cd-fd4f-4676-aba5-203c246061b4",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "1d46659e-50e1-4976-bb56-0762f53cf712",
+              "id": "2784ef47-7f6e-4108-88f9-60b873689539",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "2521326c-1eb1-4fbe-a32a-1849d2fa6690",
+          "id": "9e70acec-7324-4982-8108-78bddc3f4c0c",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "24c29f38-f690-40a6-a1f2-f2587b52d15d",
+              "id": "abebfae3-f8d2-44f3-861e-07a811eedc95",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "a3f7ff31-acfe-4ee4-9850-2f7ff6f1c5d7",
+          "id": "8e67c8d0-af29-4d8f-bb05-7f2ddae53a0e",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "c5f2ce7e-4154-4810-ba16-ec7deebccd67",
+              "id": "1112029f-d9aa-40b9-bc89-000f00ab7a3f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "9074f46d-969e-4ff6-9c66-e934d8c88543",
+          "id": "29f5e501-4de0-49be-80c3-d2d3e5a8dbe3",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "eaebf510-a8cd-4c53-831d-9f4da7fee153",
+              "id": "34026707-d240-4873-8079-ca25e1e9cb5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "b397f2df-a18c-4d8c-8fcb-0c1ca428fa0b",
+          "id": "bd341bab-19a3-472d-8f45-f7fbd9ef51b0",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "c4f81b7b-42d9-45d1-bd4e-d0aa37cc3c21",
+              "id": "aafb4e07-655a-4b6f-a32f-ea50c1601538",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "61fbff2d-58d5-4dbc-9dc6-43ce324fd932",
+          "id": "1c217997-ba7f-4e04-9eb8-cd49af6aee90",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "1fbb2613-c1c6-4fd4-824f-9328d2a8be5f",
+              "id": "f392d322-3d70-4eef-8948-154a1f72411c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "8eb6b60c-d6fe-404c-9fd3-b3b014fbf0a4",
+          "id": "76c58edc-94e5-4ac9-86bb-2a715e0a9efa",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "2f60d47e-5971-4fb3-9f82-0df8b7fcf836",
+              "id": "8013fa7f-1f64-4d7e-9316-0f6db2f0c428",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "1de1f2e6-7ad0-4a75-9d2a-937b99988bc6",
+          "id": "59104067-2c19-4da0-a3a2-f26504fcf670",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "e8c2736e-287c-4aad-b659-e54bf76c805d",
+              "id": "0588fa87-79e1-4857-9b73-1f982480bf04",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "f7ed23e4-a5d8-4280-8eec-0378e0c71a33",
+          "id": "ee94edf6-820b-40e9-8f7e-e6a799a674b1",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "c3443f31-5bb9-4c74-8257-e1fe0281c4ff",
+              "id": "1f3a66d8-fd4d-433d-addc-9d5829908a5d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "ebc23deb-8b1c-4538-bd1a-29187328a958",
+          "id": "21e0eea2-3212-4200-bfd4-89317280691a",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "0fb2c3e8-1966-42d4-8734-5cbcec29e2bf",
+              "id": "e855f7c5-623b-4379-97ce-a0bd64b9cf46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "d143c7ed-d68f-4e71-ae35-8f6007514883",
+          "id": "4270192f-11e0-4d9e-a857-99c9f76875f0",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "15f5caba-d30d-4b99-8d47-8a460a1acb14",
+              "id": "cdb15af6-1757-4fc3-a9c0-00d3c847fe09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "7b19d224-3d61-48e8-9364-b3859d346f2d",
+          "id": "4d4d1c35-c87b-422d-84a9-b1528e136019",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "87d4309a-8170-4811-83e7-73d748d1ecef",
+              "id": "e9a115ec-2a2f-4037-bed8-4a0158988393",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "be8def4d-d381-4f11-b4da-a98cb44d436b",
+          "id": "82ae2e0e-df04-439d-8347-3c8228d740c6",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "39cbcbaf-7c99-47d0-ae01-7c76cfd2a85e",
+              "id": "eab24b9c-dcec-4a01-8975-df423b12d7dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "7ed88fe4-de3b-48f5-8502-ffa1b4a77f18",
+          "id": "183b89b6-cf57-4bef-855f-88a0a3aaa3e4",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "02bc9a6d-c6d0-4d39-a1f2-ee45636739cc",
+              "id": "21a7b51f-b890-4b16-b105-e452b2177c95",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "2bd96fb2-b704-4188-9105-8ae19ad8a5a1",
+          "id": "96e86c5a-f293-4321-a5c2-cd1bd9a6d8e6",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "b9e838ee-c937-4ad4-9eb5-ab19e77c8496",
+              "id": "383611ef-628e-4b39-824c-22706cd94c6b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "a0299d11-7fc8-4155-9065-acbf9d416cba",
+          "id": "bff36b50-0d95-4d7d-bbe1-eab04597429d",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "1f4b3f57-cae3-4285-83a9-a5754cc94859",
+              "id": "21aa0b0f-9ab7-40d1-b336-e3a10168ceff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "5671c7bf-e274-49e2-a0b6-d653ef3b9356",
+          "id": "ab777a41-5896-4daf-b02d-5c974675c856",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "1c741e26-02e2-494b-9259-9ea7d69918da",
+              "id": "afebfa8f-74bc-4579-bf18-22c91a556b32",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "5b791678-19e8-48cd-ad08-be29b0de31ec",
+          "id": "54e2f88d-3ef6-4980-876d-dcb659046c89",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "e1347b0c-94d2-4a15-a3d3-a20746d1a8aa",
+              "id": "56eccbfa-e670-49ed-b068-458e13041fb2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "f55327b7-27e9-489f-b126-5fdbfc0720d4",
+          "id": "a95e028c-893d-4deb-95f1-41984f831e74",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "b376612f-6dab-49f7-b737-e87ccbd625f0",
+              "id": "12e26fa5-12ce-4c0e-b943-c181b9e34ffc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "c457c711-51c6-453b-8bdc-76612582bfe6",
+          "id": "e727f917-021c-4e96-97d2-6208cd36bd99",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "67d45f91-933a-4b07-9288-cf8e3b5e8ff2",
+              "id": "afddaec0-8253-4624-af05-e1d0ba4d7437",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "06d75a11-1c9a-42e0-82ff-a1aedf5ede34",
+          "id": "b91b50f3-ffc7-4427-b811-2c8a36b2dd1d",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "cd4dd6ea-8a47-4a96-a721-aa7c5e6f1f38",
+              "id": "6f1a2e15-b5ff-4e52-8f78-7a6d5e2769ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "b30a964c-b226-4b6b-93a2-b282ec62f30f",
+          "id": "002349e1-eef5-427b-80e7-26e464c36a9a",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "5443e95a-6c5e-4b36-bf18-6c0c9fdd6aeb",
+              "id": "99b6337e-d66d-4918-a0e9-e63a47f3d493",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "11a4e05d-5976-4340-8acd-fd0e86188ba5",
+          "id": "94344b13-6d9f-4e0c-8966-e0f650a06d03",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "52c47dc8-d52b-4210-b041-dc7c7871d0ba",
+              "id": "928e7ca6-8125-4612-83bf-b8722fdabd43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "4d17d37b-a5d3-42c7-886a-77a4d449f2c8",
+          "id": "e0509db8-c205-4236-8574-a3aecb0b7c47",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "e34011bf-fa25-4e1b-b7bc-4a933256fee8",
+              "id": "3ab181e5-424d-4bf3-9f10-a09c2f0c0543",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "27cad949-5ea4-4d82-98b9-38a891b13509",
+          "id": "ccc5316a-833d-4ec3-ad56-50974835ad4e",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "11fc299f-a0fe-4190-a6b8-c72caf3f29bc",
+              "id": "2224788c-6381-42f8-8999-285dfeb71b97",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "87fb2ba2-e7ec-45ea-94ae-2d20cf49b956",
+          "id": "b9d03946-e5ce-48a5-bee7-0146f68a3dfb",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "0bd622b0-4432-4cdc-92a9-48c5429461a1",
+              "id": "e0acc31c-e766-4dee-9fce-44d3ab812d28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "278b3308-817d-493c-af8e-f7a138ae3db8",
+          "id": "ed76220e-3379-4f10-b282-42b0c2f3bf9b",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "61080265-ce00-45e5-9ce4-c4d4423e51a5",
+              "id": "a41e74b3-fc44-433c-bb71-152f658bcd43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "d9a431fe-0f96-4890-883a-204d7009f683",
+          "id": "22b741ee-be83-4602-96e6-d8faaf80c5ec",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "d2bda795-8e51-4928-abb8-3d5aa03b4bb7",
+              "id": "2d942706-d299-4a47-849b-8f13b5a10d93",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "f18ca754-f57e-479d-89d9-65b07105200a",
+          "id": "6eb2d509-4978-45c6-b19b-06dc3d8b9658",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "66fb5280-4993-4719-bf24-9eb4dc0709b9",
+              "id": "51bb2a66-c385-42d0-b038-d389cdc058e9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "5f696c55-70c5-4ca1-b640-486ac0802831",
+          "id": "1bfe18cf-fb15-4a18-bc20-a2db75c713b2",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "afbd4cab-bf3c-4173-add2-e623484eae85",
+              "id": "9f333e10-ae87-474e-8365-59ac6fa9d5d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "5366da98-6b86-45e8-babd-c565f8e18e7b",
+          "id": "620b8ee1-dac6-4839-a927-6950f0515788",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "a766dffa-ffd2-4c42-8dc5-72f169656c50",
+              "id": "a51c78f0-7b17-46fb-a6fe-2a0d42f02ced",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "3abde498-c523-4fba-befe-370c6cb6f5f7",
+          "id": "4b1457b3-3644-4050-93db-aa104ef2261f",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "a155288c-9f09-44d7-baaf-6d7c3c131689",
+              "id": "772896e2-43df-447a-ac33-89dc2fdda13b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "8a43bc43-0d2a-469d-ba0e-b34d2efcb198",
+          "id": "007e3998-8bee-48a7-8634-7e3e3ff607d9",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "ce3a1a58-3f8b-4e9f-8d65-7ab83828feb8",
+              "id": "03f3862d-8349-4810-871f-3f9b4154fce9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "ec588992-3454-4654-92c2-ab762a15fa3e",
+          "id": "52a44e34-84b2-443e-9ad0-3afdfd4308db",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "5cc984c0-b3e0-4dcb-96eb-36789816e943",
+              "id": "460cc03a-721d-4b87-99bc-410fcb0301ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "2dd1d731-a5b9-4dc0-af4e-09d7ec3b1e1d",
+          "id": "d03bc5f6-a9cc-4a3a-8a9c-3b612459ca7e",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "d7210a6b-7bd1-453e-a2e1-70062d2a8e73",
+              "id": "97d4d18b-4c5c-47e5-9c88-245ac4482be3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "c7b6150b-3f26-4830-bfe3-3b0fe7449f18",
+          "id": "aafd66e3-64a8-4dcc-b433-6b359d6dbf7c",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "001253ac-bff0-431d-8402-5200292612db",
+              "id": "aec51c36-1b38-4873-95e4-17e916f85729",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3fd57281-9769-4b85-a5f6-b67d5ee5e983",
+              "id": "2f6f11a3-9491-42cb-a5a8-f262b1aa7f8c",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "91ba44fa-5a74-4923-a68a-606fe410c024",
+          "id": "ab5b6500-520d-451e-97ff-51ba09ec24f8",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "077aea56-29ae-4d15-8d2f-eb1419712fef",
+              "id": "a266b152-6e48-4191-9195-c860e356d6c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f8872cf2-a95d-40bd-a1dd-d405324118d0",
+              "id": "fbcced24-9384-4e47-918d-dcb2a639bfd4",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d4d7dc3a-0271-4957-b89f-c82a6b69761b",
+              "id": "be469126-02a4-4996-b498-ccbbd3dc25ff",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "cc52b961-23b2-4c10-b7e1-2773e8919920",
+          "id": "27e7651e-f9af-47c7-8433-c51e2e42439c",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "adbb9460-5d0d-4a38-9131-4ca461ef9cd0",
+              "id": "fbf3dfc3-1134-4c69-bafa-0fdcd459687b",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "9bb4429e-230e-4cb1-a1b7-8355c590f14a",
+              "id": "b4ebf551-0e39-4743-b51a-86e2390bf6fc",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "eb053861-01eb-43c7-8840-5d7bc1309cb7",
+              "id": "cb04de95-d257-4b31-8368-762396a102fa",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "d6c3e3e0-3a04-4298-bf70-a46065d225ce",
+          "id": "44d7d2c2-48ad-4d84-986f-7e07df8911b6",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "07ffeb68-4992-4ba0-9002-423f8b1be33a",
+              "id": "42501218-e303-497f-8348-2d8070c81842",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "aa04e5b1-3dac-4eba-a285-d835df6cae7c",
+          "id": "ebe964cb-6fd6-408f-97b4-b5ba040f9559",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "f40cc6f9-cedd-4811-a297-0a0f2a4c7319",
+              "id": "56dfdb16-cd02-4133-9c9b-c891699a1663",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a1765131-83ee-4da6-a8b6-40a98e494b09",
+              "id": "40154822-c203-4eb5-9a6d-7566a556ce1c",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "6645c9b9-a351-401d-9ac6-29ac8c520196",
+          "id": "d6f0a93b-8931-41de-a1bd-a71684608f8e",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "6736e0a4-1b56-4e5e-aaf8-39efbeef6bbb",
+              "id": "6f0d3eb7-139f-4c1f-b3c2-a1e924fd3829",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "d29f0e15-85f6-4121-b6a6-527b20f947da",
+          "id": "492fb4f8-0a40-4d7d-8560-2f39f91d2ffc",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "1d72cc5f-3e81-49eb-a8e5-b29b74a29513",
+              "id": "a864de56-7f6e-4c63-8e6b-5a6b86f0cef1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "aa82317e-aa5f-406f-b424-4c82abab5c86",
+          "id": "117834fa-8f17-4bc3-894d-80e10a41b94b",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "22f3b037-3c81-4ec0-a71c-bc4d959dca2c",
+              "id": "566e1ce5-613f-4dcd-b4a0-5128fba045a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "d9a6c93e-b4be-4996-b4bf-9115414523f3",
+          "id": "9c9d5546-6181-42cb-8c9b-76f40d7061c0",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#EC37d8\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#bD919C\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "3e103bfb-394b-489d-845f-0406ebb1cf1e",
+              "id": "e28a9462-c07c-463e-9587-aae3661c96cd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#EC37d8\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#bD919C\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "bd83308d-2627-4655-a5c0-9ee3d884f79e",
+          "id": "afc8045f-68b2-4d96-8245-29bd418916d1",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "c3ea296a-0a3a-481c-b1b8-0b0378f32c7a",
+              "id": "864c670a-7b2f-4fc6-a160-db330556b765",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "9111a186-0969-410d-bdee-caffd8f7e449",
+          "id": "94c11f0f-cb61-46ab-a6db-83e578eddfec",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "80b85943-3f83-4951-8237-973d63828341",
+              "id": "0cdd7a53-85f1-4f02-af1e-802f172d0018",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "19ae2e8a-7015-4569-88dd-b5901767790c",
+          "id": "56f34775-9d24-4cd2-a51a-728ade19d337",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#16ffc8\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#ABfF36\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "894c148f-4ad5-4fce-afc5-f3da9dadecc7",
+              "id": "3dcd9c0c-9af8-4452-b07e-124e1ae963d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#16ffc8\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#ABfF36\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "3f2bc065-3bf6-45be-b401-b97816b7e688",
+          "id": "6a920d16-4668-4e9b-99ed-55d03193a1bb",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "aa65c53c-11bf-41fb-9cfe-2b6e50fabd9a",
+              "id": "0c611d78-c057-4690-bef4-941ac8f77efe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "38c63d74-b0fe-4fd7-b33b-6e9904202cee",
+          "id": "59d98e35-bca2-4fcf-aeca-b10d2ad709ab",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "d31b88f6-20c5-4c82-b6da-78be57f008e9",
+              "id": "7735652a-3e44-4a57-93bf-759f88f29a15",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "6ba0b0de-3462-4bff-8232-aae7d0fce1e4",
+          "id": "804ab3c6-893a-482f-a3fe-25764adfd050",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "60ef3ed2-7ccb-4bbe-82e1-47a3ffda36a4",
+              "id": "49e54220-d481-442b-b005-2bdbab2b6d56",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "7e0f8aeb-b980-4b1e-be0c-1462936849a4",
+          "id": "9c58a39e-f045-4856-8123-3164a58563c2",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "89088bf6-36e2-4027-9ea5-a1eb3652b245",
+              "id": "147d1804-13f3-44ab-9406-089106516389",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "d9b65465-d709-448e-9464-f04a7e2a7497",
+          "id": "40589256-e4dd-40ec-bed7-9fa673271e7b",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "0a487d12-5d6c-4dc9-a14a-16beff553748",
+              "id": "42f867ca-feec-43c5-b069-7aa8df9cc850",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "73f1db1b-5dec-4d32-83a5-60540481fea5",
+          "id": "ba2ae004-e62c-4868-bfa7-2a16c4460386",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "eb267794-73a4-47c2-91d1-367d554d7b4f",
+              "id": "fb5fb8f2-0e58-4b03-869e-a8fabe0f7e8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "47a27ed7-95bf-41b5-97f6-4600fdabf40e",
+          "id": "7fadaab2-2996-4a85-a60f-5d75e5e381c1",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "50287a10-8030-42a8-8409-2017ad12c5f1",
+              "id": "4d9c749e-fa57-40da-ba16-b6ba46896818",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "cb47fd12-6c00-4a10-a53c-8b21ae47776c",
+          "id": "d93ea3ae-5ed9-47f1-b552-05f3829009e0",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "4d292eae-eed5-4731-9a4a-e6a8cd1ba0f6",
+              "id": "4a35b7ef-8bb1-40f5-ba02-bf2e42e3f34e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "d58b31ee-7ecd-463a-8859-c482deeff69a",
+          "id": "eab5bb92-3168-47e5-bf5a-c86c229d3bd1",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "f3da4629-8df1-4054-82d3-36924e1d1863",
+              "id": "d5f66220-aa9a-48b4-9145-862f36aac4b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "d1e96641-801b-4258-90a9-f60b66c6aea3",
+          "id": "7c0d1c31-acc9-453a-8e23-5b3789cb072d",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "0eb3cc9b-3e7f-488f-99bc-6ec32b549baf",
+              "id": "d27b4672-d898-4e76-a75e-b828c8ede0c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "e27726fc-0668-493a-b0a3-2affd7ebb8cd",
+          "id": "b271089c-9000-4346-b799-8033e12b4b11",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "ef552d20-e4db-44a7-9bf3-1d9c9b830627",
+              "id": "65513650-5bd9-4221-8c1b-41b378e5d4eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "bf3e97f8-1729-4df7-856f-dec60cd3a180",
+          "id": "f13d397f-db80-46e2-9bf9-306669b09fe4",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "df36c33b-06fb-4fe2-afe3-69c86918095a",
+              "id": "003938f4-588d-4125-9b7f-b4bea3185863",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "b8c51678-36c3-47aa-bac2-cdbfd2989ba3",
+          "id": "fbcafbfe-5a8f-4f6f-b0cc-935dffea8229",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "a9b29d3f-f145-4a5f-9c8d-64ec6ca434d5",
+              "id": "6f724e43-fa2e-4b22-916c-e4fd4aced2fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "95782d79-c361-4088-88c6-c422b18ce35e",
+          "id": "c1aecbce-f503-4de4-9691-59c3e1df4544",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "a3afafde-6444-4d1a-8c54-f17bc0a7fd47",
+              "id": "2696f5da-7c50-47f7-b920-2d7a939d7df1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "57f2049b-f11b-4fd0-9904-fbda4297bb88",
+          "id": "aa96276a-2917-4807-a344-1640d2024692",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "76f053df-6f39-4411-ac44-04d61561b302",
+              "id": "520021dd-4e54-4941-8971-f265ba42eaf9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "03d9a909-6a07-4abc-8cba-050e04e25777",
+          "id": "274ddb3f-8de3-49ed-9eca-b443c025fa1d",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "35871f49-9458-4e33-80f4-eb15d34c67a0",
+              "id": "6501b801-370c-41dc-b3b4-d5d67148e883",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "c9c78e0a-7fbb-481a-abf7-fa9765f81284",
+          "id": "14d441ef-4c6b-4617-b6be-ac729e362955",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "0d0cebe6-aade-45a2-9309-0c37c3b60466",
+              "id": "2465044a-277d-45ce-af5a-c185def4f923",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "490e5ce1-68f9-4f3e-91a0-be665cbb6477",
+          "id": "fb6f8588-3e4b-4dc7-8711-d80abc2e728d",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "bd2d9cc9-25ac-4346-9bfe-11d53eb0f1c5",
+              "id": "66c91f9f-b93d-4f86-9526-11387a54899f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "823e927c-6ee5-4d00-b722-36495f643fa9",
+          "id": "228e5ff5-b7c7-4a46-b8a1-0812115c7ba5",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "60cc883c-575e-4401-9fd8-51f631f208fe",
+              "id": "9dbae909-c6f2-4942-90d8-a1054dbfd186",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "c82c198f-adbd-4a79-9c16-b7733c02c656",
+          "id": "dba987d6-75b2-487b-b994-f2ee2969de6e",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "f39bdf52-7951-4e5d-8aee-33921dbbd36a",
+              "id": "bb59b776-e268-4f88-b5a6-9cc41e213196",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "50a10940-e092-4273-9e08-da6fcd308de4",
+          "id": "dd1307fe-e5d5-4a32-9f80-126ebf05f5ca",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "10def026-b5ba-4cf8-a5e3-5f49d7182077",
+              "id": "d4bfb16c-15ea-42e1-808a-b122e2fd31a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "3852022f-098b-4a34-92e7-2f7806314042",
+          "id": "b3a427b3-fdff-41dd-9552-5865e27f3283",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "f0cf2d13-bd9d-4836-8906-9990c543ccfc",
+              "id": "3470b496-c074-42e5-84a7-ba718035235f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "3dea392b-f0fa-4864-8d4a-c6a3bafdb2d0",
+          "id": "25f94da7-904a-4a71-8af2-4f546f621d43",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "09b41843-d670-4d28-a4f8-37e82e24da46",
+              "id": "fa8731e4-72ce-4f18-a6bb-b7bcac1db0c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "bfb6e005-b5b1-4139-bd3e-aaa125e7981b",
+          "id": "e798c528-fc86-4665-903b-ea03056b168b",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "621e17a7-2241-4cc0-bb0c-8b6aba65e893",
+              "id": "4e62bf78-bb89-491c-a537-b5c2a2b82857",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13520,7 +13520,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "110fd217-592a-48e1-8555-71bcd71234d0",
+          "id": "8c9e0d0d-e9e6-4807-b872-f194151e610f",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "574edd6c-05ad-421a-9f27-b70d33c4fb7b",
+              "id": "514bf8c5-cd28-47cc-9f88-ecda2131b877",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13630,7 +13630,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "1e7b2a1d-e094-46c6-a420-c293b62d67b4",
+          "id": "6882a1ab-066e-4771-8343-a6efec74fd6e",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "0159cc13-1e50-48e3-a935-0021bc68faa1",
+              "id": "a7020279-9304-4e92-bd16-4c1015c04e77",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ce99b33a-9020-4612-abdc-9e58604c5e16",
+              "id": "c3f0fc56-56e4-4f53-ad2c-b5fce63b3186",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "eb6cd6ba-27ed-497f-906e-34eba5a6cd6d",
+          "id": "34fe120d-a9ef-409d-be36-8a608cdce0c4",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "2fae0d98-f581-4de4-8d1d-e21d70335af2",
+              "id": "40b8e30e-f041-4d5a-83b9-036e9d7be821",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8c3e9016-c3dc-4f09-a9c1-dfe08f6981d8",
+              "id": "01c0d9ef-9a0c-4835-89f1-3d2a03c59f04",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "0d045f09-19b7-4a21-ab0d-bf8f0a22734d",
+          "id": "8c6440f0-55c6-46d6-8065-b1f9c9839a5f",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "33c4c998-70cf-45aa-9ff4-1c1e92e9f836",
+              "id": "b2834f61-43a4-4bca-aadf-ed10e6d62fae",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "fd4a2b68-c22f-4a71-9402-36f984a27e16",
+              "id": "63c05e17-64f5-4126-949f-2bbac3ca4c1c",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "264f54d4-49b3-4370-80b5-8c6497d477d0",
+          "id": "e6a6faf7-4cb1-491b-ad0a-bf31d1226f9d",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "ef1aad57-1cc6-40b9-adb1-7822f131e0fe",
+              "id": "5096f4a8-bad6-4c3e-bf24-3dd7404169fb",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "39632efe-1c0c-4679-9340-681304638eb3",
+          "id": "0b53b8c1-4b19-40cd-be67-e5fd4a32c211",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "3195cea9-67e0-457a-9f25-b2c9480107fe",
+              "id": "b04e6e08-5375-4449-a6f5-1325d9b48fce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "0988ca62-88bb-4c48-9683-98abb54d25e7",
+          "id": "5a50c309-e8e5-4324-86c3-318734fd2ec3",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "3b54c988-be97-4e6f-b69e-7f66e69c5ca2",
+              "id": "fe587b4b-f67c-4e86-a378-24117134e681",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "3222df66-358f-4cb3-9601-84427f2722f8",
+          "id": "7c9769ed-3c63-41fe-a934-4fc27364e9fd",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "6bab25d4-4d8a-4769-af56-20ac010b0659",
+              "id": "6a881775-e942-4a33-a7a5-165be8407433",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "5a2b3e30-02bd-40bd-bb28-dc8fe835b544",
+          "id": "46b642d9-915c-42bd-a687-ce7b71a6699e",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "1dc83eba-902d-46a5-be1f-820806358729",
+              "id": "489574f8-3acd-4afa-b9d0-2c98fc3edb8d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "43748f8f-33b3-4d20-9ba9-15c68e902b66",
+          "id": "830d39aa-641a-4154-bf45-d7ad2f7fd712",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "383b1aa3-cdd3-4046-9422-ba28d24f7164",
+              "id": "4ef052b7-ce15-47c5-a340-75bceb2e6ca5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "883603e6-9328-407c-9f66-da9bb38def0c",
+          "id": "903c2fbd-9239-4e1a-96d2-507bd7a00a83",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "b018100a-dc32-4f93-a5e6-7e696b1c0eed",
+              "id": "b40610ea-6a72-43d5-aaab-258837cc360e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "3eff6fba-3255-403c-867c-c7b670ceb04e",
+          "id": "4f491e26-8ee4-4c89-9994-fe46232ba2c5",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "7686e9f2-677f-43df-8d8b-32c55c789c78",
+              "id": "d8ce841b-969f-48d5-9b58-577a0ea71176",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "8552881e-276a-478e-8e3c-8a7b2ba1f6cc",
+          "id": "e8330f5e-3e47-4e65-8b5f-c1e48452b07b",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "51699e5c-c3fb-402f-80d9-29221f3d2812",
+              "id": "a0d64c9e-df72-4e6b-89d1-9313ed5685d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "8fec6f2b-2a87-4e32-b8a5-a9a33e4468d2",
+          "id": "e42c3fa9-e47f-4e47-a7d4-ef9ceb0332e4",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "c99bc930-34cc-4920-9330-4022a45594e8",
+              "id": "3340bd66-cf76-40e1-8d5b-8ffc4919b124",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "586742d0-476c-49b3-8a24-74279393f59b",
+          "id": "8a88f209-d825-4f19-928f-ab8f97ebe5c1",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "eee8c16b-9ee7-4c27-9201-7d116ca5ad6e",
+              "id": "932b1856-34c4-440a-a041-3127842e6faf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "62fbd0fc-b169-4dce-acaa-6c0748c9eaa3",
+          "id": "0c4f8dcf-2768-41b1-bb29-4c6bb061ff4d",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "a93265e2-7e60-462c-b4a6-36396ceb4a93",
+              "id": "99a87ff8-8f99-42d6-a1f6-4fb20185da6c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "e491c164-1b16-4103-a73b-bebc11be3c0b",
+          "id": "0edd18df-556f-4927-a012-93e7eab9b55b",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "fd229e91-7e50-475e-a21f-64b50b529d3e",
+              "id": "cac95c2b-5254-4a10-b189-1dac2e433591",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15533,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "6df7155b-2f7c-426b-b81f-9c08e6b98952",
+          "id": "3e0a314a-8c72-4019-b40b-32812d4e7187",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "601ba7b3-ae21-4cda-9b40-2f7b52cbbde9",
+              "id": "7ff7e77c-b178-442a-aed9-dea93ee141f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "f0742945-eb0a-47c9-87cd-da30a1a6007f",
+    "_postman_id": "f1d8a827-d489-4b72-99d9-f00a2fa93d79",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-27 19:23 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-27 19:30 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "960b62ea-f950-406c-a172-0e104c2eb21a",
+          "id": "9ffc53cc-05f6-4462-ae84-6dcc81206345",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "473d481e-d606-4f43-940b-02b512247b98",
+              "id": "6ba9e6d7-5c5f-4c06-a60f-d430929ed293",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "e483eca7-386b-487d-90c6-0e514ac63592",
+          "id": "b1acc2d0-0d4c-496a-8507-6669175d3f8e",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "cb9b0f93-2e6a-47eb-9724-c6b950fce997",
+              "id": "ae53497d-fbce-4279-8a7a-25426e6f2e14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "147c26d6-61ef-496e-922e-3f65511232da",
+          "id": "5f53f9ab-6211-4e49-949f-597979069808",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "015670ab-6163-4b38-8886-b522ac2b381f",
+              "id": "148c3fdc-08d0-4772-89d1-7885fa3f5a0f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "ace774b0-32fe-4813-971d-5575738bd59d",
+          "id": "00bc40d9-b338-4ab0-8d89-f3736415b54c",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "3191be66-7720-464f-927a-62ef0af264d2",
+              "id": "1cb6cf8a-47ee-4184-aa2c-6c53e6bd29eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "0e8dbd0d-1c82-4832-9cf0-189b0acf4bdf",
+          "id": "3dfc8167-ab05-4a76-aff9-e50617031adf",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "e1d507c5-9d4e-4701-b173-ce71fa1b296b",
+              "id": "460864ac-34f4-4458-a926-25c574ff9cf1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "989931aa-6052-45a1-86e9-27903ec4c9ca",
+          "id": "00687a49-784e-4743-890f-39cbb3552b86",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "2477af8b-a691-40f2-9533-732810223251",
+              "id": "cd807232-fd05-4aef-b27a-1328d55ecf37",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "7ca97103-0319-4707-9cac-007ef71217df",
+          "id": "0f273554-fcb7-4ebe-a731-46f3a18cc583",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "1869cba8-4080-4c0a-8e8b-89b315f4f673",
+              "id": "96858376-cfdc-4193-b7b3-cbde3d85ac9c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "6ea533de-63d7-4763-b15b-f54baf2ce665",
+          "id": "66e24a14-760f-43ee-8553-e970f5b4481f",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "5eb195eb-c7f1-48b5-86e5-b82f7225520b",
+              "id": "4a1f4053-b89a-439f-b82e-6262a6ef7157",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "acc4f513-8075-4a12-87f0-1164ecb646b7",
+          "id": "8f88fa95-2dde-4363-952f-2e0b3e791eea",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "0fc7a96b-58c2-4994-95a7-b9c50e580d20",
+              "id": "aeb19060-26b6-438d-8b4e-a21c9771f270",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "d24dbac1-cc09-452e-80b2-88a73ff7f8d1",
+          "id": "72645689-6452-42c5-8d29-d6efe38b11b8",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "382cc988-762d-4ea9-949e-a9ac0ee0b837",
+              "id": "a9de3ff5-7cb9-458f-bfdf-d0cf3f402d59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "48476540-1545-4d99-85ce-e1855d416e86",
+          "id": "8ee03ee9-62e7-4884-aef5-f6819762e629",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "e494f4a5-8540-4e74-9489-b951bc0225e3",
+              "id": "fd7ecdea-b858-48c6-a0a5-94654d01d0e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "ef8b0e2a-e916-44ad-8d81-2f3e31bf1368",
+          "id": "09a7f0d4-4868-49bf-9bed-03fc54b3fe87",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "3f0ee90f-665a-44db-9962-ea238df60d66",
+              "id": "5d2a00c7-fd70-471d-b1d4-1daf50e3281c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "e2b72689-df13-4d51-bd03-ded67db086a1",
+          "id": "5137239c-9cf5-491e-86fe-274ce89d6013",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "55f42fce-9ff8-4d7d-bbb3-a20313257f7f",
+              "id": "357937a6-45d6-4d81-ba86-34a0f626ccd6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "325ad206-0471-43d2-9765-e124f7cdb672",
+          "id": "f113aa34-5f5d-4c2c-8bb5-4061b04abc0e",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "265f2a9b-b3d0-4cc0-a373-eda690ea5715",
+              "id": "b8ac1be9-9da2-446a-b768-db757c42c7a9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "4c4f39ed-2829-40e6-9b58-d93617e7ae20",
+          "id": "65a8c8cf-8fb6-4fd8-899a-11446acd82a9",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "fd98114d-b79b-4422-8222-63af54e3ab46",
+              "id": "de516a4d-131e-4779-bc86-46538ffed51f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "cee362b5-299d-4d43-a5f7-bc664a15bbbd",
+          "id": "cf3be0a8-e0dc-4f36-a7d2-de242f0d53cf",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "374d4c84-f345-4938-b088-c943e26f5f68",
+              "id": "5be301f1-1dbd-4aac-ac0d-e740e1e1a2a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "ccd32814-aeef-4f8e-ad1f-7954cfad9715",
+          "id": "3e753bfb-d98b-40ab-9821-0fb53c7ea168",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "4007e925-f1ab-473b-ae44-6e4abca27c90",
+              "id": "80fb89cb-7d94-48be-8219-a43d21735eaa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "8f1b2105-93e6-4a1f-b655-7a32314f7038",
+          "id": "ffa0e698-bcc4-4423-95f4-d4ed4c5203b7",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "45ae4da3-94a1-4e5d-88a8-1d5970ed5eec",
+              "id": "d655741d-d6de-4e87-a67f-71505f040169",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "8fc69cd4-81c6-469f-8845-746fa208dfa3",
+          "id": "70873e78-cd96-4605-927b-392e8ca1a5e2",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "d3a9aee2-ad24-4397-8316-35e54d7543c2",
+              "id": "b33e1279-1a37-4de9-aa60-cc26876b84f8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "6e90c5c6-5163-4d6e-81bb-abb2d9e7187a",
+          "id": "14d233e8-8991-43e4-bf7c-40f25ae0fd1d",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "93b07871-4701-447f-81d9-e6d594143631",
+              "id": "043b1895-16e1-4e5f-9705-aa371bbc7b6a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "66f94a6a-fae5-433d-9b10-7cd0e01a5cf0",
+          "id": "3a304d9d-fffc-4537-b4b6-8f2d5a9d51a4",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "106584a7-e533-43b3-bcc3-bedfd79abb52",
+              "id": "7af93a98-83e4-4469-aed6-8af1fedb949f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "6b55f150-1fca-4479-8b28-fe89bc6d1cd6",
+          "id": "173632c9-1116-4007-8cdf-d5800f3a48c4",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "38c35ba5-65b2-43cb-8c21-18d535e87463",
+              "id": "665ad270-0840-4b05-89a8-8f3a5788d9d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "9bb90a36-a6e5-4dce-a239-6a9318011e5a",
+          "id": "3ba8641c-18fd-4d61-9945-a027f6b5896d",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "8e6bdb6a-d0b3-4a52-bf8d-84145ee26dc3",
+              "id": "c1eecc9f-accf-4bc7-b105-a2a8816df1e5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "14e5561e-e782-46ee-a60e-db78c98feac4",
+          "id": "dffc4cd9-09c1-46da-9181-891adf72147b",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#239A3E\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cA38e5\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "047367e4-8193-4459-aa90-8aef9dde5201",
+              "id": "5be85e2a-3c9e-43df-ae42-2a14379464d6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#239A3E\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cA38e5\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "d47cfe2b-b6a1-4eeb-b424-f3c0f743f67b",
+          "id": "0c7d0a03-fa6b-4b42-95b2-59b48024b445",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "23bc05e4-bc74-4f50-92d3-7ac45d40204d",
+              "id": "7635b382-a8b5-449c-96e0-37b8183ff935",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "136033d7-181e-4f43-b48c-090b63d35f49",
+          "id": "6918c58e-001f-4cb1-96c1-e2caffe8d452",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "e2d5355b-11e9-4411-983d-6da3238619d6",
+              "id": "563f8efa-7001-4724-91aa-c5bd42a9769d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "d5d432e9-952c-4fd5-88ae-ffb41a199ddd",
+          "id": "f21ba150-5df1-4622-aa5c-8344e846d4e3",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#7feeBC\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#48A54b\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "c46d93d3-7adf-4351-b9cc-c2aca54d536e",
+              "id": "0603f4a6-090d-4c35-9bbe-b0aaf1178035",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#7feeBC\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#48A54b\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "9d030bd5-540b-426e-b56d-194fb1275071",
+          "id": "cce6fdf5-07cb-4645-a48c-b5cf4236805f",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "372463d1-88c0-4687-94a9-5f173b5164fa",
+              "id": "03aacefc-bd19-45e4-8741-e9ca8d12bd21",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "fcd0ffe0-1eb3-4d5d-aad5-d0eafa5db678",
+          "id": "4e099167-7893-4907-a8f4-08d108d25343",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "0c67ff5e-de1d-4cf8-be39-4cffafc085a4",
+              "id": "efa9fc79-fe89-4dea-923b-c350b097f3aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "5bc93c8d-8113-457e-a40e-c9cb8a7fb364",
+          "id": "e23cf3d1-3658-4100-b763-77d008922960",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "7847622a-9add-4a33-a6e1-a4ae75527c30",
+              "id": "f059052d-8470-4795-a57f-801086b69faf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "e5571235-cee6-423b-9572-06c1fadd319a",
+          "id": "fec27c38-df78-4fc8-8530-02f88b97f199",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "c6a76486-2c46-426d-9bec-ed2a2ee7d2c7",
+              "id": "4562655a-c583-4aa2-a95f-8b6ef3e10ce6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "395ab193-e472-48fe-9a8b-a6c75f43e925",
+          "id": "6bde6e07-5936-465c-8744-c8c878343b60",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "81ee3c3c-d5f9-4e85-af22-36a7e9364255",
+              "id": "2d469427-63fd-468f-8e87-0d747115d194",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "ac181bd6-2641-4754-b840-191140f1ff1e",
+          "id": "ba1989b8-5777-4a43-865b-5a975912870a",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "f29a436e-f492-4cd1-9161-22a731e32f51",
+              "id": "a4b4e360-b850-4ff5-b308-edf3ecf4d9ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "2b5d1409-dd97-4c7d-86a5-c21ab9a1647e",
+          "id": "f553313a-38ab-49b7-b7f3-8abcf657e31e",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "81b28cf4-fecd-469c-8883-7f9902c73b3f",
+              "id": "0c30e617-58a1-4788-ac95-7da3f9e01d62",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "dbf69d96-096b-40d7-af92-b833e39f6961",
+          "id": "b25def73-b91b-40ee-9329-e8c3bf6cfc86",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "fdad7347-43e3-4451-965c-845067089769",
+              "id": "415e3742-f7fb-4ec5-9706-5ce8b0965dab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "9461e721-3313-486d-aa61-b542208e2d7d",
+          "id": "c5f41166-034b-450f-8266-a09f075d2088",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "ef328fcb-3512-45f5-a379-a5adbb9d3bb1",
+              "id": "606759c9-bb01-48fa-bdc3-12f899a5984a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "8eee801b-c8b0-440c-862d-b4a98235349c",
+          "id": "a7a546e3-aa17-49a4-8ef0-287669c8066d",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "3356f1e9-9cca-4599-a7f8-2cd57fb13961",
+              "id": "7d27c708-d0a4-4509-b2bc-cf5bf2e4aab2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "77c2d8fa-1e50-4fba-8998-713d67bde2ef",
+          "id": "d5a79ed2-6d48-4320-937e-fff435b122c3",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "c40eefae-48de-4e38-ac27-cb735459a849",
+              "id": "0932768c-4288-4dda-839f-cf1cbd1a6e87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "0054c414-c657-4235-9c29-d36e43b93d0b",
+          "id": "5da8d970-6109-4aa5-8229-7d41d6ea6def",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "13424960-de39-4e6a-955b-8b1bf00f3a68",
+              "id": "1ed5cc65-3eba-4dd6-949f-62deb819ff39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "a8f48d59-cd70-438c-acae-17706b63f8a9",
+          "id": "37ffd5e7-c319-4e65-b577-149f862d3446",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "76197803-62c2-4c06-890b-5b0e1f849238",
+              "id": "a3a5e8ab-04aa-46bb-819f-dfdf4fd41291",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "dd2e8956-35a3-4951-ab77-d1659f3f038b",
+          "id": "1dafeeef-ed3b-4eb1-82de-9aea59c2ccc9",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "8d602bb2-644b-4eef-9c08-229aa10fd7a2",
+              "id": "98d1f38b-6d00-4254-b79f-cab94feedfde",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "bd6a9c85-01cf-413f-aa00-427c136c8fff",
+          "id": "b91f48f7-7ff1-45dc-8afa-b0e6063f5659",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "4ad287ba-a683-44a3-9977-e8d6a821ae72",
+              "id": "dc3c4ec6-96b4-4f05-9c57-2cb51c669e93",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "d933e61e-0ff6-46ee-905f-64288602ca07",
+          "id": "7ba07151-5201-4347-8021-e3520ef6e49b",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "8981e4ab-1f26-4923-8430-1d97c9fafb73",
+              "id": "ec9c9be6-cc73-412e-a2f6-c80936da5795",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "73e141cd-5f0c-43b0-bba2-484ad90999f9",
+          "id": "0a02de1d-9e60-459e-b7cb-99b92dbe173a",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "850359a0-dc14-43c5-8f03-4efc97bee4f7",
+              "id": "fa529b63-ef8b-4a00-b9df-a8bdfe02b0d2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "8d03339c-e24d-439b-b2a1-fe4e8952d931",
+          "id": "9d6629ec-e98e-440d-b454-380bcc349bd4",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "af75e2f4-d7f7-4ae0-9121-ddcd4e284e64",
+              "id": "3b573edd-dad0-4458-9fdd-cf6abf47b686",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "256bda34-68c1-4c2e-8c8a-0d6b46ca670c",
+          "id": "35e1a466-c331-4467-b403-a4c0a8e58e06",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "44b4a539-60e6-4ba4-a054-3cd6542c05f1",
+              "id": "f2dc53dd-a7e0-4c54-b97a-29dacf807088",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "f98e8caf-3cfb-496d-91eb-e773ac54a3e5",
+          "id": "955190aa-09e5-44e8-9a19-013bb867f385",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "7c6474c8-cb2d-4463-830c-5850ed57c87d",
+              "id": "db91b7da-9e21-438d-9998-bb336584e104",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "10c00ac7-7df7-4106-98f1-374963474a45",
+          "id": "dd8d9751-81c0-4b00-812e-27165ad0630e",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "37d963dd-3a9d-489f-b04b-596dcf538886",
+              "id": "44bf21fc-df56-4491-b151-e5e80f9072d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "b2b5153f-8a52-4e63-8ea8-bc415b204883",
+          "id": "13327758-6121-4a78-a7f1-6b0bcebefd1f",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "9a8a1a08-c060-4cc5-8a52-700e85593ed3",
+              "id": "8666ee55-c4cd-4ac8-a105-ce906a7ee115",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "7c9bca1a-b01d-4ef0-94b5-67c76c77287c",
+          "id": "f2257622-ab9e-41c2-942e-42efce030ab9",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "77da0ec2-ee1e-47c1-8d9b-ce4a8b277475",
+              "id": "52c24df6-7076-4992-b00a-7b1b53e24ecf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "498f6375-ee6f-4b4b-8317-cbf6e5039743",
+          "id": "5b9ac1f8-4d28-4e62-af06-fe5a2af163e7",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "e25565cf-6e86-4cff-a1e7-a66a41f3422c",
+              "id": "860b88b5-c46f-4569-aa7a-c4751c4d9c27",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "e5e3708f-4c9a-420d-b29e-71843f740ca4",
+          "id": "94c2177a-5d89-4bcd-8a2f-bff8dc7af4f4",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "706aeaeb-11b9-443a-bdac-39cf1301b978",
+              "id": "aff5e92c-c0dc-426a-bac3-3304add75340",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "161c3714-625f-482b-aeec-47d8e7056c51",
+          "id": "5fd8f364-ef32-48d4-bd50-577ac68e2c59",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "2a660e76-ac9b-4ba4-8b9e-8731204dcac8",
+              "id": "155505e9-11f7-4642-9b8e-1afddcf67348",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "01a94240-f951-4f32-996a-c515fef46142",
+          "id": "3204f9a0-8f94-4616-990b-78a4a7fbea8d",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "8b7e14b6-b19b-4c8e-a655-9e2337023b90",
+              "id": "795af47c-03c3-4802-bce4-ad28742966b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "f112f683-df16-4a1b-a62d-f17d0825a8ef",
+          "id": "526a23a1-9741-4f97-9ddc-dac5180a1f85",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "6dcc9e3e-1cae-4534-a0bf-3bb933c6d077",
+              "id": "bf7f6f18-6474-4239-b862-8c00355fd190",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "ddcf2986-0481-4079-9f3b-79d1be6f6f52",
+          "id": "a8144bd9-f9f5-4c6e-9619-8af72074c72f",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "8edeae5a-43d3-4b6d-94d5-3f755af77be1",
+              "id": "8bc82073-b458-4c38-8d3b-9b4e8b279312",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "45acee1c-a9ee-47e7-ad0b-897256cb820e",
+          "id": "e474bbc1-958f-4a65-a0e7-c36e3136ea3c",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "d200802f-11e1-4913-be14-3ff18fce02d5",
+              "id": "07ef2dd7-0551-45cc-b6e2-f479c781513e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "b50e0503-53c6-4809-80b5-2c8af375097d",
+          "id": "575908ec-39d0-47b6-adc5-c50e3501f928",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "3f274fc9-a310-4e49-897d-45e420ea45b2",
+              "id": "d6de9258-9977-423c-b30b-1e0dc14d9780",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "2968dc45-d016-4f44-b4c2-c6dcce531668",
+          "id": "7e611f61-0027-4922-afd6-abb052864f06",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "78358444-5534-4dc2-a38c-20089e100b75",
+              "id": "9b2518f9-25ac-4441-a1a4-f56f53d74c67",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "9bd45c0c-8ebb-4c16-ab9a-ebc41c9b33ef",
+          "id": "c0f2eb6c-43f1-42cc-afa1-ad61bca4c4b3",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "888c760d-a4b5-440d-abea-241c775992e6",
+              "id": "08ee1651-1197-442b-a22f-7c8c256b075a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "72f6b7e7-1004-49f7-9e77-9a3d09896f2e",
+          "id": "672401c1-4a28-4ab9-8b15-b53119192fc1",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "8fb82e76-b58e-4eec-a233-3cd2024e80dc",
+              "id": "4fb7ba60-8f4d-4ecd-8a94-7c8d393c9229",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "8f706b46-f710-4502-bcce-4c1b0f95b643",
+          "id": "25c8dbda-3013-44ca-bf02-fa535f6b2b6f",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "32651073-e812-448a-a9dd-85168b390fea",
+              "id": "3fa51f54-5ba2-4493-bc27-d0ea195d9aa0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "b9f1ec8f-478b-4562-bb00-b2ea0b15f7b8",
+          "id": "0bc8eedb-c0b4-44ec-839c-ccb44333d45a",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "7c50fbf2-0117-4f27-807d-ef57026c3934",
+              "id": "be899ba2-37d9-4528-af58-465486fd6012",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "e7fcee75-c501-4bcd-a506-ba103d23594e",
+          "id": "ddaad373-5737-4f34-a23b-5bfcc523500f",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "922fd441-f0fa-4fef-9de7-24aa699bae28",
+              "id": "1b8caa8f-3440-405f-b2fb-2b61348bbaf4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "a4738259-d11c-4b7c-82d9-2de764de6948",
+          "id": "09753a6e-9f84-466a-9122-c82ae82e689e",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "5ec06ea6-6c22-4a67-9c41-2e8076ff6e4c",
+              "id": "ca7ed5f0-8974-49cb-98ab-add520b74135",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "4d305893-012c-48a3-9fd0-d0180c145289",
+          "id": "5187e7cb-4dc2-47ee-af20-982043d68e27",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "ecde92fe-d127-4e61-acba-e357cf2f1dfd",
+              "id": "2808cd63-fb4c-4ba2-bcb2-934b37323e09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "a85ff1d8-7eb8-470e-993a-00f74a0112fe",
+          "id": "a410d1d1-1555-413c-99a3-1e0b86f691f0",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "0fe32b27-3f26-47c8-ad1e-970e791bcfea",
+              "id": "268adc39-88e6-41e0-bba8-a610331c5cea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "fe5ba0c7-022b-423c-ae04-be31aea5ab2f",
+          "id": "8a250921-5784-4d39-b8f4-3ee412288a44",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "2e4de499-1ac0-4712-8818-b132297b75cf",
+              "id": "ce3c1e20-9b12-467e-a9ab-021f9c9557c0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "32c884cc-1d89-4b2d-b56f-faab3fee571c",
+          "id": "d33a73bd-8432-4ce5-ba47-cb5534bb7a19",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "dd6e2040-cbd2-4a04-b89e-7ca83ef10b89",
+              "id": "c4576183-e888-44b6-b032-e97645ad8df3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "3f769655-d23c-4515-93c6-329c4e249484",
+          "id": "d8267a63-a96d-446a-9752-837ef206d4f5",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "a994dcf5-4f6f-435d-b83f-045105e65b46",
+              "id": "6986975e-c191-4f68-9ccc-37b44012a087",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "26d45a3b-747a-4a0b-a299-9b353f131ea2",
+          "id": "7c7e4333-68b3-4406-a9a8-7c141793c7a7",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "d59a5123-4774-41b1-8688-a6a71c545d84",
+              "id": "59eb1407-3995-471e-917d-2a4d3c153b26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "ea3af132-42c6-48bf-9586-316ea4985128",
+          "id": "0507af80-7331-4fcb-8de5-2e371e295c1e",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "48e4103d-c7fe-4757-8b14-e8e520bfd95d",
+              "id": "4e962631-8350-4cd4-aa4e-e8f04c0c9f3a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "298dd049-262b-4b9f-af97-ac9b8fa2dcf1",
+          "id": "7efe264c-ed80-4a9c-82ee-8eeff1f35dcc",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "61ea9528-016c-4153-a80b-c635792bab28",
+              "id": "2f5f00c0-9588-4681-87a3-8b1d9843a146",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "1dde10a9-3699-43dc-879e-77b4101a2f02",
+          "id": "d6386d1d-987c-422d-94b8-4f5251ba3560",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "ae92a421-6d64-48a5-b37a-db884871dd50",
+              "id": "c9afbbdd-fbcd-4625-9536-c0a61fdb4dff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "63ffa1c8-f580-4c5d-af06-44c5389d47b4",
+          "id": "1b6e965b-828b-4697-849e-4a5799b7ce62",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "b06bc320-5aa4-4852-9909-28eff02563b7",
+              "id": "0487f695-0f15-47a4-96f1-c7e33f04a34b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "82dd33e4-6178-42c4-b667-b16cc34891dc",
+          "id": "aceaa084-e8d4-4ff5-b7c9-a4c55064219a",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "156cec2d-43d2-4173-9d43-ab9ec805e5c9",
+              "id": "58c2e101-9a50-4c00-b654-516c6bb8905b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "c8cf74f3-eee7-4893-877d-e2899d89d14f",
+          "id": "894f3981-e606-442e-8d0e-20bf5ad9ab5f",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "802a6c95-4bc3-4110-b8c6-dd1716335478",
+              "id": "3a92c5c5-d1f2-40fd-8915-9082caaffb65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "a7f8e302-a935-4b46-8f34-b9b43362c5bf",
+          "id": "09c95e05-92de-4965-99e4-8a0b0bcc1d76",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "97368ed0-ff97-4a28-8472-7d442640021d",
+              "id": "b5bf0aea-f0fe-4453-a8ef-87428142ce6b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "fe9814e2-e9fe-4f86-a55d-b1a00658b6a3",
+              "id": "1e0de2dd-9b66-4a96-bee0-ef7eba1f8a8b",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "143cb71f-ceef-4051-91f4-6941d72cf235",
+          "id": "beaeeb17-3c48-47ec-9da0-62f8b23eafc9",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "47fc8cee-cd81-4fe1-93d0-bd89bdc55373",
+              "id": "a67ab2b3-7218-4414-89b8-363eb38d6105",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1e179aa2-d4e8-4290-8ac2-a9984139cb60",
+              "id": "c4a6e93d-a455-4e7f-960b-afeede3361e1",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1ccb5afc-c434-47ce-a33e-f01a7eccac69",
+              "id": "38fe5c59-7d0d-4313-a9a6-58f0a89c0220",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "cd1a8635-5c14-4bd1-adb3-13bd3ca376d8",
+          "id": "b5cb44ea-c74e-470f-8897-38ed6aafabac",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "2012b187-bc99-4df2-951d-8f60e6822d7c",
+              "id": "7d465f40-5643-4833-aa8a-b7525937e290",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ef92ff6f-b184-4843-8448-8057775b7e3c",
+              "id": "3ea312ca-8d83-4dca-be0c-457e75f8240a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4e4b1e61-a366-4574-8b79-c78e4ee38e2d",
+              "id": "ab4df938-7987-454c-9ead-71f6835ff6fe",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "a681c94f-2e8d-4613-bd81-8ee3c8d8cf98",
+          "id": "cbcffd24-d00a-4d7f-91dc-5ff7792e47ce",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "b450eb64-08e9-4575-a07a-bf52246c469d",
+              "id": "c233d25b-53ab-4d72-b239-641f07050707",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "262081c1-f398-440a-919d-95d28d499608",
+          "id": "6dea3415-760e-45e3-82b2-c94ad4bbafbd",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "ceab3f3f-0770-4df5-afc0-8afcd7516ce3",
+              "id": "df3c8532-1074-4fc7-8f28-2ef31a8b54ea",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "5ae2bc53-39dc-4495-a845-14a9626e1c42",
+              "id": "ef28b9de-9f60-4b6f-9682-78cebc6a29cd",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "c0d812c2-87f9-49d5-bba6-c56cf4654624",
+          "id": "c9db93b2-d66b-412d-a140-63b37c3498f7",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "94d37fec-00fb-4a03-90d2-1358c86b70b6",
+              "id": "2cf7aa84-1f76-4ae5-9ad4-20f8fd193e16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "8d514651-a64c-4d42-9edb-21be133dfaa9",
+          "id": "e251335a-76d8-4639-b669-f2a7c02d03b9",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "d85b55a6-67ef-48b3-a18f-6a375d56143a",
+              "id": "99c0eada-32b0-46f6-a92b-af99fcc17aaf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "7edd8a62-8319-4b01-a245-e0d342233e2e",
+          "id": "bab76795-62a1-4c62-88df-5e24f07c042a",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "814fd53b-9a18-49bf-8ba3-34cf725c61c7",
+              "id": "68c662dd-94a7-4613-b35a-dde6db14c1a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "f8129546-9e0e-46ce-8f47-ae63ecca7452",
+          "id": "b503bed3-f17d-4fdf-8089-ca4fe500bdc4",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2ec0eA\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#4dFd10\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "91f0687c-4cf9-4abb-a7b4-7c67fac4aa30",
+              "id": "f0b9c24f-3071-4c15-a1f6-db9045bc974b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2ec0eA\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#4dFd10\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "159a3a73-5256-406a-b1db-c90d7191cfef",
+          "id": "ff0af29d-bbbe-4019-abf2-766502ab608e",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "a5385562-0400-4d39-a058-508a203afe58",
+              "id": "3b0ed177-bdb1-435c-b72d-8fec75fa875f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "6e0b2348-f153-4feb-adc9-cd0706b47fd0",
+          "id": "e6bf2eeb-fb25-463e-92df-882e6e17a85d",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "b32bfaeb-b5db-4564-94e8-73b49c0b309b",
+              "id": "6e3dd5fb-65c2-4970-bc0e-5cb201fdaf68",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "d7d3c863-8e49-46cb-bfd9-4833e6892898",
+          "id": "6a779ad9-7ffa-467d-9fa2-3d551cdc7597",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#54c282\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9aBcbE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "3535eb70-83ef-4943-a93b-c05311c0a5d3",
+              "id": "8d4ee78b-1799-4e25-b91e-190b8a144fa6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#54c282\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9aBcbE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "91f30e55-2f20-40dd-9b4b-01519fa9574f",
+          "id": "20c5f9f9-a6a5-43ef-89c1-ac620ddee5e2",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "0193c585-2f52-4a72-8f12-8e43184fe801",
+              "id": "e44e7e6e-3903-49ad-96cb-64da6328e6b5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "7074643a-df3c-492b-b1a2-d4c4a08deaaf",
+          "id": "b4a760c8-9384-4016-a055-40600ea1f87b",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "550ddfe0-bbd9-4f96-98a6-dc7be316e4a6",
+              "id": "173c4f5c-9e0b-4b65-8a1a-5016ab14f0bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "8bb415d0-7b4a-4663-9488-244227ee27c7",
+          "id": "c4724a22-4b6d-4daa-a810-b7265c9bb21c",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "e7212186-5d0c-44e3-bedb-7106822bd116",
+              "id": "683268f6-fab8-463a-b59c-0732b8ce918a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "d02c07ca-83c8-40ec-a7e2-0af781d018f3",
+          "id": "43dd3cb4-7b7a-4f62-99ac-6a8ef610b653",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "fa7e6921-7efc-4614-ae27-d9adf4894718",
+              "id": "078e3df8-4c2d-4087-bd7f-ab156ba654d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "f4adcbbe-274f-4838-9c7b-24a991861717",
+          "id": "efbad210-d645-419d-8b96-cdcb3162bf15",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "f85298d2-3048-4ac1-a69e-3efe5174ff72",
+              "id": "14a04728-3dae-49a1-b3d1-b888fa4f913d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "f98d91f6-6a91-4717-8974-6f335c3fa772",
+          "id": "076b90de-ee4b-4ce3-b8f5-b19a8d61f000",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "b6afd0fe-ab3e-4a0d-8d64-4ebdf3b877c6",
+              "id": "fb710661-f6da-4317-94df-8fdcddad6584",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "84a3e113-3884-4433-b8a5-63cbd48aa699",
+          "id": "a1a93b3a-d187-4859-be31-39306efcf0e8",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "ab1faab4-2375-4c73-b18f-f9741ddf0b0c",
+              "id": "c3414864-ab5f-4482-8192-5dc368e1c33d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "c957b581-8ddd-4a20-bea2-ed4190904d6b",
+          "id": "e68dbc95-9a4c-4c80-ab34-d3a0932436ed",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "ef8539c4-5c8f-4dd0-97c8-eac84bb39765",
+              "id": "e8765bed-9690-415c-b124-a55de08139f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "ddb1f819-c463-4ac9-b883-cfa0412f4543",
+          "id": "88e5d7d8-fc62-4e3c-840d-0bdd245dd4b3",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "6e2265d7-1657-4ed6-aba0-dc0d51a184f0",
+              "id": "b8e5bf74-3e1d-494d-a8cf-9fce7b9dcc2c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "5483a4d0-3718-458c-bdb0-8ce66293f72d",
+          "id": "4a5fe0af-55a8-45e7-be63-dda5381213f1",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "f66b7389-d7e9-4589-a2f9-dbae928a575f",
+              "id": "226f4d5d-ea7d-4ef9-98fc-700fc43c5e1b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "d33cb8a6-3ab9-4b02-ad42-c65126c21990",
+          "id": "f16d7086-ca23-417b-a1f6-a0fd16058ef5",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "b6d47b81-dc0d-41a4-8c14-951a2ffeb971",
+              "id": "3eee0e8b-c422-48df-964a-7f8516efddba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "056fe9ba-73e9-4d61-9b63-4eff3031dfa1",
+          "id": "fa27de3c-aee0-48d8-b2dc-be01a1f0b22c",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "de21f22f-1ef6-4f3e-ab5f-2993df3c3c30",
+              "id": "bd8eb121-48dd-4363-9453-df6fdcc8f9b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "af5af880-dade-4fd8-afe0-5f6fe252e789",
+          "id": "8dc307f6-861e-4e13-b914-d85d4efa0744",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "475ae6e9-06e0-4903-b775-8daebf4cb32f",
+              "id": "f7770dae-9df3-429a-b9c8-a487fe2c72bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "7d662f66-16d1-413c-9568-4de26fdfc3bf",
+          "id": "865dee27-7585-4ad7-a9da-09378434b0e2",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "bb2acbf1-a3c9-4a4c-8246-9850359f2b8c",
+              "id": "ed26aef1-1b2c-4606-91c9-cdb4c7769172",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "be0c75a6-7240-4326-9873-3530f71d713b",
+          "id": "4781edb1-926e-42a7-8317-db0e82686766",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "89f05eb9-f084-4a54-a048-e83931ae89ca",
+              "id": "178c02c2-af9d-425d-9754-a1c0eb9eea85",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "de35a167-35bb-4c46-9acc-48df7bae7391",
+          "id": "6e7f87c2-b73e-4da9-a4fc-eb527cc705e6",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "79afb542-eb71-4ae4-9d55-c3590b73e1eb",
+              "id": "a73e18b5-8eac-453c-8586-44c15b8fb33a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "45c8c65e-2d80-476c-89b4-d529c0d33653",
+          "id": "500b1f9f-b0ac-4fab-ac3a-0ca549a48ff9",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "5a650a95-454d-4f35-8060-702b461b4731",
+              "id": "8b19d63d-756e-4b54-9121-e6783eea633b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "a0802426-5f35-4476-b7ae-6909b43ec2ab",
+          "id": "092d620d-6c58-46bd-97c1-8632bb1c545e",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "41b090f8-248d-4301-9cef-52f77e27fd16",
+              "id": "caed833c-fe45-4f8c-bd06-b40c3d67db71",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "1fe47d94-ce38-4dd0-9383-c9929e392fec",
+          "id": "b801653d-fb28-4b5e-9f69-73afe258789d",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "48965461-5a28-422f-98c6-83334664aeaa",
+              "id": "94acc276-50f5-440d-b492-45c779ed260b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "8adb3ee5-46a5-4c6d-a310-37e90f0ab8c0",
+          "id": "6cced245-dd21-4fd6-8a28-115f573c5980",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "737ed5dc-92cf-4f1a-bc16-801b7cc106f9",
+              "id": "9af69ae6-62c6-4cba-8a12-cde01f8ee4bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "12e76c6f-d5cc-471a-9e05-26a5aad4567d",
+          "id": "49894374-2c74-4d44-b9c0-b65ca5013843",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "25cb1d99-9aad-4a75-a227-29102c7a1a7e",
+              "id": "147a5911-b6f9-4a57-9d4b-34f97a8ffe15",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "0cb8a47e-963d-4194-a693-14c1126e4aa0",
+          "id": "469ad9b1-9c43-411a-b99a-c4a8a3da3261",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "34778c4d-cfc9-4207-964b-3f022b6901a2",
+              "id": "9fbba15c-6d25-4fce-aabb-ac5c3740810a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "fc6c5dc0-9de4-47a0-ba47-451e74b8e79d",
+          "id": "84b883ab-716c-4c52-9833-b501cdc040ad",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "c724bfdb-3ccb-42b4-a5c5-bf1ec175fc3a",
+              "id": "34fb4b1c-12fb-41b6-a3fb-fb60d073e5ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "0f6e7402-948c-4f06-90c6-dfb0caf0397c",
+          "id": "480fb9e1-b572-42c0-99a1-cdcdec81a968",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "13e3696c-49ba-432a-af0b-4d44f02383e6",
+              "id": "3b8fd7c8-3f15-476c-8302-b289eae2aaf4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13520,7 +13520,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "51b231f1-4db8-475b-a1ef-45703e80387f",
+          "id": "43d6a74a-c9d2-43e7-b22a-8370e806de1b",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "88aea6c1-642b-43c2-acbc-417fa0d8b0c2",
+              "id": "f6d20614-e015-4981-8e1e-a3ad4da2281e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13630,7 +13630,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "3f297bf9-68d8-449c-8180-befa6b1037a2",
+          "id": "2ac9cd2d-74c5-4e15-ac19-3891faca3b41",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "14aaa10c-c495-4134-98f9-5543813de518",
+              "id": "75538897-5e4f-4d6f-802f-409d97828af5",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "64fc8ff3-1738-4141-905c-449405d13643",
+              "id": "7e06680c-a439-463b-9d15-f1baa4e956be",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "f33854a0-c08b-40be-b772-75403f4b2a70",
+          "id": "4858acd7-3315-4684-9c52-68ac45c80f4c",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "3a88fbb8-1c15-4409-9e4c-5765c71c620a",
+              "id": "58d347be-87b2-46a5-b1d7-e5d0170a0122",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "19aaaeea-0df4-4ada-8a66-09c90935000a",
+              "id": "3772a38a-9c1a-4562-9207-187336bba9b2",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "51506053-0558-4d73-af4a-609f462a11c4",
+          "id": "559047bb-d01b-46af-8550-a6a7af49a18c",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "52fea758-6baa-482f-bf2e-891531d1d958",
+              "id": "d3f9fb5b-4dcf-4a7e-bd44-8d5f91a56d9c",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "54f0ca7e-8276-4169-8c01-dce2aa082171",
+              "id": "a64b2055-8d31-48cb-82cd-aabd3a1d4384",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "dff242de-3ae7-4494-b55e-a6b1deaddf43",
+          "id": "b14ec65f-f41e-4221-a938-de8e74afa033",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "f0c16100-1315-4f49-92ee-46df51a5d767",
+              "id": "13939048-f12a-4593-b03e-e4982dd73f8a",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "71ef6952-f9fc-4171-b233-517c26ef1e2f",
+          "id": "45272090-333e-4673-a455-6cae88516081",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "0212e53d-daa3-4e86-8e6d-42b6ef92cdf1",
+              "id": "9fd7fc21-7049-40a5-bda7-e533fd551d9c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "16b45a1d-510b-4103-b77d-1bfdc8218446",
+          "id": "e8faa0ec-ae91-4647-b4cb-b736dcee07e6",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "1b1fc845-85f5-429a-9a4d-5ae95c19f960",
+              "id": "41384f7c-0190-41ea-becd-56546836ce8a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "dec26d4d-9b59-480e-a771-f7b2265c8167",
+          "id": "367c0ae4-2d25-4bcd-8d37-aef65d7c5b19",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "15bf3be6-799c-4fe1-a053-b113b245fc7e",
+              "id": "fde98f71-5277-4d3e-a27f-13e27a02ca9a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "74c905e2-52bc-4403-adbc-441d91aa8baf",
+          "id": "480004d8-123b-4123-b624-52463baef845",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "5a3792ad-7c94-4a93-9262-f74a52037c51",
+              "id": "cc69b591-013e-4a79-84aa-1cac1eb2996d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "4759923a-21d1-4637-99f1-805d1a594dfd",
+          "id": "08f8a8aa-96f5-4cc3-814a-679866654414",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "188edbb5-fdfe-4e68-8852-4ac86969fd9c",
+              "id": "0b3b85b3-17df-4552-9c50-6bc54d346e0a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "01f92079-6586-4a51-a700-e78ca6a01270",
+          "id": "c825d0e1-7429-4a85-83e5-37fdbbdaf3e2",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "7e2e1843-8332-4631-a757-87e0d0d77798",
+              "id": "29b668af-bab5-4a8f-9c29-d7d918043458",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "44e1fc52-e86e-4b39-b1d9-45391b310f54",
+          "id": "a8a51a0e-b59b-48e2-a91e-14fc22b107f9",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "0f0a3cf1-b083-4a1d-be61-c720dd7f73c1",
+              "id": "e9d62663-a7b2-4162-bc32-99923b1da58c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "0f9baa53-3ae3-4222-ae00-eea3eca61b37",
+          "id": "1e14da20-b1af-4957-a11d-822788241504",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "82594788-6d29-487a-8eea-3115434d10c9",
+              "id": "1a3e4dc7-2f04-49ab-a5b5-c28499d72c6f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "a7833415-86b0-408f-bbce-5dbb8369f488",
+          "id": "98506f2d-6727-4e72-b584-e3822c607634",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "003aa4a4-eb80-46d8-add1-fc721ebb827f",
+              "id": "482e6c9f-0046-4dd7-811a-62bb8d461ab8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "fbf226b1-0978-4cdd-90b9-bffebee046ae",
+          "id": "06866cca-eeaa-4fd4-9a8a-49b64eaf3868",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "33a1e779-61dd-4564-9245-41114d031bea",
+              "id": "8c46ab3b-e627-474d-8f72-1603652d3db4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3248.100130277316,\n  \"key_1\": \"string\",\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "4ae7c978-b1e3-42c9-ac6d-a36f0f3865c8",
+          "id": "749770a2-8e53-4786-b9ec-0949c20d1544",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "cb5425b9-c796-47cf-8c57-a153deaccb58",
+              "id": "81146db8-3e68-475e-bad2-ea4c104b9d6b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "e0257007-0b99-4f11-9a92-122a806b737c",
+          "id": "f38d16ef-44c6-43a1-b7eb-3d5e40d6ba0f",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "ddeb8462-d9d3-4c35-86eb-ee7bfa9e1d74",
+              "id": "b66082e3-9dd7-4a57-a71e-4b836972284e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15533,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "67b117f1-24d7-46a7-89dd-bed035ebcd16",
+          "id": "beca7519-2b09-4a6e-b76e-ee136a98760e",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "dbd87fc7-4ba4-4caa-a8eb-a9dd0f78c241",
+              "id": "eee1bcdf-ab23-4581-8edf-80d5cb91b3a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15615,7 +15615,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "4479dc77-6373-49c4-90d7-b5b2b33fd557",
+    "_postman_id": "525ae823-507f-43e7-958a-08039d1432b8",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 11:56 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 12:03 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -7338,6 +7338,28 @@
           "countReadings"
         ]
       },
+      "BooleanStatsDto": {
+        "type": "object",
+        "properties": {
+          "transitionCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "onPercentage": {
+            "type": "number",
+            "format": "double"
+          },
+          "offPercentage": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "offPercentage",
+          "onPercentage",
+          "transitionCount"
+        ]
+      },
       "ChartDataPoint": {
         "type": "object",
         "properties": {
@@ -7411,6 +7433,25 @@
           },
           "endTime": {
             "type": "string"
+          },
+          "resolution": {
+            "type": "string"
+          },
+          "pointCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isBooleanDevice": {
+            "type": "boolean"
+          },
+          "transitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransitionPoint"
+            }
+          },
+          "booleanStats": {
+            "$ref": "#/components/schemas/BooleanStatsDto"
           }
         },
         "required": [
@@ -7420,13 +7461,31 @@
           "currentValue",
           "currentValueTimestamp",
           "endTime",
+          "isBooleanDevice",
           "maxValue",
           "minValue",
           "period",
+          "pointCount",
+          "resolution",
           "startTime",
           "trendDirection",
           "trendPercent",
           "unit"
+        ]
+      },
+      "TransitionPoint": {
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "string"
+          },
+          "newState": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "newState",
+          "timestamp"
         ]
       },
       "SensorStatisticsDailyDto": {

--- a/src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt
@@ -54,6 +54,10 @@ class MqttConfig(
     @param:Value("\${spring.mqtt.client.automatic-reconnect:true}")
     private val automaticReconnect: Boolean,
 
+    // DO NOT add this property to the topics array in mqttInbound(): the wildcard
+    // GREENHOUSE/+ would match GREENHOUSE/RESPONSE and create an MQTT loop with
+    // the alert echo listener (see AlertStateChangedMqttEchoListener).
+    // MqttSubscriptionGuardTest enforces this at build time.
     @param:Value("\${spring.mqtt.topics.greenhouse-multi-tenant:GREENHOUSE/+}")
     private val greenhouseMultiTenantPattern: String,
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ResolveAlertUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ResolveAlertUseCaseImpl.kt
@@ -2,14 +2,26 @@ package com.apptolast.invernaderos.features.alert.application.usecase
 
 import com.apptolast.invernaderos.features.alert.domain.error.AlertError
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
 import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertRepositoryPort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangePersistencePort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangedEventPublisherPort
 import com.apptolast.invernaderos.features.shared.domain.Either
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import java.time.Instant
 
+/**
+ * Plain Kotlin use case — no Spring annotations. The transactional boundary lives
+ * one layer outwards in [com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertRestInboundAdapter]
+ * so that the alert update, the state-change write and the AFTER_COMMIT echo to MQTT
+ * all participate in the same metadataTransactionManager transaction.
+ */
 class ResolveAlertUseCaseImpl(
-    private val repository: AlertRepositoryPort
+    private val repository: AlertRepositoryPort,
+    private val stateChangePort: AlertStateChangePersistencePort,
+    private val eventPublisher: AlertStateChangedEventPublisherPort
 ) : ResolveAlertUseCase {
 
     override fun resolve(id: Long, tenantId: TenantId, resolvedByUserId: Long?): Either<AlertError, Alert> {
@@ -20,27 +32,59 @@ class ResolveAlertUseCaseImpl(
             return Either.Left(AlertError.AlreadyResolved(id))
         }
 
+        val now = Instant.now()
         val resolved = existing.copy(
             isResolved = true,
-            resolvedAt = Instant.now(),
+            resolvedAt = now,
             resolvedByUserId = resolvedByUserId,
-            updatedAt = Instant.now()
+            updatedAt = now
         )
 
-        return Either.Right(repository.save(resolved))
+        val persisted = repository.save(resolved)
+        val change = AlertStateChange(
+            id = null,
+            alertId = persisted.id ?: throw IllegalStateException("Alert ID cannot be null after save"),
+            fromResolved = false,
+            toResolved = true,
+            source = AlertSignalSource.API,
+            rawValue = null,
+            at = now
+        )
+        val persistedChange = stateChangePort.save(change)
+        eventPublisher.publish(persisted, persistedChange)
+
+        return Either.Right(persisted)
     }
 
     override fun reopen(id: Long, tenantId: TenantId): Either<AlertError, Alert> {
         val existing = repository.findByIdAndTenantId(id, tenantId)
             ?: return Either.Left(AlertError.NotFound(id, tenantId))
 
+        if (!existing.isResolved) {
+            return Either.Left(AlertError.NotResolved(id))
+        }
+
+        val now = Instant.now()
         val reopened = existing.copy(
             isResolved = false,
             resolvedAt = null,
             resolvedByUserId = null,
-            updatedAt = Instant.now()
+            updatedAt = now
         )
 
-        return Either.Right(repository.save(reopened))
+        val persisted = repository.save(reopened)
+        val change = AlertStateChange(
+            id = null,
+            alertId = persisted.id ?: throw IllegalStateException("Alert ID cannot be null after save"),
+            fromResolved = true,
+            toResolved = false,
+            source = AlertSignalSource.API,
+            rawValue = null,
+            at = now
+        )
+        val persistedChange = stateChangePort.save(change)
+        eventPublisher.publish(persisted, persistedChange)
+
+        return Either.Right(persisted)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/error/AlertError.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/error/AlertError.kt
@@ -21,6 +21,11 @@ sealed interface AlertError {
             get() = "Alert $id is already resolved"
     }
 
+    data class NotResolved(val id: Long) : AlertError {
+        override val message: String
+            get() = "Alert $id is already open (not resolved)"
+    }
+
     data class UnknownCode(val code: String) : AlertError {
         override val message: String
             get() = "Alert with code '$code' not found - MQTT signal ignored (strict mode)"

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertEchoPublisherPort.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertEchoPublisherPort.kt
@@ -1,0 +1,16 @@
+package com.apptolast.invernaderos.features.alert.domain.port.output
+
+/**
+ * Output port for echoing alert state transitions to the external transport
+ * (typically MQTT GREENHOUSE/RESPONSE so the Node-RED bridge stays in sync).
+ *
+ * The infrastructure adapter chooses the wire format and the transport, so the
+ * domain remains free of MQTT, JSON or any framework concern.
+ */
+interface AlertEchoPublisherPort {
+    /**
+     * Echo a state transition. The implementation is responsible for serialising
+     * `value` into whatever format the receiver expects (JSON int, boolean, etc.).
+     */
+    fun publish(code: String, value: Int)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
@@ -1,0 +1,33 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.input
+
+import com.apptolast.invernaderos.features.alert.domain.error.AlertError
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
+import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Input adapter: bridges the REST transport layer into the alert domain use case.
+ *
+ * The @Transactional boundary lives here (rather than on the use case or the controller)
+ * so that the plain-Kotlin use case stays framework-free while the three writes —
+ * alert update, state change persistence and AFTER_COMMIT echo to MQTT — share a single
+ * metadata transaction.
+ *
+ * Symmetric to [AlertMqttInboundAdapter].
+ */
+@Component
+class AlertRestInboundAdapter(
+    private val resolveUseCase: ResolveAlertUseCase
+) {
+
+    @Transactional("metadataTransactionManager")
+    fun resolve(id: Long, tenantId: TenantId, resolvedByUserId: Long?): Either<AlertError, Alert> =
+        resolveUseCase.resolve(id, tenantId, resolvedByUserId)
+
+    @Transactional("metadataTransactionManager")
+    fun reopen(id: Long, tenantId: TenantId): Either<AlertError, Alert> =
+        resolveUseCase.reopen(id, tenantId)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
@@ -129,12 +129,12 @@ class TenantAlertController(
     ): ResponseEntity<Any> {
         return restInboundAdapter.resolve(alertId, TenantId(tenantId), request?.resolvedByUserId).fold(
             onLeft = { error ->
+                // resolve() can only emit NotFound, AlreadyResolved or SectorNotOwnedByTenant.
+                // NotResolved is reachable only from reopen() — handled in /reopen below.
                 when (error) {
                     is AlertError.NotFound ->
                         ResponseEntity.notFound().build()
                     is AlertError.AlreadyResolved ->
-                        ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
-                    is AlertError.NotResolved ->
                         ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.SectorNotOwnedByTenant ->
                         ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapOf("error" to error.message))
@@ -156,11 +156,11 @@ class TenantAlertController(
     ): ResponseEntity<Any> {
         return restInboundAdapter.reopen(alertId, TenantId(tenantId)).fold(
             onLeft = { error ->
+                // reopen() can only emit NotFound or NotResolved.
+                // AlreadyResolved is reachable only from resolve() — handled in /resolve above.
                 when (error) {
                     is AlertError.NotFound ->
                         ResponseEntity.notFound().build()
-                    is AlertError.AlreadyResolved ->
-                        ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.NotResolved ->
                         ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.SectorNotOwnedByTenant ->

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
@@ -4,7 +4,6 @@ import com.apptolast.invernaderos.features.alert.domain.error.AlertError
 import com.apptolast.invernaderos.features.alert.domain.port.input.CreateAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.DeleteAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertUseCase
-import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.UpdateAlertUseCase
 import com.apptolast.invernaderos.features.alert.dto.mapper.toCommand
 import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
@@ -34,7 +33,7 @@ class TenantAlertController(
     private val findUseCase: FindAlertUseCase,
     private val updateUseCase: UpdateAlertUseCase,
     private val deleteUseCase: DeleteAlertUseCase,
-    private val resolveUseCase: ResolveAlertUseCase
+    private val restInboundAdapter: AlertRestInboundAdapter
 ) {
 
     @GetMapping
@@ -128,12 +127,14 @@ class TenantAlertController(
         @PathVariable alertId: Long,
         @RequestBody(required = false) request: AlertResolveRequest?
     ): ResponseEntity<Any> {
-        return resolveUseCase.resolve(alertId, TenantId(tenantId), request?.resolvedByUserId).fold(
+        return restInboundAdapter.resolve(alertId, TenantId(tenantId), request?.resolvedByUserId).fold(
             onLeft = { error ->
                 when (error) {
                     is AlertError.NotFound ->
                         ResponseEntity.notFound().build()
                     is AlertError.AlreadyResolved ->
+                        ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
+                    is AlertError.NotResolved ->
                         ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.SectorNotOwnedByTenant ->
                         ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapOf("error" to error.message))
@@ -153,12 +154,14 @@ class TenantAlertController(
         @PathVariable tenantId: Long,
         @PathVariable alertId: Long
     ): ResponseEntity<Any> {
-        return resolveUseCase.reopen(alertId, TenantId(tenantId)).fold(
+        return restInboundAdapter.reopen(alertId, TenantId(tenantId)).fold(
             onLeft = { error ->
                 when (error) {
                     is AlertError.NotFound ->
                         ResponseEntity.notFound().build()
                     is AlertError.AlreadyResolved ->
+                        ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
+                    is AlertError.NotResolved ->
                         ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.SectorNotOwnedByTenant ->
                         ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapOf("error" to error.message))

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertMqttEchoPublisherAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertMqttEchoPublisherAdapter.kt
@@ -1,0 +1,32 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertEchoPublisherPort
+import com.apptolast.invernaderos.mqtt.publisher.MqttPublisher
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * Implements the alert echo by publishing to the same `GREENHOUSE/RESPONSE` topic
+ * (and same numeric format) that `MqttCommandPublisherAdapter` uses for SET-/DEV-
+ * commands, keeping the bridge contract consistent without coupling alert and
+ * command bounded contexts at the domain layer.
+ *
+ * QoS=1 / retained=false matches the rest of the API→hardware traffic — the message
+ * is at-least-once and idempotent (echoing the same value twice is safe).
+ */
+@Component
+class AlertMqttEchoPublisherAdapter(
+    private val mqttPublisher: MqttPublisher,
+    @Value("\${spring.mqtt.topics.response:GREENHOUSE/RESPONSE}")
+    private val mqttResponseTopic: String
+) : AlertEchoPublisherPort {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun publish(code: String, value: Int) {
+        val payload = """{"id":"$code","value":$value}"""
+        mqttPublisher.publish(mqttResponseTopic, payload, qos = 1)
+        logger.debug("Alert echo dispatched topic={} payload={}", mqttResponseTopic, payload)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedMqttEchoListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedMqttEchoListener.kt
@@ -1,0 +1,84 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.infrastructure.config.AlertMqttProperties
+import com.apptolast.invernaderos.features.command.domain.port.output.CommandPublisherPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * Listens for [AlertStateChangedEvent] and echoes the new state to MQTT
+ * (`GREENHOUSE/RESPONSE`) so external subscribers — typically the Node-RED bridge —
+ * stay in sync with the database.
+ *
+ * Phase = AFTER_COMMIT: the echo is published only after the metadata transaction
+ * commits successfully. If the transaction rolls back, no MQTT message is emitted.
+ *
+ * Loop-prevention layers (defense in depth):
+ *  - L1: API does not subscribe to GREENHOUSE/RESPONSE (see MqttConfig.mqttInbound).
+ *  - L2: ApplyAlertMqttSignalUseCaseImpl returns NoTransitionRequired before publishing
+ *        the event when the incoming MQTT signal already matches the alert state.
+ *  - L3: this listener short-circuits when fromResolved == toResolved.
+ *  - L4: any MqttPublisher exception is swallowed and logged — never propagates.
+ *  - L5: kill-switch via alert.mqtt.echo.enabled (default true).
+ */
+@Component
+class AlertStateChangedMqttEchoListener(
+    private val commandPublisher: CommandPublisherPort,
+    private val properties: AlertMqttProperties
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onAlertStateChanged(event: AlertStateChangedEvent) {
+        if (!properties.echo.enabled) {
+            logger.debug("Echo disabled (alert.mqtt.echo.enabled=false), skipping code={}", event.alert.code)
+            return
+        }
+
+        if (event.change.fromResolved == event.change.toResolved) {
+            logger.warn(
+                "Echo received non-transition event for code={} (from={} to={}) — defensive skip",
+                event.alert.code, event.change.fromResolved, event.change.toResolved
+            )
+            return
+        }
+
+        val value = encodeValue(event.alert.isResolved, properties.valueTrueMeans)
+
+        try {
+            commandPublisher.publish(event.alert.code, value.toString())
+            logger.info(
+                "Echo published code={} source={} isResolved={} value={}",
+                event.alert.code, event.change.source, event.alert.isResolved, value
+            )
+        } catch (ex: Exception) {
+            logger.error(
+                "Echo failed for code={} source={} value={} — DB state already committed, MQTT publish lost",
+                event.alert.code, event.change.source, value, ex
+            )
+        }
+    }
+
+    /**
+     * Inverse of [com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertSignalDecisionAdapter]:
+     * given the alert's new resolved state and the configured mapping policy,
+     * encode the numeric value the hardware bridge expects.
+     *
+     * `targetActive = !isResolved`
+     *  - mode ACTIVE   → value=1 means ACTIVE,   value=0 means RESOLVED
+     *  - mode RESOLVED → value=1 means RESOLVED, value=0 means ACTIVE
+     */
+    private fun encodeValue(
+        isResolved: Boolean,
+        mode: AlertMqttProperties.ValueTrueMeans
+    ): Int {
+        val targetActive = !isResolved
+        return when (mode) {
+            AlertMqttProperties.ValueTrueMeans.ACTIVE -> if (targetActive) 1 else 0
+            AlertMqttProperties.ValueTrueMeans.RESOLVED -> if (targetActive) 0 else 1
+        }
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedMqttEchoListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedMqttEchoListener.kt
@@ -1,7 +1,7 @@
 package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
 
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertEchoPublisherPort
 import com.apptolast.invernaderos.features.alert.infrastructure.config.AlertMqttProperties
-import com.apptolast.invernaderos.features.command.domain.port.output.CommandPublisherPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
@@ -15,17 +15,38 @@ import org.springframework.transaction.event.TransactionalEventListener
  * Phase = AFTER_COMMIT: the echo is published only after the metadata transaction
  * commits successfully. If the transaction rolls back, no MQTT message is emitted.
  *
+ * `fallbackExecution` is left at its default (false): if the event is published
+ * outside an active transaction (e.g. from a future batch job that does not open
+ * one), the listener silently drops it. This is intentional — emitting an echo
+ * without a committed DB write would lie to downstream consumers.
+ *
  * Loop-prevention layers (defense in depth):
- *  - L1: API does not subscribe to GREENHOUSE/RESPONSE (see MqttConfig.mqttInbound).
- *  - L2: ApplyAlertMqttSignalUseCaseImpl returns NoTransitionRequired before publishing
- *        the event when the incoming MQTT signal already matches the alert state.
+ *  - L1: API does not subscribe to GREENHOUSE/RESPONSE (see [com.apptolast.invernaderos.config.MqttConfig.mqttInbound]).
+ *  - L2 (echo-loop only): [com.apptolast.invernaderos.features.alert.application.usecase.ApplyAlertMqttSignalUseCaseImpl]
+ *        returns NoTransitionRequired before publishing the event when an incoming
+ *        MQTT signal already matches the alert state. This breaks self-echo loops
+ *        in one round; it does not protect against an unrelated MQTT publisher
+ *        toggling values on RESPONSE.
  *  - L3: this listener short-circuits when fromResolved == toResolved.
- *  - L4: any MqttPublisher exception is swallowed and logged — never propagates.
- *  - L5: kill-switch via alert.mqtt.echo.enabled (default true).
+ *  - L4: any [AlertEchoPublisherPort] exception is swallowed and logged. Spring's
+ *        SimpleApplicationEventMulticaster also absorbs it for AFTER_COMMIT
+ *        listeners; the explicit catch is belt-and-suspenders so future authors do
+ *        not depend implicitly on Spring's error-handling policy.
+ *  - L5: [com.apptolast.invernaderos.mqtt.MqttSubscriptionGuardTest] fails the
+ *        build if anyone adds RESPONSE to MqttConfig.mqttInbound() topics or to a
+ *        non-publish key in application.yaml.
+ *  - L6: runtime kill-switch alert.mqtt.echo.enabled (default true).
+ *
+ * Concurrency note: the alerts table has no @Version. Two simultaneous REST
+ * /resolve on the same alert can both pass the use-case guard, both write
+ * AlertStateChange(API), and trigger two echoes. The DB end state is idempotent
+ * and the receiver is expected to be idempotent too, so we accept the duplicate
+ * over the cost of optimistic locking. Document this here so the next reader
+ * does not add @Version without understanding the trade-off.
  */
 @Component
 class AlertStateChangedMqttEchoListener(
-    private val commandPublisher: CommandPublisherPort,
+    private val echoPublisher: AlertEchoPublisherPort,
     private val properties: AlertMqttProperties
 ) {
 
@@ -49,7 +70,7 @@ class AlertStateChangedMqttEchoListener(
         val value = encodeValue(event.alert.isResolved, properties.valueTrueMeans)
 
         try {
-            commandPublisher.publish(event.alert.code, value.toString())
+            echoPublisher.publish(event.alert.code, value)
             logger.info(
                 "Echo published code={} source={} isResolved={} value={}",
                 event.alert.code, event.change.source, event.alert.isResolved, value

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertModuleConfig.kt
@@ -52,8 +52,10 @@ class AlertModuleConfig {
 
     @Bean
     fun resolveAlertUseCase(
-        repository: AlertRepositoryPort
-    ): ResolveAlertUseCase = ResolveAlertUseCaseImpl(repository)
+        repository: AlertRepositoryPort,
+        stateChangePort: AlertStateChangePersistencePort,
+        eventPublisher: AlertStateChangedEventPublisherPort
+    ): ResolveAlertUseCase = ResolveAlertUseCaseImpl(repository, stateChangePort, eventPublisher)
 
     @Bean
     fun applyAlertMqttSignalUseCase(

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertMqttProperties.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertMqttProperties.kt
@@ -4,7 +4,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "alert.mqtt")
 data class AlertMqttProperties(
-    val valueTrueMeans: ValueTrueMeans = ValueTrueMeans.ACTIVE
+    val valueTrueMeans: ValueTrueMeans = ValueTrueMeans.ACTIVE,
+    val echo: Echo = Echo()
 ) {
     enum class ValueTrueMeans { ACTIVE, RESOLVED }
+
+    /**
+     * Runtime kill-switch for the MQTT echo of alert state changes.
+     * Disable in production (ALERT_MQTT_ECHO_ENABLED=false) to short-circuit
+     * AlertStateChangedMqttEchoListener without redeploying.
+     */
+    data class Echo(val enabled: Boolean = true)
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/domain/usecase/ResolveAlertUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/domain/usecase/ResolveAlertUseCaseTest.kt
@@ -3,12 +3,18 @@ package com.apptolast.invernaderos.features.alert.domain.usecase
 import com.apptolast.invernaderos.features.alert.application.usecase.ResolveAlertUseCaseImpl
 import com.apptolast.invernaderos.features.alert.domain.error.AlertError
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertRepositoryPort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangePersistencePort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangedEventPublisherPort
 import com.apptolast.invernaderos.features.shared.domain.Either
 import com.apptolast.invernaderos.features.shared.domain.model.SectorId
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -17,7 +23,9 @@ import java.time.Instant
 class ResolveAlertUseCaseTest {
 
     private val repository = mockk<AlertRepositoryPort>()
-    private val useCase = ResolveAlertUseCaseImpl(repository)
+    private val stateChangePort = mockk<AlertStateChangePersistencePort>()
+    private val eventPublisher = mockk<AlertStateChangedEventPublisherPort>()
+    private val useCase = ResolveAlertUseCaseImpl(repository, stateChangePort, eventPublisher)
 
     private val unresolvedAlert = Alert(
         id = 1L, code = "ALT-00001", tenantId = TenantId(10L), sectorId = SectorId(20L),
@@ -42,6 +50,8 @@ class ResolveAlertUseCaseTest {
             val a = firstArg<Alert>()
             a.copy(isResolved = true, resolvedAt = Instant.now(), resolvedByUserId = 5L)
         }
+        every { stateChangePort.save(any()) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+        justRun { eventPublisher.publish(any(), any()) }
 
         val result = useCase.resolve(1L, TenantId(10L), 5L)
 
@@ -49,6 +59,27 @@ class ResolveAlertUseCaseTest {
         assertThat((result as Either.Right).value.isResolved).isTrue()
         assertThat(result.value.resolvedByUserId).isEqualTo(5L)
         verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { stateChangePort.save(any()) }
+        verify(exactly = 1) { eventPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should persist state change with source=API and rawValue=null on resolve`() {
+        every { repository.findByIdAndTenantId(1L, TenantId(10L)) } returns unresolvedAlert
+        every { repository.save(any()) } answers {
+            firstArg<Alert>().copy(isResolved = true, resolvedAt = Instant.now(), resolvedByUserId = 5L)
+        }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.resolve(1L, TenantId(10L), 5L)
+
+        assertThat(changeSlot.captured.source).isEqualTo(AlertSignalSource.API)
+        assertThat(changeSlot.captured.rawValue).isNull()
+        assertThat(changeSlot.captured.fromResolved).isFalse()
+        assertThat(changeSlot.captured.toResolved).isTrue()
+        assertThat(changeSlot.captured.alertId).isEqualTo(1L)
     }
 
     @Test
@@ -60,15 +91,18 @@ class ResolveAlertUseCaseTest {
         assertThat(result).isInstanceOf(Either.Left::class.java)
         assertThat((result as Either.Left).value).isInstanceOf(AlertError.AlreadyResolved::class.java)
         verify(exactly = 0) { repository.save(any()) }
+        verify(exactly = 0) { stateChangePort.save(any()) }
+        verify(exactly = 0) { eventPublisher.publish(any(), any()) }
     }
 
     @Test
     fun `should reopen alert when it is resolved`() {
         every { repository.findByIdAndTenantId(1L, TenantId(10L)) } returns resolvedAlert
         every { repository.save(any()) } answers {
-            val a = firstArg<Alert>()
-            a.copy(isResolved = false, resolvedAt = null, resolvedByUserId = null)
+            firstArg<Alert>().copy(isResolved = false, resolvedAt = null, resolvedByUserId = null)
         }
+        every { stateChangePort.save(any()) } answers { firstArg<AlertStateChange>().copy(id = 100L) }
+        justRun { eventPublisher.publish(any(), any()) }
 
         val result = useCase.reopen(1L, TenantId(10L))
 
@@ -76,6 +110,39 @@ class ResolveAlertUseCaseTest {
         assertThat((result as Either.Right).value.isResolved).isFalse()
         assertThat(result.value.resolvedAt).isNull()
         verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { stateChangePort.save(any()) }
+        verify(exactly = 1) { eventPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should persist state change with source=API and rawValue=null on reopen`() {
+        every { repository.findByIdAndTenantId(1L, TenantId(10L)) } returns resolvedAlert
+        every { repository.save(any()) } answers {
+            firstArg<Alert>().copy(isResolved = false, resolvedAt = null, resolvedByUserId = null)
+        }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 100L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.reopen(1L, TenantId(10L))
+
+        assertThat(changeSlot.captured.source).isEqualTo(AlertSignalSource.API)
+        assertThat(changeSlot.captured.rawValue).isNull()
+        assertThat(changeSlot.captured.fromResolved).isTrue()
+        assertThat(changeSlot.captured.toResolved).isFalse()
+    }
+
+    @Test
+    fun `should return NotResolved when alert is already open on reopen`() {
+        every { repository.findByIdAndTenantId(1L, TenantId(10L)) } returns unresolvedAlert
+
+        val result = useCase.reopen(1L, TenantId(10L))
+
+        assertThat(result).isInstanceOf(Either.Left::class.java)
+        assertThat((result as Either.Left).value).isInstanceOf(AlertError.NotResolved::class.java)
+        verify(exactly = 0) { repository.save(any()) }
+        verify(exactly = 0) { stateChangePort.save(any()) }
+        verify(exactly = 0) { eventPublisher.publish(any(), any()) }
     }
 
     @Test
@@ -86,6 +153,8 @@ class ResolveAlertUseCaseTest {
 
         assertThat(result).isInstanceOf(Either.Left::class.java)
         assertThat((result as Either.Left).value).isInstanceOf(AlertError.NotFound::class.java)
+        verify(exactly = 0) { stateChangePort.save(any()) }
+        verify(exactly = 0) { eventPublisher.publish(any(), any()) }
     }
 
     @Test
@@ -96,5 +165,7 @@ class ResolveAlertUseCaseTest {
 
         assertThat(result).isInstanceOf(Either.Left::class.java)
         assertThat((result as Either.Left).value).isInstanceOf(AlertError.NotFound::class.java)
+        verify(exactly = 0) { stateChangePort.save(any()) }
+        verify(exactly = 0) { eventPublisher.publish(any(), any()) }
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertRestInboundAdapterTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertRestInboundAdapterTest.kt
@@ -1,0 +1,76 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.domain.error.AlertError
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertRestInboundAdapter
+import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Unit test verifying that AlertRestInboundAdapter is a thin pass-through
+ * to the underlying ResolveAlertUseCase. The actual @Transactional behavior
+ * is verified end-to-end via @SpringBootTest (out of scope for this unit test).
+ */
+class AlertRestInboundAdapterTest {
+
+    private val resolveUseCase = mockk<ResolveAlertUseCase>()
+    private val adapter = AlertRestInboundAdapter(resolveUseCase)
+
+    private val sampleAlert = Alert(
+        id = 1L, code = "ALT-00001", tenantId = TenantId(10L), sectorId = SectorId(20L),
+        sectorCode = null, alertTypeId = null, alertTypeName = null,
+        severityId = null, severityName = null, severityLevel = null,
+        message = null, description = null, clientName = null,
+        isResolved = true, resolvedAt = Instant.now(), resolvedByUserId = 5L, resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z")
+    )
+
+    @Test
+    fun `resolve delegates to use case with same parameters`() {
+        every { resolveUseCase.resolve(1L, TenantId(10L), 5L) } returns Either.Right(sampleAlert)
+
+        val result = adapter.resolve(1L, TenantId(10L), 5L)
+
+        assertThat(result).isInstanceOf(Either.Right::class.java)
+        verify(exactly = 1) { resolveUseCase.resolve(1L, TenantId(10L), 5L) }
+    }
+
+    @Test
+    fun `resolve propagates Left from use case unchanged`() {
+        every { resolveUseCase.resolve(any(), any(), any()) } returns Either.Left(AlertError.AlreadyResolved(1L))
+
+        val result = adapter.resolve(1L, TenantId(10L), null)
+
+        assertThat(result).isInstanceOf(Either.Left::class.java)
+        assertThat((result as Either.Left).value).isInstanceOf(AlertError.AlreadyResolved::class.java)
+    }
+
+    @Test
+    fun `reopen delegates to use case with same parameters`() {
+        every { resolveUseCase.reopen(1L, TenantId(10L)) } returns Either.Right(sampleAlert.copy(isResolved = false, resolvedAt = null))
+
+        val result = adapter.reopen(1L, TenantId(10L))
+
+        assertThat(result).isInstanceOf(Either.Right::class.java)
+        verify(exactly = 1) { resolveUseCase.reopen(1L, TenantId(10L)) }
+    }
+
+    @Test
+    fun `reopen propagates NotResolved Left unchanged`() {
+        every { resolveUseCase.reopen(any(), any()) } returns Either.Left(AlertError.NotResolved(1L))
+
+        val result = adapter.reopen(1L, TenantId(10L))
+
+        assertThat(result).isInstanceOf(Either.Left::class.java)
+        assertThat((result as Either.Left).value).isInstanceOf(AlertError.NotResolved::class.java)
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertStateChangedMqttEchoListenerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertStateChangedMqttEchoListenerTest.kt
@@ -1,0 +1,257 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedEvent
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedMqttEchoListener
+import com.apptolast.invernaderos.features.alert.infrastructure.config.AlertMqttProperties
+import com.apptolast.invernaderos.features.command.domain.port.output.CommandPublisherPort
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Unit tests for the MQTT echo listener — MockK style, no Spring context.
+ *
+ * Covers:
+ *  - Value mapping for both ValueTrueMeans modes (ACTIVE/RESOLVED) on both transitions.
+ *  - Echo published for every source (API, MQTT, SYSTEM) — Option B.
+ *  - Kill switch (echo.enabled=false) short-circuits.
+ *  - Defensive filter for non-transition events.
+ *  - Exception in commandPublisher is swallowed (never propagates to Spring's
+ *    transaction event multicaster).
+ */
+class AlertStateChangedMqttEchoListenerTest {
+
+    private val commandPublisher = mockk<CommandPublisherPort>()
+
+    private fun listener(
+        valueTrueMeans: AlertMqttProperties.ValueTrueMeans = AlertMqttProperties.ValueTrueMeans.ACTIVE,
+        echoEnabled: Boolean = true
+    ): AlertStateChangedMqttEchoListener {
+        val props = AlertMqttProperties(
+            valueTrueMeans = valueTrueMeans,
+            echo = AlertMqttProperties.Echo(enabled = echoEnabled)
+        )
+        return AlertStateChangedMqttEchoListener(commandPublisher, props)
+    }
+
+    private fun alert(code: String = "ALT-00001", isResolved: Boolean): Alert = Alert(
+        id = 1L,
+        code = code,
+        tenantId = TenantId(10L),
+        sectorId = SectorId(20L),
+        sectorCode = null,
+        alertTypeId = null,
+        alertTypeName = null,
+        severityId = null,
+        severityName = null,
+        severityLevel = null,
+        message = null,
+        description = null,
+        clientName = null,
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.now() else null,
+        resolvedByUserId = null,
+        resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z")
+    )
+
+    private fun change(
+        from: Boolean,
+        to: Boolean,
+        source: AlertSignalSource = AlertSignalSource.API,
+        rawValue: String? = null
+    ): AlertStateChange = AlertStateChange(
+        id = 1L,
+        alertId = 1L,
+        fromResolved = from,
+        toResolved = to,
+        source = source,
+        rawValue = rawValue,
+        at = Instant.now()
+    )
+
+    // ---------------------------------------------------------------------------
+    // Value mapping — ACTIVE mode
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `ACTIVE mode - alert becomes ACTIVE (isResolved=false) publishes value=1`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = false),
+            change = change(from = true, to = false)
+        )
+
+        listener(AlertMqttProperties.ValueTrueMeans.ACTIVE).onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "1") }
+    }
+
+    @Test
+    fun `ACTIVE mode - alert becomes RESOLVED (isResolved=true) publishes value=0`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        listener(AlertMqttProperties.ValueTrueMeans.ACTIVE).onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "0") }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Value mapping — RESOLVED mode (inverse)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `RESOLVED mode - alert becomes ACTIVE (isResolved=false) publishes value=0`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = false),
+            change = change(from = true, to = false)
+        )
+
+        listener(AlertMqttProperties.ValueTrueMeans.RESOLVED).onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "0") }
+    }
+
+    @Test
+    fun `RESOLVED mode - alert becomes RESOLVED (isResolved=true) publishes value=1`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        listener(AlertMqttProperties.ValueTrueMeans.RESOLVED).onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "1") }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Source coverage — Option B: echo always
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `should publish echo for source=API (frontend-driven)`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true, source = AlertSignalSource.API)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should publish echo for source=MQTT (Option B - echo always)`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true, source = AlertSignalSource.MQTT, rawValue = "1")
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should publish echo for source=SYSTEM`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = false),
+            change = change(from = true, to = false, source = AlertSignalSource.SYSTEM)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Defensive layers
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `should NOT publish when echo is disabled (kill switch)`() {
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        listener(echoEnabled = false).onAlertStateChanged(event)
+
+        verify(exactly = 0) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should NOT publish when fromResolved equals toResolved (defensive filter)`() {
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = true, to = true)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 0) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should swallow exceptions from commandPublisher (no propagation)`() {
+        every { commandPublisher.publish(any(), any()) } throws RuntimeException("MQTT broker down")
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        // Should not throw — the listener catches and logs.
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should pass exact alert code (no transformation)`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(code = "ALT-99999", isResolved = false),
+            change = change(from = true, to = false)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-99999", "1") }
+    }
+
+    @Test
+    fun `value is published as integer string (no quotes around the number)`() {
+        // The CommandPublisherPort wraps it as {"id":code,"value":<value>} — the test
+        // pins down that we pass a numeric string, never a boolean string.
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify { commandPublisher.publish("ALT-00001", "0") }
+        verify(exactly = 0) { commandPublisher.publish(any(), "true") }
+        verify(exactly = 0) { commandPublisher.publish(any(), "false") }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertStateChangedMqttEchoListenerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertStateChangedMqttEchoListenerTest.kt
@@ -3,17 +3,16 @@ package com.apptolast.invernaderos.features.alert.infrastructure
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
 import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
 import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertEchoPublisherPort
 import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedEvent
 import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedMqttEchoListener
 import com.apptolast.invernaderos.features.alert.infrastructure.config.AlertMqttProperties
-import com.apptolast.invernaderos.features.command.domain.port.output.CommandPublisherPort
 import com.apptolast.invernaderos.features.shared.domain.model.SectorId
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
@@ -25,12 +24,12 @@ import java.time.Instant
  *  - Echo published for every source (API, MQTT, SYSTEM) — Option B.
  *  - Kill switch (echo.enabled=false) short-circuits.
  *  - Defensive filter for non-transition events.
- *  - Exception in commandPublisher is swallowed (never propagates to Spring's
+ *  - Exception in echoPublisher is swallowed (never propagates to Spring's
  *    transaction event multicaster).
  */
 class AlertStateChangedMqttEchoListenerTest {
 
-    private val commandPublisher = mockk<CommandPublisherPort>()
+    private val echoPublisher = mockk<AlertEchoPublisherPort>()
 
     private fun listener(
         valueTrueMeans: AlertMqttProperties.ValueTrueMeans = AlertMqttProperties.ValueTrueMeans.ACTIVE,
@@ -40,7 +39,7 @@ class AlertStateChangedMqttEchoListenerTest {
             valueTrueMeans = valueTrueMeans,
             echo = AlertMqttProperties.Echo(enabled = echoEnabled)
         )
-        return AlertStateChangedMqttEchoListener(commandPublisher, props)
+        return AlertStateChangedMqttEchoListener(echoPublisher, props)
     }
 
     private fun alert(code: String = "ALT-00001", isResolved: Boolean): Alert = Alert(
@@ -86,7 +85,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
     @Test
     fun `ACTIVE mode - alert becomes ACTIVE (isResolved=false) publishes value=1`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = false),
             change = change(from = true, to = false)
@@ -94,12 +93,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(AlertMqttProperties.ValueTrueMeans.ACTIVE).onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "1") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 1) }
     }
 
     @Test
     fun `ACTIVE mode - alert becomes RESOLVED (isResolved=true) publishes value=0`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true)
@@ -107,7 +106,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(AlertMqttProperties.ValueTrueMeans.ACTIVE).onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "0") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 0) }
     }
 
     // ---------------------------------------------------------------------------
@@ -116,7 +115,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
     @Test
     fun `RESOLVED mode - alert becomes ACTIVE (isResolved=false) publishes value=0`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = false),
             change = change(from = true, to = false)
@@ -124,12 +123,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(AlertMqttProperties.ValueTrueMeans.RESOLVED).onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "0") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 0) }
     }
 
     @Test
     fun `RESOLVED mode - alert becomes RESOLVED (isResolved=true) publishes value=1`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true)
@@ -137,7 +136,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(AlertMqttProperties.ValueTrueMeans.RESOLVED).onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "1") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 1) }
     }
 
     // ---------------------------------------------------------------------------
@@ -146,7 +145,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
     @Test
     fun `should publish echo for source=API (frontend-driven)`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true, source = AlertSignalSource.API)
@@ -154,12 +153,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 1) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
     fun `should publish echo for source=MQTT (Option B - echo always)`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true, source = AlertSignalSource.MQTT, rawValue = "1")
@@ -167,12 +166,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 1) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
     fun `should publish echo for source=SYSTEM`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = false),
             change = change(from = true, to = false, source = AlertSignalSource.SYSTEM)
@@ -180,7 +179,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 1) { echoPublisher.publish(any(), any()) }
     }
 
     // ---------------------------------------------------------------------------
@@ -196,7 +195,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(echoEnabled = false).onAlertStateChanged(event)
 
-        verify(exactly = 0) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 0) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
@@ -208,12 +207,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 0) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 0) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
-    fun `should swallow exceptions from commandPublisher (no propagation)`() {
-        every { commandPublisher.publish(any(), any()) } throws RuntimeException("MQTT broker down")
+    fun `should swallow exceptions from echoPublisher (no propagation)`() {
+        every { echoPublisher.publish(any(), any()) } throws RuntimeException("MQTT broker down")
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true)
@@ -222,12 +221,12 @@ class AlertStateChangedMqttEchoListenerTest {
         // Should not throw — the listener catches and logs.
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 1) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
     fun `should pass exact alert code (no transformation)`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(code = "ALT-99999", isResolved = false),
             change = change(from = true, to = false)
@@ -235,14 +234,14 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-99999", "1") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-99999", 1) }
     }
 
     @Test
-    fun `value is published as integer string (no quotes around the number)`() {
-        // The CommandPublisherPort wraps it as {"id":code,"value":<value>} — the test
-        // pins down that we pass a numeric string, never a boolean string.
-        justRun { commandPublisher.publish(any(), any()) }
+    fun `published value is always Int (port enforces type, not String)`() {
+        // Pinning down that the listener delegates an Int to the port — wire-format
+        // (numeric vs boolean) is the adapter's responsibility, not the listener's.
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true)
@@ -250,8 +249,6 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify { commandPublisher.publish("ALT-00001", "0") }
-        verify(exactly = 0) { commandPublisher.publish(any(), "true") }
-        verify(exactly = 0) { commandPublisher.publish(any(), "false") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 0) }
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
@@ -3,6 +3,9 @@ package com.apptolast.invernaderos.mqtt
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.yaml.snakeyaml.Yaml
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * Architectural guard: prevents future regressions where someone might subscribe
@@ -10,27 +13,33 @@ import org.yaml.snakeyaml.Yaml
  * it also subscribed to it, an MQTT loop becomes possible (Layer 1 of the
  * defense-in-depth strategy described in AlertStateChangedMqttEchoListener).
  *
- * The test parses application.yaml and verifies that the only key holding
- * `GREENHOUSE/RESPONSE` is `spring.mqtt.topics.response` (the publish topic).
- * Any other topic key resolving to that string would mean an inbound subscription
- * to RESPONSE — forbidden.
- *
- * It also verifies the source code of MqttConfig: the topics array passed to the
- * inbound adapter must NOT reference the `response` topic property.
+ * Verifies four invariants:
+ *  1. application.yaml only references GREENHOUSE/RESPONSE under
+ *     `spring.mqtt.topics.response` (the publish-only key).
+ *  2. The `mqttInbound()` topics array literal in MqttConfig.kt does not
+ *     reference the response property name.
+ *  3. The wildcard pattern `greenhouseMultiTenantPattern` (`GREENHOUSE/+`) is
+ *     NOT included in the inbound topics array — including it would match
+ *     `GREENHOUSE/RESPONSE` and defeat L1.
+ *  4. The MqttConfig source file is actually located (no silent pass when the
+ *     path resolution fails).
  */
 class MqttSubscriptionGuardTest {
 
     @Test
     fun `application yaml only references GREENHOUSE_RESPONSE in topics_response key`() {
         val yamlStream = javaClass.classLoader.getResourceAsStream("application.yaml")
-            ?: error("application.yaml not found on classpath")
+            ?: error("application.yaml not found on classpath — guard cannot run")
 
         @Suppress("UNCHECKED_CAST")
         val root = Yaml().load<Map<String, Any?>>(yamlStream)
 
-        val spring = root["spring"] as Map<String, Any?>
-        val mqtt = spring["mqtt"] as Map<String, Any?>
-        val topics = mqtt["topics"] as Map<String, Any?>
+        val spring = root["spring"] as? Map<String, Any?>
+            ?: error("spring section missing in application.yaml")
+        val mqtt = spring["mqtt"] as? Map<String, Any?>
+            ?: error("spring.mqtt section missing in application.yaml")
+        val topics = mqtt["topics"] as? Map<String, Any?>
+            ?: error("spring.mqtt.topics section missing in application.yaml")
 
         topics.forEach { (key, value) ->
             val str = value?.toString().orEmpty()
@@ -38,9 +47,10 @@ class MqttSubscriptionGuardTest {
                 assertThat(str)
                     .withFailMessage(
                         "Topic key 'spring.mqtt.topics.%s' resolves to '%s' which contains 'GREENHOUSE/RESPONSE'. " +
-                            "Only the 'response' key (used by MqttCommandPublisherAdapter to PUBLISH) is allowed " +
-                            "to reference RESPONSE. Subscribing to RESPONSE would create an MQTT loop with the " +
-                            "alert echo listener (see AlertStateChangedMqttEchoListener).",
+                            "Only the 'response' key (used by MqttCommandPublisherAdapter and " +
+                            "AlertMqttEchoPublisherAdapter to PUBLISH) is allowed to reference RESPONSE. " +
+                            "Subscribing to RESPONSE would create an MQTT loop with the alert echo listener " +
+                            "(see AlertStateChangedMqttEchoListener).",
                         key, str
                     )
                     .doesNotContain("GREENHOUSE/RESPONSE")
@@ -50,35 +60,84 @@ class MqttSubscriptionGuardTest {
 
     @Test
     fun `MqttConfig source does not subscribe to RESPONSE topic`() {
-        val source = locateMqttConfigSource()
-            ?: error("MqttConfig.kt not found — adjust the search path in this test if the file moved")
+        val source = readMqttConfigSource()
 
-        // Find the topics array inside mqttInbound()
         val mqttInboundFnIndex = source.indexOf("fun mqttInbound")
-        assertThat(mqttInboundFnIndex).isPositive()
+        assertThat(mqttInboundFnIndex)
+            .withFailMessage("mqttInbound() function not found in MqttConfig.kt — guard test must be updated")
+            .isPositive()
 
-        val arrayStart = source.indexOf("arrayOf(", mqttInboundFnIndex)
-        val arrayEnd = source.indexOf(")", arrayStart)
-        val topicsArray = source.substring(arrayStart, arrayEnd)
+        // Find the topics array literal — handle both single-line and multi-line arrayOf(...) forms.
+        val arrayOfStart = source.indexOf("arrayOf(", mqttInboundFnIndex)
+        assertThat(arrayOfStart)
+            .withFailMessage("arrayOf(...) call not found inside mqttInbound() — guard test must be updated")
+            .isPositive()
 
+        val arrayOfEnd = matchingClose(source, openIndex = arrayOfStart + "arrayOf".length)
+        assertThat(arrayOfEnd).isPositive()
+        val topicsArray = source.substring(arrayOfStart, arrayOfEnd + 1)
+
+        // Forbid both literal RESPONSE strings AND the property name `response` (which would
+        // resolve to it via @Value injection).
         assertThat(topicsArray)
             .withFailMessage(
                 "MqttConfig.mqttInbound() topics array contains a reference to RESPONSE. " +
-                    "The API must NEVER subscribe to GREENHOUSE/RESPONSE — it is the publish topic for " +
-                    "alert/command echoes. See AlertStateChangedMqttEchoListener for the loop-prevention rationale."
+                    "The API must NEVER subscribe to GREENHOUSE/RESPONSE — it is the publish topic " +
+                    "for alert/command echoes. See AlertStateChangedMqttEchoListener."
             )
-            .doesNotContain("response")
+            .doesNotContain("Response")
             .doesNotContain("RESPONSE")
+            .doesNotContain("response")
+
+        // Forbid the multi-tenant wildcard property too — including it would match RESPONSE.
+        assertThat(topicsArray)
+            .withFailMessage(
+                "MqttConfig.mqttInbound() topics array contains 'greenhouseMultiTenantPattern' which is " +
+                    "configured as 'GREENHOUSE/+' and would match GREENHOUSE/RESPONSE. " +
+                    "Including this in the inbound subscription defeats L1 of the loop-prevention defense."
+            )
+            .doesNotContain("greenhouseMultiTenant")
     }
 
-    private fun locateMqttConfigSource(): String? {
-        // Resolve from the test working directory up to the repo root.
-        val candidates = listOf(
-            "src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt",
-            "../src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt"
-        )
-        return candidates.firstNotNullOfOrNull { path ->
-            java.io.File(path).takeIf { it.exists() }?.readText()
+    /**
+     * Reads MqttConfig.kt as text. Resolves relative to the project root (located by
+     * walking upwards from `user.dir` until `build.gradle.kts` is found). Fails the
+     * test loudly if the file cannot be located, never silently passes.
+     */
+    private fun readMqttConfigSource(): String {
+        val relative = "src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt"
+        val projectRoot = locateProjectRoot()
+            ?: error("Could not locate project root (no build.gradle.kts found above ${Paths.get("").toAbsolutePath()})")
+        val file = projectRoot.resolve(relative)
+        check(Files.exists(file)) {
+            "MqttConfig.kt not found at $file — guard test must be updated if file moved"
         }
+        return Files.readString(file)
+    }
+
+    private fun locateProjectRoot(): Path? {
+        var dir: Path? = Paths.get("").toAbsolutePath()
+        while (dir != null) {
+            if (Files.exists(dir.resolve("build.gradle.kts")) || Files.exists(dir.resolve("build.gradle"))) {
+                return dir
+            }
+            dir = dir.parent
+        }
+        return null
+    }
+
+    private fun matchingClose(text: String, openIndex: Int): Int {
+        // openIndex points at '(' position
+        var depth = 0
+        for (i in openIndex until text.length) {
+            when (text[i]) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) return i
+                }
+            }
+        }
+        return -1
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
@@ -1,0 +1,84 @@
+package com.apptolast.invernaderos.mqtt
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.yaml.snakeyaml.Yaml
+
+/**
+ * Architectural guard: prevents future regressions where someone might subscribe
+ * the API to GREENHOUSE/RESPONSE. The API publishes alert echoes to RESPONSE; if
+ * it also subscribed to it, an MQTT loop becomes possible (Layer 1 of the
+ * defense-in-depth strategy described in AlertStateChangedMqttEchoListener).
+ *
+ * The test parses application.yaml and verifies that the only key holding
+ * `GREENHOUSE/RESPONSE` is `spring.mqtt.topics.response` (the publish topic).
+ * Any other topic key resolving to that string would mean an inbound subscription
+ * to RESPONSE — forbidden.
+ *
+ * It also verifies the source code of MqttConfig: the topics array passed to the
+ * inbound adapter must NOT reference the `response` topic property.
+ */
+class MqttSubscriptionGuardTest {
+
+    @Test
+    fun `application yaml only references GREENHOUSE_RESPONSE in topics_response key`() {
+        val yamlStream = javaClass.classLoader.getResourceAsStream("application.yaml")
+            ?: error("application.yaml not found on classpath")
+
+        @Suppress("UNCHECKED_CAST")
+        val root = Yaml().load<Map<String, Any?>>(yamlStream)
+
+        val spring = root["spring"] as Map<String, Any?>
+        val mqtt = spring["mqtt"] as Map<String, Any?>
+        val topics = mqtt["topics"] as Map<String, Any?>
+
+        topics.forEach { (key, value) ->
+            val str = value?.toString().orEmpty()
+            if (key != "response") {
+                assertThat(str)
+                    .withFailMessage(
+                        "Topic key 'spring.mqtt.topics.%s' resolves to '%s' which contains 'GREENHOUSE/RESPONSE'. " +
+                            "Only the 'response' key (used by MqttCommandPublisherAdapter to PUBLISH) is allowed " +
+                            "to reference RESPONSE. Subscribing to RESPONSE would create an MQTT loop with the " +
+                            "alert echo listener (see AlertStateChangedMqttEchoListener).",
+                        key, str
+                    )
+                    .doesNotContain("GREENHOUSE/RESPONSE")
+            }
+        }
+    }
+
+    @Test
+    fun `MqttConfig source does not subscribe to RESPONSE topic`() {
+        val source = locateMqttConfigSource()
+            ?: error("MqttConfig.kt not found — adjust the search path in this test if the file moved")
+
+        // Find the topics array inside mqttInbound()
+        val mqttInboundFnIndex = source.indexOf("fun mqttInbound")
+        assertThat(mqttInboundFnIndex).isPositive()
+
+        val arrayStart = source.indexOf("arrayOf(", mqttInboundFnIndex)
+        val arrayEnd = source.indexOf(")", arrayStart)
+        val topicsArray = source.substring(arrayStart, arrayEnd)
+
+        assertThat(topicsArray)
+            .withFailMessage(
+                "MqttConfig.mqttInbound() topics array contains a reference to RESPONSE. " +
+                    "The API must NEVER subscribe to GREENHOUSE/RESPONSE — it is the publish topic for " +
+                    "alert/command echoes. See AlertStateChangedMqttEchoListener for the loop-prevention rationale."
+            )
+            .doesNotContain("response")
+            .doesNotContain("RESPONSE")
+    }
+
+    private fun locateMqttConfigSource(): String? {
+        // Resolve from the test working directory up to the repo root.
+        val candidates = listOf(
+            "src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt",
+            "../src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt"
+        )
+        return candidates.firstNotNullOfOrNull { path ->
+            java.io.File(path).takeIf { it.exists() }?.readText()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix bug where MQTT messages on `GREENHOUSE/STATUS` with `id` starting with `ALT-` were silently routed to telemetry tables (`iot.sensor_readings_raw`, `iot.device_current_values`) and never updated `metadata.alerts`. Adds the missing path: `MQTT IN (ALT-) → update Alert.is_resolved + record transition in metadata.alert_state_changes + emit Spring event for future WebSocket consumers`.

Validated end-to-end in DEV (greenhouse_metadata_dev / greenhouse_timeseries_dev) with all 4 scenarios:
- RESOLVE: ALT-00010 + value=false → is_resolved=true ✅
- ACTIVATE: ALT-00010 + value=true → is_resolved=false ✅
- UnknownCode: ALT-99999 (unknown) → log WARN + ignored (strict mode) ✅
- NO_OP: signal already in target state → no DB write ✅

## Architecture

Hexagonal: domain layer (pure Kotlin, 9 new files) + application use case + 5 infra adapters. Tx boundary on `AlertMqttInboundAdapter.handleSignal` (atomic alert update + state change write). Strict mode (no auto-create on unknown codes). Mapping `value=true|false` → ACTIVE|RESOLVED is configurable via `alert.mqtt.value-true-means` (default ACTIVE).

## Migration

`V37__create_alert_state_changes.sql` — new history table `metadata.alert_state_changes` with FK to `metadata.alerts(id) ON DELETE CASCADE`, source CHECK constraint, and indexes. Already applied on DEV via Flyway.

## Tests

35 new tests, all passing:
- 11 use case (UnknownCode, InvalidSignalValue, value parsing, NO_OP/ACTIVATE/RESOLVE)
- 19 decision policy truth table (ACTIVE + RESOLVED configs)
- 5+1 wiring + non-regression (telemetry path preserved for ALT- codes)
- ArchUnit: domain stays pure Kotlin

## Test plan
- [x] `./gradlew compileKotlin` green
- [x] `./gradlew build -x test` green
- [x] 36 alert-related tests green (no regressions)
- [x] V37 applied successfully on DEV
- [x] Pod redeploy on DEV: arranque limpio (97s), listener MQTT activo
- [x] E2E validation on DEV: 4 scenarios verified manually with mosquitto_pub
- [ ] V37 applies cleanly on PROD via Flyway workflow
- [ ] Pod redeploy on PROD: arranque limpio
- [ ] Confirm Jesús semántica de value=true|false (config externalizada para cambiar sin recompilar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)