### PR TITLE
feat(alert): MQTT echo of state transitions to GREENHOUSE/RESPONSE (Phase 5)

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt
@@ -54,6 +54,10 @@ class MqttConfig(
     @param:Value("\${spring.mqtt.client.automatic-reconnect:true}")
     private val automaticReconnect: Boolean,
 
+    // DO NOT add this property to the topics array in mqttInbound(): the wildcard
+    // GREENHOUSE/+ would match GREENHOUSE/RESPONSE and create an MQTT loop with
+    // the alert echo listener (see AlertStateChangedMqttEchoListener).
+    // MqttSubscriptionGuardTest enforces this at build time.
     @param:Value("\${spring.mqtt.topics.greenhouse-multi-tenant:GREENHOUSE/+}")
     private val greenhouseMultiTenantPattern: String,
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ResolveAlertUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ResolveAlertUseCaseImpl.kt
@@ -2,14 +2,26 @@ package com.apptolast.invernaderos.features.alert.application.usecase
 
 import com.apptolast.invernaderos.features.alert.domain.error.AlertError
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
 import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertRepositoryPort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangePersistencePort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangedEventPublisherPort
 import com.apptolast.invernaderos.features.shared.domain.Either
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import java.time.Instant
 
+/**
+ * Plain Kotlin use case — no Spring annotations. The transactional boundary lives
+ * one layer outwards in [com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertRestInboundAdapter]
+ * so that the alert update, the state-change write and the AFTER_COMMIT echo to MQTT
+ * all participate in the same metadataTransactionManager transaction.
+ */
 class ResolveAlertUseCaseImpl(
-    private val repository: AlertRepositoryPort
+    private val repository: AlertRepositoryPort,
+    private val stateChangePort: AlertStateChangePersistencePort,
+    private val eventPublisher: AlertStateChangedEventPublisherPort
 ) : ResolveAlertUseCase {
 
     override fun resolve(id: Long, tenantId: TenantId, resolvedByUserId: Long?): Either<AlertError, Alert> {
@@ -20,27 +32,59 @@ class ResolveAlertUseCaseImpl(
             return Either.Left(AlertError.AlreadyResolved(id))
         }
 
+        val now = Instant.now()
         val resolved = existing.copy(
             isResolved = true,
-            resolvedAt = Instant.now(),
+            resolvedAt = now,
             resolvedByUserId = resolvedByUserId,
-            updatedAt = Instant.now()
+            updatedAt = now
         )
 
-        return Either.Right(repository.save(resolved))
+        val persisted = repository.save(resolved)
+        val change = AlertStateChange(
+            id = null,
+            alertId = persisted.id ?: throw IllegalStateException("Alert ID cannot be null after save"),
+            fromResolved = false,
+            toResolved = true,
+            source = AlertSignalSource.API,
+            rawValue = null,
+            at = now
+        )
+        val persistedChange = stateChangePort.save(change)
+        eventPublisher.publish(persisted, persistedChange)
+
+        return Either.Right(persisted)
     }
 
     override fun reopen(id: Long, tenantId: TenantId): Either<AlertError, Alert> {
         val existing = repository.findByIdAndTenantId(id, tenantId)
             ?: return Either.Left(AlertError.NotFound(id, tenantId))
 
+        if (!existing.isResolved) {
+            return Either.Left(AlertError.NotResolved(id))
+        }
+
+        val now = Instant.now()
         val reopened = existing.copy(
             isResolved = false,
             resolvedAt = null,
             resolvedByUserId = null,
-            updatedAt = Instant.now()
+            updatedAt = now
         )
 
-        return Either.Right(repository.save(reopened))
+        val persisted = repository.save(reopened)
+        val change = AlertStateChange(
+            id = null,
+            alertId = persisted.id ?: throw IllegalStateException("Alert ID cannot be null after save"),
+            fromResolved = true,
+            toResolved = false,
+            source = AlertSignalSource.API,
+            rawValue = null,
+            at = now
+        )
+        val persistedChange = stateChangePort.save(change)
+        eventPublisher.publish(persisted, persistedChange)
+
+        return Either.Right(persisted)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/error/AlertError.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/error/AlertError.kt
@@ -21,6 +21,11 @@ sealed interface AlertError {
             get() = "Alert $id is already resolved"
     }
 
+    data class NotResolved(val id: Long) : AlertError {
+        override val message: String
+            get() = "Alert $id is already open (not resolved)"
+    }
+
     data class UnknownCode(val code: String) : AlertError {
         override val message: String
             get() = "Alert with code '$code' not found - MQTT signal ignored (strict mode)"

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertEchoPublisherPort.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertEchoPublisherPort.kt
@@ -1,0 +1,16 @@
+package com.apptolast.invernaderos.features.alert.domain.port.output
+
+/**
+ * Output port for echoing alert state transitions to the external transport
+ * (typically MQTT GREENHOUSE/RESPONSE so the Node-RED bridge stays in sync).
+ *
+ * The infrastructure adapter chooses the wire format and the transport, so the
+ * domain remains free of MQTT, JSON or any framework concern.
+ */
+interface AlertEchoPublisherPort {
+    /**
+     * Echo a state transition. The implementation is responsible for serialising
+     * `value` into whatever format the receiver expects (JSON int, boolean, etc.).
+     */
+    fun publish(code: String, value: Int)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
@@ -1,0 +1,33 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.input
+
+import com.apptolast.invernaderos.features.alert.domain.error.AlertError
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
+import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Input adapter: bridges the REST transport layer into the alert domain use case.
+ *
+ * The @Transactional boundary lives here (rather than on the use case or the controller)
+ * so that the plain-Kotlin use case stays framework-free while the three writes —
+ * alert update, state change persistence and AFTER_COMMIT echo to MQTT — share a single
+ * metadata transaction.
+ *
+ * Symmetric to [AlertMqttInboundAdapter].
+ */
+@Component
+class AlertRestInboundAdapter(
+    private val resolveUseCase: ResolveAlertUseCase
+) {
+
+    @Transactional("metadataTransactionManager")
+    fun resolve(id: Long, tenantId: TenantId, resolvedByUserId: Long?): Either<AlertError, Alert> =
+        resolveUseCase.resolve(id, tenantId, resolvedByUserId)
+
+    @Transactional("metadataTransactionManager")
+    fun reopen(id: Long, tenantId: TenantId): Either<AlertError, Alert> =
+        resolveUseCase.reopen(id, tenantId)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
@@ -129,12 +129,12 @@ class TenantAlertController(
     ): ResponseEntity<Any> {
         return restInboundAdapter.resolve(alertId, TenantId(tenantId), request?.resolvedByUserId).fold(
             onLeft = { error ->
+                // resolve() can only emit NotFound, AlreadyResolved or SectorNotOwnedByTenant.
+                // NotResolved is reachable only from reopen() — handled in /reopen below.
                 when (error) {
                     is AlertError.NotFound ->
                         ResponseEntity.notFound().build()
                     is AlertError.AlreadyResolved ->
-                        ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
-                    is AlertError.NotResolved ->
                         ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.SectorNotOwnedByTenant ->
                         ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapOf("error" to error.message))
@@ -156,11 +156,11 @@ class TenantAlertController(
     ): ResponseEntity<Any> {
         return restInboundAdapter.reopen(alertId, TenantId(tenantId)).fold(
             onLeft = { error ->
+                // reopen() can only emit NotFound or NotResolved.
+                // AlreadyResolved is reachable only from resolve() — handled in /resolve above.
                 when (error) {
                     is AlertError.NotFound ->
                         ResponseEntity.notFound().build()
-                    is AlertError.AlreadyResolved ->
-                        ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.NotResolved ->
                         ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.SectorNotOwnedByTenant ->

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
@@ -4,7 +4,6 @@ import com.apptolast.invernaderos.features.alert.domain.error.AlertError
 import com.apptolast.invernaderos.features.alert.domain.port.input.CreateAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.DeleteAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertUseCase
-import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.UpdateAlertUseCase
 import com.apptolast.invernaderos.features.alert.dto.mapper.toCommand
 import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
@@ -34,7 +33,7 @@ class TenantAlertController(
     private val findUseCase: FindAlertUseCase,
     private val updateUseCase: UpdateAlertUseCase,
     private val deleteUseCase: DeleteAlertUseCase,
-    private val resolveUseCase: ResolveAlertUseCase
+    private val restInboundAdapter: AlertRestInboundAdapter
 ) {
 
     @GetMapping
@@ -128,12 +127,14 @@ class TenantAlertController(
         @PathVariable alertId: Long,
         @RequestBody(required = false) request: AlertResolveRequest?
     ): ResponseEntity<Any> {
-        return resolveUseCase.resolve(alertId, TenantId(tenantId), request?.resolvedByUserId).fold(
+        return restInboundAdapter.resolve(alertId, TenantId(tenantId), request?.resolvedByUserId).fold(
             onLeft = { error ->
                 when (error) {
                     is AlertError.NotFound ->
                         ResponseEntity.notFound().build()
                     is AlertError.AlreadyResolved ->
+                        ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
+                    is AlertError.NotResolved ->
                         ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.SectorNotOwnedByTenant ->
                         ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapOf("error" to error.message))
@@ -153,12 +154,14 @@ class TenantAlertController(
         @PathVariable tenantId: Long,
         @PathVariable alertId: Long
     ): ResponseEntity<Any> {
-        return resolveUseCase.reopen(alertId, TenantId(tenantId)).fold(
+        return restInboundAdapter.reopen(alertId, TenantId(tenantId)).fold(
             onLeft = { error ->
                 when (error) {
                     is AlertError.NotFound ->
                         ResponseEntity.notFound().build()
                     is AlertError.AlreadyResolved ->
+                        ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
+                    is AlertError.NotResolved ->
                         ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to error.message))
                     is AlertError.SectorNotOwnedByTenant ->
                         ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapOf("error" to error.message))

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertMqttEchoPublisherAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertMqttEchoPublisherAdapter.kt
@@ -1,0 +1,32 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertEchoPublisherPort
+import com.apptolast.invernaderos.mqtt.publisher.MqttPublisher
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * Implements the alert echo by publishing to the same `GREENHOUSE/RESPONSE` topic
+ * (and same numeric format) that `MqttCommandPublisherAdapter` uses for SET-/DEV-
+ * commands, keeping the bridge contract consistent without coupling alert and
+ * command bounded contexts at the domain layer.
+ *
+ * QoS=1 / retained=false matches the rest of the API→hardware traffic — the message
+ * is at-least-once and idempotent (echoing the same value twice is safe).
+ */
+@Component
+class AlertMqttEchoPublisherAdapter(
+    private val mqttPublisher: MqttPublisher,
+    @Value("\${spring.mqtt.topics.response:GREENHOUSE/RESPONSE}")
+    private val mqttResponseTopic: String
+) : AlertEchoPublisherPort {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun publish(code: String, value: Int) {
+        val payload = """{"id":"$code","value":$value}"""
+        mqttPublisher.publish(mqttResponseTopic, payload, qos = 1)
+        logger.debug("Alert echo dispatched topic={} payload={}", mqttResponseTopic, payload)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedMqttEchoListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedMqttEchoListener.kt
@@ -1,0 +1,84 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.infrastructure.config.AlertMqttProperties
+import com.apptolast.invernaderos.features.command.domain.port.output.CommandPublisherPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * Listens for [AlertStateChangedEvent] and echoes the new state to MQTT
+ * (`GREENHOUSE/RESPONSE`) so external subscribers — typically the Node-RED bridge —
+ * stay in sync with the database.
+ *
+ * Phase = AFTER_COMMIT: the echo is published only after the metadata transaction
+ * commits successfully. If the transaction rolls back, no MQTT message is emitted.
+ *
+ * Loop-prevention layers (defense in depth):
+ *  - L1: API does not subscribe to GREENHOUSE/RESPONSE (see MqttConfig.mqttInbound).
+ *  - L2: ApplyAlertMqttSignalUseCaseImpl returns NoTransitionRequired before publishing
+ *        the event when the incoming MQTT signal already matches the alert state.
+ *  - L3: this listener short-circuits when fromResolved == toResolved.
+ *  - L4: any MqttPublisher exception is swallowed and logged — never propagates.
+ *  - L5: kill-switch via alert.mqtt.echo.enabled (default true).
+ */
+@Component
+class AlertStateChangedMqttEchoListener(
+    private val commandPublisher: CommandPublisherPort,
+    private val properties: AlertMqttProperties
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onAlertStateChanged(event: AlertStateChangedEvent) {
+        if (!properties.echo.enabled) {
+            logger.debug("Echo disabled (alert.mqtt.echo.enabled=false), skipping code={}", event.alert.code)
+            return
+        }
+
+        if (event.change.fromResolved == event.change.toResolved) {
+            logger.warn(
+                "Echo received non-transition event for code={} (from={} to={}) — defensive skip",
+                event.alert.code, event.change.fromResolved, event.change.toResolved
+            )
+            return
+        }
+
+        val value = encodeValue(event.alert.isResolved, properties.valueTrueMeans)
+
+        try {
+            commandPublisher.publish(event.alert.code, value.toString())
+            logger.info(
+                "Echo published code={} source={} isResolved={} value={}",
+                event.alert.code, event.change.source, event.alert.isResolved, value
+            )
+        } catch (ex: Exception) {
+            logger.error(
+                "Echo failed for code={} source={} value={} — DB state already committed, MQTT publish lost",
+                event.alert.code, event.change.source, value, ex
+            )
+        }
+    }
+
+    /**
+     * Inverse of [com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertSignalDecisionAdapter]:
+     * given the alert's new resolved state and the configured mapping policy,
+     * encode the numeric value the hardware bridge expects.
+     *
+     * `targetActive = !isResolved`
+     *  - mode ACTIVE   → value=1 means ACTIVE,   value=0 means RESOLVED
+     *  - mode RESOLVED → value=1 means RESOLVED, value=0 means ACTIVE
+     */
+    private fun encodeValue(
+        isResolved: Boolean,
+        mode: AlertMqttProperties.ValueTrueMeans
+    ): Int {
+        val targetActive = !isResolved
+        return when (mode) {
+            AlertMqttProperties.ValueTrueMeans.ACTIVE -> if (targetActive) 1 else 0
+            AlertMqttProperties.ValueTrueMeans.RESOLVED -> if (targetActive) 0 else 1
+        }
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedMqttEchoListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedMqttEchoListener.kt
@@ -1,7 +1,7 @@
 package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
 
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertEchoPublisherPort
 import com.apptolast.invernaderos.features.alert.infrastructure.config.AlertMqttProperties
-import com.apptolast.invernaderos.features.command.domain.port.output.CommandPublisherPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
@@ -15,17 +15,38 @@ import org.springframework.transaction.event.TransactionalEventListener
  * Phase = AFTER_COMMIT: the echo is published only after the metadata transaction
  * commits successfully. If the transaction rolls back, no MQTT message is emitted.
  *
+ * `fallbackExecution` is left at its default (false): if the event is published
+ * outside an active transaction (e.g. from a future batch job that does not open
+ * one), the listener silently drops it. This is intentional — emitting an echo
+ * without a committed DB write would lie to downstream consumers.
+ *
  * Loop-prevention layers (defense in depth):
- *  - L1: API does not subscribe to GREENHOUSE/RESPONSE (see MqttConfig.mqttInbound).
- *  - L2: ApplyAlertMqttSignalUseCaseImpl returns NoTransitionRequired before publishing
- *        the event when the incoming MQTT signal already matches the alert state.
+ *  - L1: API does not subscribe to GREENHOUSE/RESPONSE (see [com.apptolast.invernaderos.config.MqttConfig.mqttInbound]).
+ *  - L2 (echo-loop only): [com.apptolast.invernaderos.features.alert.application.usecase.ApplyAlertMqttSignalUseCaseImpl]
+ *        returns NoTransitionRequired before publishing the event when an incoming
+ *        MQTT signal already matches the alert state. This breaks self-echo loops
+ *        in one round; it does not protect against an unrelated MQTT publisher
+ *        toggling values on RESPONSE.
  *  - L3: this listener short-circuits when fromResolved == toResolved.
- *  - L4: any MqttPublisher exception is swallowed and logged — never propagates.
- *  - L5: kill-switch via alert.mqtt.echo.enabled (default true).
+ *  - L4: any [AlertEchoPublisherPort] exception is swallowed and logged. Spring's
+ *        SimpleApplicationEventMulticaster also absorbs it for AFTER_COMMIT
+ *        listeners; the explicit catch is belt-and-suspenders so future authors do
+ *        not depend implicitly on Spring's error-handling policy.
+ *  - L5: [com.apptolast.invernaderos.mqtt.MqttSubscriptionGuardTest] fails the
+ *        build if anyone adds RESPONSE to MqttConfig.mqttInbound() topics or to a
+ *        non-publish key in application.yaml.
+ *  - L6: runtime kill-switch alert.mqtt.echo.enabled (default true).
+ *
+ * Concurrency note: the alerts table has no @Version. Two simultaneous REST
+ * /resolve on the same alert can both pass the use-case guard, both write
+ * AlertStateChange(API), and trigger two echoes. The DB end state is idempotent
+ * and the receiver is expected to be idempotent too, so we accept the duplicate
+ * over the cost of optimistic locking. Document this here so the next reader
+ * does not add @Version without understanding the trade-off.
  */
 @Component
 class AlertStateChangedMqttEchoListener(
-    private val commandPublisher: CommandPublisherPort,
+    private val echoPublisher: AlertEchoPublisherPort,
     private val properties: AlertMqttProperties
 ) {
 
@@ -49,7 +70,7 @@ class AlertStateChangedMqttEchoListener(
         val value = encodeValue(event.alert.isResolved, properties.valueTrueMeans)
 
         try {
-            commandPublisher.publish(event.alert.code, value.toString())
+            echoPublisher.publish(event.alert.code, value)
             logger.info(
                 "Echo published code={} source={} isResolved={} value={}",
                 event.alert.code, event.change.source, event.alert.isResolved, value

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertModuleConfig.kt
@@ -52,8 +52,10 @@ class AlertModuleConfig {
 
     @Bean
     fun resolveAlertUseCase(
-        repository: AlertRepositoryPort
-    ): ResolveAlertUseCase = ResolveAlertUseCaseImpl(repository)
+        repository: AlertRepositoryPort,
+        stateChangePort: AlertStateChangePersistencePort,
+        eventPublisher: AlertStateChangedEventPublisherPort
+    ): ResolveAlertUseCase = ResolveAlertUseCaseImpl(repository, stateChangePort, eventPublisher)
 
     @Bean
     fun applyAlertMqttSignalUseCase(

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertMqttProperties.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertMqttProperties.kt
@@ -4,7 +4,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "alert.mqtt")
 data class AlertMqttProperties(
-    val valueTrueMeans: ValueTrueMeans = ValueTrueMeans.ACTIVE
+    val valueTrueMeans: ValueTrueMeans = ValueTrueMeans.ACTIVE,
+    val echo: Echo = Echo()
 ) {
     enum class ValueTrueMeans { ACTIVE, RESOLVED }
+
+    /**
+     * Runtime kill-switch for the MQTT echo of alert state changes.
+     * Disable in production (ALERT_MQTT_ECHO_ENABLED=false) to short-circuit
+     * AlertStateChangedMqttEchoListener without redeploying.
+     */
+    data class Echo(val enabled: Boolean = true)
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/domain/usecase/ResolveAlertUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/domain/usecase/ResolveAlertUseCaseTest.kt
@@ -3,12 +3,18 @@ package com.apptolast.invernaderos.features.alert.domain.usecase
 import com.apptolast.invernaderos.features.alert.application.usecase.ResolveAlertUseCaseImpl
 import com.apptolast.invernaderos.features.alert.domain.error.AlertError
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertRepositoryPort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangePersistencePort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangedEventPublisherPort
 import com.apptolast.invernaderos.features.shared.domain.Either
 import com.apptolast.invernaderos.features.shared.domain.model.SectorId
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -17,7 +23,9 @@ import java.time.Instant
 class ResolveAlertUseCaseTest {
 
     private val repository = mockk<AlertRepositoryPort>()
-    private val useCase = ResolveAlertUseCaseImpl(repository)
+    private val stateChangePort = mockk<AlertStateChangePersistencePort>()
+    private val eventPublisher = mockk<AlertStateChangedEventPublisherPort>()
+    private val useCase = ResolveAlertUseCaseImpl(repository, stateChangePort, eventPublisher)
 
     private val unresolvedAlert = Alert(
         id = 1L, code = "ALT-00001", tenantId = TenantId(10L), sectorId = SectorId(20L),
@@ -42,6 +50,8 @@ class ResolveAlertUseCaseTest {
             val a = firstArg<Alert>()
             a.copy(isResolved = true, resolvedAt = Instant.now(), resolvedByUserId = 5L)
         }
+        every { stateChangePort.save(any()) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+        justRun { eventPublisher.publish(any(), any()) }
 
         val result = useCase.resolve(1L, TenantId(10L), 5L)
 
@@ -49,6 +59,27 @@ class ResolveAlertUseCaseTest {
         assertThat((result as Either.Right).value.isResolved).isTrue()
         assertThat(result.value.resolvedByUserId).isEqualTo(5L)
         verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { stateChangePort.save(any()) }
+        verify(exactly = 1) { eventPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should persist state change with source=API and rawValue=null on resolve`() {
+        every { repository.findByIdAndTenantId(1L, TenantId(10L)) } returns unresolvedAlert
+        every { repository.save(any()) } answers {
+            firstArg<Alert>().copy(isResolved = true, resolvedAt = Instant.now(), resolvedByUserId = 5L)
+        }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.resolve(1L, TenantId(10L), 5L)
+
+        assertThat(changeSlot.captured.source).isEqualTo(AlertSignalSource.API)
+        assertThat(changeSlot.captured.rawValue).isNull()
+        assertThat(changeSlot.captured.fromResolved).isFalse()
+        assertThat(changeSlot.captured.toResolved).isTrue()
+        assertThat(changeSlot.captured.alertId).isEqualTo(1L)
     }
 
     @Test
@@ -60,15 +91,18 @@ class ResolveAlertUseCaseTest {
         assertThat(result).isInstanceOf(Either.Left::class.java)
         assertThat((result as Either.Left).value).isInstanceOf(AlertError.AlreadyResolved::class.java)
         verify(exactly = 0) { repository.save(any()) }
+        verify(exactly = 0) { stateChangePort.save(any()) }
+        verify(exactly = 0) { eventPublisher.publish(any(), any()) }
     }
 
     @Test
     fun `should reopen alert when it is resolved`() {
         every { repository.findByIdAndTenantId(1L, TenantId(10L)) } returns resolvedAlert
         every { repository.save(any()) } answers {
-            val a = firstArg<Alert>()
-            a.copy(isResolved = false, resolvedAt = null, resolvedByUserId = null)
+            firstArg<Alert>().copy(isResolved = false, resolvedAt = null, resolvedByUserId = null)
         }
+        every { stateChangePort.save(any()) } answers { firstArg<AlertStateChange>().copy(id = 100L) }
+        justRun { eventPublisher.publish(any(), any()) }
 
         val result = useCase.reopen(1L, TenantId(10L))
 
@@ -76,6 +110,39 @@ class ResolveAlertUseCaseTest {
         assertThat((result as Either.Right).value.isResolved).isFalse()
         assertThat(result.value.resolvedAt).isNull()
         verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { stateChangePort.save(any()) }
+        verify(exactly = 1) { eventPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should persist state change with source=API and rawValue=null on reopen`() {
+        every { repository.findByIdAndTenantId(1L, TenantId(10L)) } returns resolvedAlert
+        every { repository.save(any()) } answers {
+            firstArg<Alert>().copy(isResolved = false, resolvedAt = null, resolvedByUserId = null)
+        }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 100L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.reopen(1L, TenantId(10L))
+
+        assertThat(changeSlot.captured.source).isEqualTo(AlertSignalSource.API)
+        assertThat(changeSlot.captured.rawValue).isNull()
+        assertThat(changeSlot.captured.fromResolved).isTrue()
+        assertThat(changeSlot.captured.toResolved).isFalse()
+    }
+
+    @Test
+    fun `should return NotResolved when alert is already open on reopen`() {
+        every { repository.findByIdAndTenantId(1L, TenantId(10L)) } returns unresolvedAlert
+
+        val result = useCase.reopen(1L, TenantId(10L))
+
+        assertThat(result).isInstanceOf(Either.Left::class.java)
+        assertThat((result as Either.Left).value).isInstanceOf(AlertError.NotResolved::class.java)
+        verify(exactly = 0) { repository.save(any()) }
+        verify(exactly = 0) { stateChangePort.save(any()) }
+        verify(exactly = 0) { eventPublisher.publish(any(), any()) }
     }
 
     @Test
@@ -86,6 +153,8 @@ class ResolveAlertUseCaseTest {
 
         assertThat(result).isInstanceOf(Either.Left::class.java)
         assertThat((result as Either.Left).value).isInstanceOf(AlertError.NotFound::class.java)
+        verify(exactly = 0) { stateChangePort.save(any()) }
+        verify(exactly = 0) { eventPublisher.publish(any(), any()) }
     }
 
     @Test
@@ -96,5 +165,7 @@ class ResolveAlertUseCaseTest {
 
         assertThat(result).isInstanceOf(Either.Left::class.java)
         assertThat((result as Either.Left).value).isInstanceOf(AlertError.NotFound::class.java)
+        verify(exactly = 0) { stateChangePort.save(any()) }
+        verify(exactly = 0) { eventPublisher.publish(any(), any()) }
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertRestInboundAdapterTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertRestInboundAdapterTest.kt
@@ -1,0 +1,76 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.domain.error.AlertError
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertRestInboundAdapter
+import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Unit test verifying that AlertRestInboundAdapter is a thin pass-through
+ * to the underlying ResolveAlertUseCase. The actual @Transactional behavior
+ * is verified end-to-end via @SpringBootTest (out of scope for this unit test).
+ */
+class AlertRestInboundAdapterTest {
+
+    private val resolveUseCase = mockk<ResolveAlertUseCase>()
+    private val adapter = AlertRestInboundAdapter(resolveUseCase)
+
+    private val sampleAlert = Alert(
+        id = 1L, code = "ALT-00001", tenantId = TenantId(10L), sectorId = SectorId(20L),
+        sectorCode = null, alertTypeId = null, alertTypeName = null,
+        severityId = null, severityName = null, severityLevel = null,
+        message = null, description = null, clientName = null,
+        isResolved = true, resolvedAt = Instant.now(), resolvedByUserId = 5L, resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z")
+    )
+
+    @Test
+    fun `resolve delegates to use case with same parameters`() {
+        every { resolveUseCase.resolve(1L, TenantId(10L), 5L) } returns Either.Right(sampleAlert)
+
+        val result = adapter.resolve(1L, TenantId(10L), 5L)
+
+        assertThat(result).isInstanceOf(Either.Right::class.java)
+        verify(exactly = 1) { resolveUseCase.resolve(1L, TenantId(10L), 5L) }
+    }
+
+    @Test
+    fun `resolve propagates Left from use case unchanged`() {
+        every { resolveUseCase.resolve(any(), any(), any()) } returns Either.Left(AlertError.AlreadyResolved(1L))
+
+        val result = adapter.resolve(1L, TenantId(10L), null)
+
+        assertThat(result).isInstanceOf(Either.Left::class.java)
+        assertThat((result as Either.Left).value).isInstanceOf(AlertError.AlreadyResolved::class.java)
+    }
+
+    @Test
+    fun `reopen delegates to use case with same parameters`() {
+        every { resolveUseCase.reopen(1L, TenantId(10L)) } returns Either.Right(sampleAlert.copy(isResolved = false, resolvedAt = null))
+
+        val result = adapter.reopen(1L, TenantId(10L))
+
+        assertThat(result).isInstanceOf(Either.Right::class.java)
+        verify(exactly = 1) { resolveUseCase.reopen(1L, TenantId(10L)) }
+    }
+
+    @Test
+    fun `reopen propagates NotResolved Left unchanged`() {
+        every { resolveUseCase.reopen(any(), any()) } returns Either.Left(AlertError.NotResolved(1L))
+
+        val result = adapter.reopen(1L, TenantId(10L))
+
+        assertThat(result).isInstanceOf(Either.Left::class.java)
+        assertThat((result as Either.Left).value).isInstanceOf(AlertError.NotResolved::class.java)
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertStateChangedMqttEchoListenerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertStateChangedMqttEchoListenerTest.kt
@@ -1,0 +1,257 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedEvent
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedMqttEchoListener
+import com.apptolast.invernaderos.features.alert.infrastructure.config.AlertMqttProperties
+import com.apptolast.invernaderos.features.command.domain.port.output.CommandPublisherPort
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Unit tests for the MQTT echo listener — MockK style, no Spring context.
+ *
+ * Covers:
+ *  - Value mapping for both ValueTrueMeans modes (ACTIVE/RESOLVED) on both transitions.
+ *  - Echo published for every source (API, MQTT, SYSTEM) — Option B.
+ *  - Kill switch (echo.enabled=false) short-circuits.
+ *  - Defensive filter for non-transition events.
+ *  - Exception in commandPublisher is swallowed (never propagates to Spring's
+ *    transaction event multicaster).
+ */
+class AlertStateChangedMqttEchoListenerTest {
+
+    private val commandPublisher = mockk<CommandPublisherPort>()
+
+    private fun listener(
+        valueTrueMeans: AlertMqttProperties.ValueTrueMeans = AlertMqttProperties.ValueTrueMeans.ACTIVE,
+        echoEnabled: Boolean = true
+    ): AlertStateChangedMqttEchoListener {
+        val props = AlertMqttProperties(
+            valueTrueMeans = valueTrueMeans,
+            echo = AlertMqttProperties.Echo(enabled = echoEnabled)
+        )
+        return AlertStateChangedMqttEchoListener(commandPublisher, props)
+    }
+
+    private fun alert(code: String = "ALT-00001", isResolved: Boolean): Alert = Alert(
+        id = 1L,
+        code = code,
+        tenantId = TenantId(10L),
+        sectorId = SectorId(20L),
+        sectorCode = null,
+        alertTypeId = null,
+        alertTypeName = null,
+        severityId = null,
+        severityName = null,
+        severityLevel = null,
+        message = null,
+        description = null,
+        clientName = null,
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.now() else null,
+        resolvedByUserId = null,
+        resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z")
+    )
+
+    private fun change(
+        from: Boolean,
+        to: Boolean,
+        source: AlertSignalSource = AlertSignalSource.API,
+        rawValue: String? = null
+    ): AlertStateChange = AlertStateChange(
+        id = 1L,
+        alertId = 1L,
+        fromResolved = from,
+        toResolved = to,
+        source = source,
+        rawValue = rawValue,
+        at = Instant.now()
+    )
+
+    // ---------------------------------------------------------------------------
+    // Value mapping — ACTIVE mode
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `ACTIVE mode - alert becomes ACTIVE (isResolved=false) publishes value=1`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = false),
+            change = change(from = true, to = false)
+        )
+
+        listener(AlertMqttProperties.ValueTrueMeans.ACTIVE).onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "1") }
+    }
+
+    @Test
+    fun `ACTIVE mode - alert becomes RESOLVED (isResolved=true) publishes value=0`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        listener(AlertMqttProperties.ValueTrueMeans.ACTIVE).onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "0") }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Value mapping — RESOLVED mode (inverse)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `RESOLVED mode - alert becomes ACTIVE (isResolved=false) publishes value=0`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = false),
+            change = change(from = true, to = false)
+        )
+
+        listener(AlertMqttProperties.ValueTrueMeans.RESOLVED).onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "0") }
+    }
+
+    @Test
+    fun `RESOLVED mode - alert becomes RESOLVED (isResolved=true) publishes value=1`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        listener(AlertMqttProperties.ValueTrueMeans.RESOLVED).onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "1") }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Source coverage — Option B: echo always
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `should publish echo for source=API (frontend-driven)`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true, source = AlertSignalSource.API)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should publish echo for source=MQTT (Option B - echo always)`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true, source = AlertSignalSource.MQTT, rawValue = "1")
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should publish echo for source=SYSTEM`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = false),
+            change = change(from = true, to = false, source = AlertSignalSource.SYSTEM)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Defensive layers
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `should NOT publish when echo is disabled (kill switch)`() {
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        listener(echoEnabled = false).onAlertStateChanged(event)
+
+        verify(exactly = 0) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should NOT publish when fromResolved equals toResolved (defensive filter)`() {
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = true, to = true)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 0) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should swallow exceptions from commandPublisher (no propagation)`() {
+        every { commandPublisher.publish(any(), any()) } throws RuntimeException("MQTT broker down")
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        // Should not throw — the listener catches and logs.
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+    }
+
+    @Test
+    fun `should pass exact alert code (no transformation)`() {
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(code = "ALT-99999", isResolved = false),
+            change = change(from = true, to = false)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify(exactly = 1) { commandPublisher.publish("ALT-99999", "1") }
+    }
+
+    @Test
+    fun `value is published as integer string (no quotes around the number)`() {
+        // The CommandPublisherPort wraps it as {"id":code,"value":<value>} — the test
+        // pins down that we pass a numeric string, never a boolean string.
+        justRun { commandPublisher.publish(any(), any()) }
+        val event = AlertStateChangedEvent(
+            alert = alert(isResolved = true),
+            change = change(from = false, to = true)
+        )
+
+        listener().onAlertStateChanged(event)
+
+        verify { commandPublisher.publish("ALT-00001", "0") }
+        verify(exactly = 0) { commandPublisher.publish(any(), "true") }
+        verify(exactly = 0) { commandPublisher.publish(any(), "false") }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertStateChangedMqttEchoListenerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertStateChangedMqttEchoListenerTest.kt
@@ -3,17 +3,16 @@ package com.apptolast.invernaderos.features.alert.infrastructure
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
 import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
 import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertEchoPublisherPort
 import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedEvent
 import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedMqttEchoListener
 import com.apptolast.invernaderos.features.alert.infrastructure.config.AlertMqttProperties
-import com.apptolast.invernaderos.features.command.domain.port.output.CommandPublisherPort
 import com.apptolast.invernaderos.features.shared.domain.model.SectorId
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
@@ -25,12 +24,12 @@ import java.time.Instant
  *  - Echo published for every source (API, MQTT, SYSTEM) — Option B.
  *  - Kill switch (echo.enabled=false) short-circuits.
  *  - Defensive filter for non-transition events.
- *  - Exception in commandPublisher is swallowed (never propagates to Spring's
+ *  - Exception in echoPublisher is swallowed (never propagates to Spring's
  *    transaction event multicaster).
  */
 class AlertStateChangedMqttEchoListenerTest {
 
-    private val commandPublisher = mockk<CommandPublisherPort>()
+    private val echoPublisher = mockk<AlertEchoPublisherPort>()
 
     private fun listener(
         valueTrueMeans: AlertMqttProperties.ValueTrueMeans = AlertMqttProperties.ValueTrueMeans.ACTIVE,
@@ -40,7 +39,7 @@ class AlertStateChangedMqttEchoListenerTest {
             valueTrueMeans = valueTrueMeans,
             echo = AlertMqttProperties.Echo(enabled = echoEnabled)
         )
-        return AlertStateChangedMqttEchoListener(commandPublisher, props)
+        return AlertStateChangedMqttEchoListener(echoPublisher, props)
     }
 
     private fun alert(code: String = "ALT-00001", isResolved: Boolean): Alert = Alert(
@@ -86,7 +85,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
     @Test
     fun `ACTIVE mode - alert becomes ACTIVE (isResolved=false) publishes value=1`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = false),
             change = change(from = true, to = false)
@@ -94,12 +93,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(AlertMqttProperties.ValueTrueMeans.ACTIVE).onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "1") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 1) }
     }
 
     @Test
     fun `ACTIVE mode - alert becomes RESOLVED (isResolved=true) publishes value=0`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true)
@@ -107,7 +106,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(AlertMqttProperties.ValueTrueMeans.ACTIVE).onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "0") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 0) }
     }
 
     // ---------------------------------------------------------------------------
@@ -116,7 +115,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
     @Test
     fun `RESOLVED mode - alert becomes ACTIVE (isResolved=false) publishes value=0`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = false),
             change = change(from = true, to = false)
@@ -124,12 +123,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(AlertMqttProperties.ValueTrueMeans.RESOLVED).onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "0") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 0) }
     }
 
     @Test
     fun `RESOLVED mode - alert becomes RESOLVED (isResolved=true) publishes value=1`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true)
@@ -137,7 +136,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(AlertMqttProperties.ValueTrueMeans.RESOLVED).onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-00001", "1") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 1) }
     }
 
     // ---------------------------------------------------------------------------
@@ -146,7 +145,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
     @Test
     fun `should publish echo for source=API (frontend-driven)`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true, source = AlertSignalSource.API)
@@ -154,12 +153,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 1) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
     fun `should publish echo for source=MQTT (Option B - echo always)`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true, source = AlertSignalSource.MQTT, rawValue = "1")
@@ -167,12 +166,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 1) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
     fun `should publish echo for source=SYSTEM`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = false),
             change = change(from = true, to = false, source = AlertSignalSource.SYSTEM)
@@ -180,7 +179,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 1) { echoPublisher.publish(any(), any()) }
     }
 
     // ---------------------------------------------------------------------------
@@ -196,7 +195,7 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener(echoEnabled = false).onAlertStateChanged(event)
 
-        verify(exactly = 0) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 0) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
@@ -208,12 +207,12 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 0) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 0) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
-    fun `should swallow exceptions from commandPublisher (no propagation)`() {
-        every { commandPublisher.publish(any(), any()) } throws RuntimeException("MQTT broker down")
+    fun `should swallow exceptions from echoPublisher (no propagation)`() {
+        every { echoPublisher.publish(any(), any()) } throws RuntimeException("MQTT broker down")
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true)
@@ -222,12 +221,12 @@ class AlertStateChangedMqttEchoListenerTest {
         // Should not throw — the listener catches and logs.
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish(any(), any()) }
+        verify(exactly = 1) { echoPublisher.publish(any(), any()) }
     }
 
     @Test
     fun `should pass exact alert code (no transformation)`() {
-        justRun { commandPublisher.publish(any(), any()) }
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(code = "ALT-99999", isResolved = false),
             change = change(from = true, to = false)
@@ -235,14 +234,14 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify(exactly = 1) { commandPublisher.publish("ALT-99999", "1") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-99999", 1) }
     }
 
     @Test
-    fun `value is published as integer string (no quotes around the number)`() {
-        // The CommandPublisherPort wraps it as {"id":code,"value":<value>} — the test
-        // pins down that we pass a numeric string, never a boolean string.
-        justRun { commandPublisher.publish(any(), any()) }
+    fun `published value is always Int (port enforces type, not String)`() {
+        // Pinning down that the listener delegates an Int to the port — wire-format
+        // (numeric vs boolean) is the adapter's responsibility, not the listener's.
+        justRun { echoPublisher.publish(any(), any()) }
         val event = AlertStateChangedEvent(
             alert = alert(isResolved = true),
             change = change(from = false, to = true)
@@ -250,8 +249,6 @@ class AlertStateChangedMqttEchoListenerTest {
 
         listener().onAlertStateChanged(event)
 
-        verify { commandPublisher.publish("ALT-00001", "0") }
-        verify(exactly = 0) { commandPublisher.publish(any(), "true") }
-        verify(exactly = 0) { commandPublisher.publish(any(), "false") }
+        verify(exactly = 1) { echoPublisher.publish("ALT-00001", 0) }
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
@@ -3,6 +3,9 @@ package com.apptolast.invernaderos.mqtt
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.yaml.snakeyaml.Yaml
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * Architectural guard: prevents future regressions where someone might subscribe
@@ -10,27 +13,33 @@ import org.yaml.snakeyaml.Yaml
  * it also subscribed to it, an MQTT loop becomes possible (Layer 1 of the
  * defense-in-depth strategy described in AlertStateChangedMqttEchoListener).
  *
- * The test parses application.yaml and verifies that the only key holding
- * `GREENHOUSE/RESPONSE` is `spring.mqtt.topics.response` (the publish topic).
- * Any other topic key resolving to that string would mean an inbound subscription
- * to RESPONSE — forbidden.
- *
- * It also verifies the source code of MqttConfig: the topics array passed to the
- * inbound adapter must NOT reference the `response` topic property.
+ * Verifies four invariants:
+ *  1. application.yaml only references GREENHOUSE/RESPONSE under
+ *     `spring.mqtt.topics.response` (the publish-only key).
+ *  2. The `mqttInbound()` topics array literal in MqttConfig.kt does not
+ *     reference the response property name.
+ *  3. The wildcard pattern `greenhouseMultiTenantPattern` (`GREENHOUSE/+`) is
+ *     NOT included in the inbound topics array — including it would match
+ *     `GREENHOUSE/RESPONSE` and defeat L1.
+ *  4. The MqttConfig source file is actually located (no silent pass when the
+ *     path resolution fails).
  */
 class MqttSubscriptionGuardTest {
 
     @Test
     fun `application yaml only references GREENHOUSE_RESPONSE in topics_response key`() {
         val yamlStream = javaClass.classLoader.getResourceAsStream("application.yaml")
-            ?: error("application.yaml not found on classpath")
+            ?: error("application.yaml not found on classpath — guard cannot run")
 
         @Suppress("UNCHECKED_CAST")
         val root = Yaml().load<Map<String, Any?>>(yamlStream)
 
-        val spring = root["spring"] as Map<String, Any?>
-        val mqtt = spring["mqtt"] as Map<String, Any?>
-        val topics = mqtt["topics"] as Map<String, Any?>
+        val spring = root["spring"] as? Map<String, Any?>
+            ?: error("spring section missing in application.yaml")
+        val mqtt = spring["mqtt"] as? Map<String, Any?>
+            ?: error("spring.mqtt section missing in application.yaml")
+        val topics = mqtt["topics"] as? Map<String, Any?>
+            ?: error("spring.mqtt.topics section missing in application.yaml")
 
         topics.forEach { (key, value) ->
             val str = value?.toString().orEmpty()
@@ -38,9 +47,10 @@ class MqttSubscriptionGuardTest {
                 assertThat(str)
                     .withFailMessage(
                         "Topic key 'spring.mqtt.topics.%s' resolves to '%s' which contains 'GREENHOUSE/RESPONSE'. " +
-                            "Only the 'response' key (used by MqttCommandPublisherAdapter to PUBLISH) is allowed " +
-                            "to reference RESPONSE. Subscribing to RESPONSE would create an MQTT loop with the " +
-                            "alert echo listener (see AlertStateChangedMqttEchoListener).",
+                            "Only the 'response' key (used by MqttCommandPublisherAdapter and " +
+                            "AlertMqttEchoPublisherAdapter to PUBLISH) is allowed to reference RESPONSE. " +
+                            "Subscribing to RESPONSE would create an MQTT loop with the alert echo listener " +
+                            "(see AlertStateChangedMqttEchoListener).",
                         key, str
                     )
                     .doesNotContain("GREENHOUSE/RESPONSE")
@@ -50,35 +60,84 @@ class MqttSubscriptionGuardTest {
 
     @Test
     fun `MqttConfig source does not subscribe to RESPONSE topic`() {
-        val source = locateMqttConfigSource()
-            ?: error("MqttConfig.kt not found — adjust the search path in this test if the file moved")
+        val source = readMqttConfigSource()
 
-        // Find the topics array inside mqttInbound()
         val mqttInboundFnIndex = source.indexOf("fun mqttInbound")
-        assertThat(mqttInboundFnIndex).isPositive()
+        assertThat(mqttInboundFnIndex)
+            .withFailMessage("mqttInbound() function not found in MqttConfig.kt — guard test must be updated")
+            .isPositive()
 
-        val arrayStart = source.indexOf("arrayOf(", mqttInboundFnIndex)
-        val arrayEnd = source.indexOf(")", arrayStart)
-        val topicsArray = source.substring(arrayStart, arrayEnd)
+        // Find the topics array literal — handle both single-line and multi-line arrayOf(...) forms.
+        val arrayOfStart = source.indexOf("arrayOf(", mqttInboundFnIndex)
+        assertThat(arrayOfStart)
+            .withFailMessage("arrayOf(...) call not found inside mqttInbound() — guard test must be updated")
+            .isPositive()
 
+        val arrayOfEnd = matchingClose(source, openIndex = arrayOfStart + "arrayOf".length)
+        assertThat(arrayOfEnd).isPositive()
+        val topicsArray = source.substring(arrayOfStart, arrayOfEnd + 1)
+
+        // Forbid both literal RESPONSE strings AND the property name `response` (which would
+        // resolve to it via @Value injection).
         assertThat(topicsArray)
             .withFailMessage(
                 "MqttConfig.mqttInbound() topics array contains a reference to RESPONSE. " +
-                    "The API must NEVER subscribe to GREENHOUSE/RESPONSE — it is the publish topic for " +
-                    "alert/command echoes. See AlertStateChangedMqttEchoListener for the loop-prevention rationale."
+                    "The API must NEVER subscribe to GREENHOUSE/RESPONSE — it is the publish topic " +
+                    "for alert/command echoes. See AlertStateChangedMqttEchoListener."
             )
-            .doesNotContain("response")
+            .doesNotContain("Response")
             .doesNotContain("RESPONSE")
+            .doesNotContain("response")
+
+        // Forbid the multi-tenant wildcard property too — including it would match RESPONSE.
+        assertThat(topicsArray)
+            .withFailMessage(
+                "MqttConfig.mqttInbound() topics array contains 'greenhouseMultiTenantPattern' which is " +
+                    "configured as 'GREENHOUSE/+' and would match GREENHOUSE/RESPONSE. " +
+                    "Including this in the inbound subscription defeats L1 of the loop-prevention defense."
+            )
+            .doesNotContain("greenhouseMultiTenant")
     }
 
-    private fun locateMqttConfigSource(): String? {
-        // Resolve from the test working directory up to the repo root.
-        val candidates = listOf(
-            "src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt",
-            "../src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt"
-        )
-        return candidates.firstNotNullOfOrNull { path ->
-            java.io.File(path).takeIf { it.exists() }?.readText()
+    /**
+     * Reads MqttConfig.kt as text. Resolves relative to the project root (located by
+     * walking upwards from `user.dir` until `build.gradle.kts` is found). Fails the
+     * test loudly if the file cannot be located, never silently passes.
+     */
+    private fun readMqttConfigSource(): String {
+        val relative = "src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt"
+        val projectRoot = locateProjectRoot()
+            ?: error("Could not locate project root (no build.gradle.kts found above ${Paths.get("").toAbsolutePath()})")
+        val file = projectRoot.resolve(relative)
+        check(Files.exists(file)) {
+            "MqttConfig.kt not found at $file — guard test must be updated if file moved"
         }
+        return Files.readString(file)
+    }
+
+    private fun locateProjectRoot(): Path? {
+        var dir: Path? = Paths.get("").toAbsolutePath()
+        while (dir != null) {
+            if (Files.exists(dir.resolve("build.gradle.kts")) || Files.exists(dir.resolve("build.gradle"))) {
+                return dir
+            }
+            dir = dir.parent
+        }
+        return null
+    }
+
+    private fun matchingClose(text: String, openIndex: Int): Int {
+        // openIndex points at '(' position
+        var depth = 0
+        for (i in openIndex until text.length) {
+            when (text[i]) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) return i
+                }
+            }
+        }
+        return -1
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
@@ -1,0 +1,84 @@
+package com.apptolast.invernaderos.mqtt
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.yaml.snakeyaml.Yaml
+
+/**
+ * Architectural guard: prevents future regressions where someone might subscribe
+ * the API to GREENHOUSE/RESPONSE. The API publishes alert echoes to RESPONSE; if
+ * it also subscribed to it, an MQTT loop becomes possible (Layer 1 of the
+ * defense-in-depth strategy described in AlertStateChangedMqttEchoListener).
+ *
+ * The test parses application.yaml and verifies that the only key holding
+ * `GREENHOUSE/RESPONSE` is `spring.mqtt.topics.response` (the publish topic).
+ * Any other topic key resolving to that string would mean an inbound subscription
+ * to RESPONSE — forbidden.
+ *
+ * It also verifies the source code of MqttConfig: the topics array passed to the
+ * inbound adapter must NOT reference the `response` topic property.
+ */
+class MqttSubscriptionGuardTest {
+
+    @Test
+    fun `application yaml only references GREENHOUSE_RESPONSE in topics_response key`() {
+        val yamlStream = javaClass.classLoader.getResourceAsStream("application.yaml")
+            ?: error("application.yaml not found on classpath")
+
+        @Suppress("UNCHECKED_CAST")
+        val root = Yaml().load<Map<String, Any?>>(yamlStream)
+
+        val spring = root["spring"] as Map<String, Any?>
+        val mqtt = spring["mqtt"] as Map<String, Any?>
+        val topics = mqtt["topics"] as Map<String, Any?>
+
+        topics.forEach { (key, value) ->
+            val str = value?.toString().orEmpty()
+            if (key != "response") {
+                assertThat(str)
+                    .withFailMessage(
+                        "Topic key 'spring.mqtt.topics.%s' resolves to '%s' which contains 'GREENHOUSE/RESPONSE'. " +
+                            "Only the 'response' key (used by MqttCommandPublisherAdapter to PUBLISH) is allowed " +
+                            "to reference RESPONSE. Subscribing to RESPONSE would create an MQTT loop with the " +
+                            "alert echo listener (see AlertStateChangedMqttEchoListener).",
+                        key, str
+                    )
+                    .doesNotContain("GREENHOUSE/RESPONSE")
+            }
+        }
+    }
+
+    @Test
+    fun `MqttConfig source does not subscribe to RESPONSE topic`() {
+        val source = locateMqttConfigSource()
+            ?: error("MqttConfig.kt not found — adjust the search path in this test if the file moved")
+
+        // Find the topics array inside mqttInbound()
+        val mqttInboundFnIndex = source.indexOf("fun mqttInbound")
+        assertThat(mqttInboundFnIndex).isPositive()
+
+        val arrayStart = source.indexOf("arrayOf(", mqttInboundFnIndex)
+        val arrayEnd = source.indexOf(")", arrayStart)
+        val topicsArray = source.substring(arrayStart, arrayEnd)
+
+        assertThat(topicsArray)
+            .withFailMessage(
+                "MqttConfig.mqttInbound() topics array contains a reference to RESPONSE. " +
+                    "The API must NEVER subscribe to GREENHOUSE/RESPONSE — it is the publish topic for " +
+                    "alert/command echoes. See AlertStateChangedMqttEchoListener for the loop-prevention rationale."
+            )
+            .doesNotContain("response")
+            .doesNotContain("RESPONSE")
+    }
+
+    private fun locateMqttConfigSource(): String? {
+        // Resolve from the test working directory up to the repo root.
+        val candidates = listOf(
+            "src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt",
+            "../src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt"
+        )
+        return candidates.firstNotNullOfOrNull { path ->
+            java.io.File(path).takeIf { it.exists() }?.readText()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the asymmetry where SET-/DEV- commands published an MQTT echo to `GREENHOUSE/RESPONSE` on every change but ALT- transitions did not. From now on, every alert state change — REST, MQTT or SYSTEM — is echoed to the same topic in the same numeric format (`{"id":"ALT-XXX","value":1|0}`).

This PR is the **Phase 5 implementation**, blocked on PR #100 (sync develop with main).

## How it works

- New domain port `AlertEchoPublisherPort` (alert module owns its echo abstraction).
- New infrastructure adapter `AlertMqttEchoPublisherAdapter` publishes via the shared `MqttPublisher` to `${spring.mqtt.topics.response}` (qos=1, retained=false), exactly matching the format `MqttCommandPublisherAdapter` uses for SET-/DEV-.
- New listener `AlertStateChangedMqttEchoListener` consumes `AlertStateChangedEvent` with `@TransactionalEventListener(AFTER_COMMIT)` — echo never fires before the DB write commits.
- New input adapter `AlertRestInboundAdapter` holds `@Transactional("metadataTransactionManager")`, symmetric to the existing `AlertMqttInboundAdapter`. The use case stays plain Kotlin.
- `ResolveAlertUseCaseImpl` now also persists `AlertStateChange(source=API, rawValue=null)` and publishes the event for symmetry with the MQTT flow.
- Reopening an already-open alert returns new `AlertError.NotResolved` (HTTP 409), avoiding spurious echoes.

## Defense in depth against MQTT loops

| Layer | Mechanism |
|---|---|
| L1 | API does NOT subscribe to `GREENHOUSE/RESPONSE` (`MqttConfig.mqttInbound`) |
| L2 | `ApplyAlertMqttSignalUseCaseImpl` returns `NoTransitionRequired` before publishing the event when an inbound MQTT signal already matches state — breaks self-echo loops in one round |
| L3 | Listener short-circuits `fromResolved == toResolved` |
| L4 | Listener swallows `AlertEchoPublisherPort` exceptions (DB already committed) |
| L5 | New `MqttSubscriptionGuardTest` fails the build if anyone adds `RESPONSE` to `MqttConfig.mqttInbound()` topics or to a non-publish key in `application.yaml`, including the `greenhouseMultiTenantPattern` wildcard |
| L6 | Runtime kill-switch `alert.mqtt.echo.enabled` (default `true`) — flip via ConfigMap edit + restart, no redeploy |

## DB migration

**None required.** `V37__create_alert_state_changes.sql` already accepts `source IN ('MQTT', 'API', 'SYSTEM')`.

## Test plan

- [x] **Unit (MockK)**: 12 listener tests, 8 use case tests, 4 REST adapter tests, 2 subscription guard tests. All green.
- [x] **Regression**: `ApplyAlertMqttSignalUseCaseTest`, `AlertMqttSignalIntegrationTest`, `AlertSignalDecisionAdapterTest`, `ArchitectureTest` — all green.
- [ ] **Manual on DEV after merge**:
  - `POST /api/v1/tenants/{tid}/alerts/{aid}/resolve` → expect `{"id":"ALT-X","value":0}` on `GREENHOUSE/RESPONSE`.
  - `POST .../reopen` → expect `value:1`.
  - Second `POST .../reopen` → expect HTTP 409 (NotResolved).
  - Jesús sends `STATUS` for an active alert → API persists + echoes RESPONSE; second STATUS with same value (idempotency) → **only one echo** because L2 cuts the second pass.

## Rollback plan

| Level | Command | ETA |
|---|---|---|
| R1 (hot) | `kubectl set env deploy/invernaderos-api -n apptolast-invernadero-api-dev ALERT_MQTT_ECHO_ENABLED=false` | <60s |
| R2 (rollout) | `kubectl rollout undo deployment/invernaderos-api -n apptolast-invernadero-api-dev` | ~3min |
| R3 (revert) | Revert this PR | ~10min |

Same applies to `apptolast-invernadero-api-prod` once the change reaches main.

## Code review

Independent code review (`code-reviewer` subagent) raised 2 blockers and 6 warnings on the initial commit `ab49d59`. Both blockers and the relevant warnings were addressed in `a0c7b2e`:
- **Blocker 1 (cross-module coupling)**: replaced the import of `command.CommandPublisherPort` with the new alert-owned `AlertEchoPublisherPort`.
- **Blocker 2 (test fragility)**: hardened `MqttSubscriptionGuardTest` with project-root location and bracket-matching parser; added explicit assertion that `greenhouseMultiTenantPattern` is not in the inbound array.
- Warnings on KDoc, dead branches, fallbackExecution and concurrency trade-offs documented or fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)