### PR TITLE
fix(websocket): normalise BOOLEAN currentValue to true/false (Phase 6)

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "9ffc53cc-05f6-4462-ae84-6dcc81206345",
+          "id": "6e355af5-3b0c-4a4d-8729-3294e14763b2",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "6ba9e6d7-5c5f-4c06-a60f-d430929ed293",
+              "id": "68f2339d-c7e4-4ed8-941d-3ea54f730784",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "b1acc2d0-0d4c-496a-8507-6669175d3f8e",
+          "id": "cca9bbdc-87f3-402e-88b1-5fc782397738",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "ae53497d-fbce-4279-8a7a-25426e6f2e14",
+              "id": "df6715d4-79f6-4885-807a-2865d814885b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "5f53f9ab-6211-4e49-949f-597979069808",
+          "id": "1d3d6d8f-a39e-47b8-b644-34e70c4ae5e7",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "148c3fdc-08d0-4772-89d1-7885fa3f5a0f",
+              "id": "c7cb67e3-f52c-4b59-9bf8-096cde73cd2f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "00bc40d9-b338-4ab0-8d89-f3736415b54c",
+          "id": "784806c5-84c5-4f85-a05f-cf5b2cf7754b",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "1cb6cf8a-47ee-4184-aa2c-6c53e6bd29eb",
+              "id": "b510b265-8057-43da-9296-fd7ce4b221f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "3dfc8167-ab05-4a76-aff9-e50617031adf",
+          "id": "94c14302-e3af-43f2-a015-545d871b2e1f",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "460864ac-34f4-4458-a926-25c574ff9cf1",
+              "id": "db81c7e3-6b3f-4daf-88f2-1385460011b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "00687a49-784e-4743-890f-39cbb3552b86",
+          "id": "725c24da-40cd-4b2d-a347-a3cb62c83040",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "cd807232-fd05-4aef-b27a-1328d55ecf37",
+              "id": "472bfbe6-aa17-4a78-b1bc-6023c1fa15a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "0f273554-fcb7-4ebe-a731-46f3a18cc583",
+          "id": "35a2109a-02e1-45b8-b645-9178ea2bc5f7",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "96858376-cfdc-4193-b7b3-cbde3d85ac9c",
+              "id": "d6102fe4-9a40-449c-9fc7-11a84cd915d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "66e24a14-760f-43ee-8553-e970f5b4481f",
+          "id": "58de1669-c8ed-4970-859f-e2e2d129e69b",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "4a1f4053-b89a-439f-b82e-6262a6ef7157",
+              "id": "5524fcce-3f34-459e-933d-4a209f8b646d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "8f88fa95-2dde-4363-952f-2e0b3e791eea",
+          "id": "9007c23d-0a90-427a-9f5a-cdbe5afab277",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "aeb19060-26b6-438d-8b4e-a21c9771f270",
+              "id": "15e1baec-2fa6-4f76-ae0e-5ea3666ca0aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "72645689-6452-42c5-8d29-d6efe38b11b8",
+          "id": "3cf393b1-62a6-47d4-9ade-b5871c245154",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "a9de3ff5-7cb9-458f-bfdf-d0cf3f402d59",
+              "id": "a0b6bf51-6483-4475-af6a-3b038d54207c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "8ee03ee9-62e7-4884-aef5-f6819762e629",
+          "id": "05ee4356-165f-4639-b79c-8ffd019906f7",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "fd7ecdea-b858-48c6-a0a5-94654d01d0e7",
+              "id": "73d3a23f-7104-49c5-8867-4e65df765889",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "09a7f0d4-4868-49bf-9bed-03fc54b3fe87",
+          "id": "ed9a7ed6-db41-424e-9b44-3afa60a5bebe",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "5d2a00c7-fd70-471d-b1d4-1daf50e3281c",
+              "id": "ff1ccad4-1b8e-4dae-a23e-d4e2d4579aae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "5137239c-9cf5-491e-86fe-274ce89d6013",
+          "id": "454613ed-ea0c-4ccb-9149-6be16c59065b",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "357937a6-45d6-4d81-ba86-34a0f626ccd6",
+              "id": "d74a3987-df71-4a73-9ed7-276f87c8aadb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "f113aa34-5f5d-4c2c-8bb5-4061b04abc0e",
+          "id": "80e394eb-0012-49fb-87a1-c82a8c1dbd37",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "b8ac1be9-9da2-446a-b768-db757c42c7a9",
+              "id": "b89618ad-3414-4dc1-8751-f2be3b6c7eda",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "65a8c8cf-8fb6-4fd8-899a-11446acd82a9",
+          "id": "f7f11bcb-1b9e-4984-b6a5-0b1647ea1f5e",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "de516a4d-131e-4779-bc86-46538ffed51f",
+              "id": "0a45c4a3-2204-4a50-aac7-4ccb6e7d3ddd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "cf3be0a8-e0dc-4f36-a7d2-de242f0d53cf",
+          "id": "a360fe5f-d102-4da9-9a6e-318ad5a84ca5",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "5be301f1-1dbd-4aac-ac0d-e740e1e1a2a8",
+              "id": "c83497cb-0f0f-4d22-9ad8-76f8c4526b04",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "3e753bfb-d98b-40ab-9821-0fb53c7ea168",
+          "id": "235abce6-dfa7-4738-8b5d-be1e5c761bc9",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "80fb89cb-7d94-48be-8219-a43d21735eaa",
+              "id": "52accdaa-2b77-461d-976b-bca8cad1adac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "ffa0e698-bcc4-4423-95f4-d4ed4c5203b7",
+          "id": "75906c19-0ebf-47b1-9729-92b550ce52d2",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "d655741d-d6de-4e87-a67f-71505f040169",
+              "id": "c18c8c7e-8c68-4d8e-98a3-f3d3916ee36e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "70873e78-cd96-4605-927b-392e8ca1a5e2",
+          "id": "4551bf44-c65b-4ae4-99d8-37083de72033",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "b33e1279-1a37-4de9-aa60-cc26876b84f8",
+              "id": "c2ddac71-2c43-4f2f-bba7-30f9da640295",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "14d233e8-8991-43e4-bf7c-40f25ae0fd1d",
+          "id": "25e6e9d9-c5d6-4e01-8b47-9a7958993d10",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "043b1895-16e1-4e5f-9705-aa371bbc7b6a",
+              "id": "809b0ab7-14f7-4040-8e47-19ea29b4fdfc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "3a304d9d-fffc-4537-b4b6-8f2d5a9d51a4",
+          "id": "31bfae14-ac26-4a95-916e-bf5b0cb8fddb",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "7af93a98-83e4-4469-aed6-8af1fedb949f",
+              "id": "a150fd12-353d-4da9-9132-4f620ebcfd84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "173632c9-1116-4007-8cdf-d5800f3a48c4",
+          "id": "038a06d9-bc9f-465a-9c4d-dd4cd43a2d7b",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "665ad270-0840-4b05-89a8-8f3a5788d9d8",
+              "id": "fbb62e92-d299-4fde-8904-179abfbdbd7a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "3ba8641c-18fd-4d61-9945-a027f6b5896d",
+          "id": "a69e10f1-2094-4920-a929-08027c89fa90",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "c1eecc9f-accf-4bc7-b105-a2a8816df1e5",
+              "id": "b6472eaa-847e-4c16-a9d1-2fdb00280954",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "dffc4cd9-09c1-46da-9181-891adf72147b",
+          "id": "f8108df3-16fc-455a-88a9-e064bc3ea232",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cA38e5\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9A64aE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "5be85e2a-3c9e-43df-ae42-2a14379464d6",
+              "id": "9f006f6e-dfd4-4203-89f7-4540be7c46e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cA38e5\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9A64aE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "0c7d0a03-fa6b-4b42-95b2-59b48024b445",
+          "id": "c51a81aa-92ea-4c5a-9e42-635be1859073",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "7635b382-a8b5-449c-96e0-37b8183ff935",
+              "id": "4bee4aec-4fe7-49c3-bc62-40298e7a565b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "6918c58e-001f-4cb1-96c1-e2caffe8d452",
+          "id": "3aebaded-849e-4803-b123-a0a7728726be",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "563f8efa-7001-4724-91aa-c5bd42a9769d",
+              "id": "650c21f7-9859-4cba-97b2-a6ceeecc8486",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "f21ba150-5df1-4622-aa5c-8344e846d4e3",
+          "id": "f1a38f54-959f-40f6-9ecd-7d376d674366",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#48A54b\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aD40E9\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "0603f4a6-090d-4c35-9bbe-b0aaf1178035",
+              "id": "a3a25c1b-cfb8-4d76-8495-6a1b4e511043",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#48A54b\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aD40E9\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "cce6fdf5-07cb-4645-a48c-b5cf4236805f",
+          "id": "65d95d5c-3712-456f-ab9d-63d8120b4b7a",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "03aacefc-bd19-45e4-8741-e9ca8d12bd21",
+              "id": "be56a362-ce4d-401b-8f22-a3d76e473de4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "4e099167-7893-4907-a8f4-08d108d25343",
+          "id": "74a3ae24-e929-4e56-8bb3-98127ba4aa31",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "efa9fc79-fe89-4dea-923b-c350b097f3aa",
+              "id": "7dfa519c-a15c-45d6-9213-ba8f98d950ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "e23cf3d1-3658-4100-b763-77d008922960",
+          "id": "5dd1987c-cbea-4829-8c23-d7b6c96e7222",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "f059052d-8470-4795-a57f-801086b69faf",
+              "id": "537d93f7-6d88-40c1-89b3-74636b977c6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "fec27c38-df78-4fc8-8530-02f88b97f199",
+          "id": "0c656ff0-2384-47c0-b969-9706b1ca9899",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "4562655a-c583-4aa2-a95f-8b6ef3e10ce6",
+              "id": "1101d873-bddf-4a1c-abe7-2da247f6715e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "6bde6e07-5936-465c-8744-c8c878343b60",
+          "id": "8b4f1c76-7c8c-4d52-b90a-08a5f0b101cd",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "2d469427-63fd-468f-8e87-0d747115d194",
+              "id": "03a6d6df-8be9-4ae4-8faf-ea1b6c2bcc7d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "ba1989b8-5777-4a43-865b-5a975912870a",
+          "id": "db8270b2-d2a4-46cf-a063-74b9313f802b",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "a4b4e360-b850-4ff5-b308-edf3ecf4d9ce",
+              "id": "3a16f8ab-89ab-4c31-9de5-0aef2b521cea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "f553313a-38ab-49b7-b7f3-8abcf657e31e",
+          "id": "4757c8df-8202-4025-af89-c479518603e4",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "0c30e617-58a1-4788-ac95-7da3f9e01d62",
+              "id": "b993d380-8d18-4cf2-82fe-58ef1644a321",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "b25def73-b91b-40ee-9329-e8c3bf6cfc86",
+          "id": "c36ed0e0-0c5c-4abc-8b42-1005eee4a79f",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "415e3742-f7fb-4ec5-9706-5ce8b0965dab",
+              "id": "f7574674-e961-4a99-817e-543aea51db97",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "c5f41166-034b-450f-8266-a09f075d2088",
+          "id": "61a040a5-2d1b-46f7-a84c-b007b752a3b9",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "606759c9-bb01-48fa-bdc3-12f899a5984a",
+              "id": "bf941edf-00e8-48ad-956c-1d80aae227fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "a7a546e3-aa17-49a4-8ef0-287669c8066d",
+          "id": "eb536d97-92e7-4dd6-a928-81dd60724196",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "7d27c708-d0a4-4509-b2bc-cf5bf2e4aab2",
+              "id": "ab6dfbad-ede5-45bb-b067-1a15ea7f3561",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "d5a79ed2-6d48-4320-937e-fff435b122c3",
+          "id": "4fd6efeb-e355-4fe2-9170-df30c2c945d9",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "0932768c-4288-4dda-839f-cf1cbd1a6e87",
+              "id": "898f9512-87c5-4774-a7ec-56d13bcf6cfd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "5da8d970-6109-4aa5-8229-7d41d6ea6def",
+          "id": "2bbd8ffa-1358-44ea-944f-ecdd25f477fc",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "1ed5cc65-3eba-4dd6-949f-62deb819ff39",
+              "id": "a0d0aad2-758c-4924-b288-1d5955d2328a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "37ffd5e7-c319-4e65-b577-149f862d3446",
+          "id": "d96bc45c-8402-4d84-876c-b49e20dacd8e",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "a3a5e8ab-04aa-46bb-819f-dfdf4fd41291",
+              "id": "8c1d9b28-cc80-4e42-a5f1-94d6bcadbbc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "1dafeeef-ed3b-4eb1-82de-9aea59c2ccc9",
+          "id": "d3262273-5a9e-43ce-a356-87e75b72773b",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "98d1f38b-6d00-4254-b79f-cab94feedfde",
+              "id": "4881f677-39df-4595-8e6a-6539801b8741",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "b91f48f7-7ff1-45dc-8afa-b0e6063f5659",
+          "id": "42c9a826-48ae-4f33-a757-cc85387399f6",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "dc3c4ec6-96b4-4f05-9c57-2cb51c669e93",
+              "id": "cbcc96a3-4b86-4da4-ba45-54226fd19ec1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "7ba07151-5201-4347-8021-e3520ef6e49b",
+          "id": "3e7c0828-261d-4573-83f9-24f82ebcd239",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "ec9c9be6-cc73-412e-a2f6-c80936da5795",
+              "id": "882d37ff-6fba-4c94-ba66-ec7a1a6289f7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "0a02de1d-9e60-459e-b7cb-99b92dbe173a",
+          "id": "0a870f60-4898-4f44-b910-85cb97011307",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "fa529b63-ef8b-4a00-b9df-a8bdfe02b0d2",
+              "id": "b7cc0f82-adfc-411a-b569-db102842edef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "9d6629ec-e98e-440d-b454-380bcc349bd4",
+          "id": "572c0664-c40a-4586-8a25-55952aa2daba",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "3b573edd-dad0-4458-9fdd-cf6abf47b686",
+              "id": "b94bb8bb-f2ed-411f-9131-6b14bc12a8ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "35e1a466-c331-4467-b403-a4c0a8e58e06",
+          "id": "85f6ad46-0bca-4455-a16e-1b23dc86eab1",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "f2dc53dd-a7e0-4c54-b97a-29dacf807088",
+              "id": "6b5fe573-732e-4b50-a608-13933d9a50fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "955190aa-09e5-44e8-9a19-013bb867f385",
+          "id": "c298c92d-588d-4f75-97d0-78c17ffbcc11",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "db91b7da-9e21-438d-9998-bb336584e104",
+              "id": "7797c754-f4fe-4af0-9047-7deffbe089c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "dd8d9751-81c0-4b00-812e-27165ad0630e",
+          "id": "2ee167db-5668-47ca-b1ce-4e91dfb5ce2c",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "44bf21fc-df56-4491-b151-e5e80f9072d8",
+              "id": "a163f76a-8033-4da8-96aa-fa91a108aa03",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "13327758-6121-4a78-a7f1-6b0bcebefd1f",
+          "id": "8d2ae2f7-bf88-494d-9ef7-3e088e1ee367",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "8666ee55-c4cd-4ac8-a105-ce906a7ee115",
+              "id": "4cfaa712-c45f-4a5d-a719-3ac12342ef23",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "f2257622-ab9e-41c2-942e-42efce030ab9",
+          "id": "7c393c9b-bc9c-4943-9598-b2af5c321204",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "52c24df6-7076-4992-b00a-7b1b53e24ecf",
+              "id": "031c035c-f761-434e-af2b-7c0a397b7cd6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "5b9ac1f8-4d28-4e62-af06-fe5a2af163e7",
+          "id": "f4847699-0baf-4816-8b05-d222d2881f1a",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "860b88b5-c46f-4569-aa7a-c4751c4d9c27",
+              "id": "7657ddf5-74b7-468a-bf00-239a3dc08625",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "94c2177a-5d89-4bcd-8a2f-bff8dc7af4f4",
+          "id": "7dc2254f-671b-4df9-83a7-972c70625201",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "aff5e92c-c0dc-426a-bac3-3304add75340",
+              "id": "5aad77db-c12a-43be-b4ba-312e7db85159",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "5fd8f364-ef32-48d4-bd50-577ac68e2c59",
+          "id": "6cfcc89d-286a-4f18-ac4a-4f6b73136df5",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "155505e9-11f7-4642-9b8e-1afddcf67348",
+              "id": "dc3a3e40-cd18-40b3-b59e-df0399e8de28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "3204f9a0-8f94-4616-990b-78a4a7fbea8d",
+          "id": "f33d9553-a790-4c93-9c16-b867bd2f57e1",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "795af47c-03c3-4802-bce4-ad28742966b6",
+              "id": "0a6b8c7d-ab71-43fd-ae3d-127aefe440b5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "526a23a1-9741-4f97-9ddc-dac5180a1f85",
+          "id": "838959a7-de1f-496c-845f-d4918ddeae02",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "bf7f6f18-6474-4239-b862-8c00355fd190",
+              "id": "b4904f56-e62f-48b8-9de3-5de0976bd60d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "a8144bd9-f9f5-4c6e-9619-8af72074c72f",
+          "id": "a58bf641-2336-46af-89cc-37fa391b587c",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "8bc82073-b458-4c38-8d3b-9b4e8b279312",
+              "id": "5dde6bb5-d782-447f-9463-70e6b6005efa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "e474bbc1-958f-4a65-a0e7-c36e3136ea3c",
+          "id": "b0084143-16f7-4af4-947d-37df938429fa",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "07ef2dd7-0551-45cc-b6e2-f479c781513e",
+              "id": "ad4940ea-d57d-4f4d-a319-404aeff93665",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "575908ec-39d0-47b6-adc5-c50e3501f928",
+          "id": "90843a0b-0b7c-4271-93a7-070d21f3b84c",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "d6de9258-9977-423c-b30b-1e0dc14d9780",
+              "id": "13e89121-0cbe-4677-b076-ec52566d5c33",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "7e611f61-0027-4922-afd6-abb052864f06",
+          "id": "40ee365b-5c4c-495b-90e7-ee5caa6788e7",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "9b2518f9-25ac-4441-a1a4-f56f53d74c67",
+              "id": "0ed9f544-0dcb-41ac-a42a-c0eeee8d1bfe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "c0f2eb6c-43f1-42cc-afa1-ad61bca4c4b3",
+          "id": "7af669fa-4a93-48b6-bd40-882487457911",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "08ee1651-1197-442b-a22f-7c8c256b075a",
+              "id": "da8c4eeb-2b4c-48de-be5f-6998e7418976",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "672401c1-4a28-4ab9-8b15-b53119192fc1",
+          "id": "a5169553-f5d3-4831-af8f-5721dde429a2",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "4fb7ba60-8f4d-4ecd-8a94-7c8d393c9229",
+              "id": "12d59794-e129-45fc-9f8a-ca5d8ef6fb55",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "25c8dbda-3013-44ca-bf02-fa535f6b2b6f",
+          "id": "9c38d366-914d-4ef8-95b8-57fab8740b5a",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "3fa51f54-5ba2-4493-bc27-d0ea195d9aa0",
+              "id": "2807399c-52cf-4cf6-a7f2-ca1af27367f5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "0bc8eedb-c0b4-44ec-839c-ccb44333d45a",
+          "id": "24159266-56dc-4866-9918-d75e26834282",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "be899ba2-37d9-4528-af58-465486fd6012",
+              "id": "1867fc7c-ec98-4a91-9d25-b40e60d50146",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "ddaad373-5737-4f34-a23b-5bfcc523500f",
+          "id": "8687f050-0c10-4ad9-a142-f68c5dd8f5d6",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "1b8caa8f-3440-405f-b2fb-2b61348bbaf4",
+              "id": "8354148e-3c41-4ef8-b3be-921dc593164c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "09753a6e-9f84-466a-9122-c82ae82e689e",
+          "id": "96bb7102-4acc-4688-a9e7-8f0883259891",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "ca7ed5f0-8974-49cb-98ab-add520b74135",
+              "id": "f260d957-d49c-4456-b187-679ccbbf6623",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "5187e7cb-4dc2-47ee-af20-982043d68e27",
+          "id": "98acdc0a-8680-4d46-84d8-090396621dd9",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "2808cd63-fb4c-4ba2-bcb2-934b37323e09",
+              "id": "d002da0e-4206-4127-995f-54b798e22294",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "a410d1d1-1555-413c-99a3-1e0b86f691f0",
+          "id": "ec2c76b4-4677-4712-938b-6a0e542372e6",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "268adc39-88e6-41e0-bba8-a610331c5cea",
+              "id": "4268d19b-4c02-4ff8-ad65-26bf4fe15212",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "8a250921-5784-4d39-b8f4-3ee412288a44",
+          "id": "60da0802-c332-477a-bd8a-eaed71658f8f",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "ce3c1e20-9b12-467e-a9ab-021f9c9557c0",
+              "id": "799f3553-174f-4131-90eb-346f3e84fed2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "d33a73bd-8432-4ce5-ba47-cb5534bb7a19",
+          "id": "28a70e29-2407-473a-b1ce-c2a5a68ae4d0",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "c4576183-e888-44b6-b032-e97645ad8df3",
+              "id": "91fdb685-29fd-49f4-83ee-4ac723b75933",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "d8267a63-a96d-446a-9752-837ef206d4f5",
+          "id": "029c6137-42fd-4a14-9acb-24be5111b29b",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "6986975e-c191-4f68-9ccc-37b44012a087",
+              "id": "b4537a18-e1fd-44b2-8cf8-5b00f09b0b1a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "7c7e4333-68b3-4406-a9a8-7c141793c7a7",
+          "id": "94876886-e488-4b49-ae7d-18b81853457c",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "59eb1407-3995-471e-917d-2a4d3c153b26",
+              "id": "d7bb2396-d86a-4550-a9af-aa4ad7c80567",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "0507af80-7331-4fcb-8de5-2e371e295c1e",
+          "id": "316a987a-06bf-4445-aff6-64dfb8da58a0",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "4e962631-8350-4cd4-aa4e-e8f04c0c9f3a",
+              "id": "56c6e850-6c8f-4a63-ae17-3854ee10d4ec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "7efe264c-ed80-4a9c-82ee-8eeff1f35dcc",
+          "id": "629951e5-f432-4ac4-b2df-2cc36e0d7bb2",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "2f5f00c0-9588-4681-87a3-8b1d9843a146",
+              "id": "d05c5965-05e1-4ac2-8f2d-c886b8453918",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "d6386d1d-987c-422d-94b8-4f5251ba3560",
+          "id": "3c02c799-9ed8-4164-a5c6-04081c507483",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "c9afbbdd-fbcd-4625-9536-c0a61fdb4dff",
+              "id": "2f8d0558-c90a-47ca-9780-0f7740098322",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "1b6e965b-828b-4697-849e-4a5799b7ce62",
+          "id": "5e9a09c6-25bd-49f1-8214-30e4f5fa6895",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "0487f695-0f15-47a4-96f1-c7e33f04a34b",
+              "id": "45c2e303-7289-41f7-ba08-3b50787d821a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "aceaa084-e8d4-4ff5-b7c9-a4c55064219a",
+          "id": "85c23087-82f9-4288-a16a-9fe754020a7c",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "58c2e101-9a50-4c00-b654-516c6bb8905b",
+              "id": "1f944290-3cf5-4995-95fe-19a247324a63",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "894f3981-e606-442e-8d0e-20bf5ad9ab5f",
+          "id": "34a1d6bf-803c-4567-b0a9-ec4343cd6cce",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "3a92c5c5-d1f2-40fd-8915-9082caaffb65",
+              "id": "8ad34e95-9312-4363-bf66-054ff8065df4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "09c95e05-92de-4965-99e4-8a0b0bcc1d76",
+          "id": "71a0a252-af1c-4e47-9796-7fc85075be19",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "b5bf0aea-f0fe-4453-a8ef-87428142ce6b",
+              "id": "bfe8d3e5-d743-4f78-835d-487e18841bdd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1e0de2dd-9b66-4a96-bee0-ef7eba1f8a8b",
+              "id": "eec79c15-7076-420b-917c-b073a4ebd95e",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "beaeeb17-3c48-47ec-9da0-62f8b23eafc9",
+          "id": "3075cd8a-3d12-4ce3-988e-68ca6bad77ad",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "a67ab2b3-7218-4414-89b8-363eb38d6105",
+              "id": "8f344015-c2cd-431c-a28a-b4af4254312f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c4a6e93d-a455-4e7f-960b-afeede3361e1",
+              "id": "f6c1f823-5128-4014-84e3-aaeb79160e36",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "38fe5c59-7d0d-4313-a9a6-58f0a89c0220",
+              "id": "3a5e5859-4c43-410b-ae8a-cab14637265b",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "b5cb44ea-c74e-470f-8897-38ed6aafabac",
+          "id": "aab9145e-e6e0-44d5-8350-2f0071112265",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "7d465f40-5643-4833-aa8a-b7525937e290",
+              "id": "c15e0a59-3674-4add-92da-fd3504be615f",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3ea312ca-8d83-4dca-be0c-457e75f8240a",
+              "id": "dc5b7cbd-4ce0-40a0-9f98-997edfabcbee",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ab4df938-7987-454c-9ead-71f6835ff6fe",
+              "id": "478182bd-73ef-4682-b98c-efb8902e18d0",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "cbcffd24-d00a-4d7f-91dc-5ff7792e47ce",
+          "id": "4bc560e9-b66e-4240-a334-823aab0324ea",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "c233d25b-53ab-4d72-b239-641f07050707",
+              "id": "b6e4918c-7a83-4e2e-8fdb-6ea84eb756e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "6dea3415-760e-45e3-82b2-c94ad4bbafbd",
+          "id": "8a31a0eb-7ebb-4fba-b4cf-af4bbdb8ffd2",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "df3c8532-1074-4fc7-8f28-2ef31a8b54ea",
+              "id": "53be0a13-6f37-4bba-88ec-e7e1a20f0afc",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ef28b9de-9f60-4b6f-9682-78cebc6a29cd",
+              "id": "881d33ad-cf37-4781-a6ef-99f9ee0cea42",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "c9db93b2-d66b-412d-a140-63b37c3498f7",
+          "id": "e3859ce9-0dcd-4968-9bac-eb0a2a5b0c5b",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "2cf7aa84-1f76-4ae5-9ad4-20f8fd193e16",
+              "id": "c8b741d5-61c8-47f9-84c3-3e0fa1b5e3b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "e251335a-76d8-4639-b669-f2a7c02d03b9",
+          "id": "a1f96c9a-37ca-4ed0-87c0-f3f52ac6bf77",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "99c0eada-32b0-46f6-a92b-af99fcc17aaf",
+              "id": "ff06fa3a-7d4e-436b-8bb6-5d3b30eef3cd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "bab76795-62a1-4c62-88df-5e24f07c042a",
+          "id": "c9c489f7-b830-4f69-95bd-a05bdd9c4143",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "68c662dd-94a7-4613-b35a-dde6db14c1a6",
+              "id": "15a396cc-7264-4d0f-a82b-b8288cb03470",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "b503bed3-f17d-4fdf-8089-ca4fe500bdc4",
+          "id": "6a540c10-af1c-44e4-98fa-e4adb9e3a7d6",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#4dFd10\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#33adb2\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "f0b9c24f-3071-4c15-a1f6-db9045bc974b",
+              "id": "80ef5594-0990-4134-a0e6-2d1115fde14b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#4dFd10\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#33adb2\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "ff0af29d-bbbe-4019-abf2-766502ab608e",
+          "id": "43950031-ef82-4dec-b34b-66cb0381755a",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "3b0ed177-bdb1-435c-b72d-8fec75fa875f",
+              "id": "12576d45-a8a1-4b95-93d8-0f62bed9a150",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "e6bf2eeb-fb25-463e-92df-882e6e17a85d",
+          "id": "529d65c9-2011-4268-a8de-a8bf9bf308a9",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "6e3dd5fb-65c2-4970-bc0e-5cb201fdaf68",
+              "id": "c55d25ee-efb1-489b-923a-444fe15b8ae5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "6a779ad9-7ffa-467d-9fa2-3d551cdc7597",
+          "id": "ad00f19e-0bae-46cb-ad58-cadb5ee14ec0",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9aBcbE\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#C9fDF8\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "8d4ee78b-1799-4e25-b91e-190b8a144fa6",
+              "id": "5f298b6f-abb4-4e4f-8e16-112cfe51ea69",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9aBcbE\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#C9fDF8\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "20c5f9f9-a6a5-43ef-89c1-ac620ddee5e2",
+          "id": "3f9f46c8-737d-4222-87c3-f7f07d5d6134",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "e44e7e6e-3903-49ad-96cb-64da6328e6b5",
+              "id": "4a671da0-7a9e-4572-bfe8-0b08caa75312",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "b4a760c8-9384-4016-a055-40600ea1f87b",
+          "id": "af73d5bc-b2a1-4740-952d-79f4b11ef95d",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "173c4f5c-9e0b-4b65-8a1a-5016ab14f0bc",
+              "id": "b1009ed7-04c6-4fb4-a767-448d242111dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "c4724a22-4b6d-4daa-a810-b7265c9bb21c",
+          "id": "ab18480b-a91a-4231-a1b7-0869ef8bc7ec",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "683268f6-fab8-463a-b59c-0732b8ce918a",
+              "id": "afeae6de-9216-4a78-80f6-17fe02ec6803",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "43dd3cb4-7b7a-4f62-99ac-6a8ef610b653",
+          "id": "628331e8-0834-499e-b09a-19dca6cf7639",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "078e3df8-4c2d-4087-bd7f-ab156ba654d1",
+              "id": "ce6c6fa6-b19f-4427-a8a5-cd8607b18b58",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "efbad210-d645-419d-8b96-cdcb3162bf15",
+          "id": "165e9819-d9b1-4d8b-a923-6a2b6bf358ad",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "14a04728-3dae-49a1-b3d1-b888fa4f913d",
+              "id": "189d4857-8257-40b3-9ab8-81ef1f1db88b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "076b90de-ee4b-4ce3-b8f5-b19a8d61f000",
+          "id": "0a4ed7f0-38b1-4b90-92a4-945ab77eb33c",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "fb710661-f6da-4317-94df-8fdcddad6584",
+              "id": "b400a7cc-534c-4ab1-9578-c7358c701a0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "a1a93b3a-d187-4859-be31-39306efcf0e8",
+          "id": "7cd2ac2d-b9e2-434c-837d-4b8b1d4b9522",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "c3414864-ab5f-4482-8192-5dc368e1c33d",
+              "id": "5a83dc53-1957-496e-9e19-c45408535ac6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "e68dbc95-9a4c-4c80-ab34-d3a0932436ed",
+          "id": "ef5877fe-58f7-4b6e-af3f-bf6507117750",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "e8765bed-9690-415c-b124-a55de08139f0",
+              "id": "34a1c209-a90c-440f-8650-1ab7955ca12f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "88e5d7d8-fc62-4e3c-840d-0bdd245dd4b3",
+          "id": "cf476b59-7881-4d52-8375-933038b4dc52",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "b8e5bf74-3e1d-494d-a8cf-9fce7b9dcc2c",
+              "id": "8442abe9-0671-40aa-a1b7-2e9fcdfb3c9e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "4a5fe0af-55a8-45e7-be63-dda5381213f1",
+          "id": "83115618-7e52-403f-88a5-071988baa0c4",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "226f4d5d-ea7d-4ef9-98fc-700fc43c5e1b",
+              "id": "3869a507-efab-44cf-8a86-fa7f4e6c87ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "f16d7086-ca23-417b-a1f6-a0fd16058ef5",
+          "id": "6f675fd2-d34a-49f4-9633-7f3472f78824",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "3eee0e8b-c422-48df-964a-7f8516efddba",
+              "id": "2a50eb1d-9466-4d73-bee5-e7ddfcf87de7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "fa27de3c-aee0-48d8-b2dc-be01a1f0b22c",
+          "id": "651a0644-8ca5-4cec-9ad3-3aee9f1ce3b9",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "bd8eb121-48dd-4363-9453-df6fdcc8f9b7",
+              "id": "d2dad28d-9ca6-492d-af00-f909a5aeb984",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "8dc307f6-861e-4e13-b914-d85d4efa0744",
+          "id": "3a4c647f-f44a-4b48-a435-cb138df0f4b0",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "f7770dae-9df3-429a-b9c8-a487fe2c72bc",
+              "id": "b4136933-e018-4374-8790-4af228ebdddb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "865dee27-7585-4ad7-a9da-09378434b0e2",
+          "id": "b610e3c4-515f-4682-bb58-52d3dd00f312",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "ed26aef1-1b2c-4606-91c9-cdb4c7769172",
+              "id": "e3bd1ac7-5bcf-4587-ad58-b9fcb1ac1211",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "4781edb1-926e-42a7-8317-db0e82686766",
+          "id": "1593ee4e-e1fe-4ce3-af75-addbc08d1856",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "178c02c2-af9d-425d-9754-a1c0eb9eea85",
+              "id": "7b04a90c-071a-4a80-975e-3c7fdc2dc9ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "6e7f87c2-b73e-4da9-a4fc-eb527cc705e6",
+          "id": "2e6a36a6-43d2-42fe-987d-268264ff7491",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "a73e18b5-8eac-453c-8586-44c15b8fb33a",
+              "id": "754562aa-1572-4686-bd3d-f4659b0eee26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "500b1f9f-b0ac-4fab-ac3a-0ca549a48ff9",
+          "id": "f66fa2cc-c152-4b95-b0a1-ee2f034fd48a",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "8b19d63d-756e-4b54-9121-e6783eea633b",
+              "id": "ce074e0f-6822-419e-ac2f-a74ac7cd68bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "092d620d-6c58-46bd-97c1-8632bb1c545e",
+          "id": "4c02e13f-6a75-418e-9750-83ede7b92448",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "caed833c-fe45-4f8c-bd06-b40c3d67db71",
+              "id": "cf077c7b-98e9-4cfc-9f8f-c176bbc5ee2b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "b801653d-fb28-4b5e-9f69-73afe258789d",
+          "id": "4daffad1-c7ea-4a28-8867-20b6ebf7f233",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "94acc276-50f5-440d-b492-45c779ed260b",
+              "id": "e7bd2dde-9556-4727-a534-bed5e535cd3c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "6cced245-dd21-4fd6-8a28-115f573c5980",
+          "id": "066546e9-5148-4c07-849f-783a9f23efe0",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "9af69ae6-62c6-4cba-8a12-cde01f8ee4bb",
+              "id": "82eafb0b-0708-4fcf-b7fa-d6c24b18d524",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "49894374-2c74-4d44-b9c0-b65ca5013843",
+          "id": "180bf543-1011-48e6-b1f9-4264b18bbcb7",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "147a5911-b6f9-4a57-9d4b-34f97a8ffe15",
+              "id": "b41a341b-5a2d-4eb8-8f67-0ba5705ddcc0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "469ad9b1-9c43-411a-b99a-c4a8a3da3261",
+          "id": "a6dffec1-c86e-4102-b579-01c145f06692",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "9fbba15c-6d25-4fce-aabb-ac5c3740810a",
+              "id": "e26f8d5f-3cdf-4742-bf5a-dfcd6421c9ff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "84b883ab-716c-4c52-9833-b501cdc040ad",
+          "id": "3ebbd2fa-9d8d-49b5-ad55-c75a70048753",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "34fb4b1c-12fb-41b6-a3fb-fb60d073e5ac",
+              "id": "91744795-0d52-4250-b39a-272620beecf8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "480fb9e1-b572-42c0-99a1-cdcdec81a968",
+          "id": "f29c3a43-3a41-4808-9a8a-71b8b583093f",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "3b8fd7c8-3f15-476c-8302-b289eae2aaf4",
+              "id": "f7eaa899-8d96-432d-b3df-a9ab435f9c88",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13520,7 +13520,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "43d6a74a-c9d2-43e7-b22a-8370e806de1b",
+          "id": "0c3d1a90-b6e7-41b5-9050-7138a6325f34",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "f6d20614-e015-4981-8e1e-a3ad4da2281e",
+              "id": "cace4fd5-d641-483f-9018-9641164cb0ad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13630,7 +13630,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "2ac9cd2d-74c5-4e15-ac19-3891faca3b41",
+          "id": "631d254c-7fec-4b1c-952b-4d598493a980",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "75538897-5e4f-4d6f-802f-409d97828af5",
+              "id": "4e494c9e-196a-4b79-945f-0bfa55df0523",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "7e06680c-a439-463b-9d15-f1baa4e956be",
+              "id": "57529cd8-b7f0-47f1-950a-534593675977",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "4858acd7-3315-4684-9c52-68ac45c80f4c",
+          "id": "9c958d04-d620-4eb6-bb3c-1daa53dbeb13",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "58d347be-87b2-46a5-b1d7-e5d0170a0122",
+              "id": "5ec760ca-a95b-483b-a551-c4646114b7ed",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3772a38a-9c1a-4562-9207-187336bba9b2",
+              "id": "8486cb55-05d0-4717-8f14-f6777417c0a1",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "559047bb-d01b-46af-8550-a6a7af49a18c",
+          "id": "a3ac9715-70be-44e9-8186-ccf78c46664d",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "d3f9fb5b-4dcf-4a7e-bd44-8d5f91a56d9c",
+              "id": "eed5f88b-983f-401c-9adf-cbf906e6d99b",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a64b2055-8d31-48cb-82cd-aabd3a1d4384",
+              "id": "e8d5ea79-622e-4062-9750-2feb793014a8",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "b14ec65f-f41e-4221-a938-de8e74afa033",
+          "id": "730d743e-8de4-433a-90b3-40f349711401",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "13939048-f12a-4593-b03e-e4982dd73f8a",
+              "id": "6fe3e8c7-3fe6-4e45-95ad-313a59919cb8",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "45272090-333e-4673-a455-6cae88516081",
+          "id": "4e046bc0-4ea2-4acf-984d-7482ebd13fee",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "9fd7fc21-7049-40a5-bda7-e533fd551d9c",
+              "id": "bdd8a58e-2eca-4b8a-809d-391adae15112",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "e8faa0ec-ae91-4647-b4cb-b736dcee07e6",
+          "id": "fd68d384-270c-4944-b494-0b381ff838d8",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "41384f7c-0190-41ea-becd-56546836ce8a",
+              "id": "f8e54245-8573-46f8-8b86-8bbb9f6eb18e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "367c0ae4-2d25-4bcd-8d37-aef65d7c5b19",
+          "id": "3db5c4c5-b6b4-4998-8c85-d5cda4068d91",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "fde98f71-5277-4d3e-a27f-13e27a02ca9a",
+              "id": "3c82a5e6-9e9e-423a-a85d-ac919b924af2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "480004d8-123b-4123-b624-52463baef845",
+          "id": "b21752be-5689-498f-a8c1-e8c0fba2581b",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "cc69b591-013e-4a79-84aa-1cac1eb2996d",
+              "id": "6d5ce8c5-921f-4670-9eac-a250a3906cb4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "08f8a8aa-96f5-4cc3-814a-679866654414",
+          "id": "d47f178e-d9dc-44ac-bfb6-20a153d6e5ca",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "0b3b85b3-17df-4552-9c50-6bc54d346e0a",
+              "id": "d76e4d1d-58d4-4d19-ad51-7d086d64821e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "c825d0e1-7429-4a85-83e5-37fdbbdaf3e2",
+          "id": "ed45feb7-bd4d-447e-bbef-2342eccf4ae0",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "29b668af-bab5-4a8f-9c29-d7d918043458",
+              "id": "307425f7-3f99-43c4-96df-78df5b371eb5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "a8a51a0e-b59b-48e2-a91e-14fc22b107f9",
+          "id": "ef5c43e6-6bd6-4249-9662-1731736d7185",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "e9d62663-a7b2-4162-bc32-99923b1da58c",
+              "id": "5482696a-7847-4826-9453-7ac8e029be30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "1e14da20-b1af-4957-a11d-822788241504",
+          "id": "34f43ec3-0ba6-4955-9977-a21f1a9434e8",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "1a3e4dc7-2f04-49ab-a5b5-c28499d72c6f",
+              "id": "48e05eac-a482-447b-92d1-d55028bababd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "98506f2d-6727-4e72-b584-e3822c607634",
+          "id": "d029ab87-bec9-454b-8209-ce0ea169a56f",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "482e6c9f-0046-4dd7-811a-62bb8d461ab8",
+              "id": "12aa4404-4c9a-47e9-a93d-26c1b90f2603",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "06866cca-eeaa-4fd4-9a8a-49b64eaf3868",
+          "id": "887c5ea3-10eb-4c2a-bb10-cd81fe19c79b",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "8c46ab3b-e627-474d-8f72-1603652d3db4",
+              "id": "01e62e0d-9e0f-4ce3-b559-dcc5e059845d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "749770a2-8e53-4786-b9ec-0949c20d1544",
+          "id": "c8292511-eb83-450c-a72b-3ae5799f623d",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "81146db8-3e68-475e-bad2-ea4c104b9d6b",
+              "id": "946389dd-8994-4ef7-950d-7df257df306f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "f38d16ef-44c6-43a1-b7eb-3d5e40d6ba0f",
+          "id": "c456ea7a-0767-4c7d-94c3-f34147edfefd",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "b66082e3-9dd7-4a57-a71e-4b836972284e",
+              "id": "9d12194f-cc58-4091-a0f2-592bb2bf9ef0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15533,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "beca7519-2b09-4a6e-b76e-ee136a98760e",
+          "id": "b6ce7502-b182-40ae-b9ec-a537d55d7e42",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "eee1bcdf-ab23-4581-8edf-80d5cb91b3a7",
+              "id": "f084f845-3705-4750-a385-b1da001e6492",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15615,7 +15615,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "525ae823-507f-43e7-958a-08039d1432b8",
+    "_postman_id": "06c89801-04bf-43f1-ba25-3c35a4f76d47",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 12:03 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 12:09 UTC\nRama: main\nEntorno: prod\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssembler.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssembler.kt
@@ -113,7 +113,7 @@ class GreenhouseStatusAssembler(
         val deviceResponses = devices.map { device ->
             val currentValue = readingsMap[device.code]
             device.toResponse(
-                currentValue = currentValue?.value,
+                currentValue = normalizeCurrentValue(currentValue?.value, device.type?.dataType),
                 lastUpdated = currentValue?.lastSeenAt
             )
         }
@@ -123,7 +123,7 @@ class GreenhouseStatusAssembler(
         val settingResponses = settings.map { setting ->
             val currentValue = readingsMap[setting.code]
             setting.toResponse(
-                currentValue = currentValue?.value,
+                currentValue = normalizeCurrentValue(currentValue?.value, setting.dataType?.name),
                 lastUpdated = currentValue?.lastSeenAt
             )
         }
@@ -137,5 +137,35 @@ class GreenhouseStatusAssembler(
             settings = settingResponses,
             alerts = alertResponses
         )
+    }
+
+    companion object {
+        /**
+         * Normalises the wire representation of a current value before sending it to the client.
+         *
+         * The MQTT ingestion path (`DeviceStatusListener`) converts JSON booleans into the
+         * strings `"1"` / `"0"` to keep TimescaleDB continuous aggregates that cast value to
+         * `double precision` (commit 6c98ca6) working. That choice is correct for the storage
+         * layer but breaks UI consumers that read `currentValue` and compare against the
+         * conventional `"true"` / `"false"` strings (the case for the mobile app's
+         * SetpointBooleanEditor and several view models).
+         *
+         * For codes whose catalog declares `dataType == "BOOLEAN"`, this method translates
+         * the stored `"1"` → `"true"` and `"0"` → `"false"`. Any other value (or non-boolean
+         * dataType) is passed through unchanged. The DB layout is not touched; only the
+         * representation that travels over the WebSocket changes.
+         *
+         * @param storedValue The raw value as stored in iot.device_current_values (or null).
+         * @param dataType Catalog dataType name (e.g. "BOOLEAN", "DOUBLE", "INTEGER", "STRING").
+         */
+        internal fun normalizeCurrentValue(storedValue: String?, dataType: String?): String? {
+            if (storedValue == null) return null
+            if (!dataType.equals("BOOLEAN", ignoreCase = true)) return storedValue
+            return when (storedValue) {
+                "1" -> "true"
+                "0" -> "false"
+                else -> storedValue
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssemblerNormalizationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssemblerNormalizationTest.kt
@@ -1,0 +1,83 @@
+package com.apptolast.invernaderos.features.websocket
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure tests for the BOOLEAN currentValue normalisation in GreenhouseStatusAssembler.
+ *
+ * Pins down the contract between the API and any UI consumer of the WebSocket status
+ * payload: BOOLEAN-typed codes always travel as the canonical strings "true" / "false",
+ * never as "1" / "0", regardless of how the value was stored in TimescaleDB.
+ *
+ * For non-boolean dataTypes the value is passed through unchanged so DOUBLE / INTEGER /
+ * STRING readings keep their wire representation.
+ */
+class GreenhouseStatusAssemblerNormalizationTest {
+
+    @Test
+    fun `BOOLEAN dataType maps stored 1 to true`() {
+        val out = GreenhouseStatusAssembler.normalizeCurrentValue("1", "BOOLEAN")
+        assertThat(out).isEqualTo("true")
+    }
+
+    @Test
+    fun `BOOLEAN dataType maps stored 0 to false`() {
+        val out = GreenhouseStatusAssembler.normalizeCurrentValue("0", "BOOLEAN")
+        assertThat(out).isEqualTo("false")
+    }
+
+    @Test
+    fun `BOOLEAN dataType is case-insensitive on the dataType name`() {
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "boolean")).isEqualTo("true")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("0", "Boolean")).isEqualTo("false")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "BoOlEaN")).isEqualTo("true")
+    }
+
+    @Test
+    fun `BOOLEAN dataType passes already-canonical true and false unchanged`() {
+        // If a future caller pre-normalises (or the source already had "true"/"false"),
+        // we don't want to mangle it.
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("true", "BOOLEAN")).isEqualTo("true")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("false", "BOOLEAN")).isEqualTo("false")
+    }
+
+    @Test
+    fun `BOOLEAN dataType leaves unrecognised values untouched`() {
+        // Defensive: garbage in → garbage out, but never silently cast to true/false.
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("yes", "BOOLEAN")).isEqualTo("yes")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("", "BOOLEAN")).isEqualTo("")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("2", "BOOLEAN")).isEqualTo("2")
+    }
+
+    @Test
+    fun `DOUBLE dataType is never normalised - 1 stays 1, not true`() {
+        // Critical: a sensor reading of 1.0 (e.g. 1 amp, 1 lux) must never become "true".
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "DOUBLE")).isEqualTo("1")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("0", "DOUBLE")).isEqualTo("0")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1.5", "DOUBLE")).isEqualTo("1.5")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("185", "DOUBLE")).isEqualTo("185")
+    }
+
+    @Test
+    fun `INTEGER and STRING dataTypes are never normalised`() {
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "INTEGER")).isEqualTo("1")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("0", "INTEGER")).isEqualTo("0")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("hello", "STRING")).isEqualTo("hello")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "LONG")).isEqualTo("1")
+    }
+
+    @Test
+    fun `null dataType means non-boolean - pass-through`() {
+        // Devices/settings without a catalogued type fall back to raw transport.
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", null)).isEqualTo("1")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("true", null)).isEqualTo("true")
+    }
+
+    @Test
+    fun `null storedValue stays null regardless of dataType`() {
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue(null, "BOOLEAN")).isNull()
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue(null, "DOUBLE")).isNull()
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue(null, null)).isNull()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the BOOLEAN currentValue mismatch between the API and UI consumers.

`DeviceStatusListener` stores boolean readings as `"1"`/`"0"` (commit `6c98ca6`, kept on purpose to make TimescaleDB continuous aggregates work with `value::double precision` casts). But the mobile app's `SetpointBooleanEditor` and most viewmodels compare `currentValue` against the canonical `"true"`/`"false"` strings, so booleans never light up in the UI.

This PR keeps the storage layer untouched and normalises `"1"` → `"true"` and `"0"` → `"false"` only on the wire (WebSocket `/queue/status/response`) when the code's catalog declares `dataType = "BOOLEAN"`. Any other dataType (DOUBLE, INTEGER, STRING, LONG, …) is passed through unchanged.

Concrete impact spotted today on DEV (BOOLEAN_TEST = SET-00080):
- `SetpointBooleanEditor` switch stuck at OFF even when value is actually true.
- `IrrigationConfigViewModel:170,176,183,189` REGANDO/EN_COLA checks miss "1".
- `DeviceDetailScreen:609`, `GreenhouseDetailScreen:548` map boolean labels.

Mobile-side defensive tightening (accept `"1"` too) will follow in `GreenhouseFronts`.

## Test plan

- [x] 9 new unit tests on `GreenhouseStatusAssembler.normalizeCurrentValue` (BOOLEAN truth table both modes, idempotency on already-canonical values, garbage in / garbage out, DOUBLE/INTEGER/STRING never accidentally booleanised, null storedValue and null dataType, case-insensitive dataType).
- [x] ArchUnit + Phase 4/5 regression all green.
- [ ] Manual on DEV after merge: BOOLEAN_TEST switch reflects state changes from MQTT, REAL_TEST keeps working as before.

## Rollback

| Level | Command |
|---|---|
| R1 | `git revert` this commit and redeploy |
| R2 | `kubectl rollout undo deployment/invernaderos-api -n apptolast-invernadero-api-dev` |

No DB migration. No flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)