### PR TITLE
release: Phase 6 — BOOLEAN currentValue normalisation

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "6e355af5-3b0c-4a4d-8729-3294e14763b2",
+          "id": "4cfb2b55-3fd1-4055-a7ff-cefc5918a4d2",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "68f2339d-c7e4-4ed8-941d-3ea54f730784",
+              "id": "8c796564-7c08-4db8-9c36-d78ffad434a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "cca9bbdc-87f3-402e-88b1-5fc782397738",
+          "id": "00e88c23-5597-4346-b4a1-be56240f32b2",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "df6715d4-79f6-4885-807a-2865d814885b",
+              "id": "6c5a73eb-ac93-4067-9bb4-8c0f1469319b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "1d3d6d8f-a39e-47b8-b644-34e70c4ae5e7",
+          "id": "76a2ab11-8ec6-4ce5-be9e-a90d1d603fd6",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "c7cb67e3-f52c-4b59-9bf8-096cde73cd2f",
+              "id": "deb5bf9b-6f80-45d0-bb8e-da01df8d0486",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "784806c5-84c5-4f85-a05f-cf5b2cf7754b",
+          "id": "333a78a6-2349-45cd-b9a4-ab3b3d617131",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "b510b265-8057-43da-9296-fd7ce4b221f3",
+              "id": "7e817768-3869-4ebf-9d85-00766b4d4b60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "94c14302-e3af-43f2-a015-545d871b2e1f",
+          "id": "1716d66e-e3a5-4de8-829f-468e207cffd3",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "db81c7e3-6b3f-4daf-88f2-1385460011b0",
+              "id": "f26ff100-217a-43cc-b977-50ddb5a3ea12",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "725c24da-40cd-4b2d-a347-a3cb62c83040",
+          "id": "d981ba22-8a9d-4694-8bfc-24a46635d467",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "472bfbe6-aa17-4a78-b1bc-6023c1fa15a3",
+              "id": "1c9a30b9-e2c9-4e4f-909b-0260772dd60b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "35a2109a-02e1-45b8-b645-9178ea2bc5f7",
+          "id": "583ace12-94f9-45bb-8a34-2fa7e8dc4a3d",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "d6102fe4-9a40-449c-9fc7-11a84cd915d8",
+              "id": "6b0d2633-0ec9-4188-bcbc-c4a57933745d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "58de1669-c8ed-4970-859f-e2e2d129e69b",
+          "id": "100b02b7-7bf4-481a-b9d4-6e0a75f62386",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "5524fcce-3f34-459e-933d-4a209f8b646d",
+              "id": "e5e09250-ee94-4845-95cc-4b6f1006daea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "9007c23d-0a90-427a-9f5a-cdbe5afab277",
+          "id": "1a7835af-b1ac-4b41-939f-459e1d4d9011",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "15e1baec-2fa6-4f76-ae0e-5ea3666ca0aa",
+              "id": "d3427816-0b0c-413a-91de-278fc0716e51",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "3cf393b1-62a6-47d4-9ade-b5871c245154",
+          "id": "f74f049f-94d5-495f-b8d8-ba0761fe663b",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "a0b6bf51-6483-4475-af6a-3b038d54207c",
+              "id": "84fea828-ac66-4c42-84d9-8f98b9b8e34e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "05ee4356-165f-4639-b79c-8ffd019906f7",
+          "id": "8a4052d0-861f-415e-a78c-754bbb272826",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "73d3a23f-7104-49c5-8867-4e65df765889",
+              "id": "9c2aa678-8ebe-44ab-b396-c9922a7d5d0a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "ed9a7ed6-db41-424e-9b44-3afa60a5bebe",
+          "id": "93ebb67d-9544-4906-9572-7624fb4b2633",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "ff1ccad4-1b8e-4dae-a23e-d4e2d4579aae",
+              "id": "83eea8a0-1a86-46a4-9ed7-968d5c60313a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "454613ed-ea0c-4ccb-9149-6be16c59065b",
+          "id": "b083cc70-c226-494d-9841-8301cf0c1023",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "d74a3987-df71-4a73-9ed7-276f87c8aadb",
+              "id": "74a4b531-9860-4d34-9dd7-b48a70ccf361",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "80e394eb-0012-49fb-87a1-c82a8c1dbd37",
+          "id": "9f17645d-1370-46dd-804e-ab8f27fe3b15",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "b89618ad-3414-4dc1-8751-f2be3b6c7eda",
+              "id": "64b0a4d2-20cb-47e5-9229-c8f08ed45027",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "f7f11bcb-1b9e-4984-b6a5-0b1647ea1f5e",
+          "id": "a337ab84-2c10-4bae-8dca-8e7dd91785bc",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "0a45c4a3-2204-4a50-aac7-4ccb6e7d3ddd",
+              "id": "f7a36510-538c-4355-856a-f404a8703d9e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "a360fe5f-d102-4da9-9a6e-318ad5a84ca5",
+          "id": "72d78ae5-cdd9-41d0-a00a-0906f1352166",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "c83497cb-0f0f-4d22-9ad8-76f8c4526b04",
+              "id": "5dd76afc-9262-439f-a6ef-0c2f2c83dfd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "235abce6-dfa7-4738-8b5d-be1e5c761bc9",
+          "id": "9300ab68-89d4-415c-a5a5-39308d7fc090",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "52accdaa-2b77-461d-976b-bca8cad1adac",
+              "id": "bc3591e9-5cb1-4e88-845b-ad52b8f4fe1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "75906c19-0ebf-47b1-9729-92b550ce52d2",
+          "id": "975c3968-b2e3-4918-bca1-dac3223b013c",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "c18c8c7e-8c68-4d8e-98a3-f3d3916ee36e",
+              "id": "6b87a055-70fc-4ca6-9002-b9ff613df529",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "4551bf44-c65b-4ae4-99d8-37083de72033",
+          "id": "56a65259-7797-4f2b-819b-2b4dd66ef642",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "c2ddac71-2c43-4f2f-bba7-30f9da640295",
+              "id": "fa4e8e2d-a424-4467-b18f-9a1e11e5b911",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "25e6e9d9-c5d6-4e01-8b47-9a7958993d10",
+          "id": "4b705417-754d-4b87-a10d-a98dc9871ab9",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "809b0ab7-14f7-4040-8e47-19ea29b4fdfc",
+              "id": "c15a4c7a-2751-439e-80dd-4ac65d60159d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "31bfae14-ac26-4a95-916e-bf5b0cb8fddb",
+          "id": "d4abaed5-a9f4-4b92-b26f-814a8991bfe1",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "a150fd12-353d-4da9-9132-4f620ebcfd84",
+              "id": "6bdb389a-b48d-458f-a262-3ea789837097",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "038a06d9-bc9f-465a-9c4d-dd4cd43a2d7b",
+          "id": "47a53239-478f-4b12-a2f9-52de3454a497",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "fbb62e92-d299-4fde-8904-179abfbdbd7a",
+              "id": "2e1684b7-3134-437d-b025-63100e5763c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "a69e10f1-2094-4920-a929-08027c89fa90",
+          "id": "cee28515-f7ad-4ca5-b334-e930f64d0e54",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "b6472eaa-847e-4c16-a9d1-2fdb00280954",
+              "id": "4a43f94e-aeb4-4597-a9da-ce8ee8a593ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "f8108df3-16fc-455a-88a9-e064bc3ea232",
+          "id": "b040efb9-e606-412c-8a75-fa3a958bed8c",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9A64aE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#10CBc4\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "9f006f6e-dfd4-4203-89f7-4540be7c46e8",
+              "id": "0f25c345-7506-4c51-b284-7f4f346f3ea8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9A64aE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#10CBc4\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "c51a81aa-92ea-4c5a-9e42-635be1859073",
+          "id": "ab4a8c45-14f0-490c-b838-85423c7b0229",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "4bee4aec-4fe7-49c3-bc62-40298e7a565b",
+              "id": "6f8d5f2d-eb08-4d15-bee6-5f04ad1b4a33",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "3aebaded-849e-4803-b123-a0a7728726be",
+          "id": "b39e067f-9c4f-47f1-a89f-b23f2ce13163",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "650c21f7-9859-4cba-97b2-a6ceeecc8486",
+              "id": "f1ba27ec-12ef-47bf-9e8f-fc9aea4dc823",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "f1a38f54-959f-40f6-9ecd-7d376d674366",
+          "id": "eb976933-fe22-4be9-b9b7-ea48e87eb4db",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aD40E9\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#eA87D2\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "a3a25c1b-cfb8-4d76-8495-6a1b4e511043",
+              "id": "0c35806a-f13a-4b35-9a5f-394ce04dd1d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aD40E9\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#eA87D2\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "65d95d5c-3712-456f-ab9d-63d8120b4b7a",
+          "id": "f0635724-f3a9-4f46-b0a8-2cf87898c400",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "be56a362-ce4d-401b-8f22-a3d76e473de4",
+              "id": "173206dd-9bf2-4be2-aa37-62e36c3098f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "74a3ae24-e929-4e56-8bb3-98127ba4aa31",
+          "id": "217ddfd9-2688-499b-a825-f72c0df2f7d9",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "7dfa519c-a15c-45d6-9213-ba8f98d950ca",
+              "id": "3091891f-d099-423c-8aec-24f50379e82a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "5dd1987c-cbea-4829-8c23-d7b6c96e7222",
+          "id": "516b61cd-1805-4c0e-8db4-96638d06a2cf",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "537d93f7-6d88-40c1-89b3-74636b977c6e",
+              "id": "fb21bdcd-1cb8-4da1-9442-31e5fda23f45",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "0c656ff0-2384-47c0-b969-9706b1ca9899",
+          "id": "5db2a122-479b-4db4-b84e-2fd6abc4b6b3",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "1101d873-bddf-4a1c-abe7-2da247f6715e",
+              "id": "e9b8ef2b-e5d7-4286-8d98-e9ac28a203b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "8b4f1c76-7c8c-4d52-b90a-08a5f0b101cd",
+          "id": "c7cdcdf0-ea13-4591-86f7-11d1c2189713",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "03a6d6df-8be9-4ae4-8faf-ea1b6c2bcc7d",
+              "id": "3990a1c3-09a8-427a-99a0-af414a895278",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "db8270b2-d2a4-46cf-a063-74b9313f802b",
+          "id": "3379e0bf-5f4c-4a81-8c17-3a8e7cfb9a7d",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "3a16f8ab-89ab-4c31-9de5-0aef2b521cea",
+              "id": "1848aa07-9ed6-4721-a899-6f134c8c475f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "4757c8df-8202-4025-af89-c479518603e4",
+          "id": "9473f208-d2d9-4333-b734-8a00d89f2410",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "b993d380-8d18-4cf2-82fe-58ef1644a321",
+              "id": "9ec96c44-71a8-4c0e-8fa9-040d8f0564f5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "c36ed0e0-0c5c-4abc-8b42-1005eee4a79f",
+          "id": "f5f6cdb9-3806-45c2-bbff-4ff960fbd27a",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "f7574674-e961-4a99-817e-543aea51db97",
+              "id": "02f1d3c2-7af9-44bb-a223-8ba3573282b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "61a040a5-2d1b-46f7-a84c-b007b752a3b9",
+          "id": "d4e531d3-05b1-454e-97a9-93d0cf7a3fc1",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "bf941edf-00e8-48ad-956c-1d80aae227fa",
+              "id": "a73da6e4-b065-41df-8f4c-d9cd7cacf535",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "eb536d97-92e7-4dd6-a928-81dd60724196",
+          "id": "2a4775eb-edd5-4bdd-bf0f-347c6cadfec8",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "ab6dfbad-ede5-45bb-b067-1a15ea7f3561",
+              "id": "6137e1ba-14c1-468f-bc21-ba143553b147",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "4fd6efeb-e355-4fe2-9170-df30c2c945d9",
+          "id": "a17393fa-a455-495b-b2df-31a25b036f78",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "898f9512-87c5-4774-a7ec-56d13bcf6cfd",
+              "id": "bcbf9052-0061-4651-9161-2ac9c4d646a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "2bbd8ffa-1358-44ea-944f-ecdd25f477fc",
+          "id": "27f26732-465f-41e4-9ca9-5965a8506cbc",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "a0d0aad2-758c-4924-b288-1d5955d2328a",
+              "id": "37d052c5-a7b2-411b-aec6-85205b1b5e2d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "d96bc45c-8402-4d84-876c-b49e20dacd8e",
+          "id": "9eed87cc-5160-46b7-bb48-bf990e60521e",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "8c1d9b28-cc80-4e42-a5f1-94d6bcadbbc4",
+              "id": "a6a3e7a5-e4bd-4fd6-aa90-0bffce6c392d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "d3262273-5a9e-43ce-a356-87e75b72773b",
+          "id": "ef4c9bcb-8920-4e7e-a58e-2bace4f9fe5a",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "4881f677-39df-4595-8e6a-6539801b8741",
+              "id": "1e59b9bb-1e46-4d83-b837-767aafbba9cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "42c9a826-48ae-4f33-a757-cc85387399f6",
+          "id": "ad17a92e-4b0e-4ed1-8899-621526827a5f",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "cbcc96a3-4b86-4da4-ba45-54226fd19ec1",
+              "id": "3d553437-f1c4-435e-9a66-eb1847b9a39f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "3e7c0828-261d-4573-83f9-24f82ebcd239",
+          "id": "6167e3da-3213-4773-b050-8674647bf029",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "882d37ff-6fba-4c94-ba66-ec7a1a6289f7",
+              "id": "f3e8abe6-afa0-4c4d-ab29-fe1d1a07262a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "0a870f60-4898-4f44-b910-85cb97011307",
+          "id": "af2e7edc-81a2-460d-9cfe-fc760f41c3f0",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "b7cc0f82-adfc-411a-b569-db102842edef",
+              "id": "d37ba667-19ba-417f-809e-9e9fb9cb6dbe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "572c0664-c40a-4586-8a25-55952aa2daba",
+          "id": "d5ff8633-f95c-4739-982a-76a30d91946e",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "b94bb8bb-f2ed-411f-9131-6b14bc12a8ca",
+              "id": "684ecede-ef77-47e0-ba52-ac43a1a510e2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "85f6ad46-0bca-4455-a16e-1b23dc86eab1",
+          "id": "feba85cb-6a7b-4ec7-8f95-c79c3e5c1e85",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "6b5fe573-732e-4b50-a608-13933d9a50fc",
+              "id": "8b2c1f99-3c6c-4a47-8377-708972546244",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "c298c92d-588d-4f75-97d0-78c17ffbcc11",
+          "id": "e94294f5-ebe1-4098-b8fd-cf69cf99ef89",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "7797c754-f4fe-4af0-9047-7deffbe089c9",
+              "id": "e7249c04-202b-4002-a6a4-4c0c3b1dfb55",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "2ee167db-5668-47ca-b1ce-4e91dfb5ce2c",
+          "id": "221e2ebf-5b02-4156-bf8f-e193247696f7",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "a163f76a-8033-4da8-96aa-fa91a108aa03",
+              "id": "3207f167-4c64-42bf-bc6c-cb2d419d8d83",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "8d2ae2f7-bf88-494d-9ef7-3e088e1ee367",
+          "id": "b2d721a9-d66e-4c7b-b14f-fd772a8a435b",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "4cfaa712-c45f-4a5d-a719-3ac12342ef23",
+              "id": "684c2362-23d9-4a94-90cc-405a33b77383",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "7c393c9b-bc9c-4943-9598-b2af5c321204",
+          "id": "56a790e0-2c60-4a90-8bad-6d3263f3456d",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "031c035c-f761-434e-af2b-7c0a397b7cd6",
+              "id": "d6d2cc2a-070c-4b19-a19e-7ca3ce6c658e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "f4847699-0baf-4816-8b05-d222d2881f1a",
+          "id": "e9d90d49-2373-4e1c-8a74-be7099837d22",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "7657ddf5-74b7-468a-bf00-239a3dc08625",
+              "id": "db2d436e-2929-4281-a46f-090349cef787",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "7dc2254f-671b-4df9-83a7-972c70625201",
+          "id": "878e84b3-f803-4a55-ac36-6272f7672778",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "5aad77db-c12a-43be-b4ba-312e7db85159",
+              "id": "52613042-c0d4-4549-8709-87345152dd12",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "6cfcc89d-286a-4f18-ac4a-4f6b73136df5",
+          "id": "06ba36b9-45f5-404c-9614-a90f08d97699",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "dc3a3e40-cd18-40b3-b59e-df0399e8de28",
+              "id": "31c92e06-17d5-4453-9ffd-509b71636b14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "f33d9553-a790-4c93-9c16-b867bd2f57e1",
+          "id": "c2d55932-4dea-42f3-ac49-5e0ab9f0ec22",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "0a6b8c7d-ab71-43fd-ae3d-127aefe440b5",
+              "id": "0e0baa89-a11c-4f8e-b693-1b2fa54e39de",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "838959a7-de1f-496c-845f-d4918ddeae02",
+          "id": "88570d97-1bc9-45b6-bc46-36c7bc69ba5a",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "b4904f56-e62f-48b8-9de3-5de0976bd60d",
+              "id": "94b05444-fe27-40a3-b19e-f2ffafd958cb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "a58bf641-2336-46af-89cc-37fa391b587c",
+          "id": "ad8c24ab-e5ee-415a-b29b-cf9fb4791a0e",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "5dde6bb5-d782-447f-9463-70e6b6005efa",
+              "id": "2811a038-9108-41f7-9108-2624c2a88e52",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "b0084143-16f7-4af4-947d-37df938429fa",
+          "id": "116f57a5-7025-4720-9b6b-2fca91a87ab0",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "ad4940ea-d57d-4f4d-a319-404aeff93665",
+              "id": "defc246a-2eee-4811-a649-f725ddacd893",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "90843a0b-0b7c-4271-93a7-070d21f3b84c",
+          "id": "42198833-b3e9-4156-b00f-17a75087ed17",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "13e89121-0cbe-4677-b076-ec52566d5c33",
+              "id": "51eca6e8-85d5-44a4-a078-56b933175ab6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "40ee365b-5c4c-495b-90e7-ee5caa6788e7",
+          "id": "77c522e7-a85a-48d7-98eb-a51793a98d16",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "0ed9f544-0dcb-41ac-a42a-c0eeee8d1bfe",
+              "id": "f848adff-0c79-46b1-82fc-d11218910632",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "7af669fa-4a93-48b6-bd40-882487457911",
+          "id": "f198fd98-053c-4d28-8299-a55fa25ff4b8",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "da8c4eeb-2b4c-48de-be5f-6998e7418976",
+              "id": "98797efd-9303-47be-b618-e791da07f459",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "a5169553-f5d3-4831-af8f-5721dde429a2",
+          "id": "7150af5c-09dc-4ec8-a0f5-f366cc0f8b5c",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "12d59794-e129-45fc-9f8a-ca5d8ef6fb55",
+              "id": "cbf5674a-45f2-4a56-8edf-66263f499fc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "9c38d366-914d-4ef8-95b8-57fab8740b5a",
+          "id": "cd24fc88-4ed2-4fb7-8a59-4f48ece7c16c",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "2807399c-52cf-4cf6-a7f2-ca1af27367f5",
+              "id": "0055f1c0-ce02-476f-b0a5-67470d23ffed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "24159266-56dc-4866-9918-d75e26834282",
+          "id": "70d3c13b-4867-4386-80e3-f563f54601e8",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "1867fc7c-ec98-4a91-9d25-b40e60d50146",
+              "id": "acf1d925-c4fd-465d-b160-959d020fdfa7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "8687f050-0c10-4ad9-a142-f68c5dd8f5d6",
+          "id": "4bb35b3f-d036-4193-97fc-7fa780179890",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "8354148e-3c41-4ef8-b3be-921dc593164c",
+              "id": "55446abd-9f94-46eb-9ddb-f8e28fd6eaf2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "96bb7102-4acc-4688-a9e7-8f0883259891",
+          "id": "1591e2d7-22d6-49f5-b78f-8ea90870de48",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "f260d957-d49c-4456-b187-679ccbbf6623",
+              "id": "ce7f34f1-c5d6-4c88-9b22-e206735b5f3b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "98acdc0a-8680-4d46-84d8-090396621dd9",
+          "id": "c22dc89c-b355-42b2-a842-474daaafaf18",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "d002da0e-4206-4127-995f-54b798e22294",
+              "id": "fda9e4d6-6b2f-44d5-a1be-115ee4d3b769",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "ec2c76b4-4677-4712-938b-6a0e542372e6",
+          "id": "3e086e9d-767c-404c-b451-efe8ba13b632",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "4268d19b-4c02-4ff8-ad65-26bf4fe15212",
+              "id": "0fa4878d-e39d-4384-9c30-de0c6e3810b5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "60da0802-c332-477a-bd8a-eaed71658f8f",
+          "id": "b5a25583-2d94-4eca-b1c1-1a4f012fefaf",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "799f3553-174f-4131-90eb-346f3e84fed2",
+              "id": "05005989-4951-4708-80dd-0439f07683fb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "28a70e29-2407-473a-b1ce-c2a5a68ae4d0",
+          "id": "dd70521e-371e-4a87-a38e-952c6873ad42",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "91fdb685-29fd-49f4-83ee-4ac723b75933",
+              "id": "7f4da8ba-0980-4984-9970-35dbb39bf23c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "029c6137-42fd-4a14-9acb-24be5111b29b",
+          "id": "e6c9d5e5-4671-4c4a-a6d0-03802ef8d5c7",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "b4537a18-e1fd-44b2-8cf8-5b00f09b0b1a",
+              "id": "558801a2-ad6b-4338-b8a1-cf4a47fce090",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "94876886-e488-4b49-ae7d-18b81853457c",
+          "id": "e0fd276b-dc8c-4804-8f66-60d830349d77",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "d7bb2396-d86a-4550-a9af-aa4ad7c80567",
+              "id": "67b8e61d-61f5-48ec-9481-2efcb09c7f16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "316a987a-06bf-4445-aff6-64dfb8da58a0",
+          "id": "adb80394-ccfd-4f4b-af53-236c1c15de66",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "56c6e850-6c8f-4a63-ae17-3854ee10d4ec",
+              "id": "91ebf365-3e64-4ae8-861a-f81c4660d4fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "629951e5-f432-4ac4-b2df-2cc36e0d7bb2",
+          "id": "4f934358-e4c1-4ce1-a6e9-a9094aaacf35",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "d05c5965-05e1-4ac2-8f2d-c886b8453918",
+              "id": "283c4e6b-c8b9-4273-96cb-8ea7f690d90e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "3c02c799-9ed8-4164-a5c6-04081c507483",
+          "id": "764e8a1a-d80b-44db-a763-3a31b0f91c24",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "2f8d0558-c90a-47ca-9780-0f7740098322",
+              "id": "717e187f-7802-4a49-8d82-37605f681da8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "5e9a09c6-25bd-49f1-8214-30e4f5fa6895",
+          "id": "1e208918-3deb-4bea-9faf-26b4dcaab27c",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "45c2e303-7289-41f7-ba08-3b50787d821a",
+              "id": "5176eaa8-c88c-4e95-a90f-8f7739f9c9d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "85c23087-82f9-4288-a16a-9fe754020a7c",
+          "id": "572b07a0-6ab9-4418-a195-c10f4c10e11c",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "1f944290-3cf5-4995-95fe-19a247324a63",
+              "id": "8325db59-589c-41a3-93de-5984b8e51137",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "34a1d6bf-803c-4567-b0a9-ec4343cd6cce",
+          "id": "00d70971-1b2c-4bb2-9f96-a0400617cb4a",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "8ad34e95-9312-4363-bf66-054ff8065df4",
+              "id": "3059bee0-55df-404c-afa1-b0507bd2aadc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "71a0a252-af1c-4e47-9796-7fc85075be19",
+          "id": "07b4d461-a1a1-46cb-a90d-41c2605ab0ca",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "bfe8d3e5-d743-4f78-835d-487e18841bdd",
+              "id": "924e7f3d-1830-4548-8512-614fc2469fe8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "eec79c15-7076-420b-917c-b073a4ebd95e",
+              "id": "8a3e8fc3-8b23-4690-b637-c65509d1e5e5",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "3075cd8a-3d12-4ce3-988e-68ca6bad77ad",
+          "id": "c3bada82-61b7-41b9-8e12-1741a3df3f47",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "8f344015-c2cd-431c-a28a-b4af4254312f",
+              "id": "cc192d1a-93db-4ec0-903f-4a619ae9c0af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f6c1f823-5128-4014-84e3-aaeb79160e36",
+              "id": "06475391-76c0-4300-9d2b-b43fd839cfc4",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3a5e5859-4c43-410b-ae8a-cab14637265b",
+              "id": "2c07bb1e-1a15-49ee-8057-5ee963e396d9",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "aab9145e-e6e0-44d5-8350-2f0071112265",
+          "id": "57d2a0a2-2e94-4132-b19f-4d67a9e6e7bf",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "c15e0a59-3674-4add-92da-fd3504be615f",
+              "id": "5c266862-b160-4c2a-8cc0-3ac3247fd5c3",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "dc5b7cbd-4ce0-40a0-9f98-997edfabcbee",
+              "id": "11012a0d-351a-48c1-b08e-02c6856c7678",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "478182bd-73ef-4682-b98c-efb8902e18d0",
+              "id": "329574d3-ae15-42f9-abab-da4d4acc8707",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "4bc560e9-b66e-4240-a334-823aab0324ea",
+          "id": "1443c75e-cc62-4c15-a2dc-e7e539f50e08",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "b6e4918c-7a83-4e2e-8fdb-6ea84eb756e7",
+              "id": "406ef5df-50d4-40b1-bcce-13a699da8b57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "8a31a0eb-7ebb-4fba-b4cf-af4bbdb8ffd2",
+          "id": "1fb23e68-4728-4b8a-8ea1-895b25f86e9e",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "53be0a13-6f37-4bba-88ec-e7e1a20f0afc",
+              "id": "c1a0316d-9bf2-4b8f-98ec-c352d67e2304",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "881d33ad-cf37-4781-a6ef-99f9ee0cea42",
+              "id": "0f770103-4e80-40a1-a8ac-4af9fa330d2b",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "e3859ce9-0dcd-4968-9bac-eb0a2a5b0c5b",
+          "id": "f7620010-14bf-44d3-9fa5-469589cdd4dc",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "c8b741d5-61c8-47f9-84c3-3e0fa1b5e3b3",
+              "id": "03ed6510-4ea6-4254-add6-52791b9ad8dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "a1f96c9a-37ca-4ed0-87c0-f3f52ac6bf77",
+          "id": "91ceace8-e71c-48a0-9844-dd671299c33b",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "ff06fa3a-7d4e-436b-8bb6-5d3b30eef3cd",
+              "id": "50741bf9-6394-4a70-bd01-0637e0ee9369",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "c9c489f7-b830-4f69-95bd-a05bdd9c4143",
+          "id": "c8a2d1f2-14fe-4e35-9e5e-fe8dc8209b89",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "15a396cc-7264-4d0f-a82b-b8288cb03470",
+              "id": "5c2c68ef-325e-4dfd-b60a-220a7e213a39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "6a540c10-af1c-44e4-98fa-e4adb9e3a7d6",
+          "id": "f99d5b3a-a25c-46b5-87b9-6f0701b51b3d",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#33adb2\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#04CFB8\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "80ef5594-0990-4134-a0e6-2d1115fde14b",
+              "id": "51be0dc2-612b-4289-9121-01ecbd1aeda3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#33adb2\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#04CFB8\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "43950031-ef82-4dec-b34b-66cb0381755a",
+          "id": "db87a9cc-e298-40b1-a1c8-500f061d8eab",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "12576d45-a8a1-4b95-93d8-0f62bed9a150",
+              "id": "cf62c020-dd5d-4c40-8247-f8b57699c9fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "529d65c9-2011-4268-a8de-a8bf9bf308a9",
+          "id": "9b8789f3-dc0e-4782-8d6b-dbbfeb845a9f",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "c55d25ee-efb1-489b-923a-444fe15b8ae5",
+              "id": "9ba7447f-a5fd-4983-939c-d054dc4cc42a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "ad00f19e-0bae-46cb-ad58-cadb5ee14ec0",
+          "id": "0d990c7f-ca34-4e5d-919b-fb25377db322",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#C9fDF8\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a7F930\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "5f298b6f-abb4-4e4f-8e16-112cfe51ea69",
+              "id": "bd7ce512-885e-4174-a24e-f3d3e8bb2fb7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#C9fDF8\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a7F930\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "3f9f46c8-737d-4222-87c3-f7f07d5d6134",
+          "id": "ace58541-0af3-4ef9-8976-45c59b236e1f",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "4a671da0-7a9e-4572-bfe8-0b08caa75312",
+              "id": "4e0ded51-5822-404c-8e4f-588b58e6a21b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "af73d5bc-b2a1-4740-952d-79f4b11ef95d",
+          "id": "dd8da66d-f2a5-4f83-919b-4bc89a54f6e0",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "b1009ed7-04c6-4fb4-a767-448d242111dd",
+              "id": "cdab9e97-7c84-4f51-8e55-febe20e258a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "ab18480b-a91a-4231-a1b7-0869ef8bc7ec",
+          "id": "b6581459-b6d6-44fd-b8ac-df0fea931787",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "afeae6de-9216-4a78-80f6-17fe02ec6803",
+              "id": "b53a9200-e0ce-4367-a3ef-ed643c8dc876",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "628331e8-0834-499e-b09a-19dca6cf7639",
+          "id": "07c5727d-e583-4fc5-a76c-46dd0138d7fc",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "ce6c6fa6-b19f-4427-a8a5-cd8607b18b58",
+              "id": "9f626764-2526-4601-b687-08803ae99cc2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "165e9819-d9b1-4d8b-a923-6a2b6bf358ad",
+          "id": "53bb9264-e1d0-4c6a-8bec-379d66f28559",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "189d4857-8257-40b3-9ab8-81ef1f1db88b",
+              "id": "c02619e8-ab8d-4ead-8ed6-d1c57022a41e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "0a4ed7f0-38b1-4b90-92a4-945ab77eb33c",
+          "id": "e7ef3f41-5e4f-4d2b-a201-0fea7556d997",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "b400a7cc-534c-4ab1-9578-c7358c701a0e",
+              "id": "ceac73f8-0f1a-422e-a452-a56fe82afdb0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "7cd2ac2d-b9e2-434c-837d-4b8b1d4b9522",
+          "id": "26686493-09d6-4ecd-a02e-23c673cb5624",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "5a83dc53-1957-496e-9e19-c45408535ac6",
+              "id": "c8af0900-6945-41e1-9635-23ee3b90b20d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "ef5877fe-58f7-4b6e-af3f-bf6507117750",
+          "id": "fae19176-4870-4058-924c-09502e29c8df",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "34a1c209-a90c-440f-8650-1ab7955ca12f",
+              "id": "ca1bbb89-57a5-4dbc-beff-8cc546799121",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "cf476b59-7881-4d52-8375-933038b4dc52",
+          "id": "72499247-5321-480a-a8dd-e3e542a0ef04",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "8442abe9-0671-40aa-a1b7-2e9fcdfb3c9e",
+              "id": "6cd5fc49-1ee1-45d2-90e9-900857aea803",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "83115618-7e52-403f-88a5-071988baa0c4",
+          "id": "5ba9bc53-35f2-48a8-96fa-8328231da06c",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "3869a507-efab-44cf-8a86-fa7f4e6c87ac",
+              "id": "20688965-c579-44ed-93c9-87356ed0342a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "6f675fd2-d34a-49f4-9633-7f3472f78824",
+          "id": "8274bdd1-9d94-4efc-81ba-c8201b6b6700",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "2a50eb1d-9466-4d73-bee5-e7ddfcf87de7",
+              "id": "cb659562-cf56-4d8d-a11a-57ce6adfb3d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "651a0644-8ca5-4cec-9ad3-3aee9f1ce3b9",
+          "id": "7b5ea654-f138-4237-b2bc-a63ad0ef6de9",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "d2dad28d-9ca6-492d-af00-f909a5aeb984",
+              "id": "5b02548a-288b-445d-a138-86cc4d6bf265",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "3a4c647f-f44a-4b48-a435-cb138df0f4b0",
+          "id": "f963a082-cabf-4fb2-914e-806dbbcdf03e",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "b4136933-e018-4374-8790-4af228ebdddb",
+              "id": "3e84f7b8-4d84-4754-94e8-1d383ff660d3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "b610e3c4-515f-4682-bb58-52d3dd00f312",
+          "id": "e6bf6f24-a9ae-42a8-a8a1-123bdf175771",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "e3bd1ac7-5bcf-4587-ad58-b9fcb1ac1211",
+              "id": "3ebf5cf2-01f9-4238-90f7-daf6e3586a91",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "1593ee4e-e1fe-4ce3-af75-addbc08d1856",
+          "id": "e9a83310-4a5f-4bf9-8c84-da6e4cbcde5c",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "7b04a90c-071a-4a80-975e-3c7fdc2dc9ba",
+              "id": "7c96a004-0275-43a1-90fd-3d9019798a9b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "2e6a36a6-43d2-42fe-987d-268264ff7491",
+          "id": "e2def0d1-bc91-41a4-91e3-f4e92bc5fa81",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "754562aa-1572-4686-bd3d-f4659b0eee26",
+              "id": "dec80f2a-e2bd-4ba0-befe-49c57dde3c78",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "f66fa2cc-c152-4b95-b0a1-ee2f034fd48a",
+          "id": "7da1da6e-b55d-48a1-a86d-a21442b94699",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "ce074e0f-6822-419e-ac2f-a74ac7cd68bf",
+              "id": "a4e1d8c2-0475-47dc-ad49-307c569d7257",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "4c02e13f-6a75-418e-9750-83ede7b92448",
+          "id": "9ccf89ab-e9f9-491f-bd7f-e1d893efac25",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "cf077c7b-98e9-4cfc-9f8f-c176bbc5ee2b",
+              "id": "9c78cd03-9c65-4b85-81e9-0edd28aa1937",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "4daffad1-c7ea-4a28-8867-20b6ebf7f233",
+          "id": "241b8d2d-0db3-4aa2-a242-dccbc5a67256",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "e7bd2dde-9556-4727-a534-bed5e535cd3c",
+              "id": "45610dd1-4103-4db8-b52d-a351b2f1e147",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "066546e9-5148-4c07-849f-783a9f23efe0",
+          "id": "e6ddeaa9-2c98-48ad-a32e-2da820f2321e",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "82eafb0b-0708-4fcf-b7fa-d6c24b18d524",
+              "id": "d65153f8-d64f-4c2c-aa3c-2c32ab58be31",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "180bf543-1011-48e6-b1f9-4264b18bbcb7",
+          "id": "ff636c11-3460-4c72-9c60-862528d2a8f0",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "b41a341b-5a2d-4eb8-8f67-0ba5705ddcc0",
+              "id": "d20a10c0-0cb9-498b-a86f-ef98bb204fcf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "a6dffec1-c86e-4102-b579-01c145f06692",
+          "id": "38862028-151b-4fc1-990a-a957e02be4e9",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "e26f8d5f-3cdf-4742-bf5a-dfcd6421c9ff",
+              "id": "4822999f-5742-408f-95b2-9b7978bceec5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "3ebbd2fa-9d8d-49b5-ad55-c75a70048753",
+          "id": "1041e9df-a6c6-406d-9db3-dec52e2a3f05",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "91744795-0d52-4250-b39a-272620beecf8",
+              "id": "5d7693bd-d934-4296-9541-34a6b993159c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "f29c3a43-3a41-4808-9a8a-71b8b583093f",
+          "id": "2a0f2ad1-de29-425b-9626-a0bd5641dadf",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "f7eaa899-8d96-432d-b3df-a9ab435f9c88",
+              "id": "ef9971b3-d7c4-4e62-a929-d2078f6d47ff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13520,7 +13520,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "0c3d1a90-b6e7-41b5-9050-7138a6325f34",
+          "id": "6a8531e9-e93a-46f4-8c26-a633345959c3",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "cace4fd5-d641-483f-9018-9641164cb0ad",
+              "id": "1e039feb-0af9-48b5-9217-f6f101604ba0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13630,7 +13630,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "631d254c-7fec-4b1c-952b-4d598493a980",
+          "id": "fa6ad8ff-e815-4c02-a442-c1eb9310ce1e",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "4e494c9e-196a-4b79-945f-0bfa55df0523",
+              "id": "69cac62f-231f-41d9-a6b6-60df386df619",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "57529cd8-b7f0-47f1-950a-534593675977",
+              "id": "ce408262-8b8e-46e3-80c8-8a4bc2d95d89",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "9c958d04-d620-4eb6-bb3c-1daa53dbeb13",
+          "id": "5822a1e0-9325-41df-aeb6-c3870e84d1e9",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "5ec760ca-a95b-483b-a551-c4646114b7ed",
+              "id": "afe37782-ff7e-43ba-a57e-bdf369e1a7b5",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8486cb55-05d0-4717-8f14-f6777417c0a1",
+              "id": "b372727e-1f65-4012-9a15-72b30153d018",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "a3ac9715-70be-44e9-8186-ccf78c46664d",
+          "id": "52031a5d-3949-4865-a9ce-8f87784ebbbe",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "eed5f88b-983f-401c-9adf-cbf906e6d99b",
+              "id": "ad3f6609-981a-4d24-94d6-ba62a2d0884e",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e8d5ea79-622e-4062-9750-2feb793014a8",
+              "id": "221f4cd5-42c6-4c14-a396-fb46cd56a89e",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "730d743e-8de4-433a-90b3-40f349711401",
+          "id": "4266cfcc-8933-480e-b498-bee00ab18098",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "6fe3e8c7-3fe6-4e45-95ad-313a59919cb8",
+              "id": "f312e64e-b28b-4c97-9e67-174f4ecc0f9b",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "4e046bc0-4ea2-4acf-984d-7482ebd13fee",
+          "id": "62d2e108-022a-4b81-ab43-8ae1958d8bf0",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "bdd8a58e-2eca-4b8a-809d-391adae15112",
+              "id": "bff04126-7e53-4fa5-a4c5-ac8a60c28d11",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "fd68d384-270c-4944-b494-0b381ff838d8",
+          "id": "3debf779-9999-4fa1-9da7-c47b77546e82",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "f8e54245-8573-46f8-8b86-8bbb9f6eb18e",
+              "id": "055341a7-beaf-4ffa-b443-148ba04a0ad1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "3db5c4c5-b6b4-4998-8c85-d5cda4068d91",
+          "id": "7fcc7f37-6f1a-4b13-aceb-97c7e444c775",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "3c82a5e6-9e9e-423a-a85d-ac919b924af2",
+              "id": "8dd369d3-501d-4375-9e02-47ab82d9b665",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "b21752be-5689-498f-a8c1-e8c0fba2581b",
+          "id": "7347548a-053a-4fd0-a180-c7a52fbb7082",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "6d5ce8c5-921f-4670-9eac-a250a3906cb4",
+              "id": "4880a396-bdd4-401c-b6c9-3dd4cfe445c0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "d47f178e-d9dc-44ac-bfb6-20a153d6e5ca",
+          "id": "8a954a62-3c4d-4dcb-aeb9-a8058e2418f1",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "d76e4d1d-58d4-4d19-ad51-7d086d64821e",
+              "id": "373c0704-00b7-4c00-bcd7-7905ae4a03ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "ed45feb7-bd4d-447e-bbef-2342eccf4ae0",
+          "id": "ac383265-8aa7-433b-af8c-e0dd70a92ef6",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "307425f7-3f99-43c4-96df-78df5b371eb5",
+              "id": "198065d3-4f56-4ee5-9fcc-46b6f4f37280",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "ef5c43e6-6bd6-4249-9662-1731736d7185",
+          "id": "a17e9234-af7e-462e-8a78-f4ef98fcb521",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "5482696a-7847-4826-9453-7ac8e029be30",
+              "id": "260bdd33-966e-4e8b-bd3d-cc5753e9e9ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "34f43ec3-0ba6-4955-9977-a21f1a9434e8",
+          "id": "7b2adc5d-45a0-45c4-ae16-f38c40c71b95",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "48e05eac-a482-447b-92d1-d55028bababd",
+              "id": "4e7d573f-f5c0-4dd5-8060-efe192422c6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "d029ab87-bec9-454b-8209-ce0ea169a56f",
+          "id": "5a60e8e5-0c94-45a3-bea5-f060fa0045ba",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "12aa4404-4c9a-47e9-a93d-26c1b90f2603",
+              "id": "14d83d93-a6a8-4fc9-b0b8-3b3dccddf8b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "887c5ea3-10eb-4c2a-bb10-cd81fe19c79b",
+          "id": "83cc216e-cbc3-4ae9-b6f1-c6560cc91777",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "01e62e0d-9e0f-4ce3-b559-dcc5e059845d",
+              "id": "0744666f-c05f-4533-bcdd-3cdcdaf4f863",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1338.5624610853663\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "c8292511-eb83-450c-a72b-3ae5799f623d",
+          "id": "138d725e-09be-4de8-86fc-7c74b96ba90d",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "946389dd-8994-4ef7-950d-7df257df306f",
+              "id": "750867b6-f4ab-4639-afa2-4fb53a63df1e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "c456ea7a-0767-4c7d-94c3-f34147edfefd",
+          "id": "a8a66c00-c397-4eae-8ce6-f3c6d2a00bdd",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "9d12194f-cc58-4091-a0f2-592bb2bf9ef0",
+              "id": "89d6ba4d-b284-4945-99cb-b53b244c6caa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15533,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "b6ce7502-b182-40ae-b9ec-a537d55d7e42",
+          "id": "895bd796-b5ea-4894-87a1-bf6cf573d3f7",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "f084f845-3705-4750-a385-b1da001e6492",
+              "id": "a06d6365-9ae0-4e7d-bf89-b80a878659b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15615,7 +15615,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "06c89801-04bf-43f1-ba25-3c35a4f76d47",
+    "_postman_id": "b171f908-1d7e-4b21-99b0-499aaf665f35",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 12:09 UTC\nRama: main\nEntorno: prod\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 14:58 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssembler.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssembler.kt
@@ -113,7 +113,7 @@ class GreenhouseStatusAssembler(
         val deviceResponses = devices.map { device ->
             val currentValue = readingsMap[device.code]
             device.toResponse(
-                currentValue = currentValue?.value,
+                currentValue = normalizeCurrentValue(currentValue?.value, device.type?.dataType),
                 lastUpdated = currentValue?.lastSeenAt
             )
         }
@@ -123,7 +123,7 @@ class GreenhouseStatusAssembler(
         val settingResponses = settings.map { setting ->
             val currentValue = readingsMap[setting.code]
             setting.toResponse(
-                currentValue = currentValue?.value,
+                currentValue = normalizeCurrentValue(currentValue?.value, setting.dataType?.name),
                 lastUpdated = currentValue?.lastSeenAt
             )
         }
@@ -137,5 +137,35 @@ class GreenhouseStatusAssembler(
             settings = settingResponses,
             alerts = alertResponses
         )
+    }
+
+    companion object {
+        /**
+         * Normalises the wire representation of a current value before sending it to the client.
+         *
+         * The MQTT ingestion path (`DeviceStatusListener`) converts JSON booleans into the
+         * strings `"1"` / `"0"` to keep TimescaleDB continuous aggregates that cast value to
+         * `double precision` (commit 6c98ca6) working. That choice is correct for the storage
+         * layer but breaks UI consumers that read `currentValue` and compare against the
+         * conventional `"true"` / `"false"` strings (the case for the mobile app's
+         * SetpointBooleanEditor and several view models).
+         *
+         * For codes whose catalog declares `dataType == "BOOLEAN"`, this method translates
+         * the stored `"1"` → `"true"` and `"0"` → `"false"`. Any other value (or non-boolean
+         * dataType) is passed through unchanged. The DB layout is not touched; only the
+         * representation that travels over the WebSocket changes.
+         *
+         * @param storedValue The raw value as stored in iot.device_current_values (or null).
+         * @param dataType Catalog dataType name (e.g. "BOOLEAN", "DOUBLE", "INTEGER", "STRING").
+         */
+        internal fun normalizeCurrentValue(storedValue: String?, dataType: String?): String? {
+            if (storedValue == null) return null
+            if (!dataType.equals("BOOLEAN", ignoreCase = true)) return storedValue
+            return when (storedValue) {
+                "1" -> "true"
+                "0" -> "false"
+                else -> storedValue
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssemblerNormalizationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssemblerNormalizationTest.kt
@@ -1,0 +1,83 @@
+package com.apptolast.invernaderos.features.websocket
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure tests for the BOOLEAN currentValue normalisation in GreenhouseStatusAssembler.
+ *
+ * Pins down the contract between the API and any UI consumer of the WebSocket status
+ * payload: BOOLEAN-typed codes always travel as the canonical strings "true" / "false",
+ * never as "1" / "0", regardless of how the value was stored in TimescaleDB.
+ *
+ * For non-boolean dataTypes the value is passed through unchanged so DOUBLE / INTEGER /
+ * STRING readings keep their wire representation.
+ */
+class GreenhouseStatusAssemblerNormalizationTest {
+
+    @Test
+    fun `BOOLEAN dataType maps stored 1 to true`() {
+        val out = GreenhouseStatusAssembler.normalizeCurrentValue("1", "BOOLEAN")
+        assertThat(out).isEqualTo("true")
+    }
+
+    @Test
+    fun `BOOLEAN dataType maps stored 0 to false`() {
+        val out = GreenhouseStatusAssembler.normalizeCurrentValue("0", "BOOLEAN")
+        assertThat(out).isEqualTo("false")
+    }
+
+    @Test
+    fun `BOOLEAN dataType is case-insensitive on the dataType name`() {
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "boolean")).isEqualTo("true")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("0", "Boolean")).isEqualTo("false")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "BoOlEaN")).isEqualTo("true")
+    }
+
+    @Test
+    fun `BOOLEAN dataType passes already-canonical true and false unchanged`() {
+        // If a future caller pre-normalises (or the source already had "true"/"false"),
+        // we don't want to mangle it.
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("true", "BOOLEAN")).isEqualTo("true")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("false", "BOOLEAN")).isEqualTo("false")
+    }
+
+    @Test
+    fun `BOOLEAN dataType leaves unrecognised values untouched`() {
+        // Defensive: garbage in → garbage out, but never silently cast to true/false.
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("yes", "BOOLEAN")).isEqualTo("yes")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("", "BOOLEAN")).isEqualTo("")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("2", "BOOLEAN")).isEqualTo("2")
+    }
+
+    @Test
+    fun `DOUBLE dataType is never normalised - 1 stays 1, not true`() {
+        // Critical: a sensor reading of 1.0 (e.g. 1 amp, 1 lux) must never become "true".
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "DOUBLE")).isEqualTo("1")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("0", "DOUBLE")).isEqualTo("0")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1.5", "DOUBLE")).isEqualTo("1.5")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("185", "DOUBLE")).isEqualTo("185")
+    }
+
+    @Test
+    fun `INTEGER and STRING dataTypes are never normalised`() {
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "INTEGER")).isEqualTo("1")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("0", "INTEGER")).isEqualTo("0")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("hello", "STRING")).isEqualTo("hello")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", "LONG")).isEqualTo("1")
+    }
+
+    @Test
+    fun `null dataType means non-boolean - pass-through`() {
+        // Devices/settings without a catalogued type fall back to raw transport.
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("1", null)).isEqualTo("1")
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue("true", null)).isEqualTo("true")
+    }
+
+    @Test
+    fun `null storedValue stays null regardless of dataType`() {
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue(null, "BOOLEAN")).isNull()
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue(null, "DOUBLE")).isNull()
+        assertThat(GreenhouseStatusAssembler.normalizeCurrentValue(null, null)).isNull()
+    }
+}


### PR DESCRIPTION
## Summary

Promote develop to main. Includes only **Phase 6** (PR #102, commit `298cf22`) on top of the previous main HEAD `f5f8307`.

Phase 6 fix: WebSocket payload normalises BOOLEAN-typed `currentValue` to canonical `"true"`/`"false"` regardless of how it was stored in TimescaleDB (`"1"`/`"0"`). Solves the visible bug on Cordoplant DEV today (BOOLEAN_TEST/SET-00080 stuck OFF) and the same family of issues for any BOOLEAN consigna and BOOLEAN sensor.

Why this matters for PROD: the user cannot rebuild the mobile app right now, so the API change is the only path to get correct rendering of booleans on existing app builds. The app keeps comparing `currentValue` against `"true"` — once the API sends the canonical form, the existing app starts working without redeploy.

## Test plan

- [x] Unit tests green (9 new + ArchUnit + Phase 4/5 regression).
- [x] DEV pod reiniciado with `:develop` image build #25060296191. `/actuator/health` 200.
- [ ] After merge: PROD pod reinicia con `:latest`, `/health` 200, BOOLEAN_TEST refleja estado real en la app móvil sin recompilar.

## Rollback

| Level | Command |
|---|---|
| R1 | `kubectl rollout undo deployment/invernaderos-api -n apptolast-invernadero-api-prod` |
| R2 | Revert this PR + `:latest` rebuild |

No DB migration. No flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)