### PR TITLE
feat(push): FCM push notifications backend (V38 + push module)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,25 @@ SPRING_PROFILES_ACTIVE=local
 JAVA_OPTS=-Xms256m -Xmx512m
 
 # ============================================
+# Firebase Cloud Messaging (FCM push notifications)
+# ============================================
+# Path to the Firebase Admin SDK service-account JSON inside the running
+# container. Mount the JSON as a Kubernetes Secret and point this var at
+# the mount path. If unset, the API still starts and alerts continue to
+# flow via WebSocket; only FCM push notifications are disabled.
+#
+# The JSON file must NEVER be committed to git — it contains a private key.
+# It is generated from Firebase Console → Project settings → Service
+# accounts → Generate new private key.
+#
+# Example for Kubernetes:
+#   - kubectl create secret generic firebase-admin-sa \
+#       --from-file=service-account.json=./greenhouse-fronts-firebase-adminsdk-*.json
+#   - Mount the secret at /run/secrets/firebase
+#   - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase/service-account.json
+GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase/service-account.json
+
+# ============================================
 # Production/Development Specific
 # ============================================
 # For production environments, use stronger passwords

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ docker-compose.override.yaml
 # because they only contain behavior configuration, NOT secrets.
 # Secrets come from environment variables.
 
+### Firebase Admin SDK service account (NEVER COMMIT) ###
+*firebase-adminsdk*.json
+greenhouse-fronts-firebase-adminsdk-*.json
+firebase-service-account*.json
+
 # Environment variables and secrets
 .env
 .env.local

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,9 @@ dependencies {
     implementation("org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5")
     // OpenAPI/Swagger documentation
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14")
+    // Firebase Admin SDK - server-side FCM push notifications
+    // https://firebase.google.com/docs/admin/setup#java
+    implementation("com.google.firebase:firebase-admin:9.5.0")
     annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/com/apptolast/invernaderos/config/PostGreSQLDataSourceConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/PostGreSQLDataSourceConfig.kt
@@ -35,7 +35,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
 
                         "com.apptolast.invernaderos.features.statistics",
                         "com.apptolast.invernaderos.features.setting",
-                        "com.apptolast.invernaderos.features.command"],
+                        "com.apptolast.invernaderos.features.command",
+                        "com.apptolast.invernaderos.features.push"],
         entityManagerFactoryRef = "metadataEntityManagerFactory",
         transactionManagerRef = "metadataTransactionManager"
 )
@@ -75,7 +76,8 @@ class PostGreSQLDataSourceConfig {
                 "com.apptolast.invernaderos.features.user",
                 "com.apptolast.invernaderos.features.statistics",
                 "com.apptolast.invernaderos.features.setting",
-                "com.apptolast.invernaderos.features.command"
+                "com.apptolast.invernaderos.features.command",
+                "com.apptolast.invernaderos.features.push"
         )
         entityManager.persistenceUnitName = "metadataPersistenceUnit"
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/catalog/AlertSeverity.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/catalog/AlertSeverity.kt
@@ -42,6 +42,16 @@ data class AlertSeverity(
     @Column(name = "notification_delay_minutes")
     val notificationDelayMinutes: Int = 0,
 
+    /**
+     * Per-severity feature flag for FCM push notifications. When false,
+     * activations of alerts with this severity skip the push fan-out
+     * (the alert still travels via WebSocket as today). Toggleable at
+     * runtime via UPDATE on metadata.alert_severities so admins can mute
+     * a noisy severity without a redeploy.
+     */
+    @Column(name = "notify_push", nullable = false)
+    val notifyPush: Boolean = true,
+
     @Column(name = "created_at")
     val createdAt: Instant = Instant.now()
 ) {

--- a/src/main/kotlin/com/apptolast/invernaderos/features/catalog/dto/mapper/CatalogMappers.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/catalog/dto/mapper/CatalogMappers.kt
@@ -58,7 +58,8 @@ fun AlertSeverity.toResponse() = AlertSeverityResponse(
     description = this.description,
     color = this.color,
     requiresAction = this.requiresAction,
-    notificationDelayMinutes = this.notificationDelayMinutes
+    notificationDelayMinutes = this.notificationDelayMinutes,
+    notifyPush = this.notifyPush
 )
 
 fun Period.toResponse() = PeriodResponse(

--- a/src/main/kotlin/com/apptolast/invernaderos/features/catalog/dto/response/AlertSeverityResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/catalog/dto/response/AlertSeverityResponse.kt
@@ -23,5 +23,11 @@ data class AlertSeverityResponse(
     val requiresAction: Boolean,
 
     @Schema(description = "Minutos de retraso antes de notificar", example = "0")
-    val notificationDelayMinutes: Int
+    val notificationDelayMinutes: Int,
+
+    @Schema(
+        description = "Si esta severidad dispara notificaciones push FCM (toggle de admin)",
+        example = "true"
+    )
+    val notifyPush: Boolean = true
 )

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/AlertPushPayload.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/AlertPushPayload.kt
@@ -1,0 +1,28 @@
+package com.apptolast.invernaderos.features.push
+
+import java.time.Instant
+
+/**
+ * Payload de una notificación push generada a partir de la activación de
+ * una alerta. Sólo datos primitivos: el `FcmPushService` los traduce a los
+ * campos `notification` (display) y `data` (deep link) del `MulticastMessage`.
+ *
+ * Estructura `data` que recibe el cliente:
+ *  - alertId, alertCode → identifican la alerta concreta
+ *  - greenhouseId, sectorId → para el deep link a `GreenhouseDetailScreen`
+ *  - severity, severityLevel → para colorear / filtrar en cliente
+ *  - createdAt → ISO-8601 epoch millis
+ */
+data class AlertPushPayload(
+    val alertId: Long,
+    val alertCode: String,
+    val tenantId: Long,
+    val greenhouseId: Long,
+    val sectorId: Long,
+    val severityName: String,
+    val severityLevel: Short,
+    val severityColor: String?,
+    val title: String,
+    val body: String,
+    val createdAt: Instant
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/FcmPushService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/FcmPushService.kt
@@ -1,0 +1,173 @@
+package com.apptolast.invernaderos.features.push
+
+import com.google.firebase.messaging.AndroidConfig
+import com.google.firebase.messaging.AndroidNotification
+import com.google.firebase.messaging.ApnsConfig
+import com.google.firebase.messaging.Aps
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.Notification
+import io.micrometer.core.instrument.MeterRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Envía notificaciones push FCM a todos los tokens registrados de un tenant.
+ *
+ * Trocea el envío en grupos de [FCM_MULTICAST_BATCH] (máximo permitido por
+ * `sendEachForMulticast` según la documentación de FCM HTTP v1) para no
+ * sobrepasar el límite del SDK.
+ *
+ * Limpieza automática de tokens muertos: cuando FCM responde con
+ * `UNREGISTERED` (la app fue desinstalada) o `INVALID_ARGUMENT` (token
+ * malformado o ya rotado), se borra la fila correspondiente para que el
+ * próximo envío no la incluya.
+ *
+ * Si no hay `FirebaseMessaging` (caso "sin credenciales", ver
+ * [com.apptolast.invernaderos.features.push.infrastructure.config.FirebaseConfig]),
+ * el envío es un no-op silencioso. Esto permite que el sistema siga funcional
+ * para entornos sin Firebase configurado.
+ */
+@Service
+class FcmPushService(
+    @Autowired(required = false)
+    private val firebaseMessaging: FirebaseMessaging?,
+    private val pushTokenRepository: PushTokenRepository,
+    private val meterRegistry: MeterRegistry
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional("metadataTransactionManager")
+    fun sendAlertToTenant(payload: AlertPushPayload) {
+        val messaging = firebaseMessaging ?: run {
+            logger.debug(
+                "FCM disabled (no FirebaseMessaging bean) — skipping push for alert {}",
+                payload.alertCode
+            )
+            return
+        }
+
+        val tokens = pushTokenRepository.findAllByTenantId(payload.tenantId).map { it.token }
+        if (tokens.isEmpty()) {
+            logger.info(
+                "No push tokens registered for tenantId={} — skipping push for alert {}",
+                payload.tenantId, payload.alertCode
+            )
+            return
+        }
+
+        var totalSuccess = 0
+        var totalFailed = 0
+        tokens.chunked(FCM_MULTICAST_BATCH).forEach { chunk ->
+            val message = buildMulticastMessage(chunk, payload)
+            try {
+                val response = messaging.sendEachForMulticast(message)
+                totalSuccess += response.successCount
+                totalFailed += response.failureCount
+
+                response.responses.forEachIndexed { index, sendResponse ->
+                    if (!sendResponse.isSuccessful) {
+                        val code = sendResponse.exception?.messagingErrorCode
+                        val deadToken = chunk[index]
+                        if (code == MessagingErrorCode.UNREGISTERED ||
+                            code == MessagingErrorCode.INVALID_ARGUMENT) {
+                            val deletedRows = pushTokenRepository.deleteByToken(deadToken)
+                            logger.info(
+                                "Removed invalid FCM token (code={}) deletedRows={} alertCode={}",
+                                code, deletedRows, payload.alertCode
+                            )
+                        } else {
+                            logger.warn(
+                                "FCM send failure (code={}) tokenSuffix=...{} alertCode={}",
+                                code,
+                                deadToken.takeLast(6),
+                                payload.alertCode,
+                                sendResponse.exception
+                            )
+                        }
+                        meterRegistry.counter(
+                            "push.fcm.failed",
+                            "reason", code?.name ?: "UNKNOWN"
+                        ).increment()
+                    }
+                }
+            } catch (ex: Exception) {
+                logger.error(
+                    "FCM multicast call failed for alertCode={} chunkSize={}",
+                    payload.alertCode, chunk.size, ex
+                )
+                totalFailed += chunk.size
+                meterRegistry.counter("push.fcm.failed", "reason", "EXCEPTION").increment()
+            }
+        }
+
+        meterRegistry.counter("push.fcm.sent").increment(totalSuccess.toDouble())
+        logger.info(
+            "FCM push sent: tenantId={} alertCode={} tokens={} success={} failed={}",
+            payload.tenantId, payload.alertCode, tokens.size, totalSuccess, totalFailed
+        )
+    }
+
+    private fun buildMulticastMessage(
+        tokens: List<String>,
+        payload: AlertPushPayload
+    ): MulticastMessage {
+        val builder = MulticastMessage.builder()
+            .addAllTokens(tokens)
+            .setNotification(
+                Notification.builder()
+                    .setTitle(payload.title)
+                    .setBody(payload.body)
+                    .build()
+            )
+            .putData("alertId", payload.alertId.toString())
+            .putData("alertCode", payload.alertCode)
+            .putData("greenhouseId", payload.greenhouseId.toString())
+            .putData("sectorId", payload.sectorId.toString())
+            .putData("severity", payload.severityName)
+            .putData("severityLevel", payload.severityLevel.toString())
+            .putData("createdAt", payload.createdAt.toEpochMilli().toString())
+            .setAndroidConfig(
+                AndroidConfig.builder()
+                    .setPriority(AndroidConfig.Priority.HIGH)
+                    .setNotification(
+                        AndroidNotification.builder()
+                            .setChannelId(ANDROID_CHANNEL_ID)
+                            .setColor(payload.severityColor ?: DEFAULT_COLOR)
+                            .build()
+                    )
+                    .build()
+            )
+            .setApnsConfig(
+                ApnsConfig.builder()
+                    .setAps(
+                        Aps.builder()
+                            .setSound("default")
+                            .setContentAvailable(true)
+                            .build()
+                    )
+                    .build()
+            )
+        return builder.build()
+    }
+
+    companion object {
+        /**
+         * Máximo de tokens por llamada `sendEachForMulticast` (FCM HTTP v1).
+         */
+        const val FCM_MULTICAST_BATCH = 500
+
+        /**
+         * Canal de notificación Android. El cliente debe crear este channel
+         * antes de mostrar la primera notificación; ver `GreenhouseFcmService`
+         * en el frontend KMP.
+         */
+        const val ANDROID_CHANNEL_ID = "alerts_default"
+
+        private const val DEFAULT_COLOR = "#00E676"
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/PushToken.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/PushToken.kt
@@ -1,0 +1,55 @@
+package com.apptolast.invernaderos.features.push
+
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * Token FCM (Firebase Cloud Messaging) registrado por un dispositivo de cliente
+ * (móvil Android/iOS o navegador web) tras hacer login. El token se utiliza para
+ * enviar notificaciones push de alertas a TODOS los dispositivos asociados a un
+ * tenant.
+ *
+ * Reglas:
+ *  - `token` es UNIQUE: un mismo dispositivo (token) sólo aparece una vez. Si
+ *    el mismo token se registra desde otro user/tenant (poco probable, pero
+ *    posible si hay relogin con otro user), el upsert sobrescribe el dueño.
+ *  - El borrado en cascada por `user_id` y `tenant_id` garantiza que al borrar
+ *    un usuario o tenant los tokens también desaparezcan.
+ *  - `last_seen_at` se refresca en cada upsert; permite limpiar tokens
+ *    huérfanos en una rutina de mantenimiento futura (no implementada aquí).
+ */
+@Entity
+@Table(
+    name = "push_tokens",
+    schema = "metadata",
+    indexes = [
+        Index(name = "idx_push_tokens_tenant", columnList = "tenant_id"),
+        Index(name = "idx_push_tokens_user", columnList = "user_id")
+    ]
+)
+data class PushToken(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+
+    @Column(name = "tenant_id", nullable = false)
+    var tenantId: Long,
+
+    @Column(name = "token", nullable = false, unique = true, columnDefinition = "TEXT")
+    var token: String,
+
+    @Column(name = "platform", nullable = false, length = 16)
+    @Enumerated(EnumType.STRING)
+    var platform: PushPlatform,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: Instant = Instant.now(),
+
+    @Column(name = "last_seen_at", nullable = false)
+    var lastSeenAt: Instant = Instant.now()
+)
+
+enum class PushPlatform { ANDROID, IOS, WEB }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/PushTokenRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/PushTokenRepository.kt
@@ -1,0 +1,19 @@
+package com.apptolast.invernaderos.features.push
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PushTokenRepository : JpaRepository<PushToken, Long> {
+
+    fun findByToken(token: String): PushToken?
+
+    fun findAllByTenantId(tenantId: Long): List<PushToken>
+
+    @Modifying
+    @Query("DELETE FROM PushToken p WHERE p.token = :token")
+    fun deleteByToken(@Param("token") token: String): Int
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/PushTokenService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/PushTokenService.kt
@@ -1,0 +1,82 @@
+package com.apptolast.invernaderos.features.push
+
+import com.apptolast.invernaderos.features.user.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+/**
+ * Servicio para gestionar tokens FCM. Resuelve `userId` y `tenantId` desde
+ * la identidad autenticada (email o username del JWT) — los tokens NUNCA se
+ * registran a un usuario que no es el que está enviando la petición.
+ *
+ * Idempotencia: el endpoint POST hace upsert por `token` UNIQUE. Si el mismo
+ * token se registra de nuevo (relogin en el mismo dispositivo, rotación FCM
+ * que devuelve el mismo valor, etc.) se actualizan user_id, tenant_id,
+ * platform y last_seen_at sin crear filas duplicadas.
+ */
+@Service
+class PushTokenService(
+    private val pushTokenRepository: PushTokenRepository,
+    private val userRepository: UserRepository
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional("metadataTransactionManager")
+    fun register(authenticatedPrincipal: String, token: String, platform: PushPlatform): PushToken {
+        val (userId, tenantId) = resolveUserAndTenant(authenticatedPrincipal)
+
+        val existing = pushTokenRepository.findByToken(token)
+        return if (existing != null) {
+            existing.userId = userId
+            existing.tenantId = tenantId
+            existing.platform = platform
+            existing.lastSeenAt = Instant.now()
+            val saved = pushTokenRepository.save(existing)
+            logger.info(
+                "Push token refreshed: id={} userId={} tenantId={} platform={}",
+                saved.id, userId, tenantId, platform
+            )
+            saved
+        } else {
+            val saved = pushTokenRepository.save(
+                PushToken(
+                    userId = userId,
+                    tenantId = tenantId,
+                    token = token,
+                    platform = platform
+                )
+            )
+            logger.info(
+                "Push token registered: id={} userId={} tenantId={} platform={}",
+                saved.id, userId, tenantId, platform
+            )
+            saved
+        }
+    }
+
+    @Transactional("metadataTransactionManager")
+    fun unregister(token: String): Boolean {
+        val deleted = pushTokenRepository.deleteByToken(token)
+        if (deleted > 0) {
+            logger.info("Push token unregistered (rows={})", deleted)
+        } else {
+            logger.debug("Push token unregister: token not found, no-op")
+        }
+        return deleted > 0
+    }
+
+    private fun resolveUserAndTenant(principal: String): Pair<Long, Long> {
+        val user = userRepository.findByEmail(principal)
+            ?: userRepository.findByUsername(principal)
+            ?: throw UsernameNotFoundException(
+                "Authenticated user not found in DB: $principal"
+            )
+        val userId = user.id
+            ?: throw IllegalStateException("User has null id (should never happen): ${user.email}")
+        return userId to user.tenantId
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/dto/request/PushTokenRegisterRequest.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/dto/request/PushTokenRegisterRequest.kt
@@ -1,0 +1,23 @@
+package com.apptolast.invernaderos.features.push.dto.request
+
+import com.apptolast.invernaderos.features.push.PushPlatform
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+@Schema(description = "Request para registrar un token FCM de un dispositivo cliente")
+data class PushTokenRegisterRequest(
+
+    @field:NotBlank(message = "El token es obligatorio")
+    @field:Size(min = 10, max = 4096, message = "El token debe tener entre 10 y 4096 caracteres")
+    @Schema(
+        description = "Token FCM emitido por Firebase para este dispositivo",
+        example = "fABcD1234..."
+    )
+    val token: String,
+
+    @field:NotNull(message = "La plataforma es obligatoria")
+    @Schema(description = "Plataforma del dispositivo", example = "ANDROID")
+    val platform: PushPlatform
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/input/PushTokenController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/input/PushTokenController.kt
@@ -1,0 +1,59 @@
+package com.apptolast.invernaderos.features.push.infrastructure.adapter.input
+
+import com.apptolast.invernaderos.features.push.PushTokenService
+import com.apptolast.invernaderos.features.push.dto.request.PushTokenRegisterRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.*
+
+/**
+ * Endpoints REST para que los clientes registren / desregistren su token FCM
+ * tras login y logout. Ambos requieren JWT — el `tenantId` y `userId` se
+ * resuelven desde la identidad autenticada, NUNCA desde el body, para que un
+ * cliente no pueda registrar tokens de otro tenant.
+ */
+@RestController
+@RequestMapping("/api/v1/push-tokens")
+@CrossOrigin(origins = ["*"])
+@Tag(name = "Push Tokens", description = "Registro de tokens FCM de dispositivos para notificaciones push")
+@SecurityRequirement(name = "bearerAuth")
+class PushTokenController(
+    private val pushTokenService: PushTokenService
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping
+    @Operation(summary = "Registrar (o refrescar) el token FCM de este dispositivo")
+    fun register(
+        @Valid @RequestBody request: PushTokenRegisterRequest,
+        authentication: Authentication
+    ): ResponseEntity<Void> {
+        logger.debug(
+            "POST /api/v1/push-tokens user={} platform={}",
+            authentication.name, request.platform
+        )
+        pushTokenService.register(
+            authenticatedPrincipal = authentication.name,
+            token = request.token,
+            platform = request.platform
+        )
+        return ResponseEntity.noContent().build()
+    }
+
+    @DeleteMapping("/{token}")
+    @Operation(summary = "Desregistrar el token FCM (logout o invalidación)")
+    fun unregister(
+        @PathVariable token: String,
+        authentication: Authentication
+    ): ResponseEntity<Void> {
+        logger.debug("DELETE /api/v1/push-tokens user={}", authentication.name)
+        pushTokenService.unregister(token)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/output/AlertActivationPushListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/output/AlertActivationPushListener.kt
@@ -1,0 +1,119 @@
+package com.apptolast.invernaderos.features.push.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedEvent
+import com.apptolast.invernaderos.features.catalog.AlertSeverityRepository
+import com.apptolast.invernaderos.features.push.AlertPushPayload
+import com.apptolast.invernaderos.features.push.FcmPushService
+import com.apptolast.invernaderos.features.sector.SectorRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * Escucha [AlertStateChangedEvent] y dispara una notificación push cuando una
+ * alerta es ACTIVADA (transición de `isResolved=true` → `isResolved=false`).
+ *
+ * Filtros de envío:
+ *  - Sólo activaciones (`change.toResolved == false`). Las resoluciones se
+ *    propagan vía WebSocket pero NO disparan push (decisión de producto:
+ *    evitar saturar al usuario con notificaciones positivas).
+ *  - Sólo si la severidad de la alerta tiene `notify_push = true` en
+ *    `metadata.alert_severities`. Permite a un admin silenciar severidades
+ *    concretas con un simple UPDATE SQL.
+ *
+ * Phase = AFTER_COMMIT: el push se emite sólo después de que la transacción
+ * que cambió el estado haga commit. Si la transacción hace rollback, no se
+ * envía nada (evita "fantasmas": notificación de alerta sin alerta en BBDD).
+ *
+ * Aislamiento de errores: cualquier excepción en el envío FCM se loggea y se
+ * absorbe — el envío de push NUNCA debe romper el flujo principal de alertas.
+ *
+ * Transacción separada (`Propagation.REQUIRES_NEW`) para los lookups de
+ * `AlertSeverity` y `Sector`: como la transacción original ya se ha
+ * comiteado, el listener abre una propia, breve, sólo para leer.
+ */
+@Component
+class AlertActivationPushListener(
+    private val fcmPushService: FcmPushService,
+    private val alertSeverityRepository: AlertSeverityRepository,
+    private val sectorRepository: SectorRepository
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(
+        value = "metadataTransactionManager",
+        propagation = Propagation.REQUIRES_NEW,
+        readOnly = true
+    )
+    fun onAlertActivated(event: AlertStateChangedEvent) {
+        val change = event.change
+        val alert = event.alert
+
+        if (change.toResolved) {
+            logger.debug(
+                "Alert {} state change is a RESOLUTION (toResolved=true) — push skipped",
+                alert.code
+            )
+            return
+        }
+
+        try {
+            val severityId = alert.severityId ?: run {
+                logger.debug("Alert {} has null severityId — push skipped", alert.code)
+                return
+            }
+            val severity = alertSeverityRepository.findById(severityId).orElse(null) ?: run {
+                logger.warn(
+                    "Alert {} references unknown severityId={} — push skipped",
+                    alert.code, severityId
+                )
+                return
+            }
+            if (!severity.notifyPush) {
+                logger.debug(
+                    "Severity {} has notify_push=false — push skipped for alert {}",
+                    severity.name, alert.code
+                )
+                return
+            }
+
+            val sectorIdValue = alert.sectorId.value
+            val sector = sectorRepository.findById(sectorIdValue).orElse(null) ?: run {
+                logger.warn(
+                    "Alert {} references unknown sectorId={} — push skipped",
+                    alert.code, sectorIdValue
+                )
+                return
+            }
+
+            val payload = AlertPushPayload(
+                alertId = alert.id ?: error("Alert id null after AFTER_COMMIT — should be impossible"),
+                alertCode = alert.code,
+                tenantId = alert.tenantId.value,
+                greenhouseId = sector.greenhouseId,
+                sectorId = sectorIdValue,
+                severityName = severity.name,
+                severityLevel = severity.level,
+                severityColor = severity.color,
+                title = "Nueva alerta: ${severity.name}",
+                body = alert.message
+                    ?: alert.description
+                    ?: alert.clientName
+                    ?: alert.code,
+                createdAt = alert.createdAt
+            )
+
+            fcmPushService.sendAlertToTenant(payload)
+        } catch (ex: Exception) {
+            logger.error(
+                "Failed to send FCM push for alert {} (DB state already committed)",
+                alert.code, ex
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/config/FirebaseConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/config/FirebaseConfig.kt
@@ -1,0 +1,90 @@
+package com.apptolast.invernaderos.features.push.infrastructure.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.io.FileInputStream
+
+/**
+ * Inicializa el SDK de Firebase Admin para enviar notificaciones push FCM
+ * desde el backend.
+ *
+ * Resolución del fichero de credenciales (Service Account JSON):
+ *   1) Property `firebase.service-account-path` (application.yaml o env var
+ *      FIREBASE_SERVICE_ACCOUNT_PATH).
+ *   2) Variable de entorno estándar `GOOGLE_APPLICATION_CREDENTIALS`.
+ *
+ * Degradación graciosa: si NINGUNO de los dos está configurado o el fichero
+ * no se puede leer, se registra un WARN y NO se exponen los beans
+ * `FirebaseApp` / `FirebaseMessaging`. La aplicación arranca igualmente y los
+ * consumidores (`FcmPushService`) reciben un `FirebaseMessaging?` nulo y
+ * desactivan el envío. Esto es deliberado: el sistema debe seguir creando
+ * alertas y resolviéndolas vía MQTT/REST aunque FCM no esté operativo.
+ *
+ * Nota de seguridad: el JSON contiene una clave privada. NUNCA se commitea;
+ * se inyecta vía variable de entorno o se monta como secret en Kubernetes.
+ *
+ * Re-arranque idempotente: si la JVM ya tiene un `FirebaseApp` por defecto
+ * inicializado (caso típico en tests con contexto reciclado), reutilizamos
+ * la instancia existente en lugar de reinicializar.
+ */
+@Configuration
+class FirebaseConfig(
+    @Value("\${firebase.service-account-path:}")
+    private val serviceAccountPathProperty: String
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Bean
+    fun firebaseApp(): FirebaseApp? {
+        val path = resolveCredentialsPath() ?: run {
+            logger.warn(
+                "Firebase service account JSON not configured " +
+                        "(neither firebase.service-account-path nor GOOGLE_APPLICATION_CREDENTIALS) — " +
+                        "FCM push notifications DISABLED. Alerts will continue to flow via WebSocket."
+            )
+            return null
+        }
+
+        val existing = FirebaseApp.getApps().firstOrNull { it.name == FirebaseApp.DEFAULT_APP_NAME }
+        if (existing != null) {
+            logger.info("Reusing existing FirebaseApp instance")
+            return existing
+        }
+
+        return try {
+            FileInputStream(path).use { stream ->
+                val options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(stream))
+                    .build()
+                val app = FirebaseApp.initializeApp(options)
+                logger.info("FirebaseApp initialised from {}", path)
+                app
+            }
+        } catch (ex: Exception) {
+            logger.warn(
+                "Failed to initialise FirebaseApp from path={} — FCM push notifications DISABLED",
+                path, ex
+            )
+            null
+        }
+    }
+
+    @Bean
+    fun firebaseMessaging(firebaseApp: FirebaseApp?): FirebaseMessaging? {
+        return firebaseApp?.let { FirebaseMessaging.getInstance(it) }
+    }
+
+    private fun resolveCredentialsPath(): String? {
+        if (serviceAccountPathProperty.isNotBlank()) return serviceAccountPathProperty
+        val envPath = System.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        if (!envPath.isNullOrBlank()) return envPath
+        return null
+    }
+}

--- a/src/main/resources/db/migration/V38__create_push_tokens_and_notify_push_flag.sql
+++ b/src/main/resources/db/migration/V38__create_push_tokens_and_notify_push_flag.sql
@@ -1,0 +1,33 @@
+-- =============================================================================
+-- V38 — FCM push notification support
+-- =============================================================================
+-- 1) New table metadata.push_tokens: stores Firebase Cloud Messaging device
+--    tokens registered by mobile/web clients after login. Indexed by tenant_id
+--    so the FCM service can fan-out alerts to all devices of a tenant in one
+--    query.
+-- 2) New column metadata.alert_severities.notify_push: per-severity feature
+--    flag so an admin can disable push notifications for a given severity
+--    without redeploying (e.g. INFO → no notif, CRITICAL → always notif).
+--
+-- Idempotent (uses IF NOT EXISTS) to make re-runs against the dev/prod
+-- databases safe.
+-- =============================================================================
+
+-- Per-severity push notification flag.
+ALTER TABLE metadata.alert_severities
+    ADD COLUMN IF NOT EXISTS notify_push BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Device push tokens. One row per (device, user) login pair; rotates via
+-- onNewToken on the client.
+CREATE TABLE IF NOT EXISTS metadata.push_tokens (
+    id           BIGSERIAL PRIMARY KEY,
+    user_id      BIGINT      NOT NULL REFERENCES metadata.users(id)   ON DELETE CASCADE,
+    tenant_id    BIGINT      NOT NULL REFERENCES metadata.tenants(id) ON DELETE CASCADE,
+    token        TEXT        NOT NULL UNIQUE,
+    platform     VARCHAR(16) NOT NULL CHECK (platform IN ('ANDROID','IOS','WEB')),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_tokens_tenant ON metadata.push_tokens(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_push_tokens_user   ON metadata.push_tokens(user_id);

--- a/src/test/kotlin/com/apptolast/invernaderos/features/push/AlertActivationPushListenerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/push/AlertActivationPushListenerTest.kt
@@ -1,0 +1,201 @@
+package com.apptolast.invernaderos.features.push
+
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedEvent
+import com.apptolast.invernaderos.features.catalog.AlertSeverity
+import com.apptolast.invernaderos.features.catalog.AlertSeverityRepository
+import com.apptolast.invernaderos.features.push.infrastructure.adapter.output.AlertActivationPushListener
+import com.apptolast.invernaderos.features.sector.Sector
+import com.apptolast.invernaderos.features.sector.SectorRepository
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.Optional
+
+/**
+ * Unit tests for AlertActivationPushListener — MockK style, no Spring context.
+ */
+class AlertActivationPushListenerTest {
+
+    private lateinit var fcmPushService: FcmPushService
+    private lateinit var alertSeverityRepository: AlertSeverityRepository
+    private lateinit var sectorRepository: SectorRepository
+    private lateinit var listener: AlertActivationPushListener
+
+    @BeforeEach
+    fun setup() {
+        fcmPushService = mockk(relaxed = true)
+        alertSeverityRepository = mockk()
+        sectorRepository = mockk()
+        listener = AlertActivationPushListener(
+            fcmPushService,
+            alertSeverityRepository,
+            sectorRepository
+        )
+    }
+
+    private fun alert(
+        isResolved: Boolean = false,
+        severityId: Short? = 4,
+        message: String? = "Sensor offline"
+    ): Alert = Alert(
+        id = 1L,
+        code = "ALT-00010",
+        tenantId = TenantId(10L),
+        sectorId = SectorId(20L),
+        sectorCode = "SCT-00020",
+        alertTypeId = 1,
+        alertTypeName = "SENSOR_OFFLINE",
+        severityId = severityId,
+        severityName = "CRITICAL",
+        severityLevel = 4,
+        message = message,
+        description = null,
+        clientName = null,
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.now() else null,
+        resolvedByUserId = null,
+        resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z")
+    )
+
+    private fun change(toResolved: Boolean): AlertStateChange = AlertStateChange(
+        id = 1L,
+        alertId = 1L,
+        fromResolved = !toResolved,
+        toResolved = toResolved,
+        source = AlertSignalSource.MQTT,
+        rawValue = if (toResolved) "0" else "1",
+        at = Instant.now()
+    )
+
+    private fun severity(notifyPush: Boolean = true): AlertSeverity = AlertSeverity(
+        id = 4,
+        name = "CRITICAL",
+        level = 4,
+        description = null,
+        color = "#FF0000",
+        requiresAction = true,
+        notificationDelayMinutes = 0,
+        notifyPush = notifyPush
+    )
+
+    private fun sector(): Sector = mockk(relaxed = true) {
+        every { id } returns 20L
+        every { greenhouseId } returns 100L
+    }
+
+    @Test
+    fun `should send push when alert is activated and severity allows it`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity())
+        every { sectorRepository.findById(20L) } returns Optional.of(sector())
+        justRun { fcmPushService.sendAlertToTenant(any()) }
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 1) {
+            fcmPushService.sendAlertToTenant(match {
+                it.alertCode == "ALT-00010" &&
+                    it.tenantId == 10L &&
+                    it.greenhouseId == 100L &&
+                    it.sectorId == 20L &&
+                    it.severityName == "CRITICAL"
+            })
+        }
+    }
+
+    @Test
+    fun `should NOT send push when alert is resolved (toResolved=true)`() {
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(isResolved = true), change = change(toResolved = true))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should NOT send push when severity has notify_push=false`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity(notifyPush = false))
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should NOT send push when alert has null severityId`() {
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(severityId = null), change = change(toResolved = false))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should NOT send push when severity is unknown`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.empty()
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should NOT send push when sector is unknown`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity())
+        every { sectorRepository.findById(20L) } returns Optional.empty()
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should fall back to alert code when message and description are null`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity())
+        every { sectorRepository.findById(20L) } returns Optional.of(sector())
+        justRun { fcmPushService.sendAlertToTenant(any()) }
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(
+                alert = alert(message = null),
+                change = change(toResolved = false)
+            )
+        )
+
+        verify(exactly = 1) {
+            fcmPushService.sendAlertToTenant(match { it.body == "ALT-00010" })
+        }
+    }
+
+    @Test
+    fun `should swallow exceptions from FCM service (no propagation)`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity())
+        every { sectorRepository.findById(20L) } returns Optional.of(sector())
+        every { fcmPushService.sendAlertToTenant(any()) } throws RuntimeException("FCM down")
+
+        // Must not throw — the listener catches and logs.
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 1) { fcmPushService.sendAlertToTenant(any()) }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/push/FcmPushServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/push/FcmPushServiceTest.kt
@@ -1,0 +1,235 @@
+package com.apptolast.invernaderos.features.push
+
+import com.google.firebase.messaging.BatchResponse
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.SendResponse
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Unit tests for FcmPushService — MockK style, no Spring context.
+ */
+class FcmPushServiceTest {
+
+    private lateinit var firebaseMessaging: FirebaseMessaging
+    private lateinit var pushTokenRepository: PushTokenRepository
+    private lateinit var meterRegistry: MeterRegistry
+    private lateinit var service: FcmPushService
+
+    @BeforeEach
+    fun setup() {
+        firebaseMessaging = mockk()
+        pushTokenRepository = mockk(relaxed = true)
+        meterRegistry = SimpleMeterRegistry()
+        service = FcmPushService(firebaseMessaging, pushTokenRepository, meterRegistry)
+    }
+
+    private fun samplePayload(tenantId: Long = 10L) = AlertPushPayload(
+        alertId = 1L,
+        alertCode = "ALT-00001",
+        tenantId = tenantId,
+        greenhouseId = 100L,
+        sectorId = 20L,
+        severityName = "CRITICAL",
+        severityLevel = 4,
+        severityColor = "#FF0000",
+        title = "Nueva alerta: CRITICAL",
+        body = "Sensor offline",
+        createdAt = Instant.parse("2026-01-01T00:00:00Z")
+    )
+
+    private fun pushToken(token: String, id: Long = 1L) = PushToken(
+        id = id,
+        userId = 1L,
+        tenantId = 10L,
+        token = token,
+        platform = PushPlatform.ANDROID
+    )
+
+    @Test
+    fun `should skip multicast when no tokens are registered for tenant`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns emptyList()
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 0) { firebaseMessaging.sendEachForMulticast(any()) }
+    }
+
+    @Test
+    fun `should send single multicast message when tokens fit in one batch`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(
+            pushToken("tokA"),
+            pushToken("tokB", id = 2L),
+            pushToken("tokC", id = 3L)
+        )
+        val response: BatchResponse = mockk {
+            every { successCount } returns 3
+            every { failureCount } returns 0
+            every { responses } returns listOf(successResponse(), successResponse(), successResponse())
+        }
+        val captured = slot<MulticastMessage>()
+        every { firebaseMessaging.sendEachForMulticast(capture(captured)) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 1) { firebaseMessaging.sendEachForMulticast(any()) }
+    }
+
+    @Test
+    fun `should chunk multicast in batches of 500`() {
+        val tokens = (1..1234).map { pushToken("t$it", id = it.toLong()) }
+        every { pushTokenRepository.findAllByTenantId(10L) } returns tokens
+        val ok: BatchResponse = mockk {
+            every { successCount } returns 500
+            every { failureCount } returns 0
+            every { responses } returns List(500) { successResponse() }
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns ok
+
+        service.sendAlertToTenant(samplePayload())
+
+        // 500 + 500 + 234 = 1234 → 3 multicast calls
+        verify(exactly = 3) { firebaseMessaging.sendEachForMulticast(any()) }
+    }
+
+    @Test
+    fun `should delete token returning UNREGISTERED error`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(
+            pushToken("dead"), pushToken("alive", id = 2L)
+        )
+        every { pushTokenRepository.deleteByToken("dead") } returns 1
+        val unreg = unregisteredResponse()
+        val ok = successResponse()
+        val response: BatchResponse = mockk {
+            every { successCount } returns 1
+            every { failureCount } returns 1
+            every { responses } returns listOf(unreg, ok)
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("dead") }
+        verify(exactly = 0) { pushTokenRepository.deleteByToken("alive") }
+    }
+
+    @Test
+    fun `should delete token returning INVALID_ARGUMENT error`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("garbage"))
+        every { pushTokenRepository.deleteByToken("garbage") } returns 1
+        val invalid = invalidArgumentResponse()
+        val response: BatchResponse = mockk {
+            every { successCount } returns 0
+            every { failureCount } returns 1
+            every { responses } returns listOf(invalid)
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("garbage") }
+    }
+
+    @Test
+    fun `should NOT delete token for transient errors such as INTERNAL`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("transient"))
+        val transient = errorResponse(MessagingErrorCode.INTERNAL)
+        val response: BatchResponse = mockk {
+            every { successCount } returns 0
+            every { failureCount } returns 1
+            every { responses } returns listOf(transient)
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    @Test
+    fun `should be a no-op when FirebaseMessaging is null (graceful degradation)`() {
+        val degraded = FcmPushService(null, pushTokenRepository, meterRegistry)
+        degraded.sendAlertToTenant(samplePayload())
+        verify(exactly = 0) { pushTokenRepository.findAllByTenantId(any()) }
+    }
+
+    @Test
+    fun `should swallow exception thrown by FCM and continue`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("x"))
+        every { firebaseMessaging.sendEachForMulticast(any()) } throws RuntimeException("FCM down")
+
+        // Must not throw
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    @Test
+    fun `failure metric is incremented per failed token`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(
+            pushToken("a"), pushToken("b", id = 2L)
+        )
+        val response: BatchResponse = mockk {
+            every { successCount } returns 0
+            every { failureCount } returns 2
+            every { responses } returns listOf(unregisteredResponse(), invalidArgumentResponse())
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        val unregMetric = meterRegistry.find("push.fcm.failed").tag("reason", "UNREGISTERED").counter()
+        val invalidMetric = meterRegistry.find("push.fcm.failed").tag("reason", "INVALID_ARGUMENT").counter()
+        assertEquals(1.0, unregMetric?.count())
+        assertEquals(1.0, invalidMetric?.count())
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers — SendResponse mocks
+    // -------------------------------------------------------------------------
+
+    private fun successResponse(): SendResponse = mockk {
+        every { isSuccessful } returns true
+    }
+
+    private fun unregisteredResponse(): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns MessagingErrorCode.UNREGISTERED
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+
+    private fun invalidArgumentResponse(): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns MessagingErrorCode.INVALID_ARGUMENT
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+
+    private fun errorResponse(code: MessagingErrorCode): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns code
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/push/PushTokenServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/push/PushTokenServiceTest.kt
@@ -1,0 +1,120 @@
+package com.apptolast.invernaderos.features.push
+
+import com.apptolast.invernaderos.features.user.User
+import com.apptolast.invernaderos.features.user.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import java.time.Instant
+
+class PushTokenServiceTest {
+
+    private lateinit var pushTokenRepository: PushTokenRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var service: PushTokenService
+
+    @BeforeEach
+    fun setup() {
+        pushTokenRepository = mockk(relaxed = true)
+        userRepository = mockk()
+        service = PushTokenService(pushTokenRepository, userRepository)
+    }
+
+    private fun user(id: Long = 1L, tenantId: Long = 10L, email: String = "user@example.com") = User(
+        id = id,
+        code = "USR-00001",
+        tenantId = tenantId,
+        username = "user1",
+        email = email,
+        passwordHash = "hash",
+        role = "USER",
+        isActive = true,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now()
+    )
+
+    @Test
+    fun `register inserts a new token when none exists for the value`() {
+        every { userRepository.findByEmail("user@example.com") } returns user()
+        every { pushTokenRepository.findByToken("tokA") } returns null
+        val captured = slot<PushToken>()
+        every { pushTokenRepository.save(capture(captured)) } answers { captured.captured.also { it.id = 99L } }
+
+        val result = service.register("user@example.com", "tokA", PushPlatform.ANDROID)
+
+        assertEquals(99L, result.id)
+        assertEquals(1L, captured.captured.userId)
+        assertEquals(10L, captured.captured.tenantId)
+        assertEquals("tokA", captured.captured.token)
+        assertEquals(PushPlatform.ANDROID, captured.captured.platform)
+    }
+
+    @Test
+    fun `register updates existing row when token already present (upsert)`() {
+        val existing = PushToken(
+            id = 7L,
+            userId = 99L,            // OLD owner
+            tenantId = 999L,         // OLD tenant
+            token = "tokA",
+            platform = PushPlatform.IOS,
+            lastSeenAt = Instant.parse("2020-01-01T00:00:00Z")
+        )
+        every { userRepository.findByEmail("user@example.com") } returns user()
+        every { pushTokenRepository.findByToken("tokA") } returns existing
+        every { pushTokenRepository.save(any<PushToken>()) } answers { firstArg() }
+
+        val result = service.register("user@example.com", "tokA", PushPlatform.ANDROID)
+
+        assertEquals(7L, result.id)
+        // Upserted to new owner / tenant / platform.
+        assertEquals(1L, result.userId)
+        assertEquals(10L, result.tenantId)
+        assertEquals(PushPlatform.ANDROID, result.platform)
+        // last_seen_at refreshed.
+        assert(result.lastSeenAt.isAfter(Instant.parse("2020-01-01T00:00:00Z")))
+        verify(exactly = 1) { pushTokenRepository.save(existing) }
+    }
+
+    @Test
+    fun `register falls back to findByUsername when email lookup fails`() {
+        every { userRepository.findByEmail("user1") } returns null
+        every { userRepository.findByUsername("user1") } returns user(email = "u1@x.com")
+        every { pushTokenRepository.findByToken("t") } returns null
+        every { pushTokenRepository.save(any<PushToken>()) } answers { firstArg() }
+
+        service.register("user1", "t", PushPlatform.WEB)
+
+        verify { userRepository.findByEmail("user1") }
+        verify { userRepository.findByUsername("user1") }
+    }
+
+    @Test
+    fun `register throws when authenticated user is not in the DB`() {
+        every { userRepository.findByEmail("ghost") } returns null
+        every { userRepository.findByUsername("ghost") } returns null
+
+        assertThrows(UsernameNotFoundException::class.java) {
+            service.register("ghost", "tok", PushPlatform.ANDROID)
+        }
+    }
+
+    @Test
+    fun `unregister deletes by token and returns true on hit`() {
+        every { pushTokenRepository.deleteByToken("tokA") } returns 1
+
+        assertEquals(true, service.unregister("tokA"))
+    }
+
+    @Test
+    fun `unregister returns false on miss`() {
+        every { pushTokenRepository.deleteByToken("missing") } returns 0
+
+        assertEquals(false, service.unregister("missing"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds the backend half of the FCM push-notification feature so mobile clients receive a native OS notification when a PLC fires an alert, even when the app is closed. Companion frontend work lives in `apptolast/GreenhouseFronts` (`feature/alert-notifications`).

## What's in this PR

- **Migration `V38`** — `metadata.push_tokens` table (one row per device token, UNIQUE on `token`, FK cascade to `users` and `tenants`) and `metadata.alert_severities.notify_push BOOLEAN NOT NULL DEFAULT TRUE`. Idempotent (`IF NOT EXISTS`) so it is safe to re-run.

- **`features/push` module**
  - `PushToken` JPA entity + `PushTokenRepository`.
  - `PushTokenController` exposing `POST /api/v1/push-tokens` (upsert by token) and `DELETE /api/v1/push-tokens/{token}` (logout). `userId` and `tenantId` are resolved from the JWT — never accepted in the body.
  - `FirebaseConfig` initialises `FirebaseApp` + `FirebaseMessaging` from `firebase.service-account-path` or `GOOGLE_APPLICATION_CREDENTIALS`. If neither is configured the beans are not registered, the app starts normally and FCM is silently disabled (graceful degradation).
  - `FcmPushService` sends `MulticastMessage` in chunks of 500 (FCM HTTP v1 limit), removes `UNREGISTERED` / `INVALID_ARGUMENT` tokens automatically, and emits `push.fcm.sent` / `push.fcm.failed{reason}` Micrometer counters.
  - `AlertActivationPushListener` subscribes to the existing `AlertStateChangedEvent` with `@TransactionalEventListener(AFTER_COMMIT)`. Sends push only on activations (`toResolved=false`) and only when the severity has `notify_push=true`. Errors during the FCM call are caught — a Firebase outage never breaks the alert flow.

- **`AlertSeverity`** entity and response DTO surface the new `notifyPush` flag. Default `true` preserves today's behaviour.

- **`PostGreSQLDataSourceConfig`** scans `features.push` so the JPA repository and entity are picked up by the metadata datasource.

- **`build.gradle.kts`** adds `com.google.firebase:firebase-admin:9.5.0`.

## Why this design

- Reuses the existing `AlertStateChangedEvent` (already published by `ApplyAlertMqttSignalUseCase` and `ResolveAlertUseCase`), so the MQTT activation flow PLC → backend → push is wired automatically without touching the alert use cases.
- Push only on **activation** (resolved → unresolved). Resolutions still flow through WebSocket but do not generate an OS notification (product decision: avoid notification fatigue with positive events).
- Per-severity flag (`notify_push`) is a runtime SQL toggle, no redeploy needed: `UPDATE metadata.alert_severities SET notify_push=false WHERE name='INFO';`.
- Service account JSON is `gitignored` and read from env var or property — never embedded.

## Deploy notes

Requires the Firebase service account JSON to be available to the running pod, either via:

1. Env var `GOOGLE_APPLICATION_CREDENTIALS=/path/to/secret.json`, **or**
2. Property `firebase.service-account-path=/path/to/secret.json` in `application-dev.yaml` / `application-prod.yaml`.

Mount the JSON as a Kubernetes Secret. Without it the app still starts; only push is disabled (a `WARN` is logged at boot).

## Test plan

- [x] Unit tests pass: `FcmPushServiceTest`, `AlertActivationPushListenerTest`, `PushTokenServiceTest`.
- [x] ArchUnit tests pass.
- [ ] After merge, `flyway-migrate.yml` workflow applies V38 to dev DB.
- [ ] After deploy, smoke-test:
  - `POST /api/v1/push-tokens` with a real Android FCM token registers a row.
  - Manually toggle `SET-00080` to fire `ALT-00010` from the admin UI; the registered Android device receives a native notification within ~3 s.
  - `DELETE /api/v1/push-tokens/{token}` removes the row.
  - Without `GOOGLE_APPLICATION_CREDENTIALS`, the API still starts and alerts continue to flow via WebSocket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)