### PR TITLE
release: FCM push notifications + WS BOOLEAN normalization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,25 @@ SPRING_PROFILES_ACTIVE=local
 JAVA_OPTS=-Xms256m -Xmx512m
 
 # ============================================
+# Firebase Cloud Messaging (FCM push notifications)
+# ============================================
+# Path to the Firebase Admin SDK service-account JSON inside the running
+# container. Mount the JSON as a Kubernetes Secret and point this var at
+# the mount path. If unset, the API still starts and alerts continue to
+# flow via WebSocket; only FCM push notifications are disabled.
+#
+# The JSON file must NEVER be committed to git — it contains a private key.
+# It is generated from Firebase Console → Project settings → Service
+# accounts → Generate new private key.
+#
+# Example for Kubernetes:
+#   - kubectl create secret generic firebase-admin-sa \
+#       --from-file=service-account.json=./greenhouse-fronts-firebase-adminsdk-*.json
+#   - Mount the secret at /run/secrets/firebase
+#   - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase/service-account.json
+GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase/service-account.json
+
+# ============================================
 # Production/Development Specific
 # ============================================
 # For production environments, use stronger passwords

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ docker-compose.override.yaml
 # because they only contain behavior configuration, NOT secrets.
 # Secrets come from environment variables.
 
+### Firebase Admin SDK service account (NEVER COMMIT) ###
+*firebase-adminsdk*.json
+greenhouse-fronts-firebase-adminsdk-*.json
+firebase-service-account*.json
+
 # Environment variables and secrets
 .env
 .env.local

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "4cfb2b55-3fd1-4055-a7ff-cefc5918a4d2",
+          "id": "c653c28f-873f-4170-95ec-73544f0b17a2",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "8c796564-7c08-4db8-9c36-d78ffad434a1",
+              "id": "b76f73c4-ebc4-434e-b8b9-a7cdb8aff708",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "00e88c23-5597-4346-b4a1-be56240f32b2",
+          "id": "22a17d0c-69a6-46dc-884b-74cfcaab65b9",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "6c5a73eb-ac93-4067-9bb4-8c0f1469319b",
+              "id": "89565180-88e6-4a0b-bcfb-8ec0c864b6a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "76a2ab11-8ec6-4ce5-be9e-a90d1d603fd6",
+          "id": "6dd32a0b-a7d4-463a-8dc9-f3b62918de8f",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "deb5bf9b-6f80-45d0-bb8e-da01df8d0486",
+              "id": "c30df81b-4bf9-4440-86b7-7eebc8351c74",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "333a78a6-2349-45cd-b9a4-ab3b3d617131",
+          "id": "f17bb4f9-1902-4c31-a0b5-28d4a2118625",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "7e817768-3869-4ebf-9d85-00766b4d4b60",
+              "id": "c813c02d-a774-4cb0-b64c-9832bf0de01c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "1716d66e-e3a5-4de8-829f-468e207cffd3",
+          "id": "681c7d2d-3e2f-4b8b-975b-e70f97f8d057",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "f26ff100-217a-43cc-b977-50ddb5a3ea12",
+              "id": "38d0c9ff-31ac-4a74-be6a-93e86f5d6409",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "d981ba22-8a9d-4694-8bfc-24a46635d467",
+          "id": "2b1fc689-3945-45a1-8f88-b394177da15e",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "1c9a30b9-e2c9-4e4f-909b-0260772dd60b",
+              "id": "850bdd4f-af5d-4f52-83fb-ea2f9144bd89",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "583ace12-94f9-45bb-8a34-2fa7e8dc4a3d",
+          "id": "017f1186-b25d-4c56-99fb-b627782f9971",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "6b0d2633-0ec9-4188-bcbc-c4a57933745d",
+              "id": "99093253-6af2-43f9-923e-44de1cbcd087",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "100b02b7-7bf4-481a-b9d4-6e0a75f62386",
+          "id": "47e65278-8ca0-405d-8b6a-e7c08a8061c0",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "e5e09250-ee94-4845-95cc-4b6f1006daea",
+              "id": "3d8351fd-e3a7-47e4-90b9-6d5d02e63efb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "1a7835af-b1ac-4b41-939f-459e1d4d9011",
+          "id": "a3d9e9f4-80c1-4879-9a32-a72e21268aae",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "d3427816-0b0c-413a-91de-278fc0716e51",
+              "id": "874af070-b93e-4840-a6b7-f6dddb8b812e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "f74f049f-94d5-495f-b8d8-ba0761fe663b",
+          "id": "7e17eca6-619f-426b-a5de-dbe448ac122a",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "84fea828-ac66-4c42-84d9-8f98b9b8e34e",
+              "id": "07e5078e-0c14-4dd5-a9ab-96e2e9407d43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "8a4052d0-861f-415e-a78c-754bbb272826",
+          "id": "b8e2610c-3fa2-4492-94fb-4f3fbd29cdb8",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "9c2aa678-8ebe-44ab-b396-c9922a7d5d0a",
+              "id": "1829adaa-d2ac-4876-b5ae-c496ca5ba3c8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "93ebb67d-9544-4906-9572-7624fb4b2633",
+          "id": "4f869181-38cc-4b59-bca9-63891b2d17b5",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "83eea8a0-1a86-46a4-9ed7-968d5c60313a",
+              "id": "8da0d3fe-ae68-4496-b945-54c400cbad74",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "b083cc70-c226-494d-9841-8301cf0c1023",
+          "id": "f49ba09b-dbdf-4e57-aa68-814a7cf420ff",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "74a4b531-9860-4d34-9dd7-b48a70ccf361",
+              "id": "e22313ca-3e0e-4a48-8729-ab09eb7e377e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "9f17645d-1370-46dd-804e-ab8f27fe3b15",
+          "id": "e159b72b-5b71-4f8c-99d6-afb884e25c17",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "64b0a4d2-20cb-47e5-9229-c8f08ed45027",
+              "id": "8bc23dab-d81f-424b-8089-bba6b73fe299",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "a337ab84-2c10-4bae-8dca-8e7dd91785bc",
+          "id": "67939375-415a-4077-9dea-2fa9852faff1",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "f7a36510-538c-4355-856a-f404a8703d9e",
+              "id": "b8a3fadf-4461-4a26-94a9-c5503a33f017",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "72d78ae5-cdd9-41d0-a00a-0906f1352166",
+          "id": "b4256761-cd90-416e-a94c-2ba61c994d74",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "5dd76afc-9262-439f-a6ef-0c2f2c83dfd8",
+              "id": "dde1c8cb-ba22-41d6-a81d-5c610f5bf248",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "9300ab68-89d4-415c-a5a5-39308d7fc090",
+          "id": "3db20e12-58bc-46c6-9ead-fe66f231288d",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "bc3591e9-5cb1-4e88-845b-ad52b8f4fe1c",
+              "id": "74d52032-f422-4f3e-8f54-d48b8bd2146a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "975c3968-b2e3-4918-bca1-dac3223b013c",
+          "id": "5234ca5a-7e5f-47d4-a293-1fbc025b56c3",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "6b87a055-70fc-4ca6-9002-b9ff613df529",
+              "id": "ebb2a402-9574-42a2-b2a6-cd471b7a96ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "56a65259-7797-4f2b-819b-2b4dd66ef642",
+          "id": "76fbbed8-f7d1-493e-bb07-469bf0e07cb9",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "fa4e8e2d-a424-4467-b18f-9a1e11e5b911",
+              "id": "637da2de-8d77-49a4-9961-64530330da2b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "4b705417-754d-4b87-a10d-a98dc9871ab9",
+          "id": "32669e08-d41d-4ab2-bf45-f3c9f77f82b3",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "c15a4c7a-2751-439e-80dd-4ac65d60159d",
+              "id": "32f55b53-c4ae-4c98-8c22-7dab24c2ad49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "d4abaed5-a9f4-4b92-b26f-814a8991bfe1",
+          "id": "64c23d2d-91e1-489a-b0cb-6c7e18f3e89c",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "6bdb389a-b48d-458f-a262-3ea789837097",
+              "id": "13acf2f8-7fa0-4584-acd0-48ba2108a365",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "47a53239-478f-4b12-a2f9-52de3454a497",
+          "id": "9fa110b1-d5a6-447f-b47d-2c61fe978f1a",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "2e1684b7-3134-437d-b025-63100e5763c5",
+              "id": "ed1348e7-a90a-4c6a-a878-c6565384affe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "cee28515-f7ad-4ca5-b334-e930f64d0e54",
+          "id": "d7ae673a-a415-45d9-81a0-46a0645e3712",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "4a43f94e-aeb4-4597-a9da-ce8ee8a593ba",
+              "id": "aac4783c-2d1e-4ca2-b063-e606a8852686",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "b040efb9-e606-412c-8a75-fa3a958bed8c",
+          "id": "762eddcc-1362-4f25-856d-f3754c7b7048",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#10CBc4\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d75Af4\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "0f25c345-7506-4c51-b284-7f4f346f3ea8",
+              "id": "1cd110cc-8df2-42ca-84c9-646bf772265e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#10CBc4\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d75Af4\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "ab4a8c45-14f0-490c-b838-85423c7b0229",
+          "id": "8ab6e4c3-5e03-4d7d-bf33-03bc34be97a0",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "6f8d5f2d-eb08-4d15-bee6-5f04ad1b4a33",
+              "id": "7a82e771-5362-4823-ba66-01870e3df6d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "b39e067f-9c4f-47f1-a89f-b23f2ce13163",
+          "id": "3cef7482-c649-4567-bb2e-200442059ff9",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "f1ba27ec-12ef-47bf-9e8f-fc9aea4dc823",
+              "id": "0f3a211c-e907-4ba9-bdc2-803b6189d745",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "eb976933-fe22-4be9-b9b7-ea48e87eb4db",
+          "id": "66537a25-22da-4f4f-9b99-86627084d897",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#eA87D2\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#34eFeF\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "0c35806a-f13a-4b35-9a5f-394ce04dd1d5",
+              "id": "f30339fe-03c8-41e7-80db-251f7943490c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#eA87D2\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#34eFeF\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "f0635724-f3a9-4f46-b0a8-2cf87898c400",
+          "id": "0e2bae99-b1e4-4d48-98d8-32fca0819553",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "173206dd-9bf2-4be2-aa37-62e36c3098f6",
+              "id": "92c732ab-9b5d-43a4-9fec-fe389bb32e1d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "217ddfd9-2688-499b-a825-f72c0df2f7d9",
+          "id": "7edda7b9-9672-4746-9a88-54f42d365d79",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "3091891f-d099-423c-8aec-24f50379e82a",
+              "id": "a67dffd6-93d5-4500-85bc-11473ab49a17",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "516b61cd-1805-4c0e-8db4-96638d06a2cf",
+          "id": "a2dea240-75a5-45c8-9220-0cdc39fd9eeb",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "fb21bdcd-1cb8-4da1-9442-31e5fda23f45",
+              "id": "489cb881-a872-491a-9c3f-f25cc39ce45e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "5db2a122-479b-4db4-b84e-2fd6abc4b6b3",
+          "id": "95a21640-b8ce-4604-bc33-59c2c1296438",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "e9b8ef2b-e5d7-4286-8d98-e9ac28a203b1",
+              "id": "a8c7e83a-76d1-4189-bfb3-dab0f600d892",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "c7cdcdf0-ea13-4591-86f7-11d1c2189713",
+          "id": "43ba96f4-9213-47b9-a080-64eba0d8ada9",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "3990a1c3-09a8-427a-99a0-af414a895278",
+              "id": "512f893a-9360-487a-8bc5-9d8a241d17ee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "3379e0bf-5f4c-4a81-8c17-3a8e7cfb9a7d",
+          "id": "e0f0c8d7-3382-4c55-b20e-42113f283a02",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "1848aa07-9ed6-4721-a899-6f134c8c475f",
+              "id": "66d40410-3fd7-4974-819d-2e0ce2946ef8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "9473f208-d2d9-4333-b734-8a00d89f2410",
+          "id": "933af6b7-b65c-4720-9b7b-5805fc61ac89",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "9ec96c44-71a8-4c0e-8fa9-040d8f0564f5",
+              "id": "82116f94-24c6-4cde-be32-ff1f230dcee1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
+              "body": "{\n  \"key_0\": 7841\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "f5f6cdb9-3806-45c2-bbff-4ff960fbd27a",
+          "id": "a8ebf207-33ca-4ead-ba93-c020d9183b44",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "02f1d3c2-7af9-44bb-a223-8ba3573282b8",
+              "id": "6beda7fa-7c97-43e4-87b9-22df5cd86152",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "d4e531d3-05b1-454e-97a9-93d0cf7a3fc1",
+          "id": "68f6d3da-b700-4973-b041-685e470c0166",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "a73da6e4-b065-41df-8f4c-d9cd7cacf535",
+              "id": "7a645cf1-cee4-4035-8490-c2d7de8a916c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "2a4775eb-edd5-4bdd-bf0f-347c6cadfec8",
+          "id": "6be818f4-0b34-4587-9257-8dd35364f0b7",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "6137e1ba-14c1-468f-bc21-ba143553b147",
+              "id": "37e09557-e913-42d9-9bc0-d0b2355943b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "a17393fa-a455-495b-b2df-31a25b036f78",
+          "id": "e3497c24-cd52-4076-8574-664fce34e838",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "bcbf9052-0061-4651-9161-2ac9c4d646a6",
+              "id": "2ba430fc-6951-45f0-8feb-cb971944faac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "27f26732-465f-41e4-9ca9-5965a8506cbc",
+          "id": "585c4820-c159-464e-a2cb-cedbd15cbddf",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "37d052c5-a7b2-411b-aec6-85205b1b5e2d",
+              "id": "c5161e58-a498-4ae3-af44-262ebf355555",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "9eed87cc-5160-46b7-bb48-bf990e60521e",
+          "id": "6803cda0-6747-4a7d-97ab-a2762a8ffad9",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "a6a3e7a5-e4bd-4fd6-aa90-0bffce6c392d",
+              "id": "f0ec2b94-8fc2-4b20-a02e-bd4b25c68c2a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "ef4c9bcb-8920-4e7e-a58e-2bace4f9fe5a",
+          "id": "9a34b700-3746-44d5-a6b7-68bc4b1e4970",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "1e59b9bb-1e46-4d83-b837-767aafbba9cf",
+              "id": "b4588c5e-b01c-43db-b2cd-ae7b983c2aba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "ad17a92e-4b0e-4ed1-8899-621526827a5f",
+          "id": "fddb1543-2f91-4837-884e-6440297f1b0f",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "3d553437-f1c4-435e-9a66-eb1847b9a39f",
+              "id": "4d10430e-cfc0-4e37-9bfc-cc9ea303c90c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "6167e3da-3213-4773-b050-8674647bf029",
+          "id": "cabaeb85-36a0-4454-a98a-158bcc8f976a",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "f3e8abe6-afa0-4c4d-ab29-fe1d1a07262a",
+              "id": "becff5e4-a3cf-41b1-b951-daadf4b7fac6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "af2e7edc-81a2-460d-9cfe-fc760f41c3f0",
+          "id": "970831c5-0e8d-4497-94ad-485995961bd9",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "d37ba667-19ba-417f-809e-9e9fb9cb6dbe",
+              "id": "e75a06e8-4b82-440b-b3a7-083d798c1a99",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "d5ff8633-f95c-4739-982a-76a30d91946e",
+          "id": "da96e300-37a7-4afc-a878-b7e687788393",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "684ecede-ef77-47e0-ba52-ac43a1a510e2",
+              "id": "93fbf740-b2b9-4a6c-a5a2-e5cbed7df5ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "feba85cb-6a7b-4ec7-8f95-c79c3e5c1e85",
+          "id": "dfbef683-ebe0-4ef7-b7af-90e3e7ff5fa5",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "8b2c1f99-3c6c-4a47-8377-708972546244",
+              "id": "4a14a02a-bdf8-49be-9fdd-d2bed935b708",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "e94294f5-ebe1-4098-b8fd-cf69cf99ef89",
+          "id": "3fb4c7f0-6810-4513-a993-8b883d1ad547",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "e7249c04-202b-4002-a6a4-4c0c3b1dfb55",
+              "id": "a5f88c54-6448-4fcd-b1bd-d8975cc2cecc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "221e2ebf-5b02-4156-bf8f-e193247696f7",
+          "id": "4dbf7ed3-fd2d-4fe2-878f-20bc90ecb0ad",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "3207f167-4c64-42bf-bc6c-cb2d419d8d83",
+              "id": "03ed5eaa-ee24-4c84-9174-13642f3ce8b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "b2d721a9-d66e-4c7b-b14f-fd772a8a435b",
+          "id": "3b8e7b88-f89d-4f53-8065-2a084906f6a2",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "684c2362-23d9-4a94-90cc-405a33b77383",
+              "id": "d04ffe4b-1de2-4813-8842-9dba37638933",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "56a790e0-2c60-4a90-8bad-6d3263f3456d",
+          "id": "e0d0abf4-99b2-4619-8452-bffba11fd8d0",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "d6d2cc2a-070c-4b19-a19e-7ca3ce6c658e",
+              "id": "ba1e158b-d4a6-4e43-ba2e-d5d22bf9b656",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "e9d90d49-2373-4e1c-8a74-be7099837d22",
+          "id": "d1cc2b2d-1e53-4935-ad25-eb7f7cc5e6a0",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "db2d436e-2929-4281-a46f-090349cef787",
+              "id": "9dca104c-0283-4d2c-b530-38933ec23c22",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "878e84b3-f803-4a55-ac36-6272f7672778",
+          "id": "eebaa1cb-679f-43e2-bf9e-75f84a28dbde",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "52613042-c0d4-4549-8709-87345152dd12",
+              "id": "4e7bf131-bdf1-4bb6-bf9b-76afdf993b60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "06ba36b9-45f5-404c-9614-a90f08d97699",
+          "id": "9c23850e-1f73-4888-a6da-fbdc7b970588",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "31c92e06-17d5-4453-9ffd-509b71636b14",
+              "id": "0b8211d0-6cbc-493b-b369-cbd4fd06db26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "c2d55932-4dea-42f3-ac49-5e0ab9f0ec22",
+          "id": "734d2608-51be-44b9-b2ed-8c57c100d235",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "0e0baa89-a11c-4f8e-b693-1b2fa54e39de",
+              "id": "90145e96-3422-40a9-9c0c-ab76bee4e7ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "88570d97-1bc9-45b6-bc46-36c7bc69ba5a",
+          "id": "d4a658fc-7821-4acf-b436-dfa957dc84b3",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "94b05444-fe27-40a3-b19e-f2ffafd958cb",
+              "id": "a6f2335d-0301-4b19-af03-b9d4e64da4e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "ad8c24ab-e5ee-415a-b29b-cf9fb4791a0e",
+          "id": "30c6ca70-0dff-4314-bf16-8099d06dd074",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "2811a038-9108-41f7-9108-2624c2a88e52",
+              "id": "fd249028-b62d-4c3c-8aa6-b29d512052b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "116f57a5-7025-4720-9b6b-2fca91a87ab0",
+          "id": "32a2e367-62e6-4ad8-91c9-7d18b5cf4a21",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "defc246a-2eee-4811-a649-f725ddacd893",
+              "id": "c92efaac-d0f0-45a7-a96c-83f6622d66ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "42198833-b3e9-4156-b00f-17a75087ed17",
+          "id": "50e8fbc3-be98-4062-95d7-63aaf228c593",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "51eca6e8-85d5-44a4-a078-56b933175ab6",
+              "id": "0401fb59-6ec4-49f2-9db6-6021c3a730f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "77c522e7-a85a-48d7-98eb-a51793a98d16",
+          "id": "45b3b9d3-010c-47a3-945f-9acb7cb9043b",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "f848adff-0c79-46b1-82fc-d11218910632",
+              "id": "40e653bc-2606-4978-8fb3-04c93e496645",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "f198fd98-053c-4d28-8299-a55fa25ff4b8",
+          "id": "3df9bb82-c4c3-4257-9270-9c63dfb01b35",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "98797efd-9303-47be-b618-e791da07f459",
+              "id": "be033777-bdd3-49a5-9a62-b9db4626e3eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "7150af5c-09dc-4ec8-a0f5-f366cc0f8b5c",
+          "id": "ec221763-ba8e-4ffe-988a-93a96d54f5e1",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "cbf5674a-45f2-4a56-8edf-66263f499fc4",
+              "id": "3c282073-9047-4185-ac37-281f820a843f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "cd24fc88-4ed2-4fb7-8a59-4f48ece7c16c",
+          "id": "c64ccf67-cdfa-49f7-9e2d-d5349ca61b0a",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "0055f1c0-ce02-476f-b0a5-67470d23ffed",
+              "id": "bcef78ef-91e6-42e0-9ecd-49a1f8852b09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "70d3c13b-4867-4386-80e3-f563f54601e8",
+          "id": "11c6d8aa-681c-4b08-9c31-ec2de91f430f",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "acf1d925-c4fd-465d-b160-959d020fdfa7",
+              "id": "dab2c94c-2dc1-4e09-ba48-ec81a6dcc3b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "4bb35b3f-d036-4193-97fc-7fa780179890",
+          "id": "ff63c631-3a36-47a8-97bb-e2e5daa2887a",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "55446abd-9f94-46eb-9ddb-f8e28fd6eaf2",
+              "id": "b113cf0b-eae9-409e-bc2d-9e8b991c4b0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "1591e2d7-22d6-49f5-b78f-8ea90870de48",
+          "id": "2fe5fb0b-01d7-447b-8f5e-8795c1cd6f12",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "ce7f34f1-c5d6-4c88-9b22-e206735b5f3b",
+              "id": "16c5092f-95aa-478e-840b-d201db56f9c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "c22dc89c-b355-42b2-a842-474daaafaf18",
+          "id": "bf4a3706-093a-4058-bcd8-4273a88b29dc",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "fda9e4d6-6b2f-44d5-a1be-115ee4d3b769",
+              "id": "1b0d45d8-2c83-4113-b638-abd74f8b3a99",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "3e086e9d-767c-404c-b451-efe8ba13b632",
+          "id": "9da063aa-501a-4c8f-9d35-1c72b1a31634",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "0fa4878d-e39d-4384-9c30-de0c6e3810b5",
+              "id": "bf2aefa0-acd2-4d6d-8873-afc26e84eaaa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "b5a25583-2d94-4eca-b1c1-1a4f012fefaf",
+          "id": "34c02151-0b4b-434f-b52a-2c5cf60ef17a",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "05005989-4951-4708-80dd-0439f07683fb",
+              "id": "b11e7098-aeff-4196-b4da-099cad66d9a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "dd70521e-371e-4a87-a38e-952c6873ad42",
+          "id": "a517d5d5-af72-4fa1-8317-6e2b76e8cd5e",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "7f4da8ba-0980-4984-9970-35dbb39bf23c",
+              "id": "74c4e93c-8467-44ac-9f8a-6a2b92d459e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "e6c9d5e5-4671-4c4a-a6d0-03802ef8d5c7",
+          "id": "34d8afd0-f5ad-4677-8a54-8fe3ea12a785",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "558801a2-ad6b-4338-b8a1-cf4a47fce090",
+              "id": "1883bb0f-f162-4fcc-a2fa-2858327f2eaf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "e0fd276b-dc8c-4804-8f66-60d830349d77",
+          "id": "0961351e-7230-4df6-838c-c7ac284e987b",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "67b8e61d-61f5-48ec-9481-2efcb09c7f16",
+              "id": "3f15cf26-0759-40df-9b43-e8674c1a93bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "adb80394-ccfd-4f4b-af53-236c1c15de66",
+          "id": "3ad662fe-f05d-4099-bed2-ac09af6bb570",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "91ebf365-3e64-4ae8-861a-f81c4660d4fa",
+              "id": "46b386e0-ea76-4de0-ac1e-1df2591a1dc6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "4f934358-e4c1-4ce1-a6e9-a9094aaacf35",
+          "id": "04f5f308-3060-47dc-a857-ef695b34e8e1",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "283c4e6b-c8b9-4273-96cb-8ea7f690d90e",
+              "id": "5270cfee-ed74-4d30-ae67-bdefaf36f676",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "764e8a1a-d80b-44db-a763-3a31b0f91c24",
+          "id": "084d3720-5ff8-45a2-a9fa-27fbc856a5db",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "717e187f-7802-4a49-8d82-37605f681da8",
+              "id": "9bc67d15-b4bb-4e3b-9d67-1d6ac25d5fef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "1e208918-3deb-4bea-9faf-26b4dcaab27c",
+          "id": "7b882305-12e7-4c0c-93a4-22c201d64e50",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "5176eaa8-c88c-4e95-a90f-8f7739f9c9d9",
+              "id": "356d786e-7ca4-4659-914c-11faeff3f179",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "572b07a0-6ab9-4418-a195-c10f4c10e11c",
+          "id": "ac013927-bf3c-4e50-aa15-445c76f5c1ae",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "8325db59-589c-41a3-93de-5984b8e51137",
+              "id": "9dd8f1a2-b964-4919-a2dd-3785b140fe89",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "00d70971-1b2c-4bb2-9f96-a0400617cb4a",
+          "id": "26ff7390-5480-4f00-b105-536c2a03c47b",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "3059bee0-55df-404c-afa1-b0507bd2aadc",
+              "id": "b5a26b75-c351-4797-b9ac-e2d803b93437",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "07b4d461-a1a1-46cb-a90d-41c2605ab0ca",
+          "id": "72842722-c3d1-454c-9c6f-9a0bb3fd62c2",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "924e7f3d-1830-4548-8512-614fc2469fe8",
+              "id": "7bf89cf3-6167-488d-9b5f-bc1edefbb969",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8a3e8fc3-8b23-4690-b637-c65509d1e5e5",
+              "id": "6bf124ab-d320-4235-ba13-3ce339c5fc0e",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "c3bada82-61b7-41b9-8e12-1741a3df3f47",
+          "id": "32d5d02a-fab3-4f3a-9eaf-45d6c67b893f",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "cc192d1a-93db-4ec0-903f-4a619ae9c0af",
+              "id": "86025c1d-2d35-443f-97a8-8b3a8769f94e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "06475391-76c0-4300-9d2b-b43fd839cfc4",
+              "id": "d21ad2cb-1425-4c02-8075-7ea2ed7bd721",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "2c07bb1e-1a15-49ee-8057-5ee963e396d9",
+              "id": "f928a8be-99db-4ac6-953b-c61caae31240",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "57d2a0a2-2e94-4132-b19f-4d67a9e6e7bf",
+          "id": "505c826b-60ce-4a76-a35e-73195c2dd81b",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "5c266862-b160-4c2a-8cc0-3ac3247fd5c3",
+              "id": "dae6bd75-fcd8-46d8-b937-8377349d22c4",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "11012a0d-351a-48c1-b08e-02c6856c7678",
+              "id": "eb56fb6f-9bc2-4b73-92a7-76adc8901faf",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "329574d3-ae15-42f9-abab-da4d4acc8707",
+              "id": "e35ee21d-f016-4461-a006-77f558176c0d",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "1443c75e-cc62-4c15-a2dc-e7e539f50e08",
+          "id": "6c438463-927e-4c29-bfdb-43d6d8a0c81b",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "406ef5df-50d4-40b1-bcce-13a699da8b57",
+              "id": "074eae29-c934-4a1e-85ce-ff0d5cba7bed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "1fb23e68-4728-4b8a-8ea1-895b25f86e9e",
+          "id": "e78db546-715e-4c6b-8e16-0f2dfb9af522",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "c1a0316d-9bf2-4b8f-98ec-c352d67e2304",
+              "id": "7756b23c-b427-4bc9-bde9-6caac30788ac",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0f770103-4e80-40a1-a8ac-4af9fa330d2b",
+              "id": "b7c6e66b-2271-432d-9a19-8be8418d578b",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "f7620010-14bf-44d3-9fa5-469589cdd4dc",
+          "id": "eb70da7c-ffd8-4392-a6d1-39366df1e2cc",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "03ed6510-4ea6-4254-add6-52791b9ad8dd",
+              "id": "01756779-06e3-4a36-91ee-6ed6d77cf175",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
+              "body": "{\n  \"key_0\": 7841\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "91ceace8-e71c-48a0-9844-dd671299c33b",
+          "id": "59a8436e-860e-415c-910e-8377ff28fe60",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "50741bf9-6394-4a70-bd01-0637e0ee9369",
+              "id": "80fd8867-573e-463c-8eaa-b59d64b88ed4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "c8a2d1f2-14fe-4e35-9e5e-fe8dc8209b89",
+          "id": "65b195cb-0fef-42ab-bb2d-729e26c1a692",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "5c2c68ef-325e-4dfd-b60a-220a7e213a39",
+              "id": "1477ba38-9268-4313-abe0-967d351b9a66",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "f99d5b3a-a25c-46b5-87b9-6f0701b51b3d",
+          "id": "24033d1b-bb53-4040-9371-f04f16166f36",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#04CFB8\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#D1393f\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "51be0dc2-612b-4289-9121-01ecbd1aeda3",
+              "id": "f7d120f8-d41e-46c9-a8ed-6afd03171cdd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#04CFB8\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#D1393f\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "db87a9cc-e298-40b1-a1c8-500f061d8eab",
+          "id": "e4a96a58-aeb9-4f4b-976e-1b504c7f8044",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "cf62c020-dd5d-4c40-8247-f8b57699c9fe",
+              "id": "c143a65b-8b75-4935-914a-ce75af4d4aac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "9b8789f3-dc0e-4782-8d6b-dbbfeb845a9f",
+          "id": "4fd19882-4a85-4b28-8ddd-9083f54c6c77",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "9ba7447f-a5fd-4983-939c-d054dc4cc42a",
+              "id": "8bc771bb-4547-4ed5-ad3b-c677097a0d2a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "0d990c7f-ca34-4e5d-919b-fb25377db322",
+          "id": "e78033f1-41d8-46d6-a9cf-71d257256eb5",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a7F930\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#349Bbc\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "bd7ce512-885e-4174-a24e-f3d3e8bb2fb7",
+              "id": "a5d7502f-16bf-4931-a099-db3a50a7fb57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a7F930\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#349Bbc\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "ace58541-0af3-4ef9-8976-45c59b236e1f",
+          "id": "56ddde4d-4790-4ea2-aadf-f3ad98a813c1",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "4e0ded51-5822-404c-8e4f-588b58e6a21b",
+              "id": "e5685f0d-39b0-4ba9-b445-725517979f07",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "dd8da66d-f2a5-4f83-919b-4bc89a54f6e0",
+          "id": "f254975b-9bac-4b5c-bb3f-fbbc5b156bc1",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "cdab9e97-7c84-4f51-8e55-febe20e258a3",
+              "id": "b0410504-73df-4bfa-9b30-dd7bc4439502",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "b6581459-b6d6-44fd-b8ac-df0fea931787",
+          "id": "dafb4491-6004-499a-9e3e-d28942517ff8",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "b53a9200-e0ce-4367-a3ef-ed643c8dc876",
+              "id": "b59f6f7f-adfa-4c3f-bac8-af8d38c2b102",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "07c5727d-e583-4fc5-a76c-46dd0138d7fc",
+          "id": "4d53ac8d-044d-4c3a-a6fa-25100aadb96d",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "9f626764-2526-4601-b687-08803ae99cc2",
+              "id": "a71f8881-d0c0-4656-a365-ca98e80cbf20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "53bb9264-e1d0-4c6a-8bec-379d66f28559",
+          "id": "eab6eb3b-6975-46d8-88b0-446723daf769",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "c02619e8-ab8d-4ead-8ed6-d1c57022a41e",
+              "id": "b121eee6-632c-47be-b4dd-29991fd14319",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "e7ef3f41-5e4f-4d2b-a201-0fea7556d997",
+          "id": "a571e01a-4038-432c-90a2-41bde208dbd8",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "ceac73f8-0f1a-422e-a452-a56fe82afdb0",
+              "id": "5b26b773-8492-4178-a31f-f29280cb27ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "26686493-09d6-4ecd-a02e-23c673cb5624",
+          "id": "efd0c070-85bd-420c-b18a-84a1eaac5152",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "c8af0900-6945-41e1-9635-23ee3b90b20d",
+              "id": "751501fe-5693-4370-bba3-620436cd9bca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "fae19176-4870-4058-924c-09502e29c8df",
+          "id": "98051604-ec12-41f5-bbd3-d88968a1c7ed",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "ca1bbb89-57a5-4dbc-beff-8cc546799121",
+              "id": "b0fe8f57-9df2-4a46-bd91-64331735a2e2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "72499247-5321-480a-a8dd-e3e542a0ef04",
+          "id": "1a718f6b-fd5d-4fb4-94ca-4f1d863fe7ea",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "6cd5fc49-1ee1-45d2-90e9-900857aea803",
+              "id": "f3a13ef1-aceb-42a1-84c6-bea3704e9a90",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "5ba9bc53-35f2-48a8-96fa-8328231da06c",
+          "id": "bbdb543f-91aa-403f-9278-2d5c70fbee3e",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "20688965-c579-44ed-93c9-87356ed0342a",
+              "id": "26cf378a-21cd-48ef-b527-4dbccded8763",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "8274bdd1-9d94-4efc-81ba-c8201b6b6700",
+          "id": "12cc1c3a-c822-4321-9e76-a2d968ce02eb",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "cb659562-cf56-4d8d-a11a-57ce6adfb3d4",
+              "id": "aed17c23-5f8b-4cd1-97ad-125035efe826",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "7b5ea654-f138-4237-b2bc-a63ad0ef6de9",
+          "id": "36d2a441-9120-4357-84cb-f6570b07eb04",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "5b02548a-288b-445d-a138-86cc4d6bf265",
+              "id": "9dc2adf4-177f-4c9c-aad5-82ad79fa4f9a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "f963a082-cabf-4fb2-914e-806dbbcdf03e",
+          "id": "67c571b0-34c0-414a-bfd0-132ce1d19d4e",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "3e84f7b8-4d84-4754-94e8-1d383ff660d3",
+              "id": "f53f408d-4f41-4ec9-8ca6-888063393545",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "e6bf6f24-a9ae-42a8-a8a1-123bdf175771",
+          "id": "888e8bd6-85c1-4ab8-835c-8808e8a8ef94",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "3ebf5cf2-01f9-4238-90f7-daf6e3586a91",
+              "id": "d26cbe4e-dc17-4e65-af39-f11047c7b964",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "e9a83310-4a5f-4bf9-8c84-da6e4cbcde5c",
+          "id": "70d89423-c152-49c9-add7-01ac0c791e29",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "7c96a004-0275-43a1-90fd-3d9019798a9b",
+              "id": "d04ffbf5-cc06-4238-9cee-8c7acd4d7f2f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "e2def0d1-bc91-41a4-91e3-f4e92bc5fa81",
+          "id": "f014aeba-442c-4efd-94cd-e8a7760a9530",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "dec80f2a-e2bd-4ba0-befe-49c57dde3c78",
+              "id": "7d4df6e5-dad6-4b55-a9ba-0d9e89bc32c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "7da1da6e-b55d-48a1-a86d-a21442b94699",
+          "id": "f180d665-e64a-4f12-bf53-4e7f2cb62bc5",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "a4e1d8c2-0475-47dc-ad49-307c569d7257",
+              "id": "889a6515-b89d-48f7-ad9d-e27c7f23a476",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "9ccf89ab-e9f9-491f-bd7f-e1d893efac25",
+          "id": "d6a640fc-3334-43df-8611-e94b3f003865",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "9c78cd03-9c65-4b85-81e9-0edd28aa1937",
+              "id": "4bd979d9-a237-47ee-9be2-3243117c33fd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "241b8d2d-0db3-4aa2-a242-dccbc5a67256",
+          "id": "08a050ac-9c04-486f-8005-1c81c64c8658",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "45610dd1-4103-4db8-b52d-a351b2f1e147",
+              "id": "942ef736-8742-4af0-ab21-dfc561e8d868",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "e6ddeaa9-2c98-48ad-a32e-2da820f2321e",
+          "id": "05fc0191-949c-4b97-afc8-7d520f2d6fc3",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "d65153f8-d64f-4c2c-aa3c-2c32ab58be31",
+              "id": "380ff042-11eb-40b4-912a-cfa952e0273d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "ff636c11-3460-4c72-9c60-862528d2a8f0",
+          "id": "2aed1a8a-10be-49d7-b50e-3b05daa9c07a",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "d20a10c0-0cb9-498b-a86f-ef98bb204fcf",
+              "id": "0e912649-e834-4495-8e36-da311d394613",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "38862028-151b-4fc1-990a-a957e02be4e9",
+          "id": "c4935a19-c8e4-4725-8ead-390307b8c7e4",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "4822999f-5742-408f-95b2-9b7978bceec5",
+              "id": "19863c9d-7642-4f18-9e61-a46a53705371",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "1041e9df-a6c6-406d-9db3-dec52e2a3f05",
+          "id": "f7f96a8a-2db8-4528-a0f4-73343595bfab",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "5d7693bd-d934-4296-9541-34a6b993159c",
+              "id": "d522df1f-abfc-4ef1-b11e-79b90b7a2624",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "2a0f2ad1-de29-425b-9626-a0bd5641dadf",
+          "id": "1e80d19d-6d10-49d5-a617-0951b9a43df6",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "ef9971b3-d7c4-4e62-a929-d2078f6d47ff",
+              "id": "1f833881-bd08-4f88-b611-3df3588599e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "6a8531e9-e93a-46f4-8c26-a633345959c3",
+          "id": "1d859322-bb42-4bea-943c-5f0730410aac",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "1e039feb-0af9-48b5-9217-f6f101604ba0",
+              "id": "850da81d-8250-4c23-9c4b-c03e5c045a9f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "fa6ad8ff-e815-4c02-a442-c1eb9310ce1e",
+          "id": "7e71b29d-aaa3-4713-afba-b5ea45eb81a0",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "69cac62f-231f-41d9-a6b6-60df386df619",
+              "id": "adc7611b-c842-42fa-9a0b-aa155619e4e2",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ce408262-8b8e-46e3-80c8-8a4bc2d95d89",
+              "id": "8a897445-f819-4059-a27f-0262b04bf2f7",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "5822a1e0-9325-41df-aeb6-c3870e84d1e9",
+          "id": "1fa04dcf-6376-4439-b974-f37c017c794d",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "afe37782-ff7e-43ba-a57e-bdf369e1a7b5",
+              "id": "abb7f193-b928-4ff1-a2b1-220e50add837",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b372727e-1f65-4012-9a15-72b30153d018",
+              "id": "f9cd9026-cad9-421e-9555-b499a6aedac4",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "52031a5d-3949-4865-a9ce-8f87784ebbbe",
+          "id": "27acfde0-7d48-491c-99bb-e7449c399754",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "ad3f6609-981a-4d24-94d6-ba62a2d0884e",
+              "id": "e2c65ca7-268f-43f6-9aba-bc2027cc5a39",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "221f4cd5-42c6-4c14-a396-fb46cd56a89e",
+              "id": "e0a5cfff-6d42-4384-924f-4ed89c96a752",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "4266cfcc-8933-480e-b498-bee00ab18098",
+          "id": "20b829ba-148b-4f06-bc6a-a9ce001b8ca0",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "f312e64e-b28b-4c97-9e67-174f4ecc0f9b",
+              "id": "2a762bc3-232b-4cbc-8b29-80e2d31884d0",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "62d2e108-022a-4b81-ab43-8ae1958d8bf0",
+          "id": "46b23720-1506-45d9-90dc-9b34b42cc78a",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "bff04126-7e53-4fa5-a4c5-ac8a60c28d11",
+              "id": "db179270-9cd1-46a7-b263-63cc1f130c85",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
+              "body": "{\n  \"key_0\": 7841\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "3debf779-9999-4fa1-9da7-c47b77546e82",
+          "id": "ef51ef02-dc82-445e-93a6-241a552ec74b",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "055341a7-beaf-4ffa-b443-148ba04a0ad1",
+              "id": "7060ca0f-3a1d-4be8-b3ee-3ff9789d291f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "7fcc7f37-6f1a-4b13-aceb-97c7e444c775",
+          "id": "027bd41d-8d03-46d5-b281-921befbae0e0",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "8dd369d3-501d-4375-9e02-47ab82d9b665",
+              "id": "7f50b28f-f676-4ef2-bf8c-2822affce0fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "7347548a-053a-4fd0-a180-c7a52fbb7082",
+          "id": "c2ab8a24-9ac0-4020-991a-fa69f0ea51d5",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "4880a396-bdd4-401c-b6c9-3dd4cfe445c0",
+              "id": "035a7031-4139-4269-9cc4-886648ba1876",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "8a954a62-3c4d-4dcb-aeb9-a8058e2418f1",
+          "id": "16890ceb-908d-441e-bf65-9fc8c1e32bb1",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "373c0704-00b7-4c00-bcd7-7905ae4a03ab",
+              "id": "a4131ee7-73a2-4156-92bf-be16db7c54ec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "ac383265-8aa7-433b-af8c-e0dd70a92ef6",
+          "id": "ca8ab110-36ef-49af-92dd-ef79964cd9c8",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "198065d3-4f56-4ee5-9fcc-46b6f4f37280",
+              "id": "c5b1aae3-8794-48e2-aadd-7a074f91fd17",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
+              "body": "{\n  \"key_0\": 7841\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "a17e9234-af7e-462e-8a78-f4ef98fcb521",
+          "id": "7dec9c2e-739b-4aa6-a982-fe2694e00327",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "260bdd33-966e-4e8b-bd3d-cc5753e9e9ac",
+              "id": "cca219ec-4856-42ad-83b3-1b72d0d15a6d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "7b2adc5d-45a0-45c4-ae16-f38c40c71b95",
+          "id": "46e2834d-5475-4de7-b30c-f48e76608d62",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "4e7d573f-f5c0-4dd5-8060-efe192422c6e",
+              "id": "87bc88ee-6973-4f57-9785-1b855aed8242",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "5a60e8e5-0c94-45a3-bea5-f060fa0045ba",
+          "id": "2896216d-6ef9-4331-9e60-0810c256eded",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "14d83d93-a6a8-4fc9-b0b8-3b3dccddf8b7",
+              "id": "a6306d54-1482-435a-9c5e-09319c6ff2a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "83cc216e-cbc3-4ae9-b6f1-c6560cc91777",
+          "id": "e1602b31-595b-4d8b-b15a-ae7dc61486a0",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "0744666f-c05f-4533-bcdd-3cdcdaf4f863",
+              "id": "c30f7712-58d2-4d11-8b4f-f2c070296a7a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 480\n}",
+              "body": "{\n  \"key_0\": 7841\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "138d725e-09be-4de8-86fc-7c74b96ba90d",
+          "id": "d519b09e-c088-4234-94a1-f9ba5eacbc0a",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "750867b6-f4ab-4639-afa2-4fb53a63df1e",
+              "id": "2f6486b5-90c2-4466-8412-89889457b103",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "a8a66c00-c397-4eae-8ce6-f3c6d2a00bdd",
+          "id": "a8f8604e-2b58-413c-868a-520c2c227217",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "89d6ba4d-b284-4945-99cb-b53b244c6caa",
+              "id": "df1aac25-1982-4e0e-ae9b-2c00487a3742",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15533,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "895bd796-b5ea-4894-87a1-bf6cf573d3f7",
+          "id": "f84aef71-596f-4170-92b8-db0ff4b9dcab",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "a06d6365-9ae0-4e7d-bf89-b80a878659b6",
+              "id": "ec22e106-9cd2-4578-af72-1394ff1683a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15615,7 +15615,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "b171f908-1d7e-4b21-99b0-499aaf665f35",
+    "_postman_id": "acd2c12b-d454-488b-b0de-d0aaacf59ac9",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 14:58 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 15:01 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,9 @@ dependencies {
     implementation("org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5")
     // OpenAPI/Swagger documentation
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14")
+    // Firebase Admin SDK - server-side FCM push notifications
+    // https://firebase.google.com/docs/admin/setup#java
+    implementation("com.google.firebase:firebase-admin:9.5.0")
     annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/com/apptolast/invernaderos/config/PostGreSQLDataSourceConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/PostGreSQLDataSourceConfig.kt
@@ -35,7 +35,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
 
                         "com.apptolast.invernaderos.features.statistics",
                         "com.apptolast.invernaderos.features.setting",
-                        "com.apptolast.invernaderos.features.command"],
+                        "com.apptolast.invernaderos.features.command",
+                        "com.apptolast.invernaderos.features.push"],
         entityManagerFactoryRef = "metadataEntityManagerFactory",
         transactionManagerRef = "metadataTransactionManager"
 )
@@ -75,7 +76,8 @@ class PostGreSQLDataSourceConfig {
                 "com.apptolast.invernaderos.features.user",
                 "com.apptolast.invernaderos.features.statistics",
                 "com.apptolast.invernaderos.features.setting",
-                "com.apptolast.invernaderos.features.command"
+                "com.apptolast.invernaderos.features.command",
+                "com.apptolast.invernaderos.features.push"
         )
         entityManager.persistenceUnitName = "metadataPersistenceUnit"
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/catalog/AlertSeverity.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/catalog/AlertSeverity.kt
@@ -42,6 +42,16 @@ data class AlertSeverity(
     @Column(name = "notification_delay_minutes")
     val notificationDelayMinutes: Int = 0,
 
+    /**
+     * Per-severity feature flag for FCM push notifications. When false,
+     * activations of alerts with this severity skip the push fan-out
+     * (the alert still travels via WebSocket as today). Toggleable at
+     * runtime via UPDATE on metadata.alert_severities so admins can mute
+     * a noisy severity without a redeploy.
+     */
+    @Column(name = "notify_push", nullable = false)
+    val notifyPush: Boolean = true,
+
     @Column(name = "created_at")
     val createdAt: Instant = Instant.now()
 ) {

--- a/src/main/kotlin/com/apptolast/invernaderos/features/catalog/dto/mapper/CatalogMappers.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/catalog/dto/mapper/CatalogMappers.kt
@@ -58,7 +58,8 @@ fun AlertSeverity.toResponse() = AlertSeverityResponse(
     description = this.description,
     color = this.color,
     requiresAction = this.requiresAction,
-    notificationDelayMinutes = this.notificationDelayMinutes
+    notificationDelayMinutes = this.notificationDelayMinutes,
+    notifyPush = this.notifyPush
 )
 
 fun Period.toResponse() = PeriodResponse(

--- a/src/main/kotlin/com/apptolast/invernaderos/features/catalog/dto/response/AlertSeverityResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/catalog/dto/response/AlertSeverityResponse.kt
@@ -23,5 +23,11 @@ data class AlertSeverityResponse(
     val requiresAction: Boolean,
 
     @Schema(description = "Minutos de retraso antes de notificar", example = "0")
-    val notificationDelayMinutes: Int
+    val notificationDelayMinutes: Int,
+
+    @Schema(
+        description = "Si esta severidad dispara notificaciones push FCM (toggle de admin)",
+        example = "true"
+    )
+    val notifyPush: Boolean = true
 )

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/AlertPushPayload.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/AlertPushPayload.kt
@@ -1,0 +1,28 @@
+package com.apptolast.invernaderos.features.push
+
+import java.time.Instant
+
+/**
+ * Payload de una notificación push generada a partir de la activación de
+ * una alerta. Sólo datos primitivos: el `FcmPushService` los traduce a los
+ * campos `notification` (display) y `data` (deep link) del `MulticastMessage`.
+ *
+ * Estructura `data` que recibe el cliente:
+ *  - alertId, alertCode → identifican la alerta concreta
+ *  - greenhouseId, sectorId → para el deep link a `GreenhouseDetailScreen`
+ *  - severity, severityLevel → para colorear / filtrar en cliente
+ *  - createdAt → ISO-8601 epoch millis
+ */
+data class AlertPushPayload(
+    val alertId: Long,
+    val alertCode: String,
+    val tenantId: Long,
+    val greenhouseId: Long,
+    val sectorId: Long,
+    val severityName: String,
+    val severityLevel: Short,
+    val severityColor: String?,
+    val title: String,
+    val body: String,
+    val createdAt: Instant
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/FcmPushService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/FcmPushService.kt
@@ -1,0 +1,173 @@
+package com.apptolast.invernaderos.features.push
+
+import com.google.firebase.messaging.AndroidConfig
+import com.google.firebase.messaging.AndroidNotification
+import com.google.firebase.messaging.ApnsConfig
+import com.google.firebase.messaging.Aps
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.Notification
+import io.micrometer.core.instrument.MeterRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Envía notificaciones push FCM a todos los tokens registrados de un tenant.
+ *
+ * Trocea el envío en grupos de [FCM_MULTICAST_BATCH] (máximo permitido por
+ * `sendEachForMulticast` según la documentación de FCM HTTP v1) para no
+ * sobrepasar el límite del SDK.
+ *
+ * Limpieza automática de tokens muertos: cuando FCM responde con
+ * `UNREGISTERED` (la app fue desinstalada) o `INVALID_ARGUMENT` (token
+ * malformado o ya rotado), se borra la fila correspondiente para que el
+ * próximo envío no la incluya.
+ *
+ * Si no hay `FirebaseMessaging` (caso "sin credenciales", ver
+ * [com.apptolast.invernaderos.features.push.infrastructure.config.FirebaseConfig]),
+ * el envío es un no-op silencioso. Esto permite que el sistema siga funcional
+ * para entornos sin Firebase configurado.
+ */
+@Service
+class FcmPushService(
+    @Autowired(required = false)
+    private val firebaseMessaging: FirebaseMessaging?,
+    private val pushTokenRepository: PushTokenRepository,
+    private val meterRegistry: MeterRegistry
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional("metadataTransactionManager")
+    fun sendAlertToTenant(payload: AlertPushPayload) {
+        val messaging = firebaseMessaging ?: run {
+            logger.debug(
+                "FCM disabled (no FirebaseMessaging bean) — skipping push for alert {}",
+                payload.alertCode
+            )
+            return
+        }
+
+        val tokens = pushTokenRepository.findAllByTenantId(payload.tenantId).map { it.token }
+        if (tokens.isEmpty()) {
+            logger.info(
+                "No push tokens registered for tenantId={} — skipping push for alert {}",
+                payload.tenantId, payload.alertCode
+            )
+            return
+        }
+
+        var totalSuccess = 0
+        var totalFailed = 0
+        tokens.chunked(FCM_MULTICAST_BATCH).forEach { chunk ->
+            val message = buildMulticastMessage(chunk, payload)
+            try {
+                val response = messaging.sendEachForMulticast(message)
+                totalSuccess += response.successCount
+                totalFailed += response.failureCount
+
+                response.responses.forEachIndexed { index, sendResponse ->
+                    if (!sendResponse.isSuccessful) {
+                        val code = sendResponse.exception?.messagingErrorCode
+                        val deadToken = chunk[index]
+                        if (code == MessagingErrorCode.UNREGISTERED ||
+                            code == MessagingErrorCode.INVALID_ARGUMENT) {
+                            val deletedRows = pushTokenRepository.deleteByToken(deadToken)
+                            logger.info(
+                                "Removed invalid FCM token (code={}) deletedRows={} alertCode={}",
+                                code, deletedRows, payload.alertCode
+                            )
+                        } else {
+                            logger.warn(
+                                "FCM send failure (code={}) tokenSuffix=...{} alertCode={}",
+                                code,
+                                deadToken.takeLast(6),
+                                payload.alertCode,
+                                sendResponse.exception
+                            )
+                        }
+                        meterRegistry.counter(
+                            "push.fcm.failed",
+                            "reason", code?.name ?: "UNKNOWN"
+                        ).increment()
+                    }
+                }
+            } catch (ex: Exception) {
+                logger.error(
+                    "FCM multicast call failed for alertCode={} chunkSize={}",
+                    payload.alertCode, chunk.size, ex
+                )
+                totalFailed += chunk.size
+                meterRegistry.counter("push.fcm.failed", "reason", "EXCEPTION").increment()
+            }
+        }
+
+        meterRegistry.counter("push.fcm.sent").increment(totalSuccess.toDouble())
+        logger.info(
+            "FCM push sent: tenantId={} alertCode={} tokens={} success={} failed={}",
+            payload.tenantId, payload.alertCode, tokens.size, totalSuccess, totalFailed
+        )
+    }
+
+    private fun buildMulticastMessage(
+        tokens: List<String>,
+        payload: AlertPushPayload
+    ): MulticastMessage {
+        val builder = MulticastMessage.builder()
+            .addAllTokens(tokens)
+            .setNotification(
+                Notification.builder()
+                    .setTitle(payload.title)
+                    .setBody(payload.body)
+                    .build()
+            )
+            .putData("alertId", payload.alertId.toString())
+            .putData("alertCode", payload.alertCode)
+            .putData("greenhouseId", payload.greenhouseId.toString())
+            .putData("sectorId", payload.sectorId.toString())
+            .putData("severity", payload.severityName)
+            .putData("severityLevel", payload.severityLevel.toString())
+            .putData("createdAt", payload.createdAt.toEpochMilli().toString())
+            .setAndroidConfig(
+                AndroidConfig.builder()
+                    .setPriority(AndroidConfig.Priority.HIGH)
+                    .setNotification(
+                        AndroidNotification.builder()
+                            .setChannelId(ANDROID_CHANNEL_ID)
+                            .setColor(payload.severityColor ?: DEFAULT_COLOR)
+                            .build()
+                    )
+                    .build()
+            )
+            .setApnsConfig(
+                ApnsConfig.builder()
+                    .setAps(
+                        Aps.builder()
+                            .setSound("default")
+                            .setContentAvailable(true)
+                            .build()
+                    )
+                    .build()
+            )
+        return builder.build()
+    }
+
+    companion object {
+        /**
+         * Máximo de tokens por llamada `sendEachForMulticast` (FCM HTTP v1).
+         */
+        const val FCM_MULTICAST_BATCH = 500
+
+        /**
+         * Canal de notificación Android. El cliente debe crear este channel
+         * antes de mostrar la primera notificación; ver `GreenhouseFcmService`
+         * en el frontend KMP.
+         */
+        const val ANDROID_CHANNEL_ID = "alerts_default"
+
+        private const val DEFAULT_COLOR = "#00E676"
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/PushToken.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/PushToken.kt
@@ -1,0 +1,55 @@
+package com.apptolast.invernaderos.features.push
+
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * Token FCM (Firebase Cloud Messaging) registrado por un dispositivo de cliente
+ * (móvil Android/iOS o navegador web) tras hacer login. El token se utiliza para
+ * enviar notificaciones push de alertas a TODOS los dispositivos asociados a un
+ * tenant.
+ *
+ * Reglas:
+ *  - `token` es UNIQUE: un mismo dispositivo (token) sólo aparece una vez. Si
+ *    el mismo token se registra desde otro user/tenant (poco probable, pero
+ *    posible si hay relogin con otro user), el upsert sobrescribe el dueño.
+ *  - El borrado en cascada por `user_id` y `tenant_id` garantiza que al borrar
+ *    un usuario o tenant los tokens también desaparezcan.
+ *  - `last_seen_at` se refresca en cada upsert; permite limpiar tokens
+ *    huérfanos en una rutina de mantenimiento futura (no implementada aquí).
+ */
+@Entity
+@Table(
+    name = "push_tokens",
+    schema = "metadata",
+    indexes = [
+        Index(name = "idx_push_tokens_tenant", columnList = "tenant_id"),
+        Index(name = "idx_push_tokens_user", columnList = "user_id")
+    ]
+)
+data class PushToken(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+
+    @Column(name = "tenant_id", nullable = false)
+    var tenantId: Long,
+
+    @Column(name = "token", nullable = false, unique = true, columnDefinition = "TEXT")
+    var token: String,
+
+    @Column(name = "platform", nullable = false, length = 16)
+    @Enumerated(EnumType.STRING)
+    var platform: PushPlatform,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: Instant = Instant.now(),
+
+    @Column(name = "last_seen_at", nullable = false)
+    var lastSeenAt: Instant = Instant.now()
+)
+
+enum class PushPlatform { ANDROID, IOS, WEB }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/PushTokenRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/PushTokenRepository.kt
@@ -1,0 +1,19 @@
+package com.apptolast.invernaderos.features.push
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PushTokenRepository : JpaRepository<PushToken, Long> {
+
+    fun findByToken(token: String): PushToken?
+
+    fun findAllByTenantId(tenantId: Long): List<PushToken>
+
+    @Modifying
+    @Query("DELETE FROM PushToken p WHERE p.token = :token")
+    fun deleteByToken(@Param("token") token: String): Int
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/PushTokenService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/PushTokenService.kt
@@ -1,0 +1,82 @@
+package com.apptolast.invernaderos.features.push
+
+import com.apptolast.invernaderos.features.user.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+/**
+ * Servicio para gestionar tokens FCM. Resuelve `userId` y `tenantId` desde
+ * la identidad autenticada (email o username del JWT) — los tokens NUNCA se
+ * registran a un usuario que no es el que está enviando la petición.
+ *
+ * Idempotencia: el endpoint POST hace upsert por `token` UNIQUE. Si el mismo
+ * token se registra de nuevo (relogin en el mismo dispositivo, rotación FCM
+ * que devuelve el mismo valor, etc.) se actualizan user_id, tenant_id,
+ * platform y last_seen_at sin crear filas duplicadas.
+ */
+@Service
+class PushTokenService(
+    private val pushTokenRepository: PushTokenRepository,
+    private val userRepository: UserRepository
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional("metadataTransactionManager")
+    fun register(authenticatedPrincipal: String, token: String, platform: PushPlatform): PushToken {
+        val (userId, tenantId) = resolveUserAndTenant(authenticatedPrincipal)
+
+        val existing = pushTokenRepository.findByToken(token)
+        return if (existing != null) {
+            existing.userId = userId
+            existing.tenantId = tenantId
+            existing.platform = platform
+            existing.lastSeenAt = Instant.now()
+            val saved = pushTokenRepository.save(existing)
+            logger.info(
+                "Push token refreshed: id={} userId={} tenantId={} platform={}",
+                saved.id, userId, tenantId, platform
+            )
+            saved
+        } else {
+            val saved = pushTokenRepository.save(
+                PushToken(
+                    userId = userId,
+                    tenantId = tenantId,
+                    token = token,
+                    platform = platform
+                )
+            )
+            logger.info(
+                "Push token registered: id={} userId={} tenantId={} platform={}",
+                saved.id, userId, tenantId, platform
+            )
+            saved
+        }
+    }
+
+    @Transactional("metadataTransactionManager")
+    fun unregister(token: String): Boolean {
+        val deleted = pushTokenRepository.deleteByToken(token)
+        if (deleted > 0) {
+            logger.info("Push token unregistered (rows={})", deleted)
+        } else {
+            logger.debug("Push token unregister: token not found, no-op")
+        }
+        return deleted > 0
+    }
+
+    private fun resolveUserAndTenant(principal: String): Pair<Long, Long> {
+        val user = userRepository.findByEmail(principal)
+            ?: userRepository.findByUsername(principal)
+            ?: throw UsernameNotFoundException(
+                "Authenticated user not found in DB: $principal"
+            )
+        val userId = user.id
+            ?: throw IllegalStateException("User has null id (should never happen): ${user.email}")
+        return userId to user.tenantId
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/dto/request/PushTokenRegisterRequest.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/dto/request/PushTokenRegisterRequest.kt
@@ -1,0 +1,23 @@
+package com.apptolast.invernaderos.features.push.dto.request
+
+import com.apptolast.invernaderos.features.push.PushPlatform
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+@Schema(description = "Request para registrar un token FCM de un dispositivo cliente")
+data class PushTokenRegisterRequest(
+
+    @field:NotBlank(message = "El token es obligatorio")
+    @field:Size(min = 10, max = 4096, message = "El token debe tener entre 10 y 4096 caracteres")
+    @Schema(
+        description = "Token FCM emitido por Firebase para este dispositivo",
+        example = "fABcD1234..."
+    )
+    val token: String,
+
+    @field:NotNull(message = "La plataforma es obligatoria")
+    @Schema(description = "Plataforma del dispositivo", example = "ANDROID")
+    val platform: PushPlatform
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/input/PushTokenController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/input/PushTokenController.kt
@@ -1,0 +1,59 @@
+package com.apptolast.invernaderos.features.push.infrastructure.adapter.input
+
+import com.apptolast.invernaderos.features.push.PushTokenService
+import com.apptolast.invernaderos.features.push.dto.request.PushTokenRegisterRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.*
+
+/**
+ * Endpoints REST para que los clientes registren / desregistren su token FCM
+ * tras login y logout. Ambos requieren JWT — el `tenantId` y `userId` se
+ * resuelven desde la identidad autenticada, NUNCA desde el body, para que un
+ * cliente no pueda registrar tokens de otro tenant.
+ */
+@RestController
+@RequestMapping("/api/v1/push-tokens")
+@CrossOrigin(origins = ["*"])
+@Tag(name = "Push Tokens", description = "Registro de tokens FCM de dispositivos para notificaciones push")
+@SecurityRequirement(name = "bearerAuth")
+class PushTokenController(
+    private val pushTokenService: PushTokenService
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping
+    @Operation(summary = "Registrar (o refrescar) el token FCM de este dispositivo")
+    fun register(
+        @Valid @RequestBody request: PushTokenRegisterRequest,
+        authentication: Authentication
+    ): ResponseEntity<Void> {
+        logger.debug(
+            "POST /api/v1/push-tokens user={} platform={}",
+            authentication.name, request.platform
+        )
+        pushTokenService.register(
+            authenticatedPrincipal = authentication.name,
+            token = request.token,
+            platform = request.platform
+        )
+        return ResponseEntity.noContent().build()
+    }
+
+    @DeleteMapping("/{token}")
+    @Operation(summary = "Desregistrar el token FCM (logout o invalidación)")
+    fun unregister(
+        @PathVariable token: String,
+        authentication: Authentication
+    ): ResponseEntity<Void> {
+        logger.debug("DELETE /api/v1/push-tokens user={}", authentication.name)
+        pushTokenService.unregister(token)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/output/AlertActivationPushListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/output/AlertActivationPushListener.kt
@@ -1,0 +1,119 @@
+package com.apptolast.invernaderos.features.push.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedEvent
+import com.apptolast.invernaderos.features.catalog.AlertSeverityRepository
+import com.apptolast.invernaderos.features.push.AlertPushPayload
+import com.apptolast.invernaderos.features.push.FcmPushService
+import com.apptolast.invernaderos.features.sector.SectorRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * Escucha [AlertStateChangedEvent] y dispara una notificación push cuando una
+ * alerta es ACTIVADA (transición de `isResolved=true` → `isResolved=false`).
+ *
+ * Filtros de envío:
+ *  - Sólo activaciones (`change.toResolved == false`). Las resoluciones se
+ *    propagan vía WebSocket pero NO disparan push (decisión de producto:
+ *    evitar saturar al usuario con notificaciones positivas).
+ *  - Sólo si la severidad de la alerta tiene `notify_push = true` en
+ *    `metadata.alert_severities`. Permite a un admin silenciar severidades
+ *    concretas con un simple UPDATE SQL.
+ *
+ * Phase = AFTER_COMMIT: el push se emite sólo después de que la transacción
+ * que cambió el estado haga commit. Si la transacción hace rollback, no se
+ * envía nada (evita "fantasmas": notificación de alerta sin alerta en BBDD).
+ *
+ * Aislamiento de errores: cualquier excepción en el envío FCM se loggea y se
+ * absorbe — el envío de push NUNCA debe romper el flujo principal de alertas.
+ *
+ * Transacción separada (`Propagation.REQUIRES_NEW`) para los lookups de
+ * `AlertSeverity` y `Sector`: como la transacción original ya se ha
+ * comiteado, el listener abre una propia, breve, sólo para leer.
+ */
+@Component
+class AlertActivationPushListener(
+    private val fcmPushService: FcmPushService,
+    private val alertSeverityRepository: AlertSeverityRepository,
+    private val sectorRepository: SectorRepository
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(
+        value = "metadataTransactionManager",
+        propagation = Propagation.REQUIRES_NEW,
+        readOnly = true
+    )
+    fun onAlertActivated(event: AlertStateChangedEvent) {
+        val change = event.change
+        val alert = event.alert
+
+        if (change.toResolved) {
+            logger.debug(
+                "Alert {} state change is a RESOLUTION (toResolved=true) — push skipped",
+                alert.code
+            )
+            return
+        }
+
+        try {
+            val severityId = alert.severityId ?: run {
+                logger.debug("Alert {} has null severityId — push skipped", alert.code)
+                return
+            }
+            val severity = alertSeverityRepository.findById(severityId).orElse(null) ?: run {
+                logger.warn(
+                    "Alert {} references unknown severityId={} — push skipped",
+                    alert.code, severityId
+                )
+                return
+            }
+            if (!severity.notifyPush) {
+                logger.debug(
+                    "Severity {} has notify_push=false — push skipped for alert {}",
+                    severity.name, alert.code
+                )
+                return
+            }
+
+            val sectorIdValue = alert.sectorId.value
+            val sector = sectorRepository.findById(sectorIdValue).orElse(null) ?: run {
+                logger.warn(
+                    "Alert {} references unknown sectorId={} — push skipped",
+                    alert.code, sectorIdValue
+                )
+                return
+            }
+
+            val payload = AlertPushPayload(
+                alertId = alert.id ?: error("Alert id null after AFTER_COMMIT — should be impossible"),
+                alertCode = alert.code,
+                tenantId = alert.tenantId.value,
+                greenhouseId = sector.greenhouseId,
+                sectorId = sectorIdValue,
+                severityName = severity.name,
+                severityLevel = severity.level,
+                severityColor = severity.color,
+                title = "Nueva alerta: ${severity.name}",
+                body = alert.message
+                    ?: alert.description
+                    ?: alert.clientName
+                    ?: alert.code,
+                createdAt = alert.createdAt
+            )
+
+            fcmPushService.sendAlertToTenant(payload)
+        } catch (ex: Exception) {
+            logger.error(
+                "Failed to send FCM push for alert {} (DB state already committed)",
+                alert.code, ex
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/config/FirebaseConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/config/FirebaseConfig.kt
@@ -1,0 +1,90 @@
+package com.apptolast.invernaderos.features.push.infrastructure.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.io.FileInputStream
+
+/**
+ * Inicializa el SDK de Firebase Admin para enviar notificaciones push FCM
+ * desde el backend.
+ *
+ * Resolución del fichero de credenciales (Service Account JSON):
+ *   1) Property `firebase.service-account-path` (application.yaml o env var
+ *      FIREBASE_SERVICE_ACCOUNT_PATH).
+ *   2) Variable de entorno estándar `GOOGLE_APPLICATION_CREDENTIALS`.
+ *
+ * Degradación graciosa: si NINGUNO de los dos está configurado o el fichero
+ * no se puede leer, se registra un WARN y NO se exponen los beans
+ * `FirebaseApp` / `FirebaseMessaging`. La aplicación arranca igualmente y los
+ * consumidores (`FcmPushService`) reciben un `FirebaseMessaging?` nulo y
+ * desactivan el envío. Esto es deliberado: el sistema debe seguir creando
+ * alertas y resolviéndolas vía MQTT/REST aunque FCM no esté operativo.
+ *
+ * Nota de seguridad: el JSON contiene una clave privada. NUNCA se commitea;
+ * se inyecta vía variable de entorno o se monta como secret en Kubernetes.
+ *
+ * Re-arranque idempotente: si la JVM ya tiene un `FirebaseApp` por defecto
+ * inicializado (caso típico en tests con contexto reciclado), reutilizamos
+ * la instancia existente en lugar de reinicializar.
+ */
+@Configuration
+class FirebaseConfig(
+    @Value("\${firebase.service-account-path:}")
+    private val serviceAccountPathProperty: String
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Bean
+    fun firebaseApp(): FirebaseApp? {
+        val path = resolveCredentialsPath() ?: run {
+            logger.warn(
+                "Firebase service account JSON not configured " +
+                        "(neither firebase.service-account-path nor GOOGLE_APPLICATION_CREDENTIALS) — " +
+                        "FCM push notifications DISABLED. Alerts will continue to flow via WebSocket."
+            )
+            return null
+        }
+
+        val existing = FirebaseApp.getApps().firstOrNull { it.name == FirebaseApp.DEFAULT_APP_NAME }
+        if (existing != null) {
+            logger.info("Reusing existing FirebaseApp instance")
+            return existing
+        }
+
+        return try {
+            FileInputStream(path).use { stream ->
+                val options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(stream))
+                    .build()
+                val app = FirebaseApp.initializeApp(options)
+                logger.info("FirebaseApp initialised from {}", path)
+                app
+            }
+        } catch (ex: Exception) {
+            logger.warn(
+                "Failed to initialise FirebaseApp from path={} — FCM push notifications DISABLED",
+                path, ex
+            )
+            null
+        }
+    }
+
+    @Bean
+    fun firebaseMessaging(firebaseApp: FirebaseApp?): FirebaseMessaging? {
+        return firebaseApp?.let { FirebaseMessaging.getInstance(it) }
+    }
+
+    private fun resolveCredentialsPath(): String? {
+        if (serviceAccountPathProperty.isNotBlank()) return serviceAccountPathProperty
+        val envPath = System.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        if (!envPath.isNullOrBlank()) return envPath
+        return null
+    }
+}

--- a/src/main/resources/db/migration/V38__create_push_tokens_and_notify_push_flag.sql
+++ b/src/main/resources/db/migration/V38__create_push_tokens_and_notify_push_flag.sql
@@ -1,0 +1,33 @@
+-- =============================================================================
+-- V38 — FCM push notification support
+-- =============================================================================
+-- 1) New table metadata.push_tokens: stores Firebase Cloud Messaging device
+--    tokens registered by mobile/web clients after login. Indexed by tenant_id
+--    so the FCM service can fan-out alerts to all devices of a tenant in one
+--    query.
+-- 2) New column metadata.alert_severities.notify_push: per-severity feature
+--    flag so an admin can disable push notifications for a given severity
+--    without redeploying (e.g. INFO → no notif, CRITICAL → always notif).
+--
+-- Idempotent (uses IF NOT EXISTS) to make re-runs against the dev/prod
+-- databases safe.
+-- =============================================================================
+
+-- Per-severity push notification flag.
+ALTER TABLE metadata.alert_severities
+    ADD COLUMN IF NOT EXISTS notify_push BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Device push tokens. One row per (device, user) login pair; rotates via
+-- onNewToken on the client.
+CREATE TABLE IF NOT EXISTS metadata.push_tokens (
+    id           BIGSERIAL PRIMARY KEY,
+    user_id      BIGINT      NOT NULL REFERENCES metadata.users(id)   ON DELETE CASCADE,
+    tenant_id    BIGINT      NOT NULL REFERENCES metadata.tenants(id) ON DELETE CASCADE,
+    token        TEXT        NOT NULL UNIQUE,
+    platform     VARCHAR(16) NOT NULL CHECK (platform IN ('ANDROID','IOS','WEB')),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_tokens_tenant ON metadata.push_tokens(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_push_tokens_user   ON metadata.push_tokens(user_id);

--- a/src/test/kotlin/com/apptolast/invernaderos/features/push/AlertActivationPushListenerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/push/AlertActivationPushListenerTest.kt
@@ -1,0 +1,201 @@
+package com.apptolast.invernaderos.features.push
+
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedEvent
+import com.apptolast.invernaderos.features.catalog.AlertSeverity
+import com.apptolast.invernaderos.features.catalog.AlertSeverityRepository
+import com.apptolast.invernaderos.features.push.infrastructure.adapter.output.AlertActivationPushListener
+import com.apptolast.invernaderos.features.sector.Sector
+import com.apptolast.invernaderos.features.sector.SectorRepository
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.Optional
+
+/**
+ * Unit tests for AlertActivationPushListener — MockK style, no Spring context.
+ */
+class AlertActivationPushListenerTest {
+
+    private lateinit var fcmPushService: FcmPushService
+    private lateinit var alertSeverityRepository: AlertSeverityRepository
+    private lateinit var sectorRepository: SectorRepository
+    private lateinit var listener: AlertActivationPushListener
+
+    @BeforeEach
+    fun setup() {
+        fcmPushService = mockk(relaxed = true)
+        alertSeverityRepository = mockk()
+        sectorRepository = mockk()
+        listener = AlertActivationPushListener(
+            fcmPushService,
+            alertSeverityRepository,
+            sectorRepository
+        )
+    }
+
+    private fun alert(
+        isResolved: Boolean = false,
+        severityId: Short? = 4,
+        message: String? = "Sensor offline"
+    ): Alert = Alert(
+        id = 1L,
+        code = "ALT-00010",
+        tenantId = TenantId(10L),
+        sectorId = SectorId(20L),
+        sectorCode = "SCT-00020",
+        alertTypeId = 1,
+        alertTypeName = "SENSOR_OFFLINE",
+        severityId = severityId,
+        severityName = "CRITICAL",
+        severityLevel = 4,
+        message = message,
+        description = null,
+        clientName = null,
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.now() else null,
+        resolvedByUserId = null,
+        resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z")
+    )
+
+    private fun change(toResolved: Boolean): AlertStateChange = AlertStateChange(
+        id = 1L,
+        alertId = 1L,
+        fromResolved = !toResolved,
+        toResolved = toResolved,
+        source = AlertSignalSource.MQTT,
+        rawValue = if (toResolved) "0" else "1",
+        at = Instant.now()
+    )
+
+    private fun severity(notifyPush: Boolean = true): AlertSeverity = AlertSeverity(
+        id = 4,
+        name = "CRITICAL",
+        level = 4,
+        description = null,
+        color = "#FF0000",
+        requiresAction = true,
+        notificationDelayMinutes = 0,
+        notifyPush = notifyPush
+    )
+
+    private fun sector(): Sector = mockk(relaxed = true) {
+        every { id } returns 20L
+        every { greenhouseId } returns 100L
+    }
+
+    @Test
+    fun `should send push when alert is activated and severity allows it`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity())
+        every { sectorRepository.findById(20L) } returns Optional.of(sector())
+        justRun { fcmPushService.sendAlertToTenant(any()) }
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 1) {
+            fcmPushService.sendAlertToTenant(match {
+                it.alertCode == "ALT-00010" &&
+                    it.tenantId == 10L &&
+                    it.greenhouseId == 100L &&
+                    it.sectorId == 20L &&
+                    it.severityName == "CRITICAL"
+            })
+        }
+    }
+
+    @Test
+    fun `should NOT send push when alert is resolved (toResolved=true)`() {
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(isResolved = true), change = change(toResolved = true))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should NOT send push when severity has notify_push=false`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity(notifyPush = false))
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should NOT send push when alert has null severityId`() {
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(severityId = null), change = change(toResolved = false))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should NOT send push when severity is unknown`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.empty()
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should NOT send push when sector is unknown`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity())
+        every { sectorRepository.findById(20L) } returns Optional.empty()
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 0) { fcmPushService.sendAlertToTenant(any()) }
+    }
+
+    @Test
+    fun `should fall back to alert code when message and description are null`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity())
+        every { sectorRepository.findById(20L) } returns Optional.of(sector())
+        justRun { fcmPushService.sendAlertToTenant(any()) }
+
+        listener.onAlertActivated(
+            AlertStateChangedEvent(
+                alert = alert(message = null),
+                change = change(toResolved = false)
+            )
+        )
+
+        verify(exactly = 1) {
+            fcmPushService.sendAlertToTenant(match { it.body == "ALT-00010" })
+        }
+    }
+
+    @Test
+    fun `should swallow exceptions from FCM service (no propagation)`() {
+        every { alertSeverityRepository.findById(4) } returns Optional.of(severity())
+        every { sectorRepository.findById(20L) } returns Optional.of(sector())
+        every { fcmPushService.sendAlertToTenant(any()) } throws RuntimeException("FCM down")
+
+        // Must not throw — the listener catches and logs.
+        listener.onAlertActivated(
+            AlertStateChangedEvent(alert = alert(), change = change(toResolved = false))
+        )
+
+        verify(exactly = 1) { fcmPushService.sendAlertToTenant(any()) }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/push/FcmPushServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/push/FcmPushServiceTest.kt
@@ -1,0 +1,235 @@
+package com.apptolast.invernaderos.features.push
+
+import com.google.firebase.messaging.BatchResponse
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.SendResponse
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Unit tests for FcmPushService — MockK style, no Spring context.
+ */
+class FcmPushServiceTest {
+
+    private lateinit var firebaseMessaging: FirebaseMessaging
+    private lateinit var pushTokenRepository: PushTokenRepository
+    private lateinit var meterRegistry: MeterRegistry
+    private lateinit var service: FcmPushService
+
+    @BeforeEach
+    fun setup() {
+        firebaseMessaging = mockk()
+        pushTokenRepository = mockk(relaxed = true)
+        meterRegistry = SimpleMeterRegistry()
+        service = FcmPushService(firebaseMessaging, pushTokenRepository, meterRegistry)
+    }
+
+    private fun samplePayload(tenantId: Long = 10L) = AlertPushPayload(
+        alertId = 1L,
+        alertCode = "ALT-00001",
+        tenantId = tenantId,
+        greenhouseId = 100L,
+        sectorId = 20L,
+        severityName = "CRITICAL",
+        severityLevel = 4,
+        severityColor = "#FF0000",
+        title = "Nueva alerta: CRITICAL",
+        body = "Sensor offline",
+        createdAt = Instant.parse("2026-01-01T00:00:00Z")
+    )
+
+    private fun pushToken(token: String, id: Long = 1L) = PushToken(
+        id = id,
+        userId = 1L,
+        tenantId = 10L,
+        token = token,
+        platform = PushPlatform.ANDROID
+    )
+
+    @Test
+    fun `should skip multicast when no tokens are registered for tenant`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns emptyList()
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 0) { firebaseMessaging.sendEachForMulticast(any()) }
+    }
+
+    @Test
+    fun `should send single multicast message when tokens fit in one batch`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(
+            pushToken("tokA"),
+            pushToken("tokB", id = 2L),
+            pushToken("tokC", id = 3L)
+        )
+        val response: BatchResponse = mockk {
+            every { successCount } returns 3
+            every { failureCount } returns 0
+            every { responses } returns listOf(successResponse(), successResponse(), successResponse())
+        }
+        val captured = slot<MulticastMessage>()
+        every { firebaseMessaging.sendEachForMulticast(capture(captured)) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 1) { firebaseMessaging.sendEachForMulticast(any()) }
+    }
+
+    @Test
+    fun `should chunk multicast in batches of 500`() {
+        val tokens = (1..1234).map { pushToken("t$it", id = it.toLong()) }
+        every { pushTokenRepository.findAllByTenantId(10L) } returns tokens
+        val ok: BatchResponse = mockk {
+            every { successCount } returns 500
+            every { failureCount } returns 0
+            every { responses } returns List(500) { successResponse() }
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns ok
+
+        service.sendAlertToTenant(samplePayload())
+
+        // 500 + 500 + 234 = 1234 → 3 multicast calls
+        verify(exactly = 3) { firebaseMessaging.sendEachForMulticast(any()) }
+    }
+
+    @Test
+    fun `should delete token returning UNREGISTERED error`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(
+            pushToken("dead"), pushToken("alive", id = 2L)
+        )
+        every { pushTokenRepository.deleteByToken("dead") } returns 1
+        val unreg = unregisteredResponse()
+        val ok = successResponse()
+        val response: BatchResponse = mockk {
+            every { successCount } returns 1
+            every { failureCount } returns 1
+            every { responses } returns listOf(unreg, ok)
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("dead") }
+        verify(exactly = 0) { pushTokenRepository.deleteByToken("alive") }
+    }
+
+    @Test
+    fun `should delete token returning INVALID_ARGUMENT error`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("garbage"))
+        every { pushTokenRepository.deleteByToken("garbage") } returns 1
+        val invalid = invalidArgumentResponse()
+        val response: BatchResponse = mockk {
+            every { successCount } returns 0
+            every { failureCount } returns 1
+            every { responses } returns listOf(invalid)
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("garbage") }
+    }
+
+    @Test
+    fun `should NOT delete token for transient errors such as INTERNAL`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("transient"))
+        val transient = errorResponse(MessagingErrorCode.INTERNAL)
+        val response: BatchResponse = mockk {
+            every { successCount } returns 0
+            every { failureCount } returns 1
+            every { responses } returns listOf(transient)
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    @Test
+    fun `should be a no-op when FirebaseMessaging is null (graceful degradation)`() {
+        val degraded = FcmPushService(null, pushTokenRepository, meterRegistry)
+        degraded.sendAlertToTenant(samplePayload())
+        verify(exactly = 0) { pushTokenRepository.findAllByTenantId(any()) }
+    }
+
+    @Test
+    fun `should swallow exception thrown by FCM and continue`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("x"))
+        every { firebaseMessaging.sendEachForMulticast(any()) } throws RuntimeException("FCM down")
+
+        // Must not throw
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    @Test
+    fun `failure metric is incremented per failed token`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(
+            pushToken("a"), pushToken("b", id = 2L)
+        )
+        val response: BatchResponse = mockk {
+            every { successCount } returns 0
+            every { failureCount } returns 2
+            every { responses } returns listOf(unregisteredResponse(), invalidArgumentResponse())
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        val unregMetric = meterRegistry.find("push.fcm.failed").tag("reason", "UNREGISTERED").counter()
+        val invalidMetric = meterRegistry.find("push.fcm.failed").tag("reason", "INVALID_ARGUMENT").counter()
+        assertEquals(1.0, unregMetric?.count())
+        assertEquals(1.0, invalidMetric?.count())
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers — SendResponse mocks
+    // -------------------------------------------------------------------------
+
+    private fun successResponse(): SendResponse = mockk {
+        every { isSuccessful } returns true
+    }
+
+    private fun unregisteredResponse(): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns MessagingErrorCode.UNREGISTERED
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+
+    private fun invalidArgumentResponse(): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns MessagingErrorCode.INVALID_ARGUMENT
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+
+    private fun errorResponse(code: MessagingErrorCode): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns code
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/push/PushTokenServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/push/PushTokenServiceTest.kt
@@ -1,0 +1,120 @@
+package com.apptolast.invernaderos.features.push
+
+import com.apptolast.invernaderos.features.user.User
+import com.apptolast.invernaderos.features.user.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import java.time.Instant
+
+class PushTokenServiceTest {
+
+    private lateinit var pushTokenRepository: PushTokenRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var service: PushTokenService
+
+    @BeforeEach
+    fun setup() {
+        pushTokenRepository = mockk(relaxed = true)
+        userRepository = mockk()
+        service = PushTokenService(pushTokenRepository, userRepository)
+    }
+
+    private fun user(id: Long = 1L, tenantId: Long = 10L, email: String = "user@example.com") = User(
+        id = id,
+        code = "USR-00001",
+        tenantId = tenantId,
+        username = "user1",
+        email = email,
+        passwordHash = "hash",
+        role = "USER",
+        isActive = true,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now()
+    )
+
+    @Test
+    fun `register inserts a new token when none exists for the value`() {
+        every { userRepository.findByEmail("user@example.com") } returns user()
+        every { pushTokenRepository.findByToken("tokA") } returns null
+        val captured = slot<PushToken>()
+        every { pushTokenRepository.save(capture(captured)) } answers { captured.captured.also { it.id = 99L } }
+
+        val result = service.register("user@example.com", "tokA", PushPlatform.ANDROID)
+
+        assertEquals(99L, result.id)
+        assertEquals(1L, captured.captured.userId)
+        assertEquals(10L, captured.captured.tenantId)
+        assertEquals("tokA", captured.captured.token)
+        assertEquals(PushPlatform.ANDROID, captured.captured.platform)
+    }
+
+    @Test
+    fun `register updates existing row when token already present (upsert)`() {
+        val existing = PushToken(
+            id = 7L,
+            userId = 99L,            // OLD owner
+            tenantId = 999L,         // OLD tenant
+            token = "tokA",
+            platform = PushPlatform.IOS,
+            lastSeenAt = Instant.parse("2020-01-01T00:00:00Z")
+        )
+        every { userRepository.findByEmail("user@example.com") } returns user()
+        every { pushTokenRepository.findByToken("tokA") } returns existing
+        every { pushTokenRepository.save(any<PushToken>()) } answers { firstArg() }
+
+        val result = service.register("user@example.com", "tokA", PushPlatform.ANDROID)
+
+        assertEquals(7L, result.id)
+        // Upserted to new owner / tenant / platform.
+        assertEquals(1L, result.userId)
+        assertEquals(10L, result.tenantId)
+        assertEquals(PushPlatform.ANDROID, result.platform)
+        // last_seen_at refreshed.
+        assert(result.lastSeenAt.isAfter(Instant.parse("2020-01-01T00:00:00Z")))
+        verify(exactly = 1) { pushTokenRepository.save(existing) }
+    }
+
+    @Test
+    fun `register falls back to findByUsername when email lookup fails`() {
+        every { userRepository.findByEmail("user1") } returns null
+        every { userRepository.findByUsername("user1") } returns user(email = "u1@x.com")
+        every { pushTokenRepository.findByToken("t") } returns null
+        every { pushTokenRepository.save(any<PushToken>()) } answers { firstArg() }
+
+        service.register("user1", "t", PushPlatform.WEB)
+
+        verify { userRepository.findByEmail("user1") }
+        verify { userRepository.findByUsername("user1") }
+    }
+
+    @Test
+    fun `register throws when authenticated user is not in the DB`() {
+        every { userRepository.findByEmail("ghost") } returns null
+        every { userRepository.findByUsername("ghost") } returns null
+
+        assertThrows(UsernameNotFoundException::class.java) {
+            service.register("ghost", "tok", PushPlatform.ANDROID)
+        }
+    }
+
+    @Test
+    fun `unregister deletes by token and returns true on hit`() {
+        every { pushTokenRepository.deleteByToken("tokA") } returns 1
+
+        assertEquals(true, service.unregister("tokA"))
+    }
+
+    @Test
+    fun `unregister returns false on miss`() {
+        every { pushTokenRepository.deleteByToken("missing") } returns 0
+
+        assertEquals(false, service.unregister("missing"))
+    }
+}


### PR DESCRIPTION
## Summary

Promotes the latest develop work to production:

- **FCM push notifications backend (#104)** — `metadata.push_tokens`, `alert_severities.notify_push` flag, REST endpoints to register/unregister device tokens, FirebaseConfig with graceful degradation, FcmPushService (chunked multicast, dead-token cleanup, Micrometer metrics), and AlertActivationPushListener that fans out push only on alert activations whose severity has `notify_push=true`.
- WebSocket BOOLEAN `currentValue` normalization (already on develop via #102) is rolled forward to main as part of this batch.

## Test plan

- [x] CI green on develop.
- [x] Flyway-migrate workflow ran successfully on develop and applied V38 to the dev metadata DB.
- [ ] After merge, `flyway-migrate.yml` will apply V38 to the prod metadata DB and `build-and-push.yml` will build the prod Docker image.
- [ ] Operator must mount the Firebase Admin service-account JSON as a Kubernetes Secret in prod and set `GOOGLE_APPLICATION_CREDENTIALS` (see `.env.example`). Without it the API still starts; only push is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)