### PR TITLE
fix(alert): mobile 500 on /alerts endpoints — map to DTO

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "26568e32-595c-4a20-af79-dc392e17fd5f",
+          "id": "8b317ec1-abb3-40d5-acef-7376562de377",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "10cb4013-6ddd-4cf5-a195-a74db1b66c57",
+              "id": "12dffa9e-9702-41d6-ad89-e8c82e06d28b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "a5d011d6-93b0-42e7-a36f-2f1901e01b9a",
+          "id": "88a7c0c4-82d4-462c-9132-ee358047df72",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "cbadee3f-9055-4b54-8279-b8969c4e2f01",
+              "id": "c9abe690-e94d-435e-b0d8-0407438a26a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "81177086-8ebe-4971-a0ac-f87b5ab521db",
+          "id": "d285933a-8d2a-4716-91d6-64ac1777c7e2",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "70f2b6a0-e5e2-42e7-80e8-e5e8d7fbb151",
+              "id": "1a558ecd-952c-429a-9668-867ae0588af7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "73d84a99-9448-4f68-91ce-d7f5d2bad04c",
+          "id": "a70dccfb-a709-4da9-a5d3-255aff5a7def",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "e7f85b2b-505a-4bc2-96ab-418c25a7e8ac",
+              "id": "19e6f02c-e91a-4510-8d24-e4b5044edc19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "629d4c2b-1ea2-4449-be9f-840ac1216309",
+          "id": "355ea94d-6d55-48a0-ac35-68c12766ac5f",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "eddf79cf-a6b2-4010-b011-7b7960efb927",
+              "id": "5ba568bc-cfaf-48af-b26a-9b9fc1aa2d7f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "9481e9be-ade1-4ecc-85c3-ecf600bc0f58",
+          "id": "fd21a0a7-cd69-4529-a147-0e1c42ba8af4",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "fd4acb7a-b9cf-4300-90a8-424f5cfaa073",
+              "id": "85e97896-b881-4a57-9298-99fb9ee2773a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "33b5fecd-47de-4831-97ed-6e84f8fdaa4f",
+          "id": "ef6a56ae-8214-46db-8e13-137375ed26a2",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "e0562b72-7f0e-465b-9e9b-d2bb7ed003d1",
+              "id": "e4d0932e-b17f-4155-aba7-e1068ff76660",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "1763c142-31b7-4403-8c4f-7af617badb6d",
+          "id": "f0bf2b5c-d4a9-4e19-8bce-f5cef77b7942",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "12bb5d41-3143-4188-be00-763510e54cea",
+              "id": "b27a97c5-3499-4f08-9372-f55c45932365",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "177551e2-3999-4be4-90da-082f44bbafbf",
+          "id": "6a123958-37c5-41d8-bf86-1b8bd971eb52",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "8972d359-71af-4d85-9161-25f45e38951e",
+              "id": "5feeb5fd-b830-47a8-96e6-aacdf476f9d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "9cad7f7a-29d3-4fba-9d45-0e6b4400d92b",
+          "id": "0ffe3997-572b-41eb-a272-4ecb060247d4",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "dac961c2-f0b2-4a7d-8694-d28c8c8e054c",
+              "id": "89d7aee1-f85c-4b3b-8e45-98594ef91fd6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "79ae7de1-4986-490a-8380-3299e842e13a",
+          "id": "6b4a3731-65ec-4c58-9aa4-b8a66b4376e7",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "03b49b36-0758-45aa-814d-9847a177a9fa",
+              "id": "a1544c4f-35a3-4db4-b006-a10090ec1c67",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "2a8e77a8-4312-4d9e-8d14-b4399a680a18",
+          "id": "07737c81-bcd6-4877-b642-f41a4c8066d0",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "6ab30b34-e867-42b7-99e3-9511b2c2a268",
+              "id": "6f69d137-90e8-47ac-8ddd-ea08ebcbe035",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "636b69a2-7ae6-4797-b0a7-4d8c718c20b4",
+          "id": "17e043b9-ede1-48da-99d4-31a5cea826a3",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "ad2970da-b647-40af-b05d-9b905de63f86",
+              "id": "3af70d07-764f-4ef4-b706-d34dc7cc09e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "34654d1c-bf4a-487e-b94d-b97eb8d18fb9",
+          "id": "91b926dd-4488-4b26-baa8-3c913ef06dab",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "6ff1dff0-7790-4a53-8337-8498fbebfe8b",
+              "id": "bf438f67-5a03-4dc2-b52d-a7071e73e2b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "3991ebf8-0607-4a73-884b-490d30d5db0c",
+          "id": "a7bb5ff5-242f-488d-a76f-f7cdfdf306bd",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "69e86a69-6456-48da-b0f1-a6e92144d259",
+              "id": "bf2fcd83-1e46-44ea-874d-f9762d7dbaa7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\",\n  \"key_4\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "289eba1b-897b-4dca-bcec-10c2ae80b829",
+          "id": "59d4f8c9-ff3d-49b3-bdc4-6bf52f63fd75",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "2e0cd2b3-141c-414c-b740-47d9e03fcdeb",
+              "id": "0214e97d-8ff5-4eae-9f68-1403c3269dc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1829,11 +1829,213 @@
       ]
     },
     {
+      "name": "Push Tokens",
+      "description": "Registro de tokens FCM de dispositivos para notificaciones push",
+      "item": [
+        {
+          "id": "abacc445-f0a6-4bdd-a600-4b9bdd1b0244",
+          "name": "Registrar (o refrescar) el token FCM de este dispositivo",
+          "request": {
+            "name": "Registrar (o refrescar) el token FCM de este dispositivo",
+            "description": {},
+            "url": {
+              "path": [
+                "api",
+                "v1",
+                "push-tokens"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{bearerToken}}"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "id": "acd4ef53-42d3-4422-99b6-8ece648a7655",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "v1",
+                    "push-tokens"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: bearer",
+                      "type": "text/plain"
+                    },
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [],
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": [],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "id": "18b43f41-6a2d-4d08-aa7a-f486f28de99c",
+          "name": "Desregistrar el token FCM (logout o invalidación)",
+          "request": {
+            "name": "Desregistrar el token FCM (logout o invalidación)",
+            "description": {},
+            "url": {
+              "path": [
+                "api",
+                "v1",
+                "push-tokens",
+                ":token"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "type": "any",
+                  "value": "<string>",
+                  "key": "token",
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) ",
+                    "type": "text/plain"
+                  }
+                }
+              ]
+            },
+            "method": "DELETE",
+            "body": {},
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{bearerToken}}"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "id": "92b932c2-b242-47ac-8adb-b8ecb18ec142",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "v1",
+                    "push-tokens",
+                    ":token"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) ",
+                        "type": "text/plain"
+                      },
+                      "type": "any",
+                      "value": "<string>",
+                      "key": "token"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: bearer",
+                      "type": "text/plain"
+                    },
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "method": "DELETE",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [],
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": [],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        }
+      ]
+    },
+    {
       "name": "Tenant Device Management",
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "498e0332-cfc9-4834-b990-dd2770a47cb4",
+          "id": "c4b03d5d-d44e-4dd9-934e-6116c07fcc6c",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +2088,7 @@
           },
           "response": [
             {
-              "id": "7a03edba-e19a-48ec-b71c-c22561858d59",
+              "id": "e36222bb-097d-40ce-83d2-adeae2328148",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +2163,7 @@
           }
         },
         {
-          "id": "19031b7f-5619-44b2-b173-d596fee4fe1a",
+          "id": "1831baec-9573-403e-a27c-b7b4a2a4a9c8",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "88ea79cc-ef4a-491f-abc1-fc3f75a6c047",
+              "id": "f72f9b08-3a2e-4fec-8988-a754f98bfd0b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2317,7 @@
           }
         },
         {
-          "id": "f9f171bd-94bd-41b0-a46a-b56158368bdd",
+          "id": "20dc6bf1-af70-4d82-8dbb-817144015b39",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2364,7 @@
           },
           "response": [
             {
-              "id": "abb82db7-a358-4d77-a35e-97e7c8a01419",
+              "id": "838265a9-b0ac-4a5e-aef0-3fd97ff532bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2429,7 @@
           }
         },
         {
-          "id": "ff3d415a-233d-4f7d-9818-f8b1af5ed627",
+          "id": "bec01580-0c90-4fec-a11b-46144f5feaf0",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2471,7 @@
           },
           "response": [
             {
-              "id": "75a2c0ab-e545-47c7-a95d-6a3419581d09",
+              "id": "97c26779-ad50-4cb1-99a0-e159a5f9dbc5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2535,7 @@
           }
         },
         {
-          "id": "1f07d525-544b-4aed-abf7-7a464cead953",
+          "id": "53c7670c-3462-447b-a82f-7a120a4baa84",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2590,7 @@
           },
           "response": [
             {
-              "id": "962ce909-da69-4946-a76a-2b7afba3ead9",
+              "id": "2e966c02-19e5-488e-9b85-a5c63f1b8e2d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2667,7 @@
           }
         },
         {
-          "id": "f9a112a1-f12e-40a7-a760-778485996a98",
+          "id": "700c0338-149b-4572-aad7-4be08ed73a91",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2731,7 @@
           },
           "response": [
             {
-              "id": "e40a0284-75c5-4548-bac6-cb3ccedc9410",
+              "id": "0b8d4dac-fbdb-4d8d-ab73-e5707bb9a1bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2823,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "d246b197-99c5-4de5-915b-b547ee02eda5",
+          "id": "4e0e95e1-c254-4af8-89f1-b1d99282a9b3",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2865,7 @@
           },
           "response": [
             {
-              "id": "c579f472-081c-4ae1-b18a-83a0b5fdcdc7",
+              "id": "ad0af5ad-c52c-4df2-93d1-a7f927967c32",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2716,7 +2918,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"id\": \"<integer>\",\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"<string>\"\n}",
+              "body": "{\n  \"id\": \"<integer>\",\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"notifyPush\": \"<boolean>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2727,7 +2929,7 @@
           }
         },
         {
-          "id": "ee6979d4-3959-4a8a-957b-4c0462529378",
+          "id": "aa0727cc-f325-40de-aa12-6bf77d8d8c98",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2972,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FA0583\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e15EC8\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2984,7 @@
           },
           "response": [
             {
-              "id": "23af8fee-33b8-4de2-b27b-3bfcabb352fc",
+              "id": "53875dae-3445-45eb-aa17-d2ee598d2842",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +3033,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FA0583\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e15EC8\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2848,7 +3050,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"id\": \"<integer>\",\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"<string>\"\n}",
+              "body": "{\n  \"id\": \"<integer>\",\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"notifyPush\": \"<boolean>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2859,7 +3061,7 @@
           }
         },
         {
-          "id": "92cd5b02-71f1-402f-9de3-077944e5bda1",
+          "id": "9e908452-82c9-4122-82f7-58aeca376b0d",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +3097,7 @@
           },
           "response": [
             {
-              "id": "08fc719d-6f1e-4698-9a01-9653c13b08a4",
+              "id": "d0f73e9b-da5a-4190-b52c-ab63f66b891a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +3151,7 @@
           }
         },
         {
-          "id": "2484705b-0368-4ec2-81a4-2517ba274f5e",
+          "id": "05052d80-09e6-49b8-8677-781fa40c401f",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +3181,7 @@
           },
           "response": [
             {
-              "id": "0061d5a8-781f-4476-82ba-7b0bd69aa6b1",
+              "id": "60aed338-60a8-4675-8d8a-62bfb345e678",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3020,7 +3222,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"id\": \"<integer>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  {\n    \"id\": \"<integer>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n]",
+              "body": "[\n  {\n    \"id\": \"<integer>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  {\n    \"id\": \"<integer>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3031,7 +3233,7 @@
           }
         },
         {
-          "id": "33375ff6-5b4b-4338-9702-ffa258a5bc5e",
+          "id": "8c49aac5-5f26-486c-9ca9-abae7f12d667",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3264,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3fBD19\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2Cc15A\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3276,7 @@
           },
           "response": [
             {
-              "id": "97153d53-ed94-48d6-92bf-c18fdf9624d7",
+              "id": "79d169af-34fc-41be-a47c-01af574cd277",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3313,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3fBD19\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2Cc15A\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3128,7 +3330,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"id\": \"<integer>\",\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"<string>\"\n}",
+              "body": "{\n  \"id\": \"<integer>\",\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"notifyPush\": \"<boolean>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3139,7 +3341,7 @@
           }
         },
         {
-          "id": "774f2f04-8a94-4688-afbb-42ce36ef0534",
+          "id": "7c57ad4a-b540-4254-9edc-bfc50d5071d2",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3372,7 @@
           },
           "response": [
             {
-              "id": "a78f15ae-71f2-4c30-86e0-86044bbce515",
+              "id": "2e9c8790-efd4-4b78-80b4-c774f355d34d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3212,7 +3414,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"id\": \"<integer>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  {\n    \"id\": \"<integer>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n]",
+              "body": "[\n  {\n    \"id\": \"<integer>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  {\n    \"id\": \"<integer>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3229,7 +3431,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "f89199d8-26cd-4ac0-8431-51ba0f927c67",
+          "id": "0599fd08-bf91-4464-9f8a-c923e336259b",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3473,7 @@
           },
           "response": [
             {
-              "id": "285e41c9-9cc0-40bf-9618-6bac5ec9103f",
+              "id": "74072d7b-b08a-4cd1-9a78-705cbf117ae9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3537,7 @@
           }
         },
         {
-          "id": "503ec0cc-bdb1-472d-bf09-4300fe84a41d",
+          "id": "99f14277-dc2d-47a8-9977-da64d3c96fa7",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3592,7 @@
           },
           "response": [
             {
-              "id": "5b1ff0b4-cbeb-45b2-b827-73c158b612c5",
+              "id": "308924fa-ffe2-4235-b4c2-80c153742726",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3669,7 @@
           }
         },
         {
-          "id": "48312769-cac6-4190-afcb-50fc7e8c401f",
+          "id": "720f3977-01e8-43ba-bd66-1c1bff85fe3e",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3711,7 @@
           },
           "response": [
             {
-              "id": "265892c7-79cc-43ab-bf06-7d5e15c3a546",
+              "id": "98d5e1c1-344d-41cc-9e5b-55454f7b2941",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3775,7 @@
           }
         },
         {
-          "id": "40c7a621-1537-46c5-9856-ee2985409a6e",
+          "id": "02eae6e8-115a-479b-924c-c7291cce3252",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3805,7 @@
           },
           "response": [
             {
-              "id": "e998499d-a706-4663-a670-1e3ef59e8497",
+              "id": "744a6d96-280c-4be7-90f5-87ae6d971e1d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3857,7 @@
           }
         },
         {
-          "id": "2756945d-a423-482a-86aa-aac2090c8943",
+          "id": "856daefa-ef69-42ad-b2c7-f403715485ea",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3900,7 @@
           },
           "response": [
             {
-              "id": "73229f45-615c-4f5b-a2be-7f0cfadcff16",
+              "id": "6d7ad3ff-70bc-4978-b2fc-1e8463263668",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3965,7 @@
           }
         },
         {
-          "id": "f4d053b9-d232-4439-86d0-2d66376a02b9",
+          "id": "32009698-b952-4bc7-ba42-5cbe6f6b59ff",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +4018,7 @@
           },
           "response": [
             {
-              "id": "03b6b357-4768-48df-9d8e-f8be4f8cec2f",
+              "id": "be7a1513-c747-49e7-82d6-3d9ee5709e7f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +4082,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
+              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +4093,7 @@
           }
         },
         {
-          "id": "b8cc4cf3-7a4b-42d4-862e-33e65b96c8f6",
+          "id": "e1054215-6c3c-45b0-8157-30cf4ac371eb",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +4136,7 @@
           },
           "response": [
             {
-              "id": "dfe4b162-2bd2-4b09-a665-4bf56ff11921",
+              "id": "99e4273f-3cc1-43a1-a047-6253b9ae463d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +4201,7 @@
           }
         },
         {
-          "id": "f7f8f50a-1fd0-4854-9948-2e63b408234f",
+          "id": "3882d55f-3904-4006-affb-3057131aac23",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4232,7 @@
           },
           "response": [
             {
-              "id": "821af4bb-4c65-4c19-aabc-e40c0c342f3b",
+              "id": "432d0862-cfea-489a-8192-7dd4265617bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4291,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "e321a21d-bdfb-4e38-b515-17a43bdd153a",
+          "id": "728ce99e-2178-4506-9907-2ad995b7b1b4",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4333,7 @@
           },
           "response": [
             {
-              "id": "0f8bb88e-1a34-4e4a-8dda-e64730d7d096",
+              "id": "f9eb4dc4-1cf3-4830-af69-af337c02bdc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4397,7 @@
           }
         },
         {
-          "id": "5859854e-2f65-4ed6-8fbf-76c51cb07912",
+          "id": "41aa437f-22c6-487b-a92a-b25200ab55e8",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4440,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4452,7 @@
           },
           "response": [
             {
-              "id": "64ea46bc-4802-458b-8a95-f50f6003345f",
+              "id": "b9491033-5507-4b55-9870-dbaea6a74349",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4501,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4529,7 @@
           }
         },
         {
-          "id": "e545d71f-36ff-4384-9afa-011da8cb9c4a",
+          "id": "66ab367b-c9f6-4a42-a98e-5ca7d3712fd1",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4565,7 @@
           },
           "response": [
             {
-              "id": "75a3f94f-548c-482d-8023-bb1a8029fb80",
+              "id": "7299a85a-2aee-4713-bee8-cb78352e9bc3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4619,7 @@
           }
         },
         {
-          "id": "14e41932-472d-4090-8e48-5ddc4da343ca",
+          "id": "92696488-e8d1-40a7-9a6d-e2bd7af709a4",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4668,7 @@
           },
           "response": [
             {
-              "id": "95a4f0c9-2972-45a0-bb54-c78d69a03c6f",
+              "id": "f5601a79-1451-4b58-a272-dc1f2558bfec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4739,7 @@
           }
         },
         {
-          "id": "5ae56112-8758-4793-a314-0c7ffd0c3256",
+          "id": "14fc31d9-2a96-436b-bbf6-dfcee248de72",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4580,7 +4782,7 @@
           },
           "response": [
             {
-              "id": "0e9f255a-26e5-4437-9dc3-22c11df9b48f",
+              "id": "6a0545e3-51ec-4d8e-8799-dd96580b521c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4645,7 +4847,7 @@
           }
         },
         {
-          "id": "60fa9559-a570-4ea5-97fc-ef401c878e9f",
+          "id": "96c5cc24-9ea9-4b84-a1b9-81eddfaf8c9a",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4890,7 @@
           },
           "response": [
             {
-              "id": "f3104b57-1c30-4acd-ba58-49f1332642b6",
+              "id": "cc705a6e-2f42-44e4-9295-53c4ff9da5dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4955,7 @@
           }
         },
         {
-          "id": "72ee1ea2-b548-40bb-b843-90a536936995",
+          "id": "2eebc3f4-06ac-450e-9bbc-12ea29bdbc73",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4998,7 @@
           },
           "response": [
             {
-              "id": "e62509ae-5b8b-4cfd-b5e0-01e13f30986b",
+              "id": "5a245473-a709-4d9a-8882-6e3982eae65b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +5063,7 @@
           }
         },
         {
-          "id": "dbb5d699-0aec-407c-92d3-562603549329",
+          "id": "701fbfce-7b23-46aa-bf6c-c80772b0a2c6",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +5094,7 @@
           },
           "response": [
             {
-              "id": "9b85e7b7-bdb1-4658-b0d9-b52535360681",
+              "id": "a3898eac-f673-45c7-8e14-bb5ac09d47d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +5147,7 @@
           }
         },
         {
-          "id": "4aa9b84f-7d99-4451-9c74-043208cd2614",
+          "id": "166bf9cc-aebc-427b-b940-27ce4870479a",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +5178,7 @@
           },
           "response": [
             {
-              "id": "e1d6100e-40b8-442f-acca-e748f591041d",
+              "id": "b0aacfd8-4ac6-4928-ab82-9bcd97086d0b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5237,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "f4f4c815-9b92-4c3f-8f11-9623dabdbace",
+          "id": "61415841-b10f-47e0-a61e-62e759401010",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5279,7 @@
           },
           "response": [
             {
-              "id": "8862b0d1-39cd-4e4c-ba66-b6f5329b5859",
+              "id": "4d8ac291-73f2-40b7-a770-4ee4831835f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5343,7 @@
           }
         },
         {
-          "id": "87b8aa07-a381-4e87-895c-319671a2e6d9",
+          "id": "fc9504ce-4784-412e-94e7-c1556eaff666",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5398,7 @@
           },
           "response": [
             {
-              "id": "88753309-0fbb-4721-9692-c8c0a0cf89db",
+              "id": "0146a661-6ec8-4328-a0f9-76ac652a6b8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5475,7 @@
           }
         },
         {
-          "id": "8d754ff3-8431-4b4a-836d-969eb088a19a",
+          "id": "c3451289-a4b1-47f9-b2b2-510e84d8d711",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5511,7 @@
           },
           "response": [
             {
-              "id": "3f9088b0-d6a7-4077-9ac2-68b193f966d5",
+              "id": "be71be44-15c7-4597-97c7-cd8d32306c29",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5565,7 @@
           }
         },
         {
-          "id": "103fc98a-ce2a-4003-9372-8f2de2c8c070",
+          "id": "eb97ce2f-029b-4113-a37e-58315edf37b6",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5595,7 @@
           },
           "response": [
             {
-              "id": "274935b7-f28c-46b7-a748-8fdf74af56c2",
+              "id": "e303733a-3f6d-470c-a231-5e1213cbf47c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5647,7 @@
           }
         },
         {
-          "id": "e959c406-9cf8-4e06-813e-2c8498a77adf",
+          "id": "3a8c9cb0-bd43-4a48-a663-cd47f11a9bc0",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5690,7 @@
           },
           "response": [
             {
-              "id": "37027f12-8d62-4236-9abd-77a3ff7c5b06",
+              "id": "f681356c-c844-446c-9201-4ae7bb63c33b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5761,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "afb608a6-6712-4a33-a397-6610b44e6323",
+          "id": "223e2214-58d8-4552-b5f1-57ab469b876c",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5814,7 @@
           },
           "response": [
             {
-              "id": "ec0ebd26-f004-46ed-87be-033fefdb88dd",
+              "id": "43943965-5c65-40b7-ac27-44ad3362dda6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5889,7 @@
           }
         },
         {
-          "id": "9d0f5e49-5612-402a-a830-3c30c199b1c0",
+          "id": "a88e0846-1f0a-4aa1-8092-5d9d8d28ee07",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5955,7 @@
           },
           "response": [
             {
-              "id": "27acaaa3-3bf5-4f2f-9b0e-de92bf0b7ee6",
+              "id": "5e75c146-c9e1-4107-a632-3f731876b06c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +6043,7 @@
           }
         },
         {
-          "id": "5d37e1be-e5ec-4800-b1bc-89f43ca9eafa",
+          "id": "e45645fd-2a42-4963-b698-165cdcc27427",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +6090,7 @@
           },
           "response": [
             {
-              "id": "4db1b259-99c3-4a1b-90c0-2d9ac61e3a7b",
+              "id": "4c34acee-0c90-43bd-8182-7b046321e209",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +6155,7 @@
           }
         },
         {
-          "id": "a0f913d1-352b-4b01-a4d0-b5d15c6925e7",
+          "id": "99ff7ec7-9366-40a9-bd3c-6383667bda5c",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +6197,7 @@
           },
           "response": [
             {
-              "id": "a827e889-62f9-4f20-93db-9756ec25a047",
+              "id": "a29bac23-c784-4f44-8015-bb77ce67a13a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6261,7 @@
           }
         },
         {
-          "id": "55ed8d4b-7a4f-40d6-b64e-d13d49488eae",
+          "id": "bb9daa40-3e2c-4614-9e2f-3cae44f956a0",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6316,7 @@
           },
           "response": [
             {
-              "id": "869f56b9-8360-4e3f-a5bb-e46b7ea063a1",
+              "id": "bf09dd51-da0e-423f-8a7f-b5812f4d7581",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6393,7 @@
           }
         },
         {
-          "id": "3f0ef7c2-de16-47bf-9964-562bfcaa6d53",
+          "id": "e943109c-ae1e-4c18-9966-8c126bac4822",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6460,7 @@
           },
           "response": [
             {
-              "id": "7b63ef45-b67f-4ca7-8876-ebad3a02b371",
+              "id": "b8bbe815-bba9-46d6-8ace-3f2473114ca7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6549,7 @@
           }
         },
         {
-          "id": "9d3277d7-d700-4e2c-be66-f690b20737de",
+          "id": "73e424f3-88ae-4b95-8f30-526bc63f9628",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6603,7 @@
           },
           "response": [
             {
-              "id": "627063ce-d7d4-4661-8ca5-e593f036173d",
+              "id": "a255c3a6-25ca-4a56-b7bb-4bbe82d6910d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6685,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "2a677455-d371-4ff7-a10e-bb88ee84f100",
+          "id": "9bba1bd4-cc76-4000-9259-f9c66fbdf70e",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6738,7 @@
           },
           "response": [
             {
-              "id": "b6bc0ac4-79b8-450d-9b35-20c734c519b7",
+              "id": "d8631586-7e25-4e5e-ab19-4c6e2b4a7187",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6813,7 @@
           }
         },
         {
-          "id": "64e1f491-b73b-4ecf-b629-c0cd28ec360e",
+          "id": "a373414c-0474-44bf-851e-15d4ab464ab4",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6879,7 @@
           },
           "response": [
             {
-              "id": "d5d7f926-82a5-4535-8124-b17158e12ee6",
+              "id": "febf2c3d-9a62-4ffc-8c6d-1797a0ca0624",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6967,7 @@
           }
         },
         {
-          "id": "8a42ad78-e2f6-41d5-b731-6ae7e6ecfe4f",
+          "id": "9fda01c1-2ac6-4e1a-bf4d-a681334dc3ba",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +7014,7 @@
           },
           "response": [
             {
-              "id": "ec1bfd85-1a19-4561-9ddf-c8e53003b510",
+              "id": "57ac044c-1013-4714-975f-97a4bf51b117",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +7079,7 @@
           }
         },
         {
-          "id": "5efe6380-41b6-4d74-ba4b-d66fb00b8996",
+          "id": "e9b754a3-3156-4091-9e32-5c20504e4fac",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +7121,7 @@
           },
           "response": [
             {
-              "id": "d8a3ff9a-d80c-429e-bc0d-7458ff62814b",
+              "id": "e1d7201f-ed16-4301-9d7d-4177a0a3c091",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +7185,7 @@
           }
         },
         {
-          "id": "d7fc72c2-1e84-4a59-9c6e-83d4ed1d10b8",
+          "id": "6ea997f0-71f5-40a1-b726-bcfef93898b6",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7240,7 @@
           },
           "response": [
             {
-              "id": "3b7d9164-d0bc-4511-bc3f-b2c7a69fe456",
+              "id": "c0e8015d-99b9-4d95-994b-a69ed5f50b24",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7323,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "68abd3f5-ec93-4c77-94e5-0b46f29f1432",
+          "id": "eba22304-9ca1-492f-8220-92ab00ba09d2",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7364,7 @@
           },
           "response": [
             {
-              "id": "5ece8cde-8330-4cd2-b129-114b0107ee03",
+              "id": "cec75375-65c7-4868-ba5b-00058705cf36",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7427,7 @@
           }
         },
         {
-          "id": "a4452dea-72b7-4396-80c7-930327db7d68",
+          "id": "678e3829-17a5-44c3-812d-18d1580c4949",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7481,7 @@
           },
           "response": [
             {
-              "id": "a8af667f-8553-44ec-b33c-629a3e6cecb2",
+              "id": "267d7b1a-610b-4652-85a4-d390b136e318",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7557,7 @@
           }
         },
         {
-          "id": "9ff70d6c-79f2-4387-b886-8ed40ae33a98",
+          "id": "7c23a110-bd12-4935-bb13-55f198a10cb8",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7592,7 @@
           },
           "response": [
             {
-              "id": "406ca3da-51a8-4f96-ba89-e9fbc2b76375",
+              "id": "6833acf9-44c1-461f-9034-26da9a63ad16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7645,7 @@
           }
         },
         {
-          "id": "7252b884-9e0f-4434-930f-fc16834f618c",
+          "id": "5702e1c9-fac0-40c2-936c-e4c1a88cc763",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7702,7 @@
           },
           "response": [
             {
-              "id": "f25ed379-848f-40a6-a0f1-138c78a9741a",
+              "id": "39d43eff-6ee0-470e-a9b0-8a0300bc07db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7781,7 @@
           }
         },
         {
-          "id": "215f24b2-85c8-4c03-853e-78a07582c33b",
+          "id": "3f103835-e5e4-4cea-a815-9e17ba663f9a",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7823,7 @@
           },
           "response": [
             {
-              "id": "b2ffcc84-dd56-4704-b0a0-13c319784211",
+              "id": "7ef64adb-5eb7-4863-8380-fcc3593b8ccc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7893,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "0a4ad31d-3812-425a-9db3-b62b9c297c00",
+          "id": "896177e3-28e2-43ad-9371-1ab2a3be5bdf",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7946,7 @@
           },
           "response": [
             {
-              "id": "60252dcc-088e-4258-8c9f-3f169dad2fb2",
+              "id": "dbb47a36-0581-4162-b12f-5f47b5dfd6ad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +8021,7 @@
           }
         },
         {
-          "id": "17000dc5-73b1-40cb-8c5c-af37318c914f",
+          "id": "4a00ad68-372c-4ac0-af3f-d7c5aa1f737c",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +8087,7 @@
           },
           "response": [
             {
-              "id": "ffea569d-13db-488d-beb5-10a3c289ec0f",
+              "id": "2603d5e5-ed38-4db9-aef1-695e8c1e00a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +8175,7 @@
           }
         },
         {
-          "id": "12cfe5ae-01d3-446d-bc76-f281e2ff328b",
+          "id": "519e705e-c93e-425b-a43d-97b028ba6b3c",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8222,7 @@
           },
           "response": [
             {
-              "id": "3d3afd1a-3a36-4c93-96fc-33b5a14b0b8f",
+              "id": "ec63658c-bc26-4f26-9c26-886e91e68886",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8287,7 @@
           }
         },
         {
-          "id": "074d138e-e53b-42d8-9602-fe68faf979b1",
+          "id": "6367a065-f436-4a31-8bc8-29a7a1b5945c",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8329,7 @@
           },
           "response": [
             {
-              "id": "e6083200-7d33-4e7d-8fc2-5776abc92218",
+              "id": "7e5cc628-acc4-4ea3-b621-59586f522b84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8393,7 @@
           }
         },
         {
-          "id": "fe1c7723-a808-4b1d-af0a-8c52efc98399",
+          "id": "d29ffe48-11d3-4a46-b5d3-262e421f1202",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8448,7 @@
           },
           "response": [
             {
-              "id": "5d25a42a-a0c0-4070-9aea-f5f9b80f7b91",
+              "id": "74b4e932-8567-4bc9-8a7b-74a94d51cc71",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8531,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "4381054e-e31b-4f6b-85a7-2124c35ad80d",
+          "id": "51cd6405-83bc-4ffa-98bb-51fcd040dfa5",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8573,7 @@
           },
           "response": [
             {
-              "id": "d20cc8dd-0323-4854-b9df-f41c9e4c5f57",
+              "id": "e94920f4-fbd5-479c-8bf6-69c8f4ddd2a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8637,7 @@
           }
         },
         {
-          "id": "ac824088-51bf-4c29-915a-f3ae8dcea24b",
+          "id": "340a0f01-c756-43c5-8b31-db04876a6ae2",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8692,7 @@
           },
           "response": [
             {
-              "id": "c2f00c50-e541-47d8-a724-c997f731d4fc",
+              "id": "2bd897d0-9b12-47b0-9227-a784d4afc86d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8769,7 @@
           }
         },
         {
-          "id": "c0a3aabf-229d-45bb-8f18-9298f0683ed1",
+          "id": "2fa031f3-189b-4c8e-a2e1-082cebcebedd",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8805,7 @@
           },
           "response": [
             {
-              "id": "18c80b2a-2513-49fa-b3fc-3e6ad4444e88",
+              "id": "eb7e67b8-2bf6-4f94-b2ef-c8de5fd591bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8859,7 @@
           }
         },
         {
-          "id": "fce674b7-6420-4bb3-b321-3d5edd7aa781",
+          "id": "82b20fde-24f9-4505-bf6a-682387e8ba6d",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8889,7 @@
           },
           "response": [
             {
-              "id": "681eb9d8-4dc8-483d-bb21-7fc9f50d2ab4",
+              "id": "4e9ace00-d0d0-4e79-b844-7195ae9dc79a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8941,7 @@
           }
         },
         {
-          "id": "5532b0e6-da20-4f67-939d-f252a8515611",
+          "id": "a9f38fbe-c32c-4db6-9dfe-d7d12dedf784",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8984,7 @@
           },
           "response": [
             {
-              "id": "cd60abd3-aa7f-43f9-b527-13ecf53534b6",
+              "id": "a12ffbef-a7a0-4795-8e2b-4f0d18ccf35b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +9055,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "cf1fea4d-f8c7-429f-a815-e97bd3e1d0bc",
+          "id": "71baf9aa-4dd1-4787-87fd-3d14d95e6267",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +9097,7 @@
           },
           "response": [
             {
-              "id": "efb9a628-7f62-4795-bf9c-981a21fab526",
+              "id": "dc92289a-d18b-49c5-a047-7553c16f5c7b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +9155,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "672e09d9-b80e-427d-9e38-36e8fed40673",
+              "id": "4c842dec-afa6-4a23-b439-498c18d7606c",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9219,7 @@
           }
         },
         {
-          "id": "536f6bff-831a-4430-9db8-e2a17b2706fd",
+          "id": "900400b6-a7ac-48b2-a55d-3f5e596cabd3",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9274,7 @@
           },
           "response": [
             {
-              "id": "f0828eba-48ef-40d8-9592-e6f276809520",
+              "id": "059d4b20-5db9-4895-8823-4077b440179d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9345,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "91da6185-b51a-4ea8-b828-31417b5be569",
+              "id": "66150ff8-f8fb-424f-a180-9d9e75b82822",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9416,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "fe5f7caa-f256-45a6-b41d-83821e24cf09",
+              "id": "74faf7a8-425a-47f8-ae8b-122d329eb00f",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9493,7 @@
           }
         },
         {
-          "id": "0035e2d8-0261-4595-baf6-94cd9477867f",
+          "id": "7581e91a-307f-499b-bc91-fa73b802cf0b",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9529,7 @@
           },
           "response": [
             {
-              "id": "3cb9afdd-db4e-4254-803c-894df248fb70",
+              "id": "3e86707a-1f40-4bd8-bd0e-8fcec6973064",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9577,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6f4f90cd-07cf-4abd-9cf1-38c7ec7ba7a8",
+              "id": "d3c505cc-1ce1-4b20-8125-c068b700a75a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9625,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "44f0432d-6eb2-4775-98e8-df240f10292a",
+              "id": "0108f31a-e636-4c5d-abe9-e3cce315521c",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9679,7 @@
           }
         },
         {
-          "id": "c03ae8bd-1a9f-424c-a0c7-af952be3de51",
+          "id": "ffe8114c-d3f7-409b-a7e9-fd10d4826e2a",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9709,7 @@
           },
           "response": [
             {
-              "id": "45bec1da-e326-4e4a-8850-93eb0d618746",
+              "id": "6cff633e-a741-47f4-bfe9-4cc500908254",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9761,7 @@
           }
         },
         {
-          "id": "e7dafffd-4859-42f7-a2da-a6d2240b3f66",
+          "id": "0fc1bef1-cd62-4f6e-81d9-c6f4c9842b95",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9804,7 @@
           },
           "response": [
             {
-              "id": "ceaac097-f6e7-4342-a71d-e46d00f5c9cd",
+              "id": "0202de1c-f6a0-4003-8159-12957b666729",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9863,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "347ba6d9-c3b9-4e64-bb55-7df2007f022e",
+              "id": "8d3da19c-a5d3-4842-9773-c5eebaafe4b4",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9934,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "0d0075da-3562-4afe-9923-86a2ff7d9b8c",
+          "id": "ca0a377b-b7fa-47cf-97bb-45a68ea71f08",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +10000,7 @@
           },
           "response": [
             {
-              "id": "3d1bf687-44c4-42e9-b793-e77efe7c6c72",
+              "id": "20a8d3bf-a327-4c4d-84e3-7e581b27bcd4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +10074,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
+              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +10091,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "736d38a0-bbaa-4a49-b8c8-b52e3c56e89e",
+          "id": "b6199504-3c7a-4943-a8bb-31c093c221da",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +10133,7 @@
           },
           "response": [
             {
-              "id": "0a8d75b2-9e2a-4b7f-98e8-2539849d0b7a",
+              "id": "3848dbef-c139-47e0-95ee-2bbbc75288c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10203,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "e822dd44-d5a3-4875-936b-ee853b0d7704",
+          "id": "6f40b137-72b8-462b-aaf9-4923808e73b9",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10245,7 @@
           },
           "response": [
             {
-              "id": "bd5870bb-183f-46ea-bd38-c1a9fa9dc59d",
+              "id": "d078bbac-61a9-442f-86c0-b3d1d9b83879",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10309,7 @@
           }
         },
         {
-          "id": "134642d3-c342-4d27-acc4-1d69f648c701",
+          "id": "e1707080-79a0-4fc2-8c81-02341a401ec9",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10352,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2Aec4F\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#149d6e\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10364,7 @@
           },
           "response": [
             {
-              "id": "5d07423f-6899-4b93-9d9b-a8fdaac90d60",
+              "id": "744dcfd0-c2ac-4183-aa16-ef87e373cbf3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10413,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2Aec4F\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#149d6e\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10441,7 @@
           }
         },
         {
-          "id": "7f1dbd83-44b7-4f45-9b9c-4f8cf56cd997",
+          "id": "f0bfdd5d-3bb6-4dca-9959-8e2ed9d9b458",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10477,7 @@
           },
           "response": [
             {
-              "id": "d9c9aadc-1f2b-4431-bcfe-93cefed7c72b",
+              "id": "6ed7f25a-3382-4e6c-983d-4c34ba728d29",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10531,7 @@
           }
         },
         {
-          "id": "0fe7d98f-0ffd-46a9-95ea-d2af1b14667b",
+          "id": "2e53958e-330a-4e16-9e2c-44b7fd5b67ac",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10561,7 @@
           },
           "response": [
             {
-              "id": "e3788b4b-d540-4ba0-9b8a-c5178b8cc746",
+              "id": "98a44db2-1470-4df3-9092-830e135ff15b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10613,7 @@
           }
         },
         {
-          "id": "efb1e374-0778-4103-85ab-4a376d3bd1ec",
+          "id": "4591658f-d8ad-4b99-8777-f47b77a171c7",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10644,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#115F4e\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#85C13c\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10656,7 @@
           },
           "response": [
             {
-              "id": "f93c15b9-e579-4acd-87a7-40eba8574577",
+              "id": "97e815f9-893a-45d4-8ab8-72b44baeacad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10693,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#115F4e\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#85C13c\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10721,7 @@
           }
         },
         {
-          "id": "16164054-83d9-4936-b6e8-d1db5f5f3604",
+          "id": "a573061d-fe47-4c99-bdd5-3ae0cd2473ad",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10752,7 @@
           },
           "response": [
             {
-              "id": "0fbaf957-afa9-4d3a-b96c-9429d7071ffa",
+              "id": "560788b5-6700-4167-8901-4ad8ea22e42a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10811,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "744bdebe-cbcb-42c3-8097-e18983e4311d",
+          "id": "85f4a410-ce5d-4ad4-b03a-42c192c4ef27",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10864,7 @@
           },
           "response": [
             {
-              "id": "ce9ae4df-b8a9-4ae9-8947-6e0525184807",
+              "id": "fb24f45f-411d-4fbe-b0d7-e1269b9b5df2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10939,7 @@
           }
         },
         {
-          "id": "a856246a-4552-4d54-857e-db3f4783bf4f",
+          "id": "c422b01b-b835-46ad-9316-67bed053a6d9",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +11005,7 @@
           },
           "response": [
             {
-              "id": "6346ec7a-4d23-479b-9e39-e36ed8e122da",
+              "id": "a01268f8-3a06-41ae-82c0-b21e4d1f96e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +11093,7 @@
           }
         },
         {
-          "id": "5300e0bf-2867-491a-802a-5df0be957297",
+          "id": "64ba3867-9a59-401e-bb48-8ed22e2b9c60",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +11140,7 @@
           },
           "response": [
             {
-              "id": "7a5d5da5-94ff-4540-a1b9-ffafbda9df4c",
+              "id": "4b7c704b-6341-4619-9ff7-902c213dead9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11205,7 @@
           }
         },
         {
-          "id": "ce099c10-afe6-408f-8e66-52a9c0503b55",
+          "id": "51525c6e-b96c-4acb-8895-b4e97b922b78",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11247,7 @@
           },
           "response": [
             {
-              "id": "98d00e34-3563-4270-943a-cbc0809c5e69",
+              "id": "8ffeaea8-03c8-46b2-a419-d2c783539d36",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11311,7 @@
           }
         },
         {
-          "id": "6701f7ca-b043-43a0-a35e-dc6d6e9dad5b",
+          "id": "6055e1c8-fa88-44d1-8b9f-5185417a0a36",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11366,7 @@
           },
           "response": [
             {
-              "id": "3b9d1f1d-30b9-48c2-b18b-cd04c271d19c",
+              "id": "8f3f464c-005d-4a0a-88a8-4edb6a05e400",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11443,7 @@
           }
         },
         {
-          "id": "9ad62f39-7ddb-46a8-8418-aaad259563fa",
+          "id": "171c12a7-bba3-4938-92b0-6e0f871de4fe",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11497,7 @@
           },
           "response": [
             {
-              "id": "ad7593ce-6b47-437e-81a7-17131eeccabd",
+              "id": "02620d02-4ca0-4edf-a3d8-59b29be90dd5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11573,7 @@
           }
         },
         {
-          "id": "94dfff15-1bb7-434e-a84f-8b6de73ee0c9",
+          "id": "b3ebe799-e552-448e-bf2f-5563160d6799",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11639,7 @@
           },
           "response": [
             {
-              "id": "8313f751-3502-4769-b8bf-861cd761375d",
+              "id": "0381c953-1982-4abe-8bc6-3eb8ac90d559",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11727,7 @@
           }
         },
         {
-          "id": "55462954-351e-476a-a230-9d0c6a1e3dc8",
+          "id": "38e37ce1-c3a9-450f-94ee-277a9de4f037",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11805,7 @@
           },
           "response": [
             {
-              "id": "3726dc63-6cbb-43eb-b869-0dbebfaac18f",
+              "id": "b1a2d671-f011-4f80-9acd-886f082df79a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11905,7 @@
           }
         },
         {
-          "id": "a2c8b67c-37f8-4c7f-96de-b2ec2f618529",
+          "id": "0afbbb83-93ac-4f52-94ae-dccf287e4d86",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11971,7 @@
           },
           "response": [
             {
-              "id": "49b4f206-582d-4a78-9f56-78cd4bf7e6e0",
+              "id": "486e5fa4-42b4-46a8-9f1d-2b0e9b1d2b43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +12059,7 @@
           }
         },
         {
-          "id": "a4dad8b1-1536-4a9d-b376-d2a79ca2693b",
+          "id": "68a8071a-2479-4bb4-9e94-66b85905eeb1",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +12114,7 @@
           },
           "response": [
             {
-              "id": "b44e902b-6ac2-4cb5-bf86-3a63d91acb5a",
+              "id": "ba8bc7df-4ce4-4687-8c33-77e67079dda7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +12197,7 @@
       "description": "",
       "item": [
         {
-          "id": "91be4304-285a-422b-afd6-74e5dfb3d026",
+          "id": "eb9f11cf-4abd-443f-b571-a0798706281f",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12238,7 @@
           },
           "response": [
             {
-              "id": "d15b50bf-4581-4831-ab52-171032432709",
+              "id": "71d8af53-a72a-4233-90d0-b8bf0df0ef15",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12088,7 +12290,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12099,7 +12301,7 @@
           }
         },
         {
-          "id": "6f8e959f-d308-4d33-a1b3-5a1d6b3501b9",
+          "id": "019b5e56-0955-4260-a507-ea13ba707a92",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12141,7 +12343,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"active\": \"<boolean>\"\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      },\n      \"active\": \"<boolean>\"\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  \"resolved\": \"<boolean>\"\n}",
+              "raw": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"active\": \"<boolean>\"\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      },\n      \"active\": \"<boolean>\"\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  \"resolved\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12153,7 +12355,7 @@
           },
           "response": [
             {
-              "id": "7a6a98f6-b3d0-4b3b-8bbd-acd9c7a7c7fe",
+              "id": "cc3940db-6a47-4af7-bfc3-048a465f9884",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12201,7 +12403,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"active\": \"<boolean>\"\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      },\n      \"active\": \"<boolean>\"\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  \"resolved\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"active\": \"<boolean>\"\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      },\n      \"active\": \"<boolean>\"\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  \"resolved\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12218,7 +12420,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12229,7 +12431,7 @@
           }
         },
         {
-          "id": "73c5b95c-6c56-4754-826d-52ccaffc5b27",
+          "id": "7a62763f-9073-4476-9d82-0f50da350572",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12466,7 @@
           },
           "response": [
             {
-              "id": "f34327a7-c7e7-4004-8a42-697643993f7e",
+              "id": "cc055572-5088-48c7-a35d-7b2ee0d660a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12519,7 @@
           }
         },
         {
-          "id": "a70c4492-969e-47d0-8ec8-0680ada8774d",
+          "id": "d2fb48df-6305-44bf-98f0-3792c05337e4",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12580,7 @@
           },
           "response": [
             {
-              "id": "d61617fd-257c-4663-a3d4-35b47b80a496",
+              "id": "7ea84b25-f32b-4d71-b872-c5b66eb27f1f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12450,7 +12652,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12461,7 +12663,7 @@
           }
         },
         {
-          "id": "94d82243-e87d-4603-b8a8-91e1c5b0443b",
+          "id": "6df77676-b894-4414-b896-bcf253ab5654",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12705,7 @@
           },
           "response": [
             {
-              "id": "52346533-6222-47c2-bc3d-c69db8cfb807",
+              "id": "f9f9d051-5ce6-4835-bb87-eecbdf43950b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12556,7 +12758,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12567,7 +12769,7 @@
           }
         },
         {
-          "id": "adf79b35-9608-4d06-a54a-73a349782ceb",
+          "id": "f8821cd3-dc6c-4f83-b912-b4124b64eb38",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12844,7 @@
           },
           "response": [
             {
-              "id": "ad2522a2-5137-418a-8cf8-7bf24ea1ecd1",
+              "id": "c404bd63-f7e2-4536-a47b-96e576b82c57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12728,7 +12930,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12739,7 +12941,7 @@
           }
         },
         {
-          "id": "56464bd5-a96f-46cc-b6f9-36bac3bb4ce2",
+          "id": "2ce8e895-81cb-482c-9b5d-e9816205bfe2",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12769,7 +12971,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"active\": \"<boolean>\"\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      },\n      \"active\": \"<boolean>\"\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  \"resolved\": \"<boolean>\"\n}",
+              "raw": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"active\": \"<boolean>\"\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      },\n      \"active\": \"<boolean>\"\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  \"resolved\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12781,7 +12983,7 @@
           },
           "response": [
             {
-              "id": "e7f2c081-3919-4dfb-a01c-2567c6db2ce5",
+              "id": "521dc78f-9ea5-47bd-8bc2-c9177e1feec5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12817,7 +13019,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"active\": \"<boolean>\"\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      },\n      \"active\": \"<boolean>\"\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  \"resolved\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        },\n        \"active\": \"<boolean>\"\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          },\n          \"active\": \"<boolean>\"\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"active\": \"<boolean>\"\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      },\n      \"active\": \"<boolean>\"\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    },\n    \"active\": \"<boolean>\"\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  },\n  \"resolved\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12834,7 +13036,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12845,7 +13047,7 @@
           }
         },
         {
-          "id": "639bbb0f-c951-4194-82f8-c074da001f74",
+          "id": "5fee4999-8f9f-45be-a02e-f27d376832be",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +13090,7 @@
           },
           "response": [
             {
-              "id": "b565d1a1-bf6b-425d-8437-7c43719923df",
+              "id": "386b6bb0-949f-49ab-a3ab-295c2d3623b5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12942,7 +13144,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12953,7 +13155,7 @@
           }
         },
         {
-          "id": "3dcca09a-384a-4fea-8e8f-1956aac7757e",
+          "id": "bc83e6bc-e0a0-4e95-b562-70179d1e8415",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "73612ecb-d518-43ea-a0be-ba2d8869410d",
+              "id": "42904379-5d36-474f-b513-748acd8892a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13050,7 +13252,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13061,7 +13263,7 @@
           }
         },
         {
-          "id": "9ccfe3f3-ea10-44cc-9d50-7734b72eaca9",
+          "id": "2943839e-bdf9-425f-a515-771a9edea334",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13315,7 @@
           },
           "response": [
             {
-              "id": "8e2bb46f-fa09-44e0-95d6-f3a8e2a92e0c",
+              "id": "eea78fdf-81b2-47e9-8226-83e754bf5aa3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13176,7 +13378,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13187,7 +13389,7 @@
           }
         },
         {
-          "id": "a4db9bdc-8209-4b98-bfe0-6e003b38bffd",
+          "id": "8333cb0e-b668-402a-9e96-240a75542159",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13431,7 @@
           },
           "response": [
             {
-              "id": "b7364ea4-d124-4a73-8602-7bd025c4282f",
+              "id": "caa65647-ae0e-4f7b-b827-f6d33286c6f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13282,7 +13484,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13293,7 +13495,7 @@
           }
         },
         {
-          "id": "ac5b3411-5102-4810-a23f-97a0a24b0b44",
+          "id": "b8bdb874-95da-44b6-ad00-af76721a3ad7",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13548,7 @@
           },
           "response": [
             {
-              "id": "7c7d0b8d-613f-4aa7-819b-a94a449db99b",
+              "id": "c8ab8d16-1d96-4adc-b789-1657a36684b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13410,7 +13612,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13421,7 +13623,7 @@
           }
         },
         {
-          "id": "f2bd17cb-6492-4b41-b650-f7205161b21e",
+          "id": "465eb26e-b3e2-494e-a28e-b68e80fa8cdb",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13667,7 @@
           },
           "response": [
             {
-              "id": "9b7dac40-ae50-4467-a74b-5a5baf36fa49",
+              "id": "23fda246-c123-4346-9f6b-0e3f2e011a0b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13520,7 +13722,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13531,7 +13733,7 @@
           }
         },
         {
-          "id": "94a6799d-6da8-44e7-94c3-077d297de4cc",
+          "id": "18162d42-6834-4165-9848-05c86c39e207",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13777,7 @@
           },
           "response": [
             {
-              "id": "68dd610a-d78e-4028-88e4-beadda644b06",
+              "id": "3615f695-cf00-46d8-8e18-15324f704326",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13630,7 +13832,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13647,7 +13849,7 @@
       "description": "",
       "item": [
         {
-          "id": "7a770393-5f41-4a2e-a1e9-78b2d78e46cd",
+          "id": "09f87f5c-f343-4f31-9acb-0a018c75fc3c",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13891,7 @@
           },
           "response": [
             {
-              "id": "d58cb964-7fb6-4a17-b8e2-026aa8a75791",
+              "id": "e14086a7-14f1-4a09-99af-58f92d66e255",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13940,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "58f1597a-3d4b-4f19-8f41-ad59c2b3a305",
+              "id": "3473f5ec-6050-4020-a247-010fc28d39b5",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13995,7 @@
           }
         },
         {
-          "id": "16865099-bf07-47e5-b336-0851c46250c9",
+          "id": "06edea87-a3bf-4368-8ed0-81c6b0ce8df3",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +14041,7 @@
           },
           "response": [
             {
-              "id": "8419f936-708f-420e-9cb2-d57b24534f71",
+              "id": "96d61143-b4e3-45db-8949-2828346a31fa",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +14100,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "34a31820-92c2-49dc-a91c-a13d30363551",
+              "id": "a26826e0-62aa-42eb-88e1-c4847476a4c2",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +14165,7 @@
           }
         },
         {
-          "id": "02042475-3997-40b6-8655-318c0e916696",
+          "id": "7ab1f83c-ae59-4c3b-bf0b-1d6a4e26e65f",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14211,7 @@
           },
           "response": [
             {
-              "id": "f2f0e916-b64c-40a8-b4dc-d85c0c62f19e",
+              "id": "0faa228b-f44a-47b2-af69-6176698c5bc9",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14270,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e7174dfa-b134-44b7-822a-ea5cee4547e2",
+              "id": "1484603f-d4a5-4690-85dd-21ad369e943e",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14335,7 @@
           }
         },
         {
-          "id": "e827ade1-8a11-4e5a-b392-de6653d08251",
+          "id": "bc9b8db9-11a7-43b4-a9da-28c3c6c779f7",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14377,7 @@
           },
           "response": [
             {
-              "id": "979e2194-1df4-4a8b-bb83-542d7eda50dd",
+              "id": "8b5d415a-e9a7-45c8-b98d-1d30e1431056",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14438,7 @@
       "description": "",
       "item": [
         {
-          "id": "98e25c84-78e5-4183-96be-3bc76d7c8b1a",
+          "id": "be8dee71-bfb5-4b3b-bc9c-777cd34adaa9",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14487,7 @@
           },
           "response": [
             {
-              "id": "730f64b9-4604-48ec-b133-a72486b94b6a",
+              "id": "dedd0efb-e3da-49f8-bfd2-f93a9845b664",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14547,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
+              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14558,7 @@
           }
         },
         {
-          "id": "732bec5b-c49a-459e-97b9-cddf9b7c5b18",
+          "id": "c412504f-9f43-4894-bc0f-f4902780109d",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14607,7 @@
           },
           "response": [
             {
-              "id": "0c948e8e-e388-4581-812d-77cb8ed45079",
+              "id": "72db9d98-8ddf-4132-95dd-f65df91f8c1b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14678,7 @@
           }
         },
         {
-          "id": "aa8750e8-0e7c-4ef5-ae60-03fdb692e28c",
+          "id": "f2a7ff9e-3b00-459f-bb49-2ed31742d4de",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14727,7 @@
           },
           "response": [
             {
-              "id": "3e979901-6e25-490c-a376-95061ba8376e",
+              "id": "3513e9ab-261b-4352-835f-68ecde7f5e8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14798,7 @@
           }
         },
         {
-          "id": "988d5e92-a871-42e8-bbc6-3b4ef62cd003",
+          "id": "12cfd609-85bb-46fd-8060-2b2f9f1c87c5",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14847,7 @@
           },
           "response": [
             {
-              "id": "a4ff70ee-8902-4354-bced-cff18be9d916",
+              "id": "ed229802-8bc9-4c4a-bf00-75a4f7d9cf73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14924,7 @@
       "description": "",
       "item": [
         {
-          "id": "5b5fc9ad-1813-4aff-b584-b774f0ed50e3",
+          "id": "34f1eb7b-dc2c-441e-b9c0-482bbee6935f",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14964,7 @@
           },
           "response": [
             {
-              "id": "2dba7660-7b3a-4d69-a349-a03eeb11c064",
+              "id": "8037f59d-a72a-4051-a62d-fc34ad8da404",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +15026,7 @@
           }
         },
         {
-          "id": "09fa10fa-4683-41a6-9872-2ad1d7ff6305",
+          "id": "5a142780-86af-4a0b-9f77-c0d6cc994d18",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +15056,7 @@
           },
           "response": [
             {
-              "id": "e04a56c9-77b3-469e-92f5-e38a5f8628b4",
+              "id": "9fac6049-5f71-4fb4-85bc-5d3631ab9bb5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +15097,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
+              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +15108,7 @@
           }
         },
         {
-          "id": "b2f03f76-50ba-425d-b7a7-1ee7be0972e3",
+          "id": "41d93da9-ecb0-47f5-b3d1-16a0a4836896",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +15160,7 @@
           },
           "response": [
             {
-              "id": "db22654b-2dd9-47b4-95f3-2a3997d44915",
+              "id": "0f76bdda-f42d-45c6-bfa9-44ea77457280",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15240,7 @@
       "description": "",
       "item": [
         {
-          "id": "e4b70eea-de70-416b-8b55-d1b320d08452",
+          "id": "111ca295-5107-423e-bb71-b982b829e7d9",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15269,7 @@
           },
           "response": [
             {
-              "id": "e6c577c3-5371-4715-8a7e-e05496cbfd62",
+              "id": "28709310-60b9-4a10-aa4f-b78275cfa3f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15320,7 @@
           }
         },
         {
-          "id": "4fbda2db-968c-472f-9ad1-d58bc304277a",
+          "id": "f80fbcdc-cbd4-43af-b684-1e769eab43b0",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15361,7 @@
           },
           "response": [
             {
-              "id": "1bb785d4-ea65-4f0c-abbc-f928464d1bd7",
+              "id": "df7683ed-1441-4d41-b276-52592e4f9a06",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15430,7 @@
       "description": "",
       "item": [
         {
-          "id": "1e551b0c-6031-4f02-a863-ed2f429b75b5",
+          "id": "28504684-6547-4c29-bbca-3bd12750cb93",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15459,7 @@
           },
           "response": [
             {
-              "id": "20cf82e8-733b-4d27-9849-32418e07b91b",
+              "id": "f4eb0e5c-860e-4cb4-9071-8f56f474717d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15499,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
+              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15516,7 @@
       "description": "",
       "item": [
         {
-          "id": "049c9f52-28d0-4d39-8a76-a1ab7c7c8cc8",
+          "id": "dcea8d3e-beef-4101-a5cf-504f71736993",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15568,7 @@
           },
           "response": [
             {
-              "id": "bca58b8a-f6a1-4b01-ba37-a5468b59dd5f",
+              "id": "2cc4abdc-2a4e-4d1b-88b2-a123ed134cbe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15642,7 @@
           }
         },
         {
-          "id": "329fb7f6-a4d2-4d4f-9704-7de1ad0de82e",
+          "id": "b96cc567-3d8a-4508-9c34-672e2be35e4b",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15683,7 @@
           },
           "response": [
             {
-              "id": "9473c085-3974-4913-81ca-878babaf0fce",
+              "id": "4a29dd3c-21b5-4de0-a2d1-16d650bf95d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15735,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15746,7 @@
           }
         },
         {
-          "id": "b731b56a-c3a6-4363-bf60-219611be1be2",
+          "id": "dbae3d1e-a67e-44cc-9e06-da2f75da3b4a",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15776,7 @@
           },
           "response": [
             {
-              "id": "643475a7-3153-43b1-92de-de453d8fb91c",
+              "id": "52b860ab-964f-4fea-b9b8-99a032da5e03",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15615,7 +15817,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\",\n  \"key_4\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15646,9 +15848,9 @@
     }
   ],
   "info": {
-    "_postman_id": "a1e7aadc-1784-4453-b2fd-e1e86ffab7ad",
+    "_postman_id": "badbaf6e-212b-4e8c-af84-8ff28d2da413",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-30 09:13 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-30 23:20 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "c653c28f-873f-4170-95ec-73544f0b17a2",
+          "id": "5490c149-181c-4768-ab65-3aff133bc663",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "b76f73c4-ebc4-434e-b8b9-a7cdb8aff708",
+              "id": "c1999ac1-5ef7-4e8b-87c4-2fda4bc87b30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "22a17d0c-69a6-46dc-884b-74cfcaab65b9",
+          "id": "f951c85a-0a64-4ceb-a65c-876695d3afb3",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "89565180-88e6-4a0b-bcfb-8ec0c864b6a1",
+              "id": "ae7f509e-be98-49b9-9585-225a02534d7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "6dd32a0b-a7d4-463a-8dc9-f3b62918de8f",
+          "id": "fe4ffb9b-fedc-480c-8f66-e9750f5f8559",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "c30df81b-4bf9-4440-86b7-7eebc8351c74",
+              "id": "5cc1c1cf-7d80-45cb-b419-a4d0ac36d620",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "f17bb4f9-1902-4c31-a0b5-28d4a2118625",
+          "id": "7f536cf9-3eee-479e-9672-d2bb9814bd1d",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "c813c02d-a774-4cb0-b64c-9832bf0de01c",
+              "id": "889aedf7-d168-4002-8710-9000ba88a30b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "681c7d2d-3e2f-4b8b-975b-e70f97f8d057",
+          "id": "8e170e12-d9dd-45b3-aac6-7c877c66203f",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "38d0c9ff-31ac-4a74-be6a-93e86f5d6409",
+              "id": "f4a9958f-fa0a-4f3c-9a3d-f68baf9f63ad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "2b1fc689-3945-45a1-8f88-b394177da15e",
+          "id": "c29713c8-1403-4153-a7f6-77ab0a217e43",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "850bdd4f-af5d-4f52-83fb-ea2f9144bd89",
+              "id": "3b77f405-f3ad-4001-a29e-70e6e2bf90ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "017f1186-b25d-4c56-99fb-b627782f9971",
+          "id": "edbcdae4-b2c7-4afe-a3b1-eed85df6d1da",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "99093253-6af2-43f9-923e-44de1cbcd087",
+              "id": "d439a11a-e114-4e78-9398-4fa236a99e00",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "47e65278-8ca0-405d-8b6a-e7c08a8061c0",
+          "id": "79c9d5a5-370b-47c6-989b-aab4f7249798",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "3d8351fd-e3a7-47e4-90b9-6d5d02e63efb",
+              "id": "71518ddc-e3b0-4555-9480-9866ba261b23",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "a3d9e9f4-80c1-4879-9a32-a72e21268aae",
+          "id": "45c94fcc-c5af-4dfb-945a-e6b3f197b1fb",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "874af070-b93e-4840-a6b7-f6dddb8b812e",
+              "id": "0a945963-7286-4a2e-a285-af18085c6aae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "7e17eca6-619f-426b-a5de-dbe448ac122a",
+          "id": "1aaec0ef-2489-414f-a706-963bc53c1903",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "07e5078e-0c14-4dd5-a9ab-96e2e9407d43",
+              "id": "62fe90fa-0e20-484d-830e-e4f6afbbb897",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "b8e2610c-3fa2-4492-94fb-4f3fbd29cdb8",
+          "id": "b0d9ab2f-87a0-48b9-8323-2b3cd0b21f76",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "1829adaa-d2ac-4876-b5ae-c496ca5ba3c8",
+              "id": "ad3bbdca-d38e-413f-b6ae-5f70c9185a99",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "4f869181-38cc-4b59-bca9-63891b2d17b5",
+          "id": "70d5ceef-93ec-4aa3-8c06-70efbf006a03",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "8da0d3fe-ae68-4496-b945-54c400cbad74",
+              "id": "96b0c033-b2df-4a4a-a318-d59e21b10683",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "f49ba09b-dbdf-4e57-aa68-814a7cf420ff",
+          "id": "76162a81-92f8-4f3a-99a0-6fe1bb8728cb",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "e22313ca-3e0e-4a48-8729-ab09eb7e377e",
+              "id": "d6bb0432-f4d5-4921-9b94-93b8f56c4a30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "e159b72b-5b71-4f8c-99d6-afb884e25c17",
+          "id": "2f0ab415-66a6-49b9-b790-e8d686d8c4bf",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "8bc23dab-d81f-424b-8089-bba6b73fe299",
+              "id": "e7e4d9b7-8f72-41fe-8a94-e801772c737c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "67939375-415a-4077-9dea-2fa9852faff1",
+          "id": "351dd797-e18f-47cf-84bb-c92b024c1d9f",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "b8a3fadf-4461-4a26-94a9-c5503a33f017",
+              "id": "8c6a78b1-e2c9-423a-8e6f-40bb5002fc3e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "b4256761-cd90-416e-a94c-2ba61c994d74",
+          "id": "8b52ede9-9f18-4d12-9c36-d227926550cf",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "dde1c8cb-ba22-41d6-a81d-5c610f5bf248",
+              "id": "ec304832-1839-43b2-abf7-87dd9a4395a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "3db20e12-58bc-46c6-9ead-fe66f231288d",
+          "id": "ddd71617-5916-4286-849c-6c370ebed43a",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "74d52032-f422-4f3e-8f54-d48b8bd2146a",
+              "id": "9ce346c0-dfee-4e9a-b27c-c59f1e0d34a9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "5234ca5a-7e5f-47d4-a293-1fbc025b56c3",
+          "id": "dc484892-7485-49fb-8dd5-26f576953211",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "ebb2a402-9574-42a2-b2a6-cd471b7a96ed",
+              "id": "20f6ac8c-cee4-445d-a903-824951d665d2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "76fbbed8-f7d1-493e-bb07-469bf0e07cb9",
+          "id": "5bbda9bf-d178-4c0a-9b77-21586f6ee952",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "637da2de-8d77-49a4-9961-64530330da2b",
+              "id": "78597035-76c0-4bc6-9ce7-bc8d821abc2e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "32669e08-d41d-4ab2-bf45-f3c9f77f82b3",
+          "id": "6b2f5b69-4963-4c7a-b430-fe8b5d0acf4e",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "32f55b53-c4ae-4c98-8c22-7dab24c2ad49",
+              "id": "1f0920d7-ed00-4687-891a-331b567e30c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "64c23d2d-91e1-489a-b0cb-6c7e18f3e89c",
+          "id": "1e7d9039-a79e-4667-8311-893e28734b18",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "13acf2f8-7fa0-4584-acd0-48ba2108a365",
+              "id": "a05644cd-0357-45c5-a5b4-40cc226157af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "9fa110b1-d5a6-447f-b47d-2c61fe978f1a",
+          "id": "2d6df073-df45-49d4-aef1-a470750f79ce",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "ed1348e7-a90a-4c6a-a878-c6565384affe",
+              "id": "3eb9cc1b-ea2f-4dca-8f37-489f2dcc29af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "d7ae673a-a415-45d9-81a0-46a0645e3712",
+          "id": "ac195429-4fdb-4e7f-940c-a567623bd020",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "aac4783c-2d1e-4ca2-b063-e606a8852686",
+              "id": "a5f97810-4b42-4c83-9b84-75fa7750a3ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "762eddcc-1362-4f25-856d-f3754c7b7048",
+          "id": "03e2c750-89c4-4980-86ee-a5193c3af360",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d75Af4\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bc8dA2\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "1cd110cc-8df2-42ca-84c9-646bf772265e",
+              "id": "ce733d01-e186-4cb8-9118-5277b22b9a16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d75Af4\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bc8dA2\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "8ab6e4c3-5e03-4d7d-bf33-03bc34be97a0",
+          "id": "e770ab71-c1a4-4d9b-9791-4e87c7845870",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "7a82e771-5362-4823-ba66-01870e3df6d5",
+              "id": "20959a54-446b-40b5-b5c1-ee85fdfe101c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "3cef7482-c649-4567-bb2e-200442059ff9",
+          "id": "746e8cf1-43f0-4038-95de-3e574388e3ea",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "0f3a211c-e907-4ba9-bdc2-803b6189d745",
+              "id": "14531862-2f3c-4e70-b794-c01248401d2a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "66537a25-22da-4f4f-9b99-86627084d897",
+          "id": "496ee8ef-b2bc-402a-ace8-28e0d23741d9",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#34eFeF\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A4A1F2\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "f30339fe-03c8-41e7-80db-251f7943490c",
+              "id": "f2afed09-6c97-492b-9f27-7458d0c3c1dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#34eFeF\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A4A1F2\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "0e2bae99-b1e4-4d48-98d8-32fca0819553",
+          "id": "b2065d22-28e2-406f-911a-25a373325e9b",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "92c732ab-9b5d-43a4-9fec-fe389bb32e1d",
+              "id": "a7a31950-25f3-4a56-8d00-54432661e86b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "7edda7b9-9672-4746-9a88-54f42d365d79",
+          "id": "92b0840c-af52-42b8-a8d7-22a3c0384d4b",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "a67dffd6-93d5-4500-85bc-11473ab49a17",
+              "id": "c0438b61-4c8d-4a8a-940a-4df92c2b8ede",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "a2dea240-75a5-45c8-9220-0cdc39fd9eeb",
+          "id": "3bd37ae1-2e1c-4a73-8e0d-6d08b74219a0",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "489cb881-a872-491a-9c3f-f25cc39ce45e",
+              "id": "40b5f8b2-7b9a-4385-ae12-bd5739233255",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "95a21640-b8ce-4604-bc33-59c2c1296438",
+          "id": "3a0dcec8-f3a5-4a71-a6d4-cb4b75a27946",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "a8c7e83a-76d1-4189-bfb3-dab0f600d892",
+              "id": "81c135d5-159b-4fbc-81dd-976cc7fe434f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "43ba96f4-9213-47b9-a080-64eba0d8ada9",
+          "id": "3eb328d5-3d6c-4b0e-b47a-3527b36d91ba",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "512f893a-9360-487a-8bc5-9d8a241d17ee",
+              "id": "5a4d9029-d042-47a5-a5e8-449e5f48b38a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "e0f0c8d7-3382-4c55-b20e-42113f283a02",
+          "id": "f8119043-739c-4ce4-b5d5-c02b3a38f2b9",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "66d40410-3fd7-4974-819d-2e0ce2946ef8",
+              "id": "7fe541ff-c4f4-4daf-a906-fe409e9e5050",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "933af6b7-b65c-4720-9b7b-5805fc61ac89",
+          "id": "f5a3974a-4b08-4a29-a2a2-66e6ccbbea34",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "82116f94-24c6-4cde-be32-ff1f230dcee1",
+              "id": "4e04602f-2563-4ad5-badf-4838cd076569",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7841\n}",
+              "body": "{\n  \"key_0\": 4899.807116108701\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "a8ebf207-33ca-4ead-ba93-c020d9183b44",
+          "id": "cfb7073d-1945-4d84-bd11-c94502cebc62",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "6beda7fa-7c97-43e4-87b9-22df5cd86152",
+              "id": "02c06885-40c0-4809-8840-ca42aa94ce66",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "68f6d3da-b700-4973-b041-685e470c0166",
+          "id": "1e53ce08-eb1f-4b6b-b35f-5f9498a9a704",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "7a645cf1-cee4-4035-8490-c2d7de8a916c",
+              "id": "9074b615-82a1-49cf-b795-6f901ad9e340",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "6be818f4-0b34-4587-9257-8dd35364f0b7",
+          "id": "a182081a-3f1f-4ce3-9208-6f6ecd472534",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "37e09557-e913-42d9-9bc0-d0b2355943b0",
+              "id": "25391f28-0bcc-4986-866a-474bc857e67d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "e3497c24-cd52-4076-8574-664fce34e838",
+          "id": "e18b5a01-e5e6-4ea4-a195-659c9009d8ec",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "2ba430fc-6951-45f0-8feb-cb971944faac",
+              "id": "a12d92a9-283c-4d02-918b-a727588e1538",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "585c4820-c159-464e-a2cb-cedbd15cbddf",
+          "id": "b24bb374-3ee4-47a0-955c-74bb327a75f5",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "c5161e58-a498-4ae3-af44-262ebf355555",
+              "id": "ba863190-9c82-4c1e-b168-8f9bb5761a38",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "6803cda0-6747-4a7d-97ab-a2762a8ffad9",
+          "id": "0181f82d-c2b2-4020-b403-51d2ce3d7519",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "f0ec2b94-8fc2-4b20-a02e-bd4b25c68c2a",
+              "id": "44746dd6-363e-4f57-af12-0d2db06ddd7f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "9a34b700-3746-44d5-a6b7-68bc4b1e4970",
+          "id": "45ab84b1-6ea5-4ad9-95e4-f2cbb574fb01",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "b4588c5e-b01c-43db-b2cd-ae7b983c2aba",
+              "id": "93551e6c-8d6d-48ec-b6ab-e0767b5d463c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "fddb1543-2f91-4837-884e-6440297f1b0f",
+          "id": "2ec9f816-7b1e-4203-b906-c93a11a3f112",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "4d10430e-cfc0-4e37-9bfc-cc9ea303c90c",
+              "id": "4b758455-8413-4f29-8aad-820b1b88d83b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "cabaeb85-36a0-4454-a98a-158bcc8f976a",
+          "id": "3872f66d-1c4c-437b-92b5-a6a56468d0a8",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "becff5e4-a3cf-41b1-b951-daadf4b7fac6",
+              "id": "8071ddd5-859e-4f8f-addb-d7ee47ba627a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "970831c5-0e8d-4497-94ad-485995961bd9",
+          "id": "16ca39bd-0a2e-4aa1-ab97-a0dedc94074e",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "e75a06e8-4b82-440b-b3a7-083d798c1a99",
+              "id": "d63333fa-2a20-486d-9522-9776a316b59b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "da96e300-37a7-4afc-a878-b7e687788393",
+          "id": "6f68a8c0-aa5d-42bc-a2fe-9476a6156b82",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "93fbf740-b2b9-4a6c-a5a2-e5cbed7df5ea",
+              "id": "51587a3b-09e6-4a4d-adb2-c8637252c35b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "dfbef683-ebe0-4ef7-b7af-90e3e7ff5fa5",
+          "id": "81e88f05-edfa-49d0-ab70-48df419e0908",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "4a14a02a-bdf8-49be-9fdd-d2bed935b708",
+              "id": "dac9be09-5a90-42f4-90d9-38ea6f3f2a3d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "3fb4c7f0-6810-4513-a993-8b883d1ad547",
+          "id": "440afb38-c8aa-453c-9c59-af8b03fbce06",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "a5f88c54-6448-4fcd-b1bd-d8975cc2cecc",
+              "id": "77f5a8e8-c39d-4610-9b2d-94e27f5c9ee5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "4dbf7ed3-fd2d-4fe2-878f-20bc90ecb0ad",
+          "id": "2100fd59-23f5-42c2-a83f-c9a0f97a1441",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "03ed5eaa-ee24-4c84-9174-13642f3ce8b6",
+              "id": "70177c48-4aba-4371-9d3b-d695bc8d10f7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "3b8e7b88-f89d-4f53-8065-2a084906f6a2",
+          "id": "e1c7e633-b6ca-44b9-bffc-6633d10d21b0",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "d04ffe4b-1de2-4813-8842-9dba37638933",
+              "id": "beff1f93-80a0-48d6-9f9e-3f3f0077cc94",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "e0d0abf4-99b2-4619-8452-bffba11fd8d0",
+          "id": "54af0283-9ebb-4670-bf9a-62b73a70c5b5",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "ba1e158b-d4a6-4e43-ba2e-d5d22bf9b656",
+              "id": "8cfd32ed-885a-4828-b680-21af41bb010f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "d1cc2b2d-1e53-4935-ad25-eb7f7cc5e6a0",
+          "id": "76247d79-60d5-4e1e-a33f-e6a8c50707a9",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "9dca104c-0283-4d2c-b530-38933ec23c22",
+              "id": "cac3f96d-cd5a-4528-b2f7-c042a2e38509",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "eebaa1cb-679f-43e2-bf9e-75f84a28dbde",
+          "id": "0453e313-b2f4-4099-b4d9-395f6ed4b50a",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "4e7bf131-bdf1-4bb6-bf9b-76afdf993b60",
+              "id": "5e5c86bf-d9ea-4b8a-bc27-44df6e91b8f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "9c23850e-1f73-4888-a6da-fbdc7b970588",
+          "id": "098b0507-5229-4161-b3f5-cd7378cac690",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "0b8211d0-6cbc-493b-b369-cbd4fd06db26",
+              "id": "574d2ccc-2ff2-4e13-ba8d-238a853f9dbc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "734d2608-51be-44b9-b2ed-8c57c100d235",
+          "id": "15a3a15d-8c70-486f-9700-05cde13bfff3",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "90145e96-3422-40a9-9c0c-ab76bee4e7ed",
+              "id": "a9b4b2cb-e31b-4989-bfd1-d9b5197fd22b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "d4a658fc-7821-4acf-b436-dfa957dc84b3",
+          "id": "f6c7c7cc-82ed-4217-898f-adc33eaa1cdb",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "a6f2335d-0301-4b19-af03-b9d4e64da4e8",
+              "id": "7983f5ce-a00f-4bfa-8207-238025894cd4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "30c6ca70-0dff-4314-bf16-8099d06dd074",
+          "id": "765478ee-0926-4d2a-bd46-8b5e158a2eac",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "fd249028-b62d-4c3c-8aa6-b29d512052b2",
+              "id": "e3cb9bb1-eb11-4800-8eb5-5d359899c6cb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "32a2e367-62e6-4ad8-91c9-7d18b5cf4a21",
+          "id": "71056e6e-8de1-4df1-be6d-c0abb29adfcb",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "c92efaac-d0f0-45a7-a96c-83f6622d66ce",
+              "id": "de7e1dfd-9a41-4618-b626-9949977ec27b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "50e8fbc3-be98-4062-95d7-63aaf228c593",
+          "id": "12a7b22b-fb5e-40db-bbee-909c95101571",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "0401fb59-6ec4-49f2-9db6-6021c3a730f6",
+              "id": "da367381-0e36-4bf5-be11-b10b595b6c16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "45b3b9d3-010c-47a3-945f-9acb7cb9043b",
+          "id": "6ff04b69-8fc4-4135-b2d7-c28c55931973",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "40e653bc-2606-4978-8fb3-04c93e496645",
+              "id": "2d5f9573-3a54-402a-a9aa-882a7123d2d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "3df9bb82-c4c3-4257-9270-9c63dfb01b35",
+          "id": "4c9f1c8b-dc91-4833-b380-40bd83638747",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "be033777-bdd3-49a5-9a62-b9db4626e3eb",
+              "id": "fc10d07e-f0b6-40e5-85d9-f33e6a1da837",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "ec221763-ba8e-4ffe-988a-93a96d54f5e1",
+          "id": "c29d4a3f-44a5-406d-9dc1-e1c862ed167c",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "3c282073-9047-4185-ac37-281f820a843f",
+              "id": "72e6906a-c334-415a-83a2-8401d578873e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "c64ccf67-cdfa-49f7-9e2d-d5349ca61b0a",
+          "id": "9c0de23d-97db-48ba-85fb-7345d831b857",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "bcef78ef-91e6-42e0-9ecd-49a1f8852b09",
+              "id": "1e8225e6-852c-4484-958d-d881587d7ae2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "11c6d8aa-681c-4b08-9c31-ec2de91f430f",
+          "id": "ae7b2774-949e-4bce-84fb-61f061c3786e",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "dab2c94c-2dc1-4e09-ba48-ec81a6dcc3b0",
+              "id": "532fa8a7-297e-4a8d-9f66-e4e880e52617",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "ff63c631-3a36-47a8-97bb-e2e5daa2887a",
+          "id": "38ce7bdf-74ac-4b48-b7d2-8b94fdc36cff",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "b113cf0b-eae9-409e-bc2d-9e8b991c4b0e",
+              "id": "75c648cd-bbba-4e84-8213-5389f8ed3cdc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "2fe5fb0b-01d7-447b-8f5e-8795c1cd6f12",
+          "id": "ad68ea5d-727a-4d39-bdc9-453d9446d85f",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "16c5092f-95aa-478e-840b-d201db56f9c1",
+              "id": "288c4c7a-88b9-4cb5-a78e-77020794898c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "bf4a3706-093a-4058-bcd8-4273a88b29dc",
+          "id": "8936139f-8c60-4405-8880-67cd26c9c0e1",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "1b0d45d8-2c83-4113-b638-abd74f8b3a99",
+              "id": "10b231f7-bfb3-4093-a836-774169122b11",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "9da063aa-501a-4c8f-9d35-1c72b1a31634",
+          "id": "48063644-4476-47ab-bab7-f8e4445dab81",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "bf2aefa0-acd2-4d6d-8873-afc26e84eaaa",
+              "id": "f2354839-198d-4107-abab-3e2aed28b3b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "34c02151-0b4b-434f-b52a-2c5cf60ef17a",
+          "id": "c18cb8db-3d89-4ce1-937d-22b900c9d13c",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "b11e7098-aeff-4196-b4da-099cad66d9a4",
+              "id": "1f4efcac-bb1e-4fdb-9a52-f02070135710",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "a517d5d5-af72-4fa1-8317-6e2b76e8cd5e",
+          "id": "2e2b49ee-6ed4-464c-a27c-fd0c22a713eb",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "74c4e93c-8467-44ac-9f8a-6a2b92d459e7",
+              "id": "1fd4cc98-26d9-4fd0-b0a6-73d4a5989c3c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "34d8afd0-f5ad-4677-8a54-8fe3ea12a785",
+          "id": "62f10c3f-8370-4fc3-9cbc-514907a798a3",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "1883bb0f-f162-4fcc-a2fa-2858327f2eaf",
+              "id": "b12b0c77-5ba5-44e0-acd6-cc7f4287d7d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "0961351e-7230-4df6-838c-c7ac284e987b",
+          "id": "ef51e7de-45db-4ba2-8cfe-cc8812e46bdf",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "3f15cf26-0759-40df-9b43-e8674c1a93bc",
+              "id": "7213a19f-3955-4e3e-8237-ac3380fbf37c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "3ad662fe-f05d-4099-bed2-ac09af6bb570",
+          "id": "59081dab-d0e4-477f-aaef-aac1fb93fd27",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "46b386e0-ea76-4de0-ac1e-1df2591a1dc6",
+              "id": "4ac6458a-5b2b-49a5-b482-6768e95d675d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "04f5f308-3060-47dc-a857-ef695b34e8e1",
+          "id": "8ed9e38b-b7af-438a-8fdf-a1c5ace45bff",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "5270cfee-ed74-4d30-ae67-bdefaf36f676",
+              "id": "f7a0068e-b439-4c31-b886-9d4808110d77",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "084d3720-5ff8-45a2-a9fa-27fbc856a5db",
+          "id": "01e64d12-fe89-4e39-b90b-725fe0025226",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "9bc67d15-b4bb-4e3b-9d67-1d6ac25d5fef",
+              "id": "21f2b082-3de0-493c-bc69-b2a04d9b4bd7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "7b882305-12e7-4c0c-93a4-22c201d64e50",
+          "id": "42ddfb1e-5326-4062-bf07-1a58dce39622",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "356d786e-7ca4-4659-914c-11faeff3f179",
+              "id": "ebeaa40b-a22c-49b3-a8dd-89e8b4f04401",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "ac013927-bf3c-4e50-aa15-445c76f5c1ae",
+          "id": "ab16c17e-3e68-4c81-9bf0-9c1b8919ca45",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "9dd8f1a2-b964-4919-a2dd-3785b140fe89",
+              "id": "b7d23c78-9636-43b5-9136-6d429d4f7eff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "26ff7390-5480-4f00-b105-536c2a03c47b",
+          "id": "e917c884-5dd9-4f74-a2aa-58f2441fe9ee",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "b5a26b75-c351-4797-b9ac-e2d803b93437",
+              "id": "d67cf808-370c-4ce8-ba92-11bacf2e13ae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "72842722-c3d1-454c-9c6f-9a0bb3fd62c2",
+          "id": "34b30267-08ea-4e55-8bdd-79f5b243fe73",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "7bf89cf3-6167-488d-9b5f-bc1edefbb969",
+              "id": "96773cc6-1201-420c-99af-d9a6e06b33f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6bf124ab-d320-4235-ba13-3ce339c5fc0e",
+              "id": "bc8a90c6-0a8e-4d79-9222-3574ef0ae338",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "32d5d02a-fab3-4f3a-9eaf-45d6c67b893f",
+          "id": "d9ebed64-5e0c-4a81-8911-8b34e943ba7b",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "86025c1d-2d35-443f-97a8-8b3a8769f94e",
+              "id": "039a76c7-54df-4d89-8307-2cad49bffe70",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d21ad2cb-1425-4c02-8075-7ea2ed7bd721",
+              "id": "45d650c2-846d-4499-af22-64264078f527",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f928a8be-99db-4ac6-953b-c61caae31240",
+              "id": "883cb606-0f73-4263-a49e-055235c929ed",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "505c826b-60ce-4a76-a35e-73195c2dd81b",
+          "id": "9d84f764-f17e-40ec-8ab8-b247ccbcf3c8",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "dae6bd75-fcd8-46d8-b937-8377349d22c4",
+              "id": "62500b32-7692-442b-9cf4-0af85c4785c1",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "eb56fb6f-9bc2-4b73-92a7-76adc8901faf",
+              "id": "e6d20a96-a88f-49dc-a726-ff2a4fb86070",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e35ee21d-f016-4461-a006-77f558176c0d",
+              "id": "9707408e-d353-4f5c-9ab0-59522ec51439",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "6c438463-927e-4c29-bfdb-43d6d8a0c81b",
+          "id": "bbfe1898-7ce4-4ab6-8036-3b9f1f6a39a9",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "074eae29-c934-4a1e-85ce-ff0d5cba7bed",
+              "id": "4572ea5c-54fa-4058-9843-de10e363c65c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "e78db546-715e-4c6b-8e16-0f2dfb9af522",
+          "id": "34f622bc-0736-4275-afd5-68130e2b2ea8",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "7756b23c-b427-4bc9-bde9-6caac30788ac",
+              "id": "63b8e2f4-d46e-4815-a26f-7da1cfae97d9",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b7c6e66b-2271-432d-9a19-8be8418d578b",
+              "id": "b45007c8-073f-438f-99a1-5045fb262786",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "eb70da7c-ffd8-4392-a6d1-39366df1e2cc",
+          "id": "f30c7c83-8092-4d99-a857-4d2fe0d76f18",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "01756779-06e3-4a36-91ee-6ed6d77cf175",
+              "id": "bdebc86a-8a49-4ba8-938c-9fff016da171",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7841\n}",
+              "body": "{\n  \"key_0\": 4899.807116108701\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "59a8436e-860e-415c-910e-8377ff28fe60",
+          "id": "5997d56c-ff6c-42dc-8821-8b9af2637f30",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "80fd8867-573e-463c-8eaa-b59d64b88ed4",
+              "id": "f6ce0b90-94eb-452b-916f-b786647c1cfa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "65b195cb-0fef-42ab-bb2d-729e26c1a692",
+          "id": "ae2d22db-d2f4-46ba-b034-ce7437842898",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "1477ba38-9268-4313-abe0-967d351b9a66",
+              "id": "516d8636-4577-4836-83d1-f0add13b7317",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "24033d1b-bb53-4040-9371-f04f16166f36",
+          "id": "a468066a-2d9e-440e-abc6-168d341d50c1",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#D1393f\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5bea73\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "f7d120f8-d41e-46c9-a8ed-6afd03171cdd",
+              "id": "911507ab-d3dc-42ef-b907-391880d493a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#D1393f\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5bea73\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "e4a96a58-aeb9-4f4b-976e-1b504c7f8044",
+          "id": "b2e9134e-a95f-4443-96d8-fb319d851c76",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "c143a65b-8b75-4935-914a-ce75af4d4aac",
+              "id": "15a8bbd9-ff41-4c8b-8ea9-71fc20d888b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "4fd19882-4a85-4b28-8ddd-9083f54c6c77",
+          "id": "ce414842-0bb5-40b7-813b-ef808034c93a",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "8bc771bb-4547-4ed5-ad3b-c677097a0d2a",
+              "id": "40b5637d-d577-46ce-b133-301c698ff134",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "e78033f1-41d8-46d6-a9cf-71d257256eb5",
+          "id": "820706a7-f091-4014-844e-59a1c0c9b824",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#349Bbc\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bC8f4E\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "a5d7502f-16bf-4931-a099-db3a50a7fb57",
+              "id": "f012b701-5476-4993-b75d-e3a0d2a7aa17",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#349Bbc\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bC8f4E\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "56ddde4d-4790-4ea2-aadf-f3ad98a813c1",
+          "id": "4170d627-3f90-40e1-8968-8c053eac9f17",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "e5685f0d-39b0-4ba9-b445-725517979f07",
+              "id": "15e107d2-eec5-48c5-95a1-d0a9fcaf1f92",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "f254975b-9bac-4b5c-bb3f-fbbc5b156bc1",
+          "id": "08372201-501c-45d4-a16a-a1f8ec812dcb",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "b0410504-73df-4bfa-9b30-dd7bc4439502",
+              "id": "88409f52-669c-41f9-a6f3-e331a46f4fc6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "dafb4491-6004-499a-9e3e-d28942517ff8",
+          "id": "ba76ff18-7df0-4260-8037-fd0d37fe878b",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "b59f6f7f-adfa-4c3f-bac8-af8d38c2b102",
+              "id": "b3ab77bb-0d99-453c-b28c-ef82060d2079",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "4d53ac8d-044d-4c3a-a6fa-25100aadb96d",
+          "id": "7628d4f2-bd31-43e4-9e00-bea830ac7f71",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "a71f8881-d0c0-4656-a365-ca98e80cbf20",
+              "id": "17d216ad-20da-495f-bf86-2e35afc5f0c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "eab6eb3b-6975-46d8-88b0-446723daf769",
+          "id": "ab8901ee-ed0d-4e55-87c0-627b4e9ce00e",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "b121eee6-632c-47be-b4dd-29991fd14319",
+              "id": "4ba63c98-52df-4e74-a26f-b94247af9ce9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "a571e01a-4038-432c-90a2-41bde208dbd8",
+          "id": "3a9612a9-6a1e-449a-bdd5-231b4cf501f8",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "5b26b773-8492-4178-a31f-f29280cb27ab",
+              "id": "4739e452-53f7-482c-b655-ee7445fb7616",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "efd0c070-85bd-420c-b18a-84a1eaac5152",
+          "id": "cba8a019-2274-400e-a184-03b25d9a3141",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "751501fe-5693-4370-bba3-620436cd9bca",
+              "id": "72906837-e53e-4144-8656-532803594d7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "98051604-ec12-41f5-bbd3-d88968a1c7ed",
+          "id": "d3ea596e-801f-413e-9cd5-7c5718332486",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "b0fe8f57-9df2-4a46-bd91-64331735a2e2",
+              "id": "48006e15-a053-4a30-9daa-96aab37478d2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "1a718f6b-fd5d-4fb4-94ca-4f1d863fe7ea",
+          "id": "136d65bc-a119-4c21-9f9a-280ea16ad117",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "f3a13ef1-aceb-42a1-84c6-bea3704e9a90",
+              "id": "f154667c-9aba-49fa-a90c-0daaad5e4333",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "bbdb543f-91aa-403f-9278-2d5c70fbee3e",
+          "id": "a2cb178e-394b-4f9b-8296-d0732472a247",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "26cf378a-21cd-48ef-b527-4dbccded8763",
+              "id": "b4d4c7d2-54b2-4a8c-a51b-94b9891c7f7d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "12cc1c3a-c822-4321-9e76-a2d968ce02eb",
+          "id": "423ae308-db70-4027-87f2-12c41333bb75",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "aed17c23-5f8b-4cd1-97ad-125035efe826",
+              "id": "72dac79d-4ef0-44db-b2ce-889273ee4279",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "36d2a441-9120-4357-84cb-f6570b07eb04",
+          "id": "2fc30667-db65-41db-b529-5cb0899400db",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "9dc2adf4-177f-4c9c-aad5-82ad79fa4f9a",
+              "id": "a53e593b-241a-4b6a-adaf-3bf9e39bc8c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "67c571b0-34c0-414a-bfd0-132ce1d19d4e",
+          "id": "ea8ef8e4-59b9-4d56-af86-6f06dfd08d2b",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "f53f408d-4f41-4ec9-8ca6-888063393545",
+              "id": "b9f76c75-1d41-407a-93c5-6f75c971601b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "888e8bd6-85c1-4ab8-835c-8808e8a8ef94",
+          "id": "e6377486-df91-40fc-827a-7fa825272ae9",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "d26cbe4e-dc17-4e65-af39-f11047c7b964",
+              "id": "1b8de95b-6db8-4958-9472-dad5be8c574d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "70d89423-c152-49c9-add7-01ac0c791e29",
+          "id": "298ef7f2-9b0c-453b-8b84-be12ed846b3d",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "d04ffbf5-cc06-4238-9cee-8c7acd4d7f2f",
+              "id": "cd4899a9-61cc-4a2b-ad25-ff9d0401c40e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "f014aeba-442c-4efd-94cd-e8a7760a9530",
+          "id": "ea8c740f-24c6-435c-b60b-0f1ed9ca0535",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "7d4df6e5-dad6-4b55-a9ba-0d9e89bc32c3",
+              "id": "9db32e6d-b6f7-43a5-bb17-4d9bf4f639e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "f180d665-e64a-4f12-bf53-4e7f2cb62bc5",
+          "id": "ac7daa8b-af35-41f5-99d8-64c07bb2090a",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "889a6515-b89d-48f7-ad9d-e27c7f23a476",
+              "id": "9fc68890-8360-4314-a328-d10705fd21be",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "d6a640fc-3334-43df-8611-e94b3f003865",
+          "id": "efeedac9-7e87-4dd1-b2d4-14f667631048",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "4bd979d9-a237-47ee-9be2-3243117c33fd",
+              "id": "a553e9d0-a330-4123-9400-5a236ad27d1b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "08a050ac-9c04-486f-8005-1c81c64c8658",
+          "id": "ed9d0652-88a1-4a75-bc97-35a8dd394622",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "942ef736-8742-4af0-ab21-dfc561e8d868",
+              "id": "ea98f500-7252-429d-98ef-9a36e613f50e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "05fc0191-949c-4b97-afc8-7d520f2d6fc3",
+          "id": "27d1b66c-d0ab-4feb-b241-9da3c6f1c7f3",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "380ff042-11eb-40b4-912a-cfa952e0273d",
+              "id": "de8ab3fc-d534-499b-b2f0-3e8dd46917cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "2aed1a8a-10be-49d7-b50e-3b05daa9c07a",
+          "id": "77743832-35a9-41c4-ad31-4166fe88e905",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "0e912649-e834-4495-8e36-da311d394613",
+              "id": "3f70b155-19af-4058-b264-3c383b574320",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "c4935a19-c8e4-4725-8ead-390307b8c7e4",
+          "id": "32d6e122-848e-44e1-8e06-081f28a7c56a",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "19863c9d-7642-4f18-9e61-a46a53705371",
+              "id": "083a4935-09c4-4c3f-952c-bfa3c2f0ab42",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "f7f96a8a-2db8-4528-a0f4-73343595bfab",
+          "id": "b25cda46-b62b-4447-9755-1a9a949c7653",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "d522df1f-abfc-4ef1-b11e-79b90b7a2624",
+              "id": "8a5afd2d-170e-4861-91a1-4e760024526b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "1e80d19d-6d10-49d5-a617-0951b9a43df6",
+          "id": "4426bb46-f773-492b-aa39-4a6e41b06d6a",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "1f833881-bd08-4f88-b611-3df3588599e3",
+              "id": "de3cb0f8-c555-47f7-8759-56f08ed8c6c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "1d859322-bb42-4bea-943c-5f0730410aac",
+          "id": "f5feb741-e3cf-40f6-9d61-7073f5137aa8",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "850da81d-8250-4c23-9c4b-c03e5c045a9f",
+              "id": "2bfe5ee6-779b-4c4c-8dc3-4f408499e438",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "7e71b29d-aaa3-4713-afba-b5ea45eb81a0",
+          "id": "31596614-f094-4eba-bb33-50b33d0cd9a6",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "adc7611b-c842-42fa-9a0b-aa155619e4e2",
+              "id": "5c5d4e74-f20f-4a97-a7d0-8f3ae95faa13",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8a897445-f819-4059-a27f-0262b04bf2f7",
+              "id": "052fae88-4f5f-4025-bc83-230951e6aedf",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "1fa04dcf-6376-4439-b974-f37c017c794d",
+          "id": "b23f2d67-57e8-4c92-8c4f-318b92157564",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "abb7f193-b928-4ff1-a2b1-220e50add837",
+              "id": "72ae2dfd-b7b4-4761-b8de-d6a66b7dc511",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f9cd9026-cad9-421e-9555-b499a6aedac4",
+              "id": "f4c157d3-c8d9-42c0-be2b-674e81083481",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "27acfde0-7d48-491c-99bb-e7449c399754",
+          "id": "eccfeee1-b0cc-481c-acc9-c35f2e44819d",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "e2c65ca7-268f-43f6-9aba-bc2027cc5a39",
+              "id": "94b539d9-903e-43ea-b6b0-143b521425ae",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e0a5cfff-6d42-4384-924f-4ed89c96a752",
+              "id": "91d9e0a5-942e-4025-b696-711cf56aca79",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "20b829ba-148b-4f06-bc6a-a9ce001b8ca0",
+          "id": "6df9abec-0370-4db5-bed0-c35c724d3f4f",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "2a762bc3-232b-4cbc-8b29-80e2d31884d0",
+              "id": "286dfb09-3543-4669-94f8-01d201cc6c1f",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "46b23720-1506-45d9-90dc-9b34b42cc78a",
+          "id": "11c772c0-46e6-4182-8869-18f4cceff684",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "db179270-9cd1-46a7-b263-63cc1f130c85",
+              "id": "e03250ae-cf14-41b2-a0fc-686ae1655059",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7841\n}",
+              "body": "{\n  \"key_0\": 4899.807116108701\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "ef51ef02-dc82-445e-93a6-241a552ec74b",
+          "id": "2d56523a-b819-46b7-938b-8da28498cfd4",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "7060ca0f-3a1d-4be8-b3ee-3ff9789d291f",
+              "id": "d127b0de-163d-47bc-9571-b85263daa6ad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "027bd41d-8d03-46d5-b281-921befbae0e0",
+          "id": "6e59d8ae-de56-4058-ad5d-0d572d384f1c",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "7f50b28f-f676-4ef2-bf8c-2822affce0fe",
+              "id": "4d7c86e5-0b78-4590-953d-ec3787b05011",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "c2ab8a24-9ac0-4020-991a-fa69f0ea51d5",
+          "id": "fa0d4a8b-e4cb-4f8f-a096-66ae731d55a6",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "035a7031-4139-4269-9cc4-886648ba1876",
+              "id": "51d64028-46aa-4529-96cd-ffd131bec4eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "16890ceb-908d-441e-bf65-9fc8c1e32bb1",
+          "id": "2899502f-78be-485b-97e9-797bc5e856aa",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "a4131ee7-73a2-4156-92bf-be16db7c54ec",
+              "id": "d855c9c0-efc0-4703-a14f-140afb9a13ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "ca8ab110-36ef-49af-92dd-ef79964cd9c8",
+          "id": "d4f0dde3-9601-4854-bed7-d40e6a9fd71b",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "c5b1aae3-8794-48e2-aadd-7a074f91fd17",
+              "id": "25ec12ba-e7de-495e-88d8-ffe2624e5cc5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7841\n}",
+              "body": "{\n  \"key_0\": 4899.807116108701\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "7dec9c2e-739b-4aa6-a982-fe2694e00327",
+          "id": "d4ba86a2-7988-4249-a284-37ed2b25c88c",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "cca219ec-4856-42ad-83b3-1b72d0d15a6d",
+              "id": "f15c1e75-5b71-4602-806d-0e2d10f2d758",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "46e2834d-5475-4de7-b30c-f48e76608d62",
+          "id": "dfd81ee4-b4a5-4cfd-a2ce-ad6bfe43491e",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "87bc88ee-6973-4f57-9785-1b855aed8242",
+              "id": "5c1c9528-d48b-4de7-b3fb-4b9b2d3153eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "2896216d-6ef9-4331-9e60-0810c256eded",
+          "id": "d893cff3-4711-4faa-9575-37c20c25d5e1",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "a6306d54-1482-435a-9c5e-09319c6ff2a8",
+              "id": "c6ccd221-986d-4d7a-8968-dd3a4ef6923a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "e1602b31-595b-4d8b-b15a-ae7dc61486a0",
+          "id": "eb1782cf-bde7-4abd-81a9-bd2bf5c691a5",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "c30f7712-58d2-4d11-8b4f-f2c070296a7a",
+              "id": "d2d3fcac-8933-4b9f-b7c8-9d6898112ab3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 7841\n}",
+              "body": "{\n  \"key_0\": 4899.807116108701\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "d519b09e-c088-4234-94a1-f9ba5eacbc0a",
+          "id": "07e75100-5e85-4755-86d3-fa49dcf412c0",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "2f6486b5-90c2-4466-8412-89889457b103",
+              "id": "394c8d3e-9d12-474b-857b-d97d4b69312d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "a8f8604e-2b58-413c-868a-520c2c227217",
+          "id": "457da538-a6da-40de-90ff-79e048e7320b",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "df1aac25-1982-4e0e-ae9b-2c00487a3742",
+              "id": "7e9c7350-1102-4685-af26-1846d7178023",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15533,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "f84aef71-596f-4170-92b8-db0ff4b9dcab",
+          "id": "103a5e7c-c4a1-4d9c-a592-f81b37007ba0",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "ec22e106-9cd2-4578-af72-1394ff1683a8",
+              "id": "a9ef04aa-bbdc-48ce-bd90-d0b7e863f2c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15615,7 +15615,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "acd2c12b-d454-488b-b0de-d0aaacf59ac9",
+    "_postman_id": "eed6b532-595b-4592-a88d-806454998832",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-28 15:01 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-30 09:09 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "5490c149-181c-4768-ab65-3aff133bc663",
+          "id": "26568e32-595c-4a20-af79-dc392e17fd5f",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "c1999ac1-5ef7-4e8b-87c4-2fda4bc87b30",
+              "id": "10cb4013-6ddd-4cf5-a195-a74db1b66c57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "f951c85a-0a64-4ceb-a65c-876695d3afb3",
+          "id": "a5d011d6-93b0-42e7-a36f-2f1901e01b9a",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "ae7f509e-be98-49b9-9585-225a02534d7e",
+              "id": "cbadee3f-9055-4b54-8279-b8969c4e2f01",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "fe4ffb9b-fedc-480c-8f66-e9750f5f8559",
+          "id": "81177086-8ebe-4971-a0ac-f87b5ab521db",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "5cc1c1cf-7d80-45cb-b419-a4d0ac36d620",
+              "id": "70f2b6a0-e5e2-42e7-80e8-e5e8d7fbb151",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "7f536cf9-3eee-479e-9672-d2bb9814bd1d",
+          "id": "73d84a99-9448-4f68-91ce-d7f5d2bad04c",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "889aedf7-d168-4002-8710-9000ba88a30b",
+              "id": "e7f85b2b-505a-4bc2-96ab-418c25a7e8ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "8e170e12-d9dd-45b3-aac6-7c877c66203f",
+          "id": "629d4c2b-1ea2-4449-be9f-840ac1216309",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "f4a9958f-fa0a-4f3c-9a3d-f68baf9f63ad",
+              "id": "eddf79cf-a6b2-4010-b011-7b7960efb927",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "c29713c8-1403-4153-a7f6-77ab0a217e43",
+          "id": "9481e9be-ade1-4ecc-85c3-ecf600bc0f58",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "3b77f405-f3ad-4001-a29e-70e6e2bf90ea",
+              "id": "fd4acb7a-b9cf-4300-90a8-424f5cfaa073",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "edbcdae4-b2c7-4afe-a3b1-eed85df6d1da",
+          "id": "33b5fecd-47de-4831-97ed-6e84f8fdaa4f",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "d439a11a-e114-4e78-9398-4fa236a99e00",
+              "id": "e0562b72-7f0e-465b-9e9b-d2bb7ed003d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "79c9d5a5-370b-47c6-989b-aab4f7249798",
+          "id": "1763c142-31b7-4403-8c4f-7af617badb6d",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "71518ddc-e3b0-4555-9480-9866ba261b23",
+              "id": "12bb5d41-3143-4188-be00-763510e54cea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "45c94fcc-c5af-4dfb-945a-e6b3f197b1fb",
+          "id": "177551e2-3999-4be4-90da-082f44bbafbf",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "0a945963-7286-4a2e-a285-af18085c6aae",
+              "id": "8972d359-71af-4d85-9161-25f45e38951e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "1aaec0ef-2489-414f-a706-963bc53c1903",
+          "id": "9cad7f7a-29d3-4fba-9d45-0e6b4400d92b",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "62fe90fa-0e20-484d-830e-e4f6afbbb897",
+              "id": "dac961c2-f0b2-4a7d-8694-d28c8c8e054c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "b0d9ab2f-87a0-48b9-8323-2b3cd0b21f76",
+          "id": "79ae7de1-4986-490a-8380-3299e842e13a",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "ad3bbdca-d38e-413f-b6ae-5f70c9185a99",
+              "id": "03b49b36-0758-45aa-814d-9847a177a9fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "70d5ceef-93ec-4aa3-8c06-70efbf006a03",
+          "id": "2a8e77a8-4312-4d9e-8d14-b4399a680a18",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "96b0c033-b2df-4a4a-a318-d59e21b10683",
+              "id": "6ab30b34-e867-42b7-99e3-9511b2c2a268",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "76162a81-92f8-4f3a-99a0-6fe1bb8728cb",
+          "id": "636b69a2-7ae6-4797-b0a7-4d8c718c20b4",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "d6bb0432-f4d5-4921-9b94-93b8f56c4a30",
+              "id": "ad2970da-b647-40af-b05d-9b905de63f86",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "2f0ab415-66a6-49b9-b790-e8d686d8c4bf",
+          "id": "34654d1c-bf4a-487e-b94d-b97eb8d18fb9",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "e7e4d9b7-8f72-41fe-8a94-e801772c737c",
+              "id": "6ff1dff0-7790-4a53-8337-8498fbebfe8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "351dd797-e18f-47cf-84bb-c92b024c1d9f",
+          "id": "3991ebf8-0607-4a73-884b-490d30d5db0c",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "8c6a78b1-e2c9-423a-8e6f-40bb5002fc3e",
+              "id": "69e86a69-6456-48da-b0f1-a6e92144d259",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\",\n  \"key_4\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "8b52ede9-9f18-4d12-9c36-d227926550cf",
+          "id": "289eba1b-897b-4dca-bcec-10c2ae80b829",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "ec304832-1839-43b2-abf7-87dd9a4395a7",
+              "id": "2e0cd2b3-141c-414c-b740-47d9e03fcdeb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "ddd71617-5916-4286-849c-6c370ebed43a",
+          "id": "498e0332-cfc9-4834-b990-dd2770a47cb4",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -1886,7 +1886,7 @@
           },
           "response": [
             {
-              "id": "9ce346c0-dfee-4e9a-b27c-c59f1e0d34a9",
+              "id": "7a03edba-e19a-48ec-b71c-c22561858d59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1961,7 +1961,7 @@
           }
         },
         {
-          "id": "dc484892-7485-49fb-8dd5-26f576953211",
+          "id": "19031b7f-5619-44b2-b173-d596fee4fe1a",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2027,7 +2027,7 @@
           },
           "response": [
             {
-              "id": "20f6ac8c-cee4-445d-a903-824951d665d2",
+              "id": "88ea79cc-ef4a-491f-abc1-fc3f75a6c047",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2115,7 +2115,7 @@
           }
         },
         {
-          "id": "5bbda9bf-d178-4c0a-9b77-21586f6ee952",
+          "id": "f9f171bd-94bd-41b0-a46a-b56158368bdd",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2162,7 +2162,7 @@
           },
           "response": [
             {
-              "id": "78597035-76c0-4bc6-9ce7-bc8d821abc2e",
+              "id": "abb82db7-a358-4d77-a35e-97e7c8a01419",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2227,7 +2227,7 @@
           }
         },
         {
-          "id": "6b2f5b69-4963-4c7a-b430-fe8b5d0acf4e",
+          "id": "ff3d415a-233d-4f7d-9818-f8b1af5ed627",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2269,7 +2269,7 @@
           },
           "response": [
             {
-              "id": "1f0920d7-ed00-4687-891a-331b567e30c2",
+              "id": "75a2c0ab-e545-47c7-a95d-6a3419581d09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2333,7 +2333,7 @@
           }
         },
         {
-          "id": "1e7d9039-a79e-4667-8311-893e28734b18",
+          "id": "1f07d525-544b-4aed-abf7-7a464cead953",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2388,7 +2388,7 @@
           },
           "response": [
             {
-              "id": "a05644cd-0357-45c5-a5b4-40cc226157af",
+              "id": "962ce909-da69-4946-a76a-2b7afba3ead9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2465,7 +2465,7 @@
           }
         },
         {
-          "id": "2d6df073-df45-49d4-aef1-a470750f79ce",
+          "id": "f9a112a1-f12e-40a7-a760-778485996a98",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2529,7 +2529,7 @@
           },
           "response": [
             {
-              "id": "3eb9cc1b-ea2f-4dca-8f37-489f2dcc29af",
+              "id": "e40a0284-75c5-4548-bac6-cb3ccedc9410",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2621,7 +2621,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "ac195429-4fdb-4e7f-940c-a567623bd020",
+          "id": "d246b197-99c5-4de5-915b-b547ee02eda5",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2663,7 +2663,7 @@
           },
           "response": [
             {
-              "id": "a5f97810-4b42-4c83-9b84-75fa7750a3ac",
+              "id": "c579f472-081c-4ae1-b18a-83a0b5fdcdc7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2727,7 +2727,7 @@
           }
         },
         {
-          "id": "03e2c750-89c4-4980-86ee-a5193c3af360",
+          "id": "ee6979d4-3959-4a8a-957b-4c0462529378",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2770,7 +2770,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bc8dA2\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FA0583\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2782,7 +2782,7 @@
           },
           "response": [
             {
-              "id": "ce733d01-e186-4cb8-9118-5277b22b9a16",
+              "id": "23af8fee-33b8-4de2-b27b-3bfcabb352fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2831,7 +2831,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bc8dA2\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#FA0583\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2859,7 +2859,7 @@
           }
         },
         {
-          "id": "e770ab71-c1a4-4d9b-9791-4e87c7845870",
+          "id": "92cd5b02-71f1-402f-9de3-077944e5bda1",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -2895,7 +2895,7 @@
           },
           "response": [
             {
-              "id": "20959a54-446b-40b5-b5c1-ee85fdfe101c",
+              "id": "08fc719d-6f1e-4698-9a01-9653c13b08a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2949,7 +2949,7 @@
           }
         },
         {
-          "id": "746e8cf1-43f0-4038-95de-3e574388e3ea",
+          "id": "2484705b-0368-4ec2-81a4-2517ba274f5e",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -2979,7 +2979,7 @@
           },
           "response": [
             {
-              "id": "14531862-2f3c-4e70-b794-c01248401d2a",
+              "id": "0061d5a8-781f-4476-82ba-7b0bd69aa6b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3031,7 +3031,7 @@
           }
         },
         {
-          "id": "496ee8ef-b2bc-402a-ace8-28e0d23741d9",
+          "id": "33375ff6-5b4b-4338-9702-ffa258a5bc5e",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3062,7 +3062,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A4A1F2\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3fBD19\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3074,7 +3074,7 @@
           },
           "response": [
             {
-              "id": "f2afed09-6c97-492b-9f27-7458d0c3c1dc",
+              "id": "97153d53-ed94-48d6-92bf-c18fdf9624d7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3111,7 +3111,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A4A1F2\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3fBD19\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3139,7 +3139,7 @@
           }
         },
         {
-          "id": "b2065d22-28e2-406f-911a-25a373325e9b",
+          "id": "774f2f04-8a94-4688-afbb-42ce36ef0534",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3170,7 +3170,7 @@
           },
           "response": [
             {
-              "id": "a7a31950-25f3-4a56-8d00-54432661e86b",
+              "id": "a78f15ae-71f2-4c30-86e0-86044bbce515",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3229,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "92b0840c-af52-42b8-a8d7-22a3c0384d4b",
+          "id": "f89199d8-26cd-4ac0-8431-51ba0f927c67",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3271,7 +3271,7 @@
           },
           "response": [
             {
-              "id": "c0438b61-4c8d-4a8a-940a-4df92c2b8ede",
+              "id": "285e41c9-9cc0-40bf-9618-6bac5ec9103f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3335,7 +3335,7 @@
           }
         },
         {
-          "id": "3bd37ae1-2e1c-4a73-8e0d-6d08b74219a0",
+          "id": "503ec0cc-bdb1-472d-bf09-4300fe84a41d",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3390,7 +3390,7 @@
           },
           "response": [
             {
-              "id": "40b5f8b2-7b9a-4385-ae12-bd5739233255",
+              "id": "5b1ff0b4-cbeb-45b2-b827-73c158b612c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3467,7 +3467,7 @@
           }
         },
         {
-          "id": "3a0dcec8-f3a5-4a71-a6d4-cb4b75a27946",
+          "id": "48312769-cac6-4190-afcb-50fc7e8c401f",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3509,7 +3509,7 @@
           },
           "response": [
             {
-              "id": "81c135d5-159b-4fbc-81dd-976cc7fe434f",
+              "id": "265892c7-79cc-43ab-bf06-7d5e15c3a546",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3573,7 +3573,7 @@
           }
         },
         {
-          "id": "3eb328d5-3d6c-4b0e-b47a-3527b36d91ba",
+          "id": "40c7a621-1537-46c5-9856-ee2985409a6e",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3603,7 +3603,7 @@
           },
           "response": [
             {
-              "id": "5a4d9029-d042-47a5-a5e8-449e5f48b38a",
+              "id": "e998499d-a706-4663-a670-1e3ef59e8497",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3655,7 +3655,7 @@
           }
         },
         {
-          "id": "f8119043-739c-4ce4-b5d5-c02b3a38f2b9",
+          "id": "2756945d-a423-482a-86aa-aac2090c8943",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3698,7 +3698,7 @@
           },
           "response": [
             {
-              "id": "7fe541ff-c4f4-4daf-a906-fe409e9e5050",
+              "id": "73229f45-615c-4f5b-a2be-7f0cfadcff16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3763,7 +3763,7 @@
           }
         },
         {
-          "id": "f5a3974a-4b08-4a29-a2a2-66e6ccbbea34",
+          "id": "f4d053b9-d232-4439-86d0-2d66376a02b9",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -3816,7 +3816,7 @@
           },
           "response": [
             {
-              "id": "4e04602f-2563-4ad5-badf-4838cd076569",
+              "id": "03b6b357-4768-48df-9d8e-f8be4f8cec2f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3880,7 +3880,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 4899.807116108701\n}",
+              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3891,7 +3891,7 @@
           }
         },
         {
-          "id": "cfb7073d-1945-4d84-bd11-c94502cebc62",
+          "id": "b8cc4cf3-7a4b-42d4-862e-33e65b96c8f6",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -3934,7 +3934,7 @@
           },
           "response": [
             {
-              "id": "02c06885-40c0-4809-8840-ca42aa94ce66",
+              "id": "dfe4b162-2bd2-4b09-a665-4bf56ff11921",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3999,7 +3999,7 @@
           }
         },
         {
-          "id": "1e53ce08-eb1f-4b6b-b35f-5f9498a9a704",
+          "id": "f7f8f50a-1fd0-4854-9948-2e63b408234f",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4030,7 +4030,7 @@
           },
           "response": [
             {
-              "id": "9074b615-82a1-49cf-b795-6f901ad9e340",
+              "id": "821af4bb-4c65-4c19-aabc-e40c0c342f3b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4089,7 +4089,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "a182081a-3f1f-4ce3-9208-6f6ecd472534",
+          "id": "e321a21d-bdfb-4e38-b515-17a43bdd153a",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4131,7 +4131,7 @@
           },
           "response": [
             {
-              "id": "25391f28-0bcc-4986-866a-474bc857e67d",
+              "id": "0f8bb88e-1a34-4e4a-8dda-e64730d7d096",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4195,7 +4195,7 @@
           }
         },
         {
-          "id": "e18b5a01-e5e6-4ea4-a195-659c9009d8ec",
+          "id": "5859854e-2f65-4ed6-8fbf-76c51cb07912",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4238,7 +4238,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4250,7 +4250,7 @@
           },
           "response": [
             {
-              "id": "a12d92a9-283c-4d02-918b-a727588e1538",
+              "id": "64ea46bc-4802-458b-8a95-f50f6003345f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4299,7 +4299,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4327,7 +4327,7 @@
           }
         },
         {
-          "id": "b24bb374-3ee4-47a0-955c-74bb327a75f5",
+          "id": "e545d71f-36ff-4384-9afa-011da8cb9c4a",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4363,7 +4363,7 @@
           },
           "response": [
             {
-              "id": "ba863190-9c82-4c1e-b168-8f9bb5761a38",
+              "id": "75a3f94f-548c-482d-8023-bb1a8029fb80",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4417,7 +4417,7 @@
           }
         },
         {
-          "id": "0181f82d-c2b2-4020-b403-51d2ce3d7519",
+          "id": "14e41932-472d-4090-8e48-5ddc4da343ca",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4466,7 +4466,7 @@
           },
           "response": [
             {
-              "id": "44746dd6-363e-4f57-af12-0d2db06ddd7f",
+              "id": "95a4f0c9-2972-45a0-bb54-c78d69a03c6f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
           }
         },
         {
-          "id": "45ab84b1-6ea5-4ad9-95e4-f2cbb574fb01",
+          "id": "5ae56112-8758-4793-a314-0c7ffd0c3256",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4568,7 +4568,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4580,7 +4580,7 @@
           },
           "response": [
             {
-              "id": "93551e6c-8d6d-48ec-b6ab-e0767b5d463c",
+              "id": "0e9f255a-26e5-4437-9dc3-22c11df9b48f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4617,7 +4617,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4645,7 +4645,7 @@
           }
         },
         {
-          "id": "2ec9f816-7b1e-4203-b906-c93a11a3f112",
+          "id": "60fa9559-a570-4ea5-97fc-ef401c878e9f",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4688,7 +4688,7 @@
           },
           "response": [
             {
-              "id": "4b758455-8413-4f29-8aad-820b1b88d83b",
+              "id": "f3104b57-1c30-4acd-ba58-49f1332642b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4753,7 +4753,7 @@
           }
         },
         {
-          "id": "3872f66d-1c4c-437b-92b5-a6a56468d0a8",
+          "id": "72ee1ea2-b548-40bb-b843-90a536936995",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4796,7 +4796,7 @@
           },
           "response": [
             {
-              "id": "8071ddd5-859e-4f8f-addb-d7ee47ba627a",
+              "id": "e62509ae-5b8b-4cfd-b5e0-01e13f30986b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4861,7 +4861,7 @@
           }
         },
         {
-          "id": "16ca39bd-0a2e-4aa1-ab97-a0dedc94074e",
+          "id": "dbb5d699-0aec-407c-92d3-562603549329",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -4892,7 +4892,7 @@
           },
           "response": [
             {
-              "id": "d63333fa-2a20-486d-9522-9776a316b59b",
+              "id": "9b85e7b7-bdb1-4658-b0d9-b52535360681",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4945,7 +4945,7 @@
           }
         },
         {
-          "id": "6f68a8c0-aa5d-42bc-a2fe-9476a6156b82",
+          "id": "4aa9b84f-7d99-4451-9c74-043208cd2614",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -4976,7 +4976,7 @@
           },
           "response": [
             {
-              "id": "51587a3b-09e6-4a4d-adb2-c8637252c35b",
+              "id": "e1d6100e-40b8-442f-acca-e748f591041d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5035,7 +5035,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "81e88f05-edfa-49d0-ab70-48df419e0908",
+          "id": "f4f4c815-9b92-4c3f-8f11-9623dabdbace",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5077,7 +5077,7 @@
           },
           "response": [
             {
-              "id": "dac9be09-5a90-42f4-90d9-38ea6f3f2a3d",
+              "id": "8862b0d1-39cd-4e4c-ba66-b6f5329b5859",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5141,7 +5141,7 @@
           }
         },
         {
-          "id": "440afb38-c8aa-453c-9c59-af8b03fbce06",
+          "id": "87b8aa07-a381-4e87-895c-319671a2e6d9",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5196,7 +5196,7 @@
           },
           "response": [
             {
-              "id": "77f5a8e8-c39d-4610-9b2d-94e27f5c9ee5",
+              "id": "88753309-0fbb-4721-9692-c8c0a0cf89db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5273,7 +5273,7 @@
           }
         },
         {
-          "id": "2100fd59-23f5-42c2-a83f-c9a0f97a1441",
+          "id": "8d754ff3-8431-4b4a-836d-969eb088a19a",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5309,7 +5309,7 @@
           },
           "response": [
             {
-              "id": "70177c48-4aba-4371-9d3b-d695bc8d10f7",
+              "id": "3f9088b0-d6a7-4077-9ac2-68b193f966d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5363,7 +5363,7 @@
           }
         },
         {
-          "id": "e1c7e633-b6ca-44b9-bffc-6633d10d21b0",
+          "id": "103fc98a-ce2a-4003-9372-8f2de2c8c070",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5393,7 +5393,7 @@
           },
           "response": [
             {
-              "id": "beff1f93-80a0-48d6-9f9e-3f3f0077cc94",
+              "id": "274935b7-f28c-46b7-a748-8fdf74af56c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5445,7 +5445,7 @@
           }
         },
         {
-          "id": "54af0283-9ebb-4670-bf9a-62b73a70c5b5",
+          "id": "e959c406-9cf8-4e06-813e-2c8498a77adf",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5488,7 +5488,7 @@
           },
           "response": [
             {
-              "id": "8cfd32ed-885a-4828-b680-21af41bb010f",
+              "id": "37027f12-8d62-4236-9abd-77a3ff7c5b06",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "76247d79-60d5-4e1e-a33f-e6a8c50707a9",
+          "id": "afb608a6-6712-4a33-a397-6610b44e6323",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5612,7 +5612,7 @@
           },
           "response": [
             {
-              "id": "cac3f96d-cd5a-4528-b2f7-c042a2e38509",
+              "id": "ec0ebd26-f004-46ed-87be-033fefdb88dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5687,7 +5687,7 @@
           }
         },
         {
-          "id": "0453e313-b2f4-4099-b4d9-395f6ed4b50a",
+          "id": "9d0f5e49-5612-402a-a830-3c30c199b1c0",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5753,7 +5753,7 @@
           },
           "response": [
             {
-              "id": "5e5c86bf-d9ea-4b8a-bc27-44df6e91b8f9",
+              "id": "27acaaa3-3bf5-4f2f-9b0e-de92bf0b7ee6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
           }
         },
         {
-          "id": "098b0507-5229-4161-b3f5-cd7378cac690",
+          "id": "5d37e1be-e5ec-4800-b1bc-89f43ca9eafa",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "574d2ccc-2ff2-4e13-ba8d-238a853f9dbc",
+              "id": "4db1b259-99c3-4a1b-90c0-2d9ac61e3a7b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "15a3a15d-8c70-486f-9700-05cde13bfff3",
+          "id": "a0f913d1-352b-4b01-a4d0-b5d15c6925e7",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -5995,7 +5995,7 @@
           },
           "response": [
             {
-              "id": "a9b4b2cb-e31b-4989-bfd1-d9b5197fd22b",
+              "id": "a827e889-62f9-4f20-93db-9756ec25a047",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6059,7 +6059,7 @@
           }
         },
         {
-          "id": "f6c7c7cc-82ed-4217-898f-adc33eaa1cdb",
+          "id": "55ed8d4b-7a4f-40d6-b64e-d13d49488eae",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6114,7 +6114,7 @@
           },
           "response": [
             {
-              "id": "7983f5ce-a00f-4bfa-8207-238025894cd4",
+              "id": "869f56b9-8360-4e3f-a5bb-e46b7ea063a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6191,7 +6191,7 @@
           }
         },
         {
-          "id": "765478ee-0926-4d2a-bd46-8b5e158a2eac",
+          "id": "3f0ef7c2-de16-47bf-9964-562bfcaa6d53",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6258,7 +6258,7 @@
           },
           "response": [
             {
-              "id": "e3cb9bb1-eb11-4800-8eb5-5d359899c6cb",
+              "id": "7b63ef45-b67f-4ca7-8876-ebad3a02b371",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6347,7 +6347,7 @@
           }
         },
         {
-          "id": "71056e6e-8de1-4df1-be6d-c0abb29adfcb",
+          "id": "9d3277d7-d700-4e2c-be66-f690b20737de",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6401,7 +6401,7 @@
           },
           "response": [
             {
-              "id": "de7e1dfd-9a41-4618-b626-9949977ec27b",
+              "id": "627063ce-d7d4-4661-8ca5-e593f036173d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6483,7 +6483,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "12a7b22b-fb5e-40db-bbee-909c95101571",
+          "id": "2a677455-d371-4ff7-a10e-bb88ee84f100",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6536,7 +6536,7 @@
           },
           "response": [
             {
-              "id": "da367381-0e36-4bf5-be11-b10b595b6c16",
+              "id": "b6bc0ac4-79b8-450d-9b35-20c734c519b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6611,7 +6611,7 @@
           }
         },
         {
-          "id": "6ff04b69-8fc4-4135-b2d7-c28c55931973",
+          "id": "64e1f491-b73b-4ecf-b629-c0cd28ec360e",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6677,7 +6677,7 @@
           },
           "response": [
             {
-              "id": "2d5f9573-3a54-402a-a9aa-882a7123d2d1",
+              "id": "d5d7f926-82a5-4535-8124-b17158e12ee6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6765,7 +6765,7 @@
           }
         },
         {
-          "id": "4c9f1c8b-dc91-4833-b380-40bd83638747",
+          "id": "8a42ad78-e2f6-41d5-b731-6ae7e6ecfe4f",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -6812,7 +6812,7 @@
           },
           "response": [
             {
-              "id": "fc10d07e-f0b6-40e5-85d9-f33e6a1da837",
+              "id": "ec1bfd85-1a19-4561-9ddf-c8e53003b510",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6877,7 +6877,7 @@
           }
         },
         {
-          "id": "c29d4a3f-44a5-406d-9dc1-e1c862ed167c",
+          "id": "5efe6380-41b6-4d74-ba4b-d66fb00b8996",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -6919,7 +6919,7 @@
           },
           "response": [
             {
-              "id": "72e6906a-c334-415a-83a2-8401d578873e",
+              "id": "d8a3ff9a-d80c-429e-bc0d-7458ff62814b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6983,7 +6983,7 @@
           }
         },
         {
-          "id": "9c0de23d-97db-48ba-85fb-7345d831b857",
+          "id": "d7fc72c2-1e84-4a59-9c6e-83d4ed1d10b8",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7038,7 +7038,7 @@
           },
           "response": [
             {
-              "id": "1e8225e6-852c-4484-958d-d881587d7ae2",
+              "id": "3b7d9164-d0bc-4511-bc3f-b2c7a69fe456",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "ae7b2774-949e-4bce-84fb-61f061c3786e",
+          "id": "68abd3f5-ec93-4c77-94e5-0b46f29f1432",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7162,7 +7162,7 @@
           },
           "response": [
             {
-              "id": "532fa8a7-297e-4a8d-9f66-e4e880e52617",
+              "id": "5ece8cde-8330-4cd2-b129-114b0107ee03",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7225,7 +7225,7 @@
           }
         },
         {
-          "id": "38ce7bdf-74ac-4b48-b7d2-8b94fdc36cff",
+          "id": "a4452dea-72b7-4396-80c7-930327db7d68",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7279,7 +7279,7 @@
           },
           "response": [
             {
-              "id": "75c648cd-bbba-4e84-8213-5389f8ed3cdc",
+              "id": "a8af667f-8553-44ec-b33c-629a3e6cecb2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7355,7 +7355,7 @@
           }
         },
         {
-          "id": "ad68ea5d-727a-4d39-bdc9-453d9446d85f",
+          "id": "9ff70d6c-79f2-4387-b886-8ed40ae33a98",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7390,7 +7390,7 @@
           },
           "response": [
             {
-              "id": "288c4c7a-88b9-4cb5-a78e-77020794898c",
+              "id": "406ca3da-51a8-4f96-ba89-e9fbc2b76375",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7443,7 +7443,7 @@
           }
         },
         {
-          "id": "8936139f-8c60-4405-8880-67cd26c9c0e1",
+          "id": "7252b884-9e0f-4434-930f-fc16834f618c",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7500,7 +7500,7 @@
           },
           "response": [
             {
-              "id": "10b231f7-bfb3-4093-a836-774169122b11",
+              "id": "f25ed379-848f-40a6-a0f1-138c78a9741a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7579,7 +7579,7 @@
           }
         },
         {
-          "id": "48063644-4476-47ab-bab7-f8e4445dab81",
+          "id": "215f24b2-85c8-4c03-853e-78a07582c33b",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7621,7 +7621,7 @@
           },
           "response": [
             {
-              "id": "f2354839-198d-4107-abab-3e2aed28b3b2",
+              "id": "b2ffcc84-dd56-4704-b0a0-13c319784211",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7691,7 +7691,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "c18cb8db-3d89-4ce1-937d-22b900c9d13c",
+          "id": "0a4ad31d-3812-425a-9db3-b62b9c297c00",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7744,7 +7744,7 @@
           },
           "response": [
             {
-              "id": "1f4efcac-bb1e-4fdb-9a52-f02070135710",
+              "id": "60252dcc-088e-4258-8c9f-3f169dad2fb2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7819,7 +7819,7 @@
           }
         },
         {
-          "id": "2e2b49ee-6ed4-464c-a27c-fd0c22a713eb",
+          "id": "17000dc5-73b1-40cb-8c5c-af37318c914f",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -7885,7 +7885,7 @@
           },
           "response": [
             {
-              "id": "1fd4cc98-26d9-4fd0-b0a6-73d4a5989c3c",
+              "id": "ffea569d-13db-488d-beb5-10a3c289ec0f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7973,7 +7973,7 @@
           }
         },
         {
-          "id": "62f10c3f-8370-4fc3-9cbc-514907a798a3",
+          "id": "12cfe5ae-01d3-446d-bc76-f281e2ff328b",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8020,7 +8020,7 @@
           },
           "response": [
             {
-              "id": "b12b0c77-5ba5-44e0-acd6-cc7f4287d7d5",
+              "id": "3d3afd1a-3a36-4c93-96fc-33b5a14b0b8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8085,7 +8085,7 @@
           }
         },
         {
-          "id": "ef51e7de-45db-4ba2-8cfe-cc8812e46bdf",
+          "id": "074d138e-e53b-42d8-9602-fe68faf979b1",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8127,7 +8127,7 @@
           },
           "response": [
             {
-              "id": "7213a19f-3955-4e3e-8237-ac3380fbf37c",
+              "id": "e6083200-7d33-4e7d-8fc2-5776abc92218",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8191,7 +8191,7 @@
           }
         },
         {
-          "id": "59081dab-d0e4-477f-aaef-aac1fb93fd27",
+          "id": "fe1c7723-a808-4b1d-af0a-8c52efc98399",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8246,7 +8246,7 @@
           },
           "response": [
             {
-              "id": "4ac6458a-5b2b-49a5-b482-6768e95d675d",
+              "id": "5d25a42a-a0c0-4070-9aea-f5f9b80f7b91",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8329,7 +8329,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "8ed9e38b-b7af-438a-8fdf-a1c5ace45bff",
+          "id": "4381054e-e31b-4f6b-85a7-2124c35ad80d",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8371,7 +8371,7 @@
           },
           "response": [
             {
-              "id": "f7a0068e-b439-4c31-b886-9d4808110d77",
+              "id": "d20cc8dd-0323-4854-b9df-f41c9e4c5f57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8435,7 +8435,7 @@
           }
         },
         {
-          "id": "01e64d12-fe89-4e39-b90b-725fe0025226",
+          "id": "ac824088-51bf-4c29-915a-f3ae8dcea24b",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8490,7 +8490,7 @@
           },
           "response": [
             {
-              "id": "21f2b082-3de0-493c-bc69-b2a04d9b4bd7",
+              "id": "c2f00c50-e541-47d8-a724-c997f731d4fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8567,7 +8567,7 @@
           }
         },
         {
-          "id": "42ddfb1e-5326-4062-bf07-1a58dce39622",
+          "id": "c0a3aabf-229d-45bb-8f18-9298f0683ed1",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8603,7 +8603,7 @@
           },
           "response": [
             {
-              "id": "ebeaa40b-a22c-49b3-a8dd-89e8b4f04401",
+              "id": "18c80b2a-2513-49fa-b3fc-3e6ad4444e88",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8657,7 +8657,7 @@
           }
         },
         {
-          "id": "ab16c17e-3e68-4c81-9bf0-9c1b8919ca45",
+          "id": "fce674b7-6420-4bb3-b321-3d5edd7aa781",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8687,7 +8687,7 @@
           },
           "response": [
             {
-              "id": "b7d23c78-9636-43b5-9136-6d429d4f7eff",
+              "id": "681eb9d8-4dc8-483d-bb21-7fc9f50d2ab4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8739,7 +8739,7 @@
           }
         },
         {
-          "id": "e917c884-5dd9-4f74-a2aa-58f2441fe9ee",
+          "id": "5532b0e6-da20-4f67-939d-f252a8515611",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "d67cf808-370c-4ce8-ba92-11bacf2e13ae",
+              "id": "cd60abd3-aa7f-43f9-b527-13ecf53534b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8853,7 +8853,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "34b30267-08ea-4e55-8bdd-79f5b243fe73",
+          "id": "cf1fea4d-f8c7-429f-a815-e97bd3e1d0bc",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -8895,7 +8895,7 @@
           },
           "response": [
             {
-              "id": "96773cc6-1201-420c-99af-d9a6e06b33f9",
+              "id": "efb9a628-7f62-4795-bf9c-981a21fab526",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8953,7 +8953,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "bc8a90c6-0a8e-4d79-9222-3574ef0ae338",
+              "id": "672e09d9-b80e-427d-9e38-36e8fed40673",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9017,7 +9017,7 @@
           }
         },
         {
-          "id": "d9ebed64-5e0c-4a81-8911-8b34e943ba7b",
+          "id": "536f6bff-831a-4430-9db8-e2a17b2706fd",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9072,7 +9072,7 @@
           },
           "response": [
             {
-              "id": "039a76c7-54df-4d89-8307-2cad49bffe70",
+              "id": "f0828eba-48ef-40d8-9592-e6f276809520",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9143,7 +9143,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "45d650c2-846d-4499-af22-64264078f527",
+              "id": "91da6185-b51a-4ea8-b828-31417b5be569",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9214,7 +9214,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "883cb606-0f73-4263-a49e-055235c929ed",
+              "id": "fe5f7caa-f256-45a6-b41d-83821e24cf09",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9291,7 +9291,7 @@
           }
         },
         {
-          "id": "9d84f764-f17e-40ec-8ab8-b247ccbcf3c8",
+          "id": "0035e2d8-0261-4595-baf6-94cd9477867f",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9327,7 +9327,7 @@
           },
           "response": [
             {
-              "id": "62500b32-7692-442b-9cf4-0af85c4785c1",
+              "id": "3cb9afdd-db4e-4254-803c-894df248fb70",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9375,7 +9375,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e6d20a96-a88f-49dc-a726-ff2a4fb86070",
+              "id": "6f4f90cd-07cf-4abd-9cf1-38c7ec7ba7a8",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9423,7 +9423,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "9707408e-d353-4f5c-9ab0-59522ec51439",
+              "id": "44f0432d-6eb2-4775-98e8-df240f10292a",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9477,7 +9477,7 @@
           }
         },
         {
-          "id": "bbfe1898-7ce4-4ab6-8036-3b9f1f6a39a9",
+          "id": "c03ae8bd-1a9f-424c-a0c7-af952be3de51",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9507,7 +9507,7 @@
           },
           "response": [
             {
-              "id": "4572ea5c-54fa-4058-9843-de10e363c65c",
+              "id": "45bec1da-e326-4e4a-8850-93eb0d618746",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9559,7 +9559,7 @@
           }
         },
         {
-          "id": "34f622bc-0736-4275-afd5-68130e2b2ea8",
+          "id": "e7dafffd-4859-42f7-a2da-a6d2240b3f66",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9602,7 +9602,7 @@
           },
           "response": [
             {
-              "id": "63b8e2f4-d46e-4815-a26f-7da1cfae97d9",
+              "id": "ceaac097-f6e7-4342-a71d-e46d00f5c9cd",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9661,7 +9661,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b45007c8-073f-438f-99a1-5045fb262786",
+              "id": "347ba6d9-c3b9-4e64-bb55-7df2007f022e",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9732,7 +9732,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "f30c7c83-8092-4d99-a857-4d2fe0d76f18",
+          "id": "0d0075da-3562-4afe-9923-86a2ff7d9b8c",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -9798,7 +9798,7 @@
           },
           "response": [
             {
-              "id": "bdebc86a-8a49-4ba8-938c-9fff016da171",
+              "id": "3d1bf687-44c4-42e9-b793-e77efe7c6c72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9872,7 +9872,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 4899.807116108701\n}",
+              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -9889,7 +9889,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "5997d56c-ff6c-42dc-8821-8b9af2637f30",
+          "id": "736d38a0-bbaa-4a49-b8c8-b52e3c56e89e",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -9931,7 +9931,7 @@
           },
           "response": [
             {
-              "id": "f6ce0b90-94eb-452b-916f-b786647c1cfa",
+              "id": "0a8d75b2-9e2a-4b7f-98e8-2539849d0b7a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10001,7 +10001,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "ae2d22db-d2f4-46ba-b034-ce7437842898",
+          "id": "e822dd44-d5a3-4875-936b-ee853b0d7704",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10043,7 +10043,7 @@
           },
           "response": [
             {
-              "id": "516d8636-4577-4836-83d1-f0add13b7317",
+              "id": "bd5870bb-183f-46ea-bd38-c1a9fa9dc59d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10107,7 +10107,7 @@
           }
         },
         {
-          "id": "a468066a-2d9e-440e-abc6-168d341d50c1",
+          "id": "134642d3-c342-4d27-acc4-1d69f648c701",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10150,7 +10150,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5bea73\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2Aec4F\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10162,7 +10162,7 @@
           },
           "response": [
             {
-              "id": "911507ab-d3dc-42ef-b907-391880d493a7",
+              "id": "5d07423f-6899-4b93-9d9b-a8fdaac90d60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10211,7 +10211,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5bea73\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2Aec4F\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10239,7 +10239,7 @@
           }
         },
         {
-          "id": "b2e9134e-a95f-4443-96d8-fb319d851c76",
+          "id": "7f1dbd83-44b7-4f45-9b9c-4f8cf56cd997",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10275,7 +10275,7 @@
           },
           "response": [
             {
-              "id": "15a8bbd9-ff41-4c8b-8ea9-71fc20d888b8",
+              "id": "d9c9aadc-1f2b-4431-bcfe-93cefed7c72b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10329,7 +10329,7 @@
           }
         },
         {
-          "id": "ce414842-0bb5-40b7-813b-ef808034c93a",
+          "id": "0fe7d98f-0ffd-46a9-95ea-d2af1b14667b",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10359,7 +10359,7 @@
           },
           "response": [
             {
-              "id": "40b5637d-d577-46ce-b133-301c698ff134",
+              "id": "e3788b4b-d540-4ba0-9b8a-c5178b8cc746",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10411,7 +10411,7 @@
           }
         },
         {
-          "id": "820706a7-f091-4014-844e-59a1c0c9b824",
+          "id": "efb1e374-0778-4103-85ab-4a376d3bd1ec",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10442,7 +10442,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bC8f4E\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#115F4e\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10454,7 +10454,7 @@
           },
           "response": [
             {
-              "id": "f012b701-5476-4993-b75d-e3a0d2a7aa17",
+              "id": "f93c15b9-e579-4acd-87a7-40eba8574577",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10491,7 +10491,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bC8f4E\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#115F4e\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10519,7 +10519,7 @@
           }
         },
         {
-          "id": "4170d627-3f90-40e1-8968-8c053eac9f17",
+          "id": "16164054-83d9-4936-b6e8-d1db5f5f3604",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10550,7 +10550,7 @@
           },
           "response": [
             {
-              "id": "15e107d2-eec5-48c5-95a1-d0a9fcaf1f92",
+              "id": "0fbaf957-afa9-4d3a-b96c-9429d7071ffa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10609,7 +10609,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "08372201-501c-45d4-a16a-a1f8ec812dcb",
+          "id": "744bdebe-cbcb-42c3-8097-e18983e4311d",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10662,7 +10662,7 @@
           },
           "response": [
             {
-              "id": "88409f52-669c-41f9-a6f3-e331a46f4fc6",
+              "id": "ce9ae4df-b8a9-4ae9-8947-6e0525184807",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10737,7 +10737,7 @@
           }
         },
         {
-          "id": "ba76ff18-7df0-4260-8037-fd0d37fe878b",
+          "id": "a856246a-4552-4d54-857e-db3f4783bf4f",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -10803,7 +10803,7 @@
           },
           "response": [
             {
-              "id": "b3ab77bb-0d99-453c-b28c-ef82060d2079",
+              "id": "6346ec7a-4d23-479b-9e39-e36ed8e122da",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10891,7 +10891,7 @@
           }
         },
         {
-          "id": "7628d4f2-bd31-43e4-9e00-bea830ac7f71",
+          "id": "5300e0bf-2867-491a-802a-5df0be957297",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -10938,7 +10938,7 @@
           },
           "response": [
             {
-              "id": "17d216ad-20da-495f-bf86-2e35afc5f0c4",
+              "id": "7a5d5da5-94ff-4540-a1b9-ffafbda9df4c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11003,7 +11003,7 @@
           }
         },
         {
-          "id": "ab8901ee-ed0d-4e55-87c0-627b4e9ce00e",
+          "id": "ce099c10-afe6-408f-8e66-52a9c0503b55",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11045,7 +11045,7 @@
           },
           "response": [
             {
-              "id": "4ba63c98-52df-4e74-a26f-b94247af9ce9",
+              "id": "98d00e34-3563-4270-943a-cbc0809c5e69",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11109,7 +11109,7 @@
           }
         },
         {
-          "id": "3a9612a9-6a1e-449a-bdd5-231b4cf501f8",
+          "id": "6701f7ca-b043-43a0-a35e-dc6d6e9dad5b",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11164,7 +11164,7 @@
           },
           "response": [
             {
-              "id": "4739e452-53f7-482c-b655-ee7445fb7616",
+              "id": "3b9d1f1d-30b9-48c2-b18b-cd04c271d19c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11241,7 +11241,7 @@
           }
         },
         {
-          "id": "cba8a019-2274-400e-a184-03b25d9a3141",
+          "id": "9ad62f39-7ddb-46a8-8418-aaad259563fa",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11295,7 +11295,7 @@
           },
           "response": [
             {
-              "id": "72906837-e53e-4144-8656-532803594d7e",
+              "id": "ad7593ce-6b47-437e-81a7-17131eeccabd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11371,7 +11371,7 @@
           }
         },
         {
-          "id": "d3ea596e-801f-413e-9cd5-7c5718332486",
+          "id": "94dfff15-1bb7-434e-a84f-8b6de73ee0c9",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11437,7 +11437,7 @@
           },
           "response": [
             {
-              "id": "48006e15-a053-4a30-9daa-96aab37478d2",
+              "id": "8313f751-3502-4769-b8bf-861cd761375d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11525,7 +11525,7 @@
           }
         },
         {
-          "id": "136d65bc-a119-4c21-9f9a-280ea16ad117",
+          "id": "55462954-351e-476a-a230-9d0c6a1e3dc8",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11603,7 +11603,7 @@
           },
           "response": [
             {
-              "id": "f154667c-9aba-49fa-a90c-0daaad5e4333",
+              "id": "3726dc63-6cbb-43eb-b869-0dbebfaac18f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11703,7 +11703,7 @@
           }
         },
         {
-          "id": "a2cb178e-394b-4f9b-8296-d0732472a247",
+          "id": "a2c8b67c-37f8-4c7f-96de-b2ec2f618529",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11769,7 +11769,7 @@
           },
           "response": [
             {
-              "id": "b4d4c7d2-54b2-4a8c-a51b-94b9891c7f7d",
+              "id": "49b4f206-582d-4a78-9f56-78cd4bf7e6e0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11857,7 +11857,7 @@
           }
         },
         {
-          "id": "423ae308-db70-4027-87f2-12c41333bb75",
+          "id": "a4dad8b1-1536-4a9d-b376-d2a79ca2693b",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -11912,7 +11912,7 @@
           },
           "response": [
             {
-              "id": "72dac79d-4ef0-44db-b2ce-889273ee4279",
+              "id": "b44e902b-6ac2-4cb5-bf86-3a63d91acb5a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11995,7 +11995,7 @@
       "description": "",
       "item": [
         {
-          "id": "2fc30667-db65-41db-b529-5cb0899400db",
+          "id": "91be4304-285a-422b-afd6-74e5dfb3d026",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12036,7 +12036,7 @@
           },
           "response": [
             {
-              "id": "a53e593b-241a-4b6a-adaf-3bf9e39bc8c2",
+              "id": "d15b50bf-4581-4831-ab52-171032432709",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12099,7 +12099,7 @@
           }
         },
         {
-          "id": "ea8ef8e4-59b9-4d56-af86-6f06dfd08d2b",
+          "id": "6f8e959f-d308-4d33-a1b3-5a1d6b3501b9",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12153,7 +12153,7 @@
           },
           "response": [
             {
-              "id": "b9f76c75-1d41-407a-93c5-6f75c971601b",
+              "id": "7a6a98f6-b3d0-4b3b-8bbd-acd9c7a7c7fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12229,7 +12229,7 @@
           }
         },
         {
-          "id": "e6377486-df91-40fc-827a-7fa825272ae9",
+          "id": "73c5b95c-6c56-4754-826d-52ccaffc5b27",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12264,7 +12264,7 @@
           },
           "response": [
             {
-              "id": "1b8de95b-6db8-4958-9472-dad5be8c574d",
+              "id": "f34327a7-c7e7-4004-8a42-697643993f7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12317,7 +12317,7 @@
           }
         },
         {
-          "id": "298ef7f2-9b0c-453b-8b84-be12ed846b3d",
+          "id": "a70c4492-969e-47d0-8ec8-0680ada8774d",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12378,7 +12378,7 @@
           },
           "response": [
             {
-              "id": "cd4899a9-61cc-4a2b-ad25-ff9d0401c40e",
+              "id": "d61617fd-257c-4663-a3d4-35b47b80a496",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12461,7 +12461,7 @@
           }
         },
         {
-          "id": "ea8c740f-24c6-435c-b60b-0f1ed9ca0535",
+          "id": "94d82243-e87d-4603-b8a8-91e1c5b0443b",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12503,7 +12503,7 @@
           },
           "response": [
             {
-              "id": "9db32e6d-b6f7-43a5-bb17-4d9bf4f639e8",
+              "id": "52346533-6222-47c2-bc3d-c69db8cfb807",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12567,7 +12567,7 @@
           }
         },
         {
-          "id": "ac7daa8b-af35-41f5-99d8-64c07bb2090a",
+          "id": "adf79b35-9608-4d06-a54a-73a349782ceb",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12642,7 +12642,7 @@
           },
           "response": [
             {
-              "id": "9fc68890-8360-4314-a328-d10705fd21be",
+              "id": "ad2522a2-5137-418a-8cf8-7bf24ea1ecd1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12739,7 +12739,7 @@
           }
         },
         {
-          "id": "efeedac9-7e87-4dd1-b2d4-14f667631048",
+          "id": "56464bd5-a96f-46cc-b6f9-36bac3bb4ce2",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12781,7 +12781,7 @@
           },
           "response": [
             {
-              "id": "a553e9d0-a330-4123-9400-5a236ad27d1b",
+              "id": "e7f2c081-3919-4dfb-a01c-2567c6db2ce5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12845,7 +12845,7 @@
           }
         },
         {
-          "id": "ed9d0652-88a1-4a75-bc97-35a8dd394622",
+          "id": "639bbb0f-c951-4194-82f8-c074da001f74",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -12888,7 +12888,7 @@
           },
           "response": [
             {
-              "id": "ea98f500-7252-429d-98ef-9a36e613f50e",
+              "id": "b565d1a1-bf6b-425d-8437-7c43719923df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12953,7 +12953,7 @@
           }
         },
         {
-          "id": "27d1b66c-d0ab-4feb-b241-9da3c6f1c7f3",
+          "id": "3dcca09a-384a-4fea-8e8f-1956aac7757e",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -12996,7 +12996,7 @@
           },
           "response": [
             {
-              "id": "de8ab3fc-d534-499b-b2f0-3e8dd46917cf",
+              "id": "73612ecb-d518-43ea-a0be-ba2d8869410d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13061,7 +13061,7 @@
           }
         },
         {
-          "id": "77743832-35a9-41c4-ad31-4166fe88e905",
+          "id": "9ccfe3f3-ea10-44cc-9d50-7734b72eaca9",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13113,7 +13113,7 @@
           },
           "response": [
             {
-              "id": "3f70b155-19af-4058-b264-3c383b574320",
+              "id": "8e2bb46f-fa09-44e0-95d6-f3a8e2a92e0c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13187,7 +13187,7 @@
           }
         },
         {
-          "id": "32d6e122-848e-44e1-8e06-081f28a7c56a",
+          "id": "a4db9bdc-8209-4b98-bfe0-6e003b38bffd",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13229,7 +13229,7 @@
           },
           "response": [
             {
-              "id": "083a4935-09c4-4c3f-952c-bfa3c2f0ab42",
+              "id": "b7364ea4-d124-4a73-8602-7bd025c4282f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13293,7 +13293,7 @@
           }
         },
         {
-          "id": "b25cda46-b62b-4447-9755-1a9a949c7653",
+          "id": "ac5b3411-5102-4810-a23f-97a0a24b0b44",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13346,7 +13346,7 @@
           },
           "response": [
             {
-              "id": "8a5afd2d-170e-4861-91a1-4e760024526b",
+              "id": "7c7d0b8d-613f-4aa7-819b-a94a449db99b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13421,7 +13421,7 @@
           }
         },
         {
-          "id": "4426bb46-f773-492b-aa39-4a6e41b06d6a",
+          "id": "f2bd17cb-6492-4b41-b650-f7205161b21e",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13465,7 +13465,7 @@
           },
           "response": [
             {
-              "id": "de3cb0f8-c555-47f7-8759-56f08ed8c6c6",
+              "id": "9b7dac40-ae50-4467-a74b-5a5baf36fa49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13520,7 +13520,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13531,7 +13531,7 @@
           }
         },
         {
-          "id": "f5feb741-e3cf-40f6-9d61-7073f5137aa8",
+          "id": "94a6799d-6da8-44e7-94c3-077d297de4cc",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13575,7 +13575,7 @@
           },
           "response": [
             {
-              "id": "2bfe5ee6-779b-4c4c-8dc3-4f408499e438",
+              "id": "68dd610a-d78e-4028-88e4-beadda644b06",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13630,7 +13630,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13647,7 +13647,7 @@
       "description": "",
       "item": [
         {
-          "id": "31596614-f094-4eba-bb33-50b33d0cd9a6",
+          "id": "7a770393-5f41-4a2e-a1e9-78b2d78e46cd",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13689,7 +13689,7 @@
           },
           "response": [
             {
-              "id": "5c5d4e74-f20f-4a97-a7d0-8f3ae95faa13",
+              "id": "d58cb964-7fb6-4a17-b8e2-026aa8a75791",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13738,7 +13738,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "052fae88-4f5f-4025-bc83-230951e6aedf",
+              "id": "58f1597a-3d4b-4f19-8f41-ad59c2b3a305",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13793,7 +13793,7 @@
           }
         },
         {
-          "id": "b23f2d67-57e8-4c92-8c4f-318b92157564",
+          "id": "16865099-bf07-47e5-b336-0851c46250c9",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -13839,7 +13839,7 @@
           },
           "response": [
             {
-              "id": "72ae2dfd-b7b4-4761-b8de-d6a66b7dc511",
+              "id": "8419f936-708f-420e-9cb2-d57b24534f71",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -13898,7 +13898,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f4c157d3-c8d9-42c0-be2b-674e81083481",
+              "id": "34a31820-92c2-49dc-a91c-a13d30363551",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -13963,7 +13963,7 @@
           }
         },
         {
-          "id": "eccfeee1-b0cc-481c-acc9-c35f2e44819d",
+          "id": "02042475-3997-40b6-8655-318c0e916696",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14009,7 +14009,7 @@
           },
           "response": [
             {
-              "id": "94b539d9-903e-43ea-b6b0-143b521425ae",
+              "id": "f2f0e916-b64c-40a8-b4dc-d85c0c62f19e",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "91d9e0a5-942e-4025-b696-711cf56aca79",
+              "id": "e7174dfa-b134-44b7-822a-ea5cee4547e2",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14133,7 +14133,7 @@
           }
         },
         {
-          "id": "6df9abec-0370-4db5-bed0-c35c724d3f4f",
+          "id": "e827ade1-8a11-4e5a-b392-de6653d08251",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14175,7 +14175,7 @@
           },
           "response": [
             {
-              "id": "286dfb09-3543-4669-94f8-01d201cc6c1f",
+              "id": "979e2194-1df4-4a8b-bb83-542d7eda50dd",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14236,7 +14236,7 @@
       "description": "",
       "item": [
         {
-          "id": "11c772c0-46e6-4182-8869-18f4cceff684",
+          "id": "98e25c84-78e5-4183-96be-3bc76d7c8b1a",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14285,7 +14285,7 @@
           },
           "response": [
             {
-              "id": "e03250ae-cf14-41b2-a0fc-686ae1655059",
+              "id": "730f64b9-4604-48ec-b133-a72486b94b6a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 4899.807116108701\n}",
+              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14356,7 +14356,7 @@
           }
         },
         {
-          "id": "2d56523a-b819-46b7-938b-8da28498cfd4",
+          "id": "732bec5b-c49a-459e-97b9-cddf9b7c5b18",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14405,7 +14405,7 @@
           },
           "response": [
             {
-              "id": "d127b0de-163d-47bc-9571-b85263daa6ad",
+              "id": "0c948e8e-e388-4581-812d-77cb8ed45079",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14476,7 +14476,7 @@
           }
         },
         {
-          "id": "6e59d8ae-de56-4058-ad5d-0d572d384f1c",
+          "id": "aa8750e8-0e7c-4ef5-ae60-03fdb692e28c",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14525,7 +14525,7 @@
           },
           "response": [
             {
-              "id": "4d7c86e5-0b78-4590-953d-ec3787b05011",
+              "id": "3e979901-6e25-490c-a376-95061ba8376e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14596,7 +14596,7 @@
           }
         },
         {
-          "id": "fa0d4a8b-e4cb-4f8f-a096-66ae731d55a6",
+          "id": "988d5e92-a871-42e8-bbc6-3b4ef62cd003",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14645,7 +14645,7 @@
           },
           "response": [
             {
-              "id": "51d64028-46aa-4529-96cd-ffd131bec4eb",
+              "id": "a4ff70ee-8902-4354-bced-cff18be9d916",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14722,7 +14722,7 @@
       "description": "",
       "item": [
         {
-          "id": "2899502f-78be-485b-97e9-797bc5e856aa",
+          "id": "5b5fc9ad-1813-4aff-b584-b774f0ed50e3",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14762,7 +14762,7 @@
           },
           "response": [
             {
-              "id": "d855c9c0-efc0-4703-a14f-140afb9a13ce",
+              "id": "2dba7660-7b3a-4d69-a349-a03eeb11c064",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14824,7 +14824,7 @@
           }
         },
         {
-          "id": "d4f0dde3-9601-4854-bed7-d40e6a9fd71b",
+          "id": "09fa10fa-4683-41a6-9872-2ad1d7ff6305",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -14854,7 +14854,7 @@
           },
           "response": [
             {
-              "id": "25ec12ba-e7de-495e-88d8-ffe2624e5cc5",
+              "id": "e04a56c9-77b3-469e-92f5-e38a5f8628b4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14895,7 +14895,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 4899.807116108701\n}",
+              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14906,7 +14906,7 @@
           }
         },
         {
-          "id": "d4ba86a2-7988-4249-a284-37ed2b25c88c",
+          "id": "b2f03f76-50ba-425d-b7a7-1ee7be0972e3",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -14958,7 +14958,7 @@
           },
           "response": [
             {
-              "id": "f15c1e75-5b71-4602-806d-0e2d10f2d758",
+              "id": "db22654b-2dd9-47b4-95f3-2a3997d44915",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15038,7 +15038,7 @@
       "description": "",
       "item": [
         {
-          "id": "dfd81ee4-b4a5-4cfd-a2ce-ad6bfe43491e",
+          "id": "e4b70eea-de70-416b-8b55-d1b320d08452",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15067,7 +15067,7 @@
           },
           "response": [
             {
-              "id": "5c1c9528-d48b-4de7-b3fb-4b9b2d3153eb",
+              "id": "e6c577c3-5371-4715-8a7e-e05496cbfd62",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15118,7 +15118,7 @@
           }
         },
         {
-          "id": "d893cff3-4711-4faa-9575-37c20c25d5e1",
+          "id": "4fbda2db-968c-472f-9ad1-d58bc304277a",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15159,7 +15159,7 @@
           },
           "response": [
             {
-              "id": "c6ccd221-986d-4d7a-8968-dd3a4ef6923a",
+              "id": "1bb785d4-ea65-4f0c-abbc-f928464d1bd7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15228,7 +15228,7 @@
       "description": "",
       "item": [
         {
-          "id": "eb1782cf-bde7-4abd-81a9-bd2bf5c691a5",
+          "id": "1e551b0c-6031-4f02-a863-ed2f429b75b5",
           "name": "health",
           "request": {
             "name": "health",
@@ -15257,7 +15257,7 @@
           },
           "response": [
             {
-              "id": "d2d3fcac-8933-4b9f-b7c8-9d6898112ab3",
+              "id": "20cf82e8-733b-4d27-9849-32418e07b91b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15297,7 +15297,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 4899.807116108701\n}",
+              "body": "{\n  \"key_0\": 622,\n  \"key_1\": 4934\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15314,7 +15314,7 @@
       "description": "",
       "item": [
         {
-          "id": "07e75100-5e85-4755-86d3-fa49dcf412c0",
+          "id": "049c9f52-28d0-4d39-8a76-a1ab7c7c8cc8",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15366,7 +15366,7 @@
           },
           "response": [
             {
-              "id": "394c8d3e-9d12-474b-857b-d97d4b69312d",
+              "id": "bca58b8a-f6a1-4b01-ba37-a5468b59dd5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15440,7 +15440,7 @@
           }
         },
         {
-          "id": "457da538-a6da-40de-90ff-79e048e7320b",
+          "id": "329fb7f6-a4d2-4d4f-9704-7de1ad0de82e",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15481,7 +15481,7 @@
           },
           "response": [
             {
-              "id": "7e9c7350-1102-4685-af26-1846d7178023",
+              "id": "9473c085-3974-4913-81ca-878babaf0fce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15533,7 +15533,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15544,7 +15544,7 @@
           }
         },
         {
-          "id": "103a5e7c-c4a1-4d9c-a592-f81b37007ba0",
+          "id": "b731b56a-c3a6-4363-bf60-219611be1be2",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15574,7 +15574,7 @@
           },
           "response": [
             {
-              "id": "a9ef04aa-bbdc-48ce-bd90-d0b7e863f2c7",
+              "id": "643475a7-3153-43b1-92de-de453d8fb91c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15615,7 +15615,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\",\n  \"key_4\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15646,9 +15646,9 @@
     }
   ],
   "info": {
-    "_postman_id": "eed6b532-595b-4592-a88d-806454998832",
+    "_postman_id": "a1e7aadc-1784-4453-b2fd-e1e86ffab7ad",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-30 09:09 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-30 09:13 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -51,6 +51,10 @@
       "description": "Gestión del rate limiter de lecturas de sensores"
     },
     {
+      "name": "Push Tokens",
+      "description": "Registro de tokens FCM de dispositivos para notificaciones push"
+    },
+    {
       "name": "Tenant Device Management",
       "description": "Endpoints para la gestión de dispositivos de un cliente"
     },
@@ -2576,6 +2580,35 @@
         }
       }
     },
+    "/api/v1/push-tokens": {
+      "post": {
+        "tags": [
+          "Push Tokens"
+        ],
+        "summary": "Registrar (o refrescar) el token FCM de este dispositivo",
+        "operationId": "register",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushTokenRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
     "/api/v1/mqtt/publish/raw": {
       "post": {
         "tags": [
@@ -3162,7 +3195,7 @@
         ],
         "summary": "Register new tenant",
         "description": "Register a new company and admin user",
-        "operationId": "register",
+        "operationId": "register_1",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4808,6 +4841,35 @@
           }
         }
       }
+    },
+    "/api/v1/push-tokens/{token}": {
+      "delete": {
+        "tags": [
+          "Push Tokens"
+        ],
+        "summary": "Desregistrar el token FCM (logout o invalidación)",
+        "operationId": "unregister",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -5534,6 +5596,11 @@
             "format": "int32",
             "description": "Minutos de retraso antes de notificar",
             "example": 0
+          },
+          "notifyPush": {
+            "type": "boolean",
+            "description": "Si esta severidad dispara notificaciones push FCM (toggle de admin)",
+            "example": true
           }
         },
         "required": [
@@ -5541,6 +5608,7 @@
           "level",
           "name",
           "notificationDelayMinutes",
+          "notifyPush",
           "requiresAction"
         ]
       },
@@ -5734,6 +5802,9 @@
             "type": "integer",
             "format": "int32"
           },
+          "notifyPush": {
+            "type": "boolean"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -5744,6 +5815,7 @@
           "level",
           "name",
           "notificationDelayMinutes",
+          "notifyPush",
           "requiresAction"
         ]
       },
@@ -6278,6 +6350,33 @@
             "description": "ID del usuario que resuelve la alerta"
           }
         }
+      },
+      "PushTokenRegisterRequest": {
+        "type": "object",
+        "description": "Request para registrar un token FCM de un dispositivo cliente",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Token FCM emitido por Firebase para este dispositivo",
+            "example": "fABcD1234...",
+            "maxLength": 4096,
+            "minLength": 10
+          },
+          "platform": {
+            "type": "string",
+            "description": "Plataforma del dispositivo",
+            "enum": [
+              "ANDROID",
+              "IOS",
+              "WEB"
+            ],
+            "example": "ANDROID"
+          }
+        },
+        "required": [
+          "platform",
+          "token"
+        ]
       },
       "SendCommandRequest": {
         "type": "object",

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
@@ -2,13 +2,14 @@ package com.apptolast.invernaderos.features.alert
 
 import com.apptolast.invernaderos.features.alert.Alert
 import com.apptolast.invernaderos.features.alert.AlertService
+import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
+import com.apptolast.invernaderos.features.alert.dto.response.AlertResponse
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import java.time.Instant
 
 /**
  * REST Controller para gestión de Alertas.
@@ -68,7 +69,7 @@ class AlertController(
         @RequestParam(required = false) severity: String?,
         @RequestParam(required = false) isResolved: Boolean?,
         @RequestParam(required = false, defaultValue = "100") limit: Int
-    ): ResponseEntity<List<Alert>> {
+    ): ResponseEntity<List<AlertResponse>> {
         logger.debug("GET /api/alerts?tenantId=$tenantId&sectorId=$sectorId&severity=$severity&isResolved=$isResolved&limit=$limit")
 
         return try {
@@ -81,7 +82,7 @@ class AlertController(
                     // Solo tenant
                     alertService.getAllByTenant(tenantId)
                 }
-            }.take(limit)
+            }.take(limit).map { it.toResponse() }
 
             ResponseEntity.ok(alerts)
         } catch (e: Exception) {
@@ -96,12 +97,12 @@ class AlertController(
      * Obtiene una alerta por ID.
      */
     @GetMapping("/{id}")
-    fun getAlertById(@PathVariable id: Long): ResponseEntity<Alert> {
+    fun getAlertById(@PathVariable id: Long): ResponseEntity<AlertResponse> {
         logger.debug("GET /api/alerts/$id")
 
         val alert = alertService.getById(id)
         return if (alert != null) {
-            ResponseEntity.ok(alert)
+            ResponseEntity.ok(alert.toResponse())
         } else {
             ResponseEntity.notFound().build()
         }
@@ -119,11 +120,11 @@ class AlertController(
     fun getAlertsByTenant(
         @PathVariable tenantId: Long,
         @RequestParam(required = false, defaultValue = "100") limit: Int
-    ): ResponseEntity<List<Alert>> {
+    ): ResponseEntity<List<AlertResponse>> {
         logger.debug("GET /api/alerts/tenant/$tenantId?limit=$limit")
 
         return try {
-            val alerts = alertService.getAllByTenant(tenantId).take(limit)
+            val alerts = alertService.getAllByTenant(tenantId).take(limit).map { it.toResponse() }
             ResponseEntity.ok(alerts)
         } catch (e: Exception) {
             logger.error("Error getting alerts for tenant: $tenantId", e)
@@ -137,11 +138,11 @@ class AlertController(
      * Obtiene todas las alertas de un sector.
      */
     @GetMapping("/sector/{sectorId}")
-    fun getAlertsBySector(@PathVariable sectorId: Long): ResponseEntity<List<Alert>> {
+    fun getAlertsBySector(@PathVariable sectorId: Long): ResponseEntity<List<AlertResponse>> {
         logger.debug("GET /api/alerts/sector/$sectorId")
 
         return try {
-            val alerts = alertService.getAllBySector(sectorId)
+            val alerts = alertService.getAllBySector(sectorId).map { it.toResponse() }
             ResponseEntity.ok(alerts)
         } catch (e: Exception) {
             logger.error("Error getting alerts for sector: $sectorId", e)
@@ -156,11 +157,11 @@ class AlertController(
      * CRITICAL primero, luego ERROR, WARNING, INFO.
      */
     @GetMapping("/unresolved/tenant/{tenantId}")
-    fun getUnresolvedByTenant(@PathVariable tenantId: Long): ResponseEntity<List<Alert>> {
+    fun getUnresolvedByTenant(@PathVariable tenantId: Long): ResponseEntity<List<AlertResponse>> {
         logger.debug("GET /api/alerts/unresolved/tenant/$tenantId")
 
         return try {
-            val alerts = alertService.getUnresolvedByTenantOrderedBySeverity(tenantId)
+            val alerts = alertService.getUnresolvedByTenantOrderedBySeverity(tenantId).map { it.toResponse() }
             ResponseEntity.ok(alerts)
         } catch (e: Exception) {
             logger.error("Error getting unresolved alerts for tenant: $tenantId", e)
@@ -174,11 +175,11 @@ class AlertController(
      * Obtiene alertas no resueltas por sector, ordenadas por severidad.
      */
     @GetMapping("/unresolved/sector/{sectorId}")
-    fun getUnresolvedBySector(@PathVariable sectorId: Long): ResponseEntity<List<Alert>> {
+    fun getUnresolvedBySector(@PathVariable sectorId: Long): ResponseEntity<List<AlertResponse>> {
         logger.debug("GET /api/alerts/unresolved/sector/$sectorId")
 
         return try {
-            val alerts = alertService.getUnresolvedBySectorOrderedBySeverity(sectorId)
+            val alerts = alertService.getUnresolvedBySectorOrderedBySeverity(sectorId).map { it.toResponse() }
             ResponseEntity.ok(alerts)
         } catch (e: Exception) {
             logger.error("Error getting unresolved alerts for sector: $sectorId", e)
@@ -238,11 +239,11 @@ class AlertController(
     fun getRecentByTenant(
         @PathVariable tenantId: Long,
         @RequestParam(required = false, defaultValue = "50") limit: Int
-    ): ResponseEntity<List<Alert>> {
+    ): ResponseEntity<List<AlertResponse>> {
         logger.debug("GET /api/alerts/recent/tenant/$tenantId?limit=$limit")
 
         return try {
-            val alerts = alertService.getRecentByTenant(tenantId, limit)
+            val alerts = alertService.getRecentByTenant(tenantId, limit).map { it.toResponse() }
             ResponseEntity.ok(alerts)
         } catch (e: Exception) {
             logger.error("Error getting recent alerts for tenant: $tenantId", e)
@@ -263,12 +264,14 @@ class AlertController(
      * - Field constraints are satisfied
      */
     @PostMapping
-    fun createAlert(@Valid @RequestBody alert: Alert): ResponseEntity<Alert> {
+    fun createAlert(@Valid @RequestBody alert: Alert): ResponseEntity<AlertResponse> {
         logger.debug("POST /api/alerts - Creating alert: ${alert.alertType}")
 
         return try {
             val created = alertService.create(alert)
-            ResponseEntity.status(HttpStatus.CREATED).body(created)
+            // Re-fetch with EntityGraph so the response includes sectorCode, severityName, etc.
+            val hydrated = created.id?.let { alertService.getById(it) } ?: created
+            ResponseEntity.status(HttpStatus.CREATED).body(hydrated.toResponse())
         } catch (e: Exception) {
             logger.error("Error creating alert", e)
             ResponseEntity.internalServerError().build()
@@ -284,13 +287,14 @@ class AlertController(
      * Response: Alert actualizado
      */
     @PutMapping("/{id}")
-    fun updateAlert(@PathVariable id: Long, @Valid @RequestBody alert: Alert): ResponseEntity<Alert> {
+    fun updateAlert(@PathVariable id: Long, @Valid @RequestBody alert: Alert): ResponseEntity<AlertResponse> {
         logger.debug("PUT /api/alerts/$id - Updating alert")
 
         return try {
             val updated = alertService.update(id, alert)
             if (updated != null) {
-                ResponseEntity.ok(updated)
+                val hydrated = alertService.getById(id) ?: updated
+                ResponseEntity.ok(hydrated.toResponse())
             } else {
                 ResponseEntity.notFound().build()
             }
@@ -316,13 +320,14 @@ class AlertController(
         @PathVariable id: Long,
         @RequestParam(required = false) userId: Long?,
         @RequestParam(required = false) userName: String?
-    ): ResponseEntity<Alert> {
+    ): ResponseEntity<AlertResponse> {
         logger.debug("PUT /api/alerts/$id/resolve - Resolving alert")
 
         return try {
             val resolved = alertService.resolve(id, userId, userName)
             if (resolved != null) {
-                ResponseEntity.ok(resolved)
+                val hydrated = alertService.getById(id) ?: resolved
+                ResponseEntity.ok(hydrated.toResponse())
             } else {
                 ResponseEntity.notFound().build()
             }
@@ -340,13 +345,14 @@ class AlertController(
      * Response: Alert reabierto
      */
     @PutMapping("/{id}/reopen")
-    fun reopenAlert(@PathVariable id: Long): ResponseEntity<Alert> {
+    fun reopenAlert(@PathVariable id: Long): ResponseEntity<AlertResponse> {
         logger.debug("PUT /api/alerts/$id/reopen - Reopening alert")
 
         return try {
             val reopened = alertService.reopen(id)
             if (reopened != null) {
-                ResponseEntity.ok(reopened)
+                val hydrated = alertService.getById(id) ?: reopened
+                ResponseEntity.ok(hydrated.toResponse())
             } else {
                 ResponseEntity.notFound().build()
             }


### PR DESCRIPTION
## Summary

Fixes the 500 Internal Server Error returned by `GET /api/v1/alerts/unresolved/tenant/{tenantId}` (and every other endpoint in the legacy `AlertController`) as soon as at least one unresolved alert exists in the database. The mobile app hits these endpoints; the admin web is unaffected because it consumes the newer `TenantAlertController` which already maps to DTOs.

### Root cause
`AlertController` returned the JPA `Alert` entity directly. The entity has 5 `@ManyToOne(LAZY)` relations and a `@NamedEntityGraph("Alert.context")` that eagerly loads `tenant`, `sector`, `resolvedByUser`, `alertType`, `severity`. **But `Tenant` and `Sector` have their own LAZY relations not in the graph** (`Tenant.greenhouses`, `Tenant.users`, `Sector.tenant`, `Sector.greenhouse`). When Jackson serialised the entity outside the closed Hibernate session, it traversed those uninitialised proxies → `LazyInitializationException` → 500. Empty result lists masked the bug; the first unresolved alert (`ALT-00010`) exposed it.

### Fix
Map the entity to `AlertResponse` (existing DTO) inside each endpoint, using the already-existing `AlertEntity.toResponse()` mapper that `TenantAlertController` uses. The mapper only touches relations covered by `Alert.context`, so it is safe to call after the transaction closes. For write endpoints the controller re-fetches via `getById()` to hydrate the relations the entity graph populates, keeping responses consistent with GETs.

### Out of scope (intentionally not changed, per the spec)
- `spring.jpa.open-in-view` (would mask the issue, anti-pattern)
- LAZY annotations on entities (loses fetch control, would introduce N+1)
- `@JsonIgnore` on entities (couples persistence to presentation)
- `@NamedEntityGraph("Alert.context")` (already loads what the mapper needs)
- `AlertResponse` contract (kept identical)

## Includes

- `bf1820c` — the fix (only file changed: `AlertController.kt`).
- `a290571` + `6b78666` — auto-generated Postman/OpenAPI doc updates from the `update-api-docs` workflow (already on develop, no manual changes).

## Test plan

- [x] `./gradlew compileKotlin` — clean
- [x] `./gradlew test` — full suite green (incl. ArchUnit + alert tests)
- [x] `./gradlew build -x test --warning-mode all` — zero warnings
- [ ] After deploy: `curl -H "Authorization: Bearer <jwt>" https://inverapi-dev.apptolast.com/api/v1/alerts/unresolved/tenant/<tenantId>` returns 200 with `List<AlertResponse>` JSON
- [ ] No `LazyInitializationException` in backend logs while exercising mobile flows
- [ ] No regression in `TenantAlertController` (admin web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)