### PR TITLE
feat(alert): /api/v1/alerts/history/tenant/{id} for mobile history feed

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "8b317ec1-abb3-40d5-acef-7376562de377",
+          "id": "9aab9086-0706-43c5-ba5f-6010eb5797cd",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "12dffa9e-9702-41d6-ad89-e8c82e06d28b",
+              "id": "6bc90b01-2b2a-4a8e-8e12-2dbc070cf16f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "88a7c0c4-82d4-462c-9132-ee358047df72",
+          "id": "177cc0e9-6899-4a8e-958d-d0bffc3a6efc",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "c9abe690-e94d-435e-b0d8-0407438a26a6",
+              "id": "5920f258-b08d-45c3-9d3a-125ea7536f05",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "d285933a-8d2a-4716-91d6-64ac1777c7e2",
+          "id": "4d1a157c-1573-4f74-9ee2-09fe8d9b3e20",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "1a558ecd-952c-429a-9668-867ae0588af7",
+              "id": "b55beff8-aa37-481a-a504-1ab0ba80bf52",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "a70dccfb-a709-4da9-a5d3-255aff5a7def",
+          "id": "8d417ddf-3fa5-4a85-b2d5-d026079ce759",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "19e6f02c-e91a-4510-8d24-e4b5044edc19",
+              "id": "4ee662d1-13db-4c02-876d-11b26422ce10",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "355ea94d-6d55-48a0-ac35-68c12766ac5f",
+          "id": "9a8c2830-eb19-4d2d-8078-7fc98e46fe42",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "5ba568bc-cfaf-48af-b26a-9b9fc1aa2d7f",
+              "id": "65135795-0a90-4c57-a33c-bbaf64ddb8ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "fd21a0a7-cd69-4529-a147-0e1c42ba8af4",
+          "id": "949a3393-3389-4c89-aa94-180b23d29e81",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "85e97896-b881-4a57-9298-99fb9ee2773a",
+              "id": "99f78b40-7500-4e4a-976a-309c8d3b72cd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "ef6a56ae-8214-46db-8e13-137375ed26a2",
+          "id": "60065a96-8db8-480a-83d8-4f69ab9486c9",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "e4d0932e-b17f-4155-aba7-e1068ff76660",
+              "id": "4140ce6e-3794-4c00-aec0-5a3d88dfe79b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "f0bf2b5c-d4a9-4e19-8bce-f5cef77b7942",
+          "id": "5050d5ff-f294-4641-acdc-5fa916762546",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "b27a97c5-3499-4f08-9372-f55c45932365",
+              "id": "da4d1865-69e7-40df-9988-2d59214c3998",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "6a123958-37c5-41d8-bf86-1b8bd971eb52",
+          "id": "03614a7a-0911-4c29-b6e1-e12816c6e56d",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "5feeb5fd-b830-47a8-96e6-aacdf476f9d9",
+              "id": "67015339-493f-42c4-b6ac-c6bcd61766f8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "0ffe3997-572b-41eb-a272-4ecb060247d4",
+          "id": "19a7b109-b8db-4277-90cb-69fa4c581e3a",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "89d7aee1-f85c-4b3b-8e45-98594ef91fd6",
+              "id": "54a85335-2f79-4ce6-b90e-4459441320f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "6b4a3731-65ec-4c58-9aa4-b8a66b4376e7",
+          "id": "d24670c0-35d3-40a3-be5f-1e8c5bfdf9ab",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "a1544c4f-35a3-4db4-b006-a10090ec1c67",
+              "id": "fde9636a-b325-43aa-b45e-5f949e81c66c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "07737c81-bcd6-4877-b642-f41a4c8066d0",
+          "id": "7989dbb9-24cb-4925-bfe6-df2a1ae7fddb",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "6f69d137-90e8-47ac-8ddd-ea08ebcbe035",
+              "id": "28236137-9809-4bb0-87fe-b6a7385af385",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "17e043b9-ede1-48da-99d4-31a5cea826a3",
+          "id": "3092d071-11fd-4958-ac4b-07a7b33b8992",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "3af70d07-764f-4ef4-b706-d34dc7cc09e8",
+              "id": "ca201157-257d-4b9d-a3f1-129a33d9421e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "91b926dd-4488-4b26-baa8-3c913ef06dab",
+          "id": "2a82e09c-55c0-4f5b-9f7f-ad8e4f81d12c",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "bf438f67-5a03-4dc2-b52d-a7071e73e2b6",
+              "id": "67f0aef2-522b-4436-a0ea-b285f0c743e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "a7bb5ff5-242f-488d-a76f-f7cdfdf306bd",
+          "id": "4323199d-f214-4fd2-861c-a82c84e609ce",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "bf2fcd83-1e46-44ea-874d-f9762d7dbaa7",
+              "id": "3b679521-7dab-4480-841f-cf5703ce63ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "59d4f8c9-ff3d-49b3-bdc4-6bf52f63fd75",
+          "id": "1b8319f4-9b57-445d-8d79-37ae1fb91dee",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "0214e97d-8ff5-4eae-9f68-1403c3269dc4",
+              "id": "23d990d0-b809-4332-8d1f-6ad6134152a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "abacc445-f0a6-4bdd-a600-4b9bdd1b0244",
+          "id": "3c42adb3-0883-4c93-b1fe-a5ce0354f315",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -1859,7 +1859,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -1879,7 +1879,7 @@
           },
           "response": [
             {
-              "id": "acd4ef53-42d3-4422-99b6-8ece648a7655",
+              "id": "683f18f0-6a73-4da4-8189-95eec930d93c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1911,7 +1911,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1933,7 +1933,7 @@
           }
         },
         {
-          "id": "18b43f41-6a2d-4d08-aa7a-f486f28de99c",
+          "id": "cc6485da-20a9-423a-8698-bbf5ddf79f16",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -1976,7 +1976,7 @@
           },
           "response": [
             {
-              "id": "92b932c2-b242-47ac-8adb-b8ecb18ec142",
+              "id": "226d745b-dc79-4f08-8f30-79b3e65cb5f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "c4b03d5d-d44e-4dd9-934e-6116c07fcc6c",
+          "id": "237dc569-aae0-4456-bbb1-e6269e2a1f88",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -2088,7 +2088,7 @@
           },
           "response": [
             {
-              "id": "e36222bb-097d-40ce-83d2-adeae2328148",
+              "id": "dd9dc639-fd22-43f0-9d01-87c973ef76ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2163,7 +2163,7 @@
           }
         },
         {
-          "id": "1831baec-9573-403e-a27c-b7b4a2a4a9c8",
+          "id": "844e8973-c16c-43d6-828c-c91a7b7bd746",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "f72f9b08-3a2e-4fec-8988-a754f98bfd0b",
+              "id": "2f043186-4664-4bfa-a772-9477d3620992",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2317,7 +2317,7 @@
           }
         },
         {
-          "id": "20dc6bf1-af70-4d82-8dbb-817144015b39",
+          "id": "168fd61b-0d95-4b72-aa82-11b0f8287e85",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2364,7 +2364,7 @@
           },
           "response": [
             {
-              "id": "838265a9-b0ac-4a5e-aef0-3fd97ff532bd",
+              "id": "1a4feb8f-35fb-4bbc-842d-8758f384c208",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2429,7 +2429,7 @@
           }
         },
         {
-          "id": "bec01580-0c90-4fec-a11b-46144f5feaf0",
+          "id": "2c7d59c8-4e2d-4ecb-a7d7-2e69b8d3e9ed",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2471,7 +2471,7 @@
           },
           "response": [
             {
-              "id": "97c26779-ad50-4cb1-99a0-e159a5f9dbc5",
+              "id": "15ea8f38-3f3a-482a-aa68-73c18ad9c5f7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2535,7 +2535,7 @@
           }
         },
         {
-          "id": "53c7670c-3462-447b-a82f-7a120a4baa84",
+          "id": "94e07ae7-771c-45f8-8647-943012d033aa",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2590,7 +2590,7 @@
           },
           "response": [
             {
-              "id": "2e966c02-19e5-488e-9b85-a5c63f1b8e2d",
+              "id": "01f9bcf9-cfac-45df-8536-310b53982552",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2667,7 +2667,7 @@
           }
         },
         {
-          "id": "700c0338-149b-4572-aad7-4be08ed73a91",
+          "id": "0c6d6b55-3501-4361-95e6-a60c098ee809",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2731,7 +2731,7 @@
           },
           "response": [
             {
-              "id": "0b8d4dac-fbdb-4d8d-ab73-e5707bb9a1bc",
+              "id": "f26692a0-d8c0-4b18-97b8-593039434a1d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2823,7 +2823,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "4e0e95e1-c254-4af8-89f1-b1d99282a9b3",
+          "id": "69262e33-1d99-4799-b80e-10cdc5efd7f8",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2865,7 +2865,7 @@
           },
           "response": [
             {
-              "id": "ad0af5ad-c52c-4df2-93d1-a7f927967c32",
+              "id": "37e960c2-a036-4d18-8b0e-6552910558ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2929,7 +2929,7 @@
           }
         },
         {
-          "id": "aa0727cc-f325-40de-aa12-6bf77d8d8c98",
+          "id": "dc256468-5c30-4c4e-b25e-7898215b5736",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2972,7 +2972,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e15EC8\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aaBF27\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2984,7 +2984,7 @@
           },
           "response": [
             {
-              "id": "53875dae-3445-45eb-aa17-d2ee598d2842",
+              "id": "7f7a1223-1268-4be1-9f5d-45b556356817",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3033,7 +3033,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e15EC8\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aaBF27\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3061,7 +3061,7 @@
           }
         },
         {
-          "id": "9e908452-82c9-4122-82f7-58aeca376b0d",
+          "id": "fbe80fd7-92c3-4f43-8609-f7a8f6f9b6b9",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -3097,7 +3097,7 @@
           },
           "response": [
             {
-              "id": "d0f73e9b-da5a-4190-b52c-ab63f66b891a",
+              "id": "62f4e447-1567-43d2-a438-6cbcd051e859",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
           }
         },
         {
-          "id": "05052d80-09e6-49b8-8677-781fa40c401f",
+          "id": "b3065ac9-95e6-4326-9efc-7cea47f4d9db",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -3181,7 +3181,7 @@
           },
           "response": [
             {
-              "id": "60aed338-60a8-4675-8d8a-62bfb345e678",
+              "id": "adee6a66-7ba4-48cf-8e66-c761dd28c5a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3233,7 +3233,7 @@
           }
         },
         {
-          "id": "8c49aac5-5f26-486c-9ca9-abae7f12d667",
+          "id": "d55bd3e0-819d-4025-b344-be18dc73e237",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3264,7 +3264,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2Cc15A\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A48dba\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3276,7 +3276,7 @@
           },
           "response": [
             {
-              "id": "79d169af-34fc-41be-a47c-01af574cd277",
+              "id": "f3b034bc-ea88-443d-a815-577a9b634889",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3313,7 +3313,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2Cc15A\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A48dba\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3341,7 +3341,7 @@
           }
         },
         {
-          "id": "7c57ad4a-b540-4254-9edc-bfc50d5071d2",
+          "id": "1fb59e7a-cb8b-46c3-8411-d5d9d81b303c",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3372,7 +3372,7 @@
           },
           "response": [
             {
-              "id": "2e9c8790-efd4-4b78-80b4-c774f355d34d",
+              "id": "df5c1bc2-2404-4357-a80c-e53ecdff3a00",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3431,7 +3431,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "0599fd08-bf91-4464-9f8a-c923e336259b",
+          "id": "0061376b-ccf4-4833-a8c0-e5b133708818",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3473,7 +3473,7 @@
           },
           "response": [
             {
-              "id": "74072d7b-b08a-4cd1-9a78-705cbf117ae9",
+              "id": "5b646d6d-409c-4a70-8190-ce1c9c39fa99",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
           }
         },
         {
-          "id": "99f14277-dc2d-47a8-9977-da64d3c96fa7",
+          "id": "3d1a938c-47d8-4153-a47b-163a17529c48",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3592,7 +3592,7 @@
           },
           "response": [
             {
-              "id": "308924fa-ffe2-4235-b4c2-80c153742726",
+              "id": "bce1ab6c-8185-4db6-8624-00bb21cafedb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3669,7 +3669,7 @@
           }
         },
         {
-          "id": "720f3977-01e8-43ba-bd66-1c1bff85fe3e",
+          "id": "09f07e64-ae24-47ff-81cb-ea64f0dffb68",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3711,7 +3711,7 @@
           },
           "response": [
             {
-              "id": "98d5e1c1-344d-41cc-9e5b-55454f7b2941",
+              "id": "cc0a625b-a446-4d92-9a29-5cc1e16c2393",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3775,7 +3775,7 @@
           }
         },
         {
-          "id": "02eae6e8-115a-479b-924c-c7291cce3252",
+          "id": "96955a54-9ad3-4c9f-a7fc-83d5b96c274f",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3805,7 +3805,7 @@
           },
           "response": [
             {
-              "id": "744a6d96-280c-4be7-90f5-87ae6d971e1d",
+              "id": "e03b8d02-a8b2-45ce-b84f-0cae5356a24b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3857,7 +3857,7 @@
           }
         },
         {
-          "id": "856daefa-ef69-42ad-b2c7-f403715485ea",
+          "id": "78590fbb-268b-4109-a961-52f5be04da8e",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3900,7 +3900,7 @@
           },
           "response": [
             {
-              "id": "6d7ad3ff-70bc-4978-b2fc-1e8463263668",
+              "id": "3a0c6171-afdc-4ded-83d2-f8f05a0db124",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3965,7 +3965,7 @@
           }
         },
         {
-          "id": "32009698-b952-4bc7-ba42-5cbe6f6b59ff",
+          "id": "b0139fd6-d668-467f-b376-2f24225c6abb",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -4018,7 +4018,7 @@
           },
           "response": [
             {
-              "id": "be7a1513-c747-49e7-82d6-3d9ee5709e7f",
+              "id": "9c5f613e-2b99-49fc-b3c6-7ca8257edf09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4082,7 +4082,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 9302.475911937629\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -4093,7 +4093,7 @@
           }
         },
         {
-          "id": "e1054215-6c3c-45b0-8157-30cf4ac371eb",
+          "id": "f31f710a-0d5d-4e21-98f5-70fd3719f343",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -4136,7 +4136,7 @@
           },
           "response": [
             {
-              "id": "99e4273f-3cc1-43a1-a047-6253b9ae463d",
+              "id": "ab9b87d3-11a5-4a12-8df5-b9ff4f3478de",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4201,7 +4201,7 @@
           }
         },
         {
-          "id": "3882d55f-3904-4006-affb-3057131aac23",
+          "id": "11560841-3f45-420a-a0fc-8dba9d7ddc98",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4232,7 +4232,7 @@
           },
           "response": [
             {
-              "id": "432d0862-cfea-489a-8192-7dd4265617bd",
+              "id": "f1c56d5c-004f-4a1c-b661-2f5f6b36b19e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4291,7 +4291,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "728ce99e-2178-4506-9907-2ad995b7b1b4",
+          "id": "51062dcf-ee1e-4105-a75b-62735e6e588d",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4333,7 +4333,7 @@
           },
           "response": [
             {
-              "id": "f9eb4dc4-1cf3-4830-af69-af337c02bdc4",
+              "id": "21edb9e8-da8c-4cc5-b91a-4adb610ef436",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4397,7 +4397,7 @@
           }
         },
         {
-          "id": "41aa437f-22c6-487b-a92a-b25200ab55e8",
+          "id": "814d3eff-2584-4a4d-9f7d-405f04037241",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4440,7 +4440,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4452,7 +4452,7 @@
           },
           "response": [
             {
-              "id": "b9491033-5507-4b55-9870-dbaea6a74349",
+              "id": "4af913fb-e8f8-44db-80e6-4c924d035551",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4501,7 +4501,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4529,7 +4529,7 @@
           }
         },
         {
-          "id": "66ab367b-c9f6-4a42-a98e-5ca7d3712fd1",
+          "id": "63057a7d-0c1a-4846-bdc3-a1e5c0a249ed",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4565,7 +4565,7 @@
           },
           "response": [
             {
-              "id": "7299a85a-2aee-4713-bee8-cb78352e9bc3",
+              "id": "7da9cd43-128f-4b57-9179-fda40d17b899",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4619,7 +4619,7 @@
           }
         },
         {
-          "id": "92696488-e8d1-40a7-9a6d-e2bd7af709a4",
+          "id": "f8e4f2e4-07fc-48ad-a6f8-6bf4c9f2c0d0",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4668,7 +4668,7 @@
           },
           "response": [
             {
-              "id": "f5601a79-1451-4b58-a272-dc1f2558bfec",
+              "id": "4356accf-ed12-4d97-b949-333ddc46d687",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "14fc31d9-2a96-436b-bbf6-dfcee248de72",
+          "id": "22fd6fb8-e68a-47c8-ac11-c552a7816370",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4770,7 +4770,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4782,7 +4782,7 @@
           },
           "response": [
             {
-              "id": "6a0545e3-51ec-4d8e-8799-dd96580b521c",
+              "id": "d625910b-11bb-4034-b8e2-ea613effb814",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4819,7 +4819,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4847,7 +4847,7 @@
           }
         },
         {
-          "id": "96c5cc24-9ea9-4b84-a1b9-81eddfaf8c9a",
+          "id": "3e18e620-abaa-42f3-9df7-63916eb4c363",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4890,7 +4890,7 @@
           },
           "response": [
             {
-              "id": "cc705a6e-2f42-44e4-9295-53c4ff9da5dc",
+              "id": "36ac4994-0955-4084-a55b-3c9da9bf68b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4955,7 +4955,7 @@
           }
         },
         {
-          "id": "2eebc3f4-06ac-450e-9bbc-12ea29bdbc73",
+          "id": "86b900e5-c161-406f-80d3-7e4fa129914a",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4998,7 +4998,7 @@
           },
           "response": [
             {
-              "id": "5a245473-a709-4d9a-8882-6e3982eae65b",
+              "id": "f115192f-ecc4-453b-a4ea-03f643a9d33f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5063,7 +5063,7 @@
           }
         },
         {
-          "id": "701fbfce-7b23-46aa-bf6c-c80772b0a2c6",
+          "id": "d5650914-2816-4fda-9221-a0f4abdbd133",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -5094,7 +5094,7 @@
           },
           "response": [
             {
-              "id": "a3898eac-f673-45c7-8e14-bb5ac09d47d5",
+              "id": "a5628a57-6391-493d-892b-c2ea7b3a3b39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5147,7 +5147,7 @@
           }
         },
         {
-          "id": "166bf9cc-aebc-427b-b940-27ce4870479a",
+          "id": "c26bc560-dc6e-4989-94e3-6033cdf5c00d",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -5178,7 +5178,7 @@
           },
           "response": [
             {
-              "id": "b0aacfd8-4ac6-4928-ab82-9bcd97086d0b",
+              "id": "7a8b9397-ef80-4acc-94e9-16b55d225ca7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5237,7 +5237,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "61415841-b10f-47e0-a61e-62e759401010",
+          "id": "2a32acdf-2b68-4506-9302-9cea512e785b",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5279,7 +5279,7 @@
           },
           "response": [
             {
-              "id": "4d8ac291-73f2-40b7-a770-4ee4831835f1",
+              "id": "47bfd37b-4603-43f1-8875-18817d965d72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5343,7 +5343,7 @@
           }
         },
         {
-          "id": "fc9504ce-4784-412e-94e7-c1556eaff666",
+          "id": "6253bc92-f50a-46db-9325-0e3fea87cfe6",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5398,7 +5398,7 @@
           },
           "response": [
             {
-              "id": "0146a661-6ec8-4328-a0f9-76ac652a6b8f",
+              "id": "fa88c4c1-05cd-4552-ae6f-4f28f169358b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5475,7 +5475,7 @@
           }
         },
         {
-          "id": "c3451289-a4b1-47f9-b2b2-510e84d8d711",
+          "id": "1d58e7ee-5538-435f-b49f-1cd36d497160",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5511,7 +5511,7 @@
           },
           "response": [
             {
-              "id": "be71be44-15c7-4597-97c7-cd8d32306c29",
+              "id": "70502220-b804-4f08-b34e-b451d930ebcf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5565,7 +5565,7 @@
           }
         },
         {
-          "id": "eb97ce2f-029b-4113-a37e-58315edf37b6",
+          "id": "cf810664-a9b4-4423-80af-0b31b123bad2",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5595,7 +5595,7 @@
           },
           "response": [
             {
-              "id": "e303733a-3f6d-470c-a231-5e1213cbf47c",
+              "id": "191add19-2b2e-48c5-b488-5d767d9b565e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5647,7 +5647,7 @@
           }
         },
         {
-          "id": "3a8c9cb0-bd43-4a48-a663-cd47f11a9bc0",
+          "id": "18e44225-8581-4004-b558-d9a92db8d21d",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5690,7 +5690,7 @@
           },
           "response": [
             {
-              "id": "f681356c-c844-446c-9201-4ae7bb63c33b",
+              "id": "3a5f2fa8-2f86-4346-a009-ce25dfb41fd9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5761,7 +5761,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "223e2214-58d8-4552-b5f1-57ab469b876c",
+          "id": "e528ae92-3004-4913-bfc4-ce4beb581880",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5814,7 +5814,7 @@
           },
           "response": [
             {
-              "id": "43943965-5c65-40b7-ac27-44ad3362dda6",
+              "id": "2f0755a1-8390-4069-a4c7-f9ee18c5095e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5889,7 +5889,7 @@
           }
         },
         {
-          "id": "a88e0846-1f0a-4aa1-8092-5d9d8d28ee07",
+          "id": "08ad35cd-2b78-4ee9-831d-3a83554becb4",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5955,7 +5955,7 @@
           },
           "response": [
             {
-              "id": "5e75c146-c9e1-4107-a632-3f731876b06c",
+              "id": "5d675932-c63c-4c87-947b-6e51d291d8a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6043,7 +6043,7 @@
           }
         },
         {
-          "id": "e45645fd-2a42-4963-b698-165cdcc27427",
+          "id": "b76d3b0f-2fcb-4c0f-abcf-24dbba42dd40",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -6090,7 +6090,7 @@
           },
           "response": [
             {
-              "id": "4c34acee-0c90-43bd-8182-7b046321e209",
+              "id": "9897009a-898a-4f64-94c6-23ff7fed1688",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6155,7 +6155,7 @@
           }
         },
         {
-          "id": "99ff7ec7-9366-40a9-bd3c-6383667bda5c",
+          "id": "daff58aa-5c44-46f3-9667-6b5ee44528f3",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -6197,7 +6197,7 @@
           },
           "response": [
             {
-              "id": "a29bac23-c784-4f44-8015-bb77ce67a13a",
+              "id": "a0c91196-7214-4234-9237-10fe56e6ed1f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6261,7 +6261,7 @@
           }
         },
         {
-          "id": "bb9daa40-3e2c-4614-9e2f-3cae44f956a0",
+          "id": "dfecbbec-2661-44e3-bf59-820d8f522790",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6316,7 +6316,7 @@
           },
           "response": [
             {
-              "id": "bf09dd51-da0e-423f-8a7f-b5812f4d7581",
+              "id": "475e6e6c-50b9-48dc-a39c-84ab12a2000b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6393,7 +6393,7 @@
           }
         },
         {
-          "id": "e943109c-ae1e-4c18-9966-8c126bac4822",
+          "id": "6b451879-6354-459a-aaf5-90ad624dcbd3",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6460,7 +6460,7 @@
           },
           "response": [
             {
-              "id": "b8bbe815-bba9-46d6-8ace-3f2473114ca7",
+              "id": "cc98bea6-a8ac-42cb-8a09-8a9aa8be0899",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6549,7 +6549,7 @@
           }
         },
         {
-          "id": "73e424f3-88ae-4b95-8f30-526bc63f9628",
+          "id": "c0dba5c6-ec5f-4dfe-9506-2b067c64f602",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6603,7 +6603,7 @@
           },
           "response": [
             {
-              "id": "a255c3a6-25ca-4a56-b7bb-4bbe82d6910d",
+              "id": "84f6b960-6894-47ee-a383-6651fe76c7c0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6685,7 +6685,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "9bba1bd4-cc76-4000-9259-f9c66fbdf70e",
+          "id": "a617e5bb-70cd-45e1-ad36-1b197f7617b9",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6738,7 +6738,7 @@
           },
           "response": [
             {
-              "id": "d8631586-7e25-4e5e-ab19-4c6e2b4a7187",
+              "id": "571cdf3e-b0ae-44e1-ab3f-b5b99c49fbf5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6813,7 +6813,7 @@
           }
         },
         {
-          "id": "a373414c-0474-44bf-851e-15d4ab464ab4",
+          "id": "5145a076-3c63-4c0b-9cc7-6adf48a66d23",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6879,7 +6879,7 @@
           },
           "response": [
             {
-              "id": "febf2c3d-9a62-4ffc-8c6d-1797a0ca0624",
+              "id": "afd432dc-687b-4f44-be38-a710ff95f175",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6967,7 +6967,7 @@
           }
         },
         {
-          "id": "9fda01c1-2ac6-4e1a-bf4d-a681334dc3ba",
+          "id": "712cc50b-35b7-45a6-a900-6241df17f49f",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -7014,7 +7014,7 @@
           },
           "response": [
             {
-              "id": "57ac044c-1013-4714-975f-97a4bf51b117",
+              "id": "23b02c52-6bc3-4232-9c02-1024b09dc31e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7079,7 +7079,7 @@
           }
         },
         {
-          "id": "e9b754a3-3156-4091-9e32-5c20504e4fac",
+          "id": "1f295faf-27ca-42dd-8d53-532ec5ba7450",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -7121,7 +7121,7 @@
           },
           "response": [
             {
-              "id": "e1d7201f-ed16-4301-9d7d-4177a0a3c091",
+              "id": "1e01105c-45ad-4ae6-a42c-dcaf672a4d59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7185,7 +7185,7 @@
           }
         },
         {
-          "id": "6ea997f0-71f5-40a1-b726-bcfef93898b6",
+          "id": "0ec764f6-7a15-48af-8f9d-55925a3e085b",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7240,7 +7240,7 @@
           },
           "response": [
             {
-              "id": "c0e8015d-99b9-4d95-994b-a69ed5f50b24",
+              "id": "0c371f43-19a0-4759-b5a5-d9d47189aeaa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7323,7 +7323,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "eba22304-9ca1-492f-8220-92ab00ba09d2",
+          "id": "b51ad564-7c3d-4e1c-9c83-4868b1ac9add",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7364,7 +7364,7 @@
           },
           "response": [
             {
-              "id": "cec75375-65c7-4868-ba5b-00058705cf36",
+              "id": "600af707-8d15-48d8-a46e-f0084118f7f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7427,7 +7427,7 @@
           }
         },
         {
-          "id": "678e3829-17a5-44c3-812d-18d1580c4949",
+          "id": "a76e8ed6-fee0-422b-a516-9ebf2a8e2984",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7481,7 +7481,7 @@
           },
           "response": [
             {
-              "id": "267d7b1a-610b-4652-85a4-d390b136e318",
+              "id": "f318e078-2848-4189-8e6d-ac3a570f427f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7557,7 +7557,7 @@
           }
         },
         {
-          "id": "7c23a110-bd12-4935-bb13-55f198a10cb8",
+          "id": "c3974a62-9a1d-4105-b76b-5ef6ec129e24",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7592,7 +7592,7 @@
           },
           "response": [
             {
-              "id": "6833acf9-44c1-461f-9034-26da9a63ad16",
+              "id": "7ddec63e-8008-40e3-924e-8ab5ef706f9d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7645,7 +7645,7 @@
           }
         },
         {
-          "id": "5702e1c9-fac0-40c2-936c-e4c1a88cc763",
+          "id": "854fa2d0-cd30-4874-84f1-2c2020f2061a",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7702,7 +7702,7 @@
           },
           "response": [
             {
-              "id": "39d43eff-6ee0-470e-a9b0-8a0300bc07db",
+              "id": "31a2e716-5fc8-4954-a769-7955cfecb434",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7781,7 +7781,7 @@
           }
         },
         {
-          "id": "3f103835-e5e4-4cea-a815-9e17ba663f9a",
+          "id": "8638d724-63bc-43c7-b58c-a596de23a6f6",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7823,7 +7823,7 @@
           },
           "response": [
             {
-              "id": "7ef64adb-5eb7-4863-8380-fcc3593b8ccc",
+              "id": "5fbad19b-dfe2-4e9f-96fc-0043a0cdc990",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "896177e3-28e2-43ad-9371-1ab2a3be5bdf",
+          "id": "c57796a3-25c1-4741-9144-5b73c3662ea3",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7946,7 +7946,7 @@
           },
           "response": [
             {
-              "id": "dbb47a36-0581-4162-b12f-5f47b5dfd6ad",
+              "id": "24bfd3f8-0e7b-4a41-bafe-b957e1f11551",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8021,7 +8021,7 @@
           }
         },
         {
-          "id": "4a00ad68-372c-4ac0-af3f-d7c5aa1f737c",
+          "id": "eedfc3f9-628c-45d9-9bd5-c416185c75f1",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -8087,7 +8087,7 @@
           },
           "response": [
             {
-              "id": "2603d5e5-ed38-4db9-aef1-695e8c1e00a5",
+              "id": "fcf46126-0e00-41f1-ab69-e69ce5a676ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8175,7 +8175,7 @@
           }
         },
         {
-          "id": "519e705e-c93e-425b-a43d-97b028ba6b3c",
+          "id": "d9d21893-17f5-4dcc-b9f5-fec3472789e2",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8222,7 +8222,7 @@
           },
           "response": [
             {
-              "id": "ec63658c-bc26-4f26-9c26-886e91e68886",
+              "id": "3d415274-50ed-49a2-b2f7-e17bf1864439",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8287,7 +8287,7 @@
           }
         },
         {
-          "id": "6367a065-f436-4a31-8bc8-29a7a1b5945c",
+          "id": "d1819ee2-7adc-439c-8818-c0630ce611cc",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8329,7 +8329,7 @@
           },
           "response": [
             {
-              "id": "7e5cc628-acc4-4ea3-b621-59586f522b84",
+              "id": "7eed6f9a-90e6-4108-9060-77406d75c7c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8393,7 +8393,7 @@
           }
         },
         {
-          "id": "d29ffe48-11d3-4a46-b5d3-262e421f1202",
+          "id": "c7d889d2-e7ef-47dd-99da-2a29822036e8",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8448,7 +8448,7 @@
           },
           "response": [
             {
-              "id": "74b4e932-8567-4bc9-8a7b-74a94d51cc71",
+              "id": "f248f526-86c5-4409-94f8-3c1da3ee7b73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8531,7 +8531,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "51cd6405-83bc-4ffa-98bb-51fcd040dfa5",
+          "id": "8793ff5d-d20e-41f3-add8-32f5c33ce184",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8573,7 +8573,7 @@
           },
           "response": [
             {
-              "id": "e94920f4-fbd5-479c-8bf6-69c8f4ddd2a4",
+              "id": "0e48ddad-9298-458e-8371-f605b89912ad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "340a0f01-c756-43c5-8b31-db04876a6ae2",
+          "id": "f7f5310a-5c7a-41c7-bff3-a7b994b8993e",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8692,7 +8692,7 @@
           },
           "response": [
             {
-              "id": "2bd897d0-9b12-47b0-9227-a784d4afc86d",
+              "id": "09cf3304-fbf7-424a-a234-0b8af5e5dca1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8769,7 +8769,7 @@
           }
         },
         {
-          "id": "2fa031f3-189b-4c8e-a2e1-082cebcebedd",
+          "id": "2ee6c648-f89f-4ed7-8aa6-7d14003ad66c",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8805,7 +8805,7 @@
           },
           "response": [
             {
-              "id": "eb7e67b8-2bf6-4f94-b2ef-c8de5fd591bc",
+              "id": "68144796-1859-4fcf-8cad-a934359c430e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8859,7 +8859,7 @@
           }
         },
         {
-          "id": "82b20fde-24f9-4505-bf6a-682387e8ba6d",
+          "id": "405d3bf2-2189-43bc-b65d-450007aa47cf",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8889,7 +8889,7 @@
           },
           "response": [
             {
-              "id": "4e9ace00-d0d0-4e79-b844-7195ae9dc79a",
+              "id": "a76e40a1-97fc-4dd1-a440-d4f565cb524c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8941,7 +8941,7 @@
           }
         },
         {
-          "id": "a9f38fbe-c32c-4db6-9dfe-d7d12dedf784",
+          "id": "ebedabbb-43fb-4a89-8db7-6efcf62ac802",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8984,7 +8984,7 @@
           },
           "response": [
             {
-              "id": "a12ffbef-a7a0-4795-8e2b-4f0d18ccf35b",
+              "id": "0266b360-77af-4ba6-b727-ac6c3c9d05bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9055,7 +9055,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "71baf9aa-4dd1-4787-87fd-3d14d95e6267",
+          "id": "b2824b22-58e5-467a-8904-2f23659bae08",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -9097,7 +9097,7 @@
           },
           "response": [
             {
-              "id": "dc92289a-d18b-49c5-a047-7553c16f5c7b",
+              "id": "414885b4-ae66-4630-a160-d58bd45dc2ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9155,7 +9155,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4c842dec-afa6-4a23-b439-498c18d7606c",
+              "id": "ee917602-42ca-469b-a2e1-1fb66d061874",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9219,7 +9219,7 @@
           }
         },
         {
-          "id": "900400b6-a7ac-48b2-a55d-3f5e596cabd3",
+          "id": "61ba457e-a5ad-46b2-82ae-1b6398ec453f",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9274,7 +9274,7 @@
           },
           "response": [
             {
-              "id": "059d4b20-5db9-4895-8823-4077b440179d",
+              "id": "94a564ad-692d-45f9-98ab-62599be990e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9345,7 +9345,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "66150ff8-f8fb-424f-a180-9d9e75b82822",
+              "id": "87825282-a9be-4509-9ce0-93fac4451f41",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9416,7 +9416,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "74faf7a8-425a-47f8-ae8b-122d329eb00f",
+              "id": "434d747d-accc-4e16-a5eb-e60864ac18e5",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9493,7 +9493,7 @@
           }
         },
         {
-          "id": "7581e91a-307f-499b-bc91-fa73b802cf0b",
+          "id": "ebdb87bc-fd65-4646-90e2-be90e350e9d7",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9529,7 +9529,7 @@
           },
           "response": [
             {
-              "id": "3e86707a-1f40-4bd8-bd0e-8fcec6973064",
+              "id": "105a3e8e-2a26-4736-9757-1774f326df76",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9577,7 +9577,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d3c505cc-1ce1-4b20-8125-c068b700a75a",
+              "id": "60509c10-438e-4158-85d1-3d7bebf690fc",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9625,7 +9625,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0108f31a-e636-4c5d-abe9-e3cce315521c",
+              "id": "d13310c0-9079-43ac-89d2-00b238d9911e",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9679,7 +9679,7 @@
           }
         },
         {
-          "id": "ffe8114c-d3f7-409b-a7e9-fd10d4826e2a",
+          "id": "20de40e0-ef94-4d66-b61b-c29b7cf24089",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9709,7 +9709,7 @@
           },
           "response": [
             {
-              "id": "6cff633e-a741-47f4-bfe9-4cc500908254",
+              "id": "7a56b604-2c40-4e80-8071-dcebb5eaa158",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9761,7 +9761,7 @@
           }
         },
         {
-          "id": "0fc1bef1-cd62-4f6e-81d9-c6f4c9842b95",
+          "id": "4acba6e7-4d21-460b-a16b-e7d56aac462f",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9804,7 +9804,7 @@
           },
           "response": [
             {
-              "id": "0202de1c-f6a0-4003-8159-12957b666729",
+              "id": "7de54419-937c-4bb9-9e52-232328ef4d4e",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9863,7 +9863,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8d3da19c-a5d3-4842-9773-c5eebaafe4b4",
+              "id": "c0002cad-2db9-4a31-8f58-9f9952404803",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9934,7 +9934,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "ca0a377b-b7fa-47cf-97bb-45a68ea71f08",
+          "id": "dba8ddab-a93b-47e2-9d21-559ddbb64a5d",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -10000,7 +10000,7 @@
           },
           "response": [
             {
-              "id": "20a8d3bf-a327-4c4d-84e3-7e581b27bcd4",
+              "id": "5a286f87-ba09-4d3a-bbe7-f94845dab1fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10074,7 +10074,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 9302.475911937629\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -10091,7 +10091,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "b6199504-3c7a-4943-a8bb-31c093c221da",
+          "id": "dd34dc22-06a4-47c0-87dd-bdfed1e7d0fb",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -10133,7 +10133,7 @@
           },
           "response": [
             {
-              "id": "3848dbef-c139-47e0-95ee-2bbbc75288c9",
+              "id": "e0645223-1c6b-49f6-ac11-ef1bb12dcc9b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10203,7 +10203,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "6f40b137-72b8-462b-aaf9-4923808e73b9",
+          "id": "3b34e7d4-37c1-4d69-85fb-93defea36009",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10245,7 +10245,7 @@
           },
           "response": [
             {
-              "id": "d078bbac-61a9-442f-86c0-b3d1d9b83879",
+              "id": "b6c6c8ba-56ca-4d63-9a24-78b671b18ff4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10309,7 +10309,7 @@
           }
         },
         {
-          "id": "e1707080-79a0-4fc2-8c81-02341a401ec9",
+          "id": "9d253cca-fa4b-44fc-af3d-c0789a104132",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10352,7 +10352,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#149d6e\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#c9eaD8\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10364,7 +10364,7 @@
           },
           "response": [
             {
-              "id": "744dcfd0-c2ac-4183-aa16-ef87e373cbf3",
+              "id": "c1752992-97b4-473e-ac8c-369627628ed8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10413,7 +10413,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#149d6e\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#c9eaD8\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10441,7 +10441,7 @@
           }
         },
         {
-          "id": "f0bfdd5d-3bb6-4dca-9959-8e2ed9d9b458",
+          "id": "78e27873-3a6a-44a6-ade5-3a604cdd049d",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10477,7 +10477,7 @@
           },
           "response": [
             {
-              "id": "6ed7f25a-3382-4e6c-983d-4c34ba728d29",
+              "id": "362ab7a3-130c-40ba-a963-cf57293ce1b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10531,7 +10531,7 @@
           }
         },
         {
-          "id": "2e53958e-330a-4e16-9e2c-44b7fd5b67ac",
+          "id": "262776e2-d90c-4cfa-95b7-29c64f7ed2fb",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10561,7 +10561,7 @@
           },
           "response": [
             {
-              "id": "98a44db2-1470-4df3-9092-830e135ff15b",
+              "id": "e2a634a2-6913-4418-bd7a-79ac5c373f45",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10613,7 +10613,7 @@
           }
         },
         {
-          "id": "4591658f-d8ad-4b99-8777-f47b77a171c7",
+          "id": "d179c60e-4a50-4732-9b4b-d8629b51f708",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10644,7 +10644,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#85C13c\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#B96d2B\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10656,7 +10656,7 @@
           },
           "response": [
             {
-              "id": "97e815f9-893a-45d4-8ab8-72b44baeacad",
+              "id": "fc3ba072-cc76-4716-b4cd-2b9b1e2c4914",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10693,7 +10693,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#85C13c\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#B96d2B\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10721,7 +10721,7 @@
           }
         },
         {
-          "id": "a573061d-fe47-4c99-bdd5-3ae0cd2473ad",
+          "id": "7c77e599-50ab-4f0d-aabc-09269775e4cb",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10752,7 +10752,7 @@
           },
           "response": [
             {
-              "id": "560788b5-6700-4167-8901-4ad8ea22e42a",
+              "id": "c06190f4-6dd6-4c83-9328-19b53fcbabb0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "85f4a410-ce5d-4ad4-b03a-42c192c4ef27",
+          "id": "effa0307-9e65-49c6-b3a3-ea869927ed1c",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10864,7 +10864,7 @@
           },
           "response": [
             {
-              "id": "fb24f45f-411d-4fbe-b0d7-e1269b9b5df2",
+              "id": "e6dd49e2-34e9-4718-95f5-8d64bba17366",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10939,7 +10939,7 @@
           }
         },
         {
-          "id": "c422b01b-b835-46ad-9316-67bed053a6d9",
+          "id": "50dcab57-5ac7-4e36-8761-b165715c43c4",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -11005,7 +11005,7 @@
           },
           "response": [
             {
-              "id": "a01268f8-3a06-41ae-82c0-b21e4d1f96e1",
+              "id": "05021c93-9c6c-4399-b049-b8bb75c8079f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11093,7 +11093,7 @@
           }
         },
         {
-          "id": "64ba3867-9a59-401e-bb48-8ed22e2b9c60",
+          "id": "506baa8a-cc21-482a-9ff7-6640e5b7ba25",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -11140,7 +11140,7 @@
           },
           "response": [
             {
-              "id": "4b7c704b-6341-4619-9ff7-902c213dead9",
+              "id": "988b462b-a0cd-45c6-9447-c9c434ef2a2f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11205,7 +11205,7 @@
           }
         },
         {
-          "id": "51525c6e-b96c-4acb-8895-b4e97b922b78",
+          "id": "6e5dec9a-d1cb-4ffb-b8e9-5c3f9bd66058",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11247,7 +11247,7 @@
           },
           "response": [
             {
-              "id": "8ffeaea8-03c8-46b2-a419-d2c783539d36",
+              "id": "e31636a1-80ba-4699-92da-d138218175d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11311,7 +11311,7 @@
           }
         },
         {
-          "id": "6055e1c8-fa88-44d1-8b9f-5185417a0a36",
+          "id": "a7a3e739-31c9-48bc-ae44-5166a296d07e",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11366,7 +11366,7 @@
           },
           "response": [
             {
-              "id": "8f3f464c-005d-4a0a-88a8-4edb6a05e400",
+              "id": "f30607c2-9488-40e0-8b16-24a5e8924ec9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11443,7 +11443,7 @@
           }
         },
         {
-          "id": "171c12a7-bba3-4938-92b0-6e0f871de4fe",
+          "id": "af54b460-590d-46df-ac0c-4ea16c2ff4e2",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11497,7 +11497,7 @@
           },
           "response": [
             {
-              "id": "02620d02-4ca0-4edf-a3d8-59b29be90dd5",
+              "id": "cbaa6559-5f24-4dde-b147-bc5f0fe34028",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11573,7 +11573,7 @@
           }
         },
         {
-          "id": "b3ebe799-e552-448e-bf2f-5563160d6799",
+          "id": "0a9e3023-c97c-4399-b669-717f6a8b5508",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11639,7 +11639,7 @@
           },
           "response": [
             {
-              "id": "0381c953-1982-4abe-8bc6-3eb8ac90d559",
+              "id": "f9b16478-3f79-46ee-85b1-58fbccf8e750",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11727,7 +11727,7 @@
           }
         },
         {
-          "id": "38e37ce1-c3a9-450f-94ee-277a9de4f037",
+          "id": "d3b21d8f-5c66-4c8c-95a9-d1817968e0ae",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11805,7 +11805,7 @@
           },
           "response": [
             {
-              "id": "b1a2d671-f011-4f80-9acd-886f082df79a",
+              "id": "d07275fa-e7b6-47cd-870e-cb1a565b6f83",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11905,7 +11905,7 @@
           }
         },
         {
-          "id": "0afbbb83-93ac-4f52-94ae-dccf287e4d86",
+          "id": "58f6966f-d85a-493e-9f24-51afd0830506",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11971,7 +11971,7 @@
           },
           "response": [
             {
-              "id": "486e5fa4-42b4-46a8-9f1d-2b0e9b1d2b43",
+              "id": "c0d0b539-81c2-4001-a675-0712a0a5b6b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12059,7 +12059,7 @@
           }
         },
         {
-          "id": "68a8071a-2479-4bb4-9e94-66b85905eeb1",
+          "id": "4b94c997-1de4-494d-9570-9dccf2fa0d41",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -12114,7 +12114,7 @@
           },
           "response": [
             {
-              "id": "ba8bc7df-4ce4-4687-8c33-77e67079dda7",
+              "id": "13445d6d-08e9-4d0d-9abf-a162f309d1ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12197,7 +12197,7 @@
       "description": "",
       "item": [
         {
-          "id": "eb9f11cf-4abd-443f-b571-a0798706281f",
+          "id": "3a818d82-fe58-45b7-a32b-cca6908b8980",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12238,7 +12238,7 @@
           },
           "response": [
             {
-              "id": "71d8af53-a72a-4233-90d0-b8bf0df0ef15",
+              "id": "1833b1ad-1a08-49e3-be2c-601daa045414",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12301,7 +12301,7 @@
           }
         },
         {
-          "id": "019b5e56-0955-4260-a507-ea13ba707a92",
+          "id": "efd3f81c-9ea4-42c7-9053-ab599462deaf",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12355,7 +12355,7 @@
           },
           "response": [
             {
-              "id": "cc3940db-6a47-4af7-bfc3-048a465f9884",
+              "id": "e1bc1864-0a9f-4a46-9190-88c6f925c2b9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12431,7 +12431,7 @@
           }
         },
         {
-          "id": "7a62763f-9073-4476-9d82-0f50da350572",
+          "id": "42d906aa-f63e-4904-881a-5cfc52e596c5",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12466,7 +12466,7 @@
           },
           "response": [
             {
-              "id": "cc055572-5088-48c7-a35d-7b2ee0d660a5",
+              "id": "6354f723-c436-4f83-9ff2-f127b5eecb31",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12519,7 +12519,7 @@
           }
         },
         {
-          "id": "d2fb48df-6305-44bf-98f0-3792c05337e4",
+          "id": "e07ec449-71fa-4e45-86f1-68e0a1a06674",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12580,7 +12580,7 @@
           },
           "response": [
             {
-              "id": "7ea84b25-f32b-4d71-b872-c5b66eb27f1f",
+              "id": "b3fc22d4-78d7-49c6-b075-c355eeef2d3d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12663,7 +12663,7 @@
           }
         },
         {
-          "id": "6df77676-b894-4414-b896-bcf253ab5654",
+          "id": "0da6e793-cd40-4ca1-839c-2af53ba7bf7b",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12705,7 +12705,7 @@
           },
           "response": [
             {
-              "id": "f9f9d051-5ce6-4835-bb87-eecbdf43950b",
+              "id": "d8957073-4b34-46de-8cf1-e67709a1ba09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12769,7 +12769,7 @@
           }
         },
         {
-          "id": "f8821cd3-dc6c-4f83-b912-b4124b64eb38",
+          "id": "b6b06a61-39cc-46e4-bdc0-b4917474e0ef",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12844,7 +12844,7 @@
           },
           "response": [
             {
-              "id": "c404bd63-f7e2-4536-a47b-96e576b82c57",
+              "id": "e66fc26c-0172-4b41-81db-03bcb2a11d31",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12941,7 +12941,7 @@
           }
         },
         {
-          "id": "2ce8e895-81cb-482c-9b5d-e9816205bfe2",
+          "id": "2a2ffb84-b6a9-44b0-9184-d031e2616546",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12983,7 +12983,7 @@
           },
           "response": [
             {
-              "id": "521dc78f-9ea5-47bd-8bc2-c9177e1feec5",
+              "id": "e1c394d3-9024-4b92-9278-de7be71c6153",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13047,7 +13047,7 @@
           }
         },
         {
-          "id": "5fee4999-8f9f-45be-a02e-f27d376832be",
+          "id": "f243df2c-d73c-4537-95b6-5ace827d4a79",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -13090,7 +13090,7 @@
           },
           "response": [
             {
-              "id": "386b6bb0-949f-49ab-a3ab-295c2d3623b5",
+              "id": "da377687-5c98-4403-8524-00cf58b50d29",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13155,7 +13155,7 @@
           }
         },
         {
-          "id": "bc83e6bc-e0a0-4e95-b562-70179d1e8415",
+          "id": "09083264-efa4-4a1f-9518-586c65e1d50c",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "42904379-5d36-474f-b513-748acd8892a0",
+              "id": "db840003-6ece-461d-adb5-e6d4c5e1c25c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13263,7 +13263,7 @@
           }
         },
         {
-          "id": "2943839e-bdf9-425f-a515-771a9edea334",
+          "id": "049a0629-0153-45a4-bb43-7509fdd0f3e3",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13315,7 +13315,7 @@
           },
           "response": [
             {
-              "id": "eea78fdf-81b2-47e9-8226-83e754bf5aa3",
+              "id": "3e0b101a-568b-4017-a69a-fb8010110059",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13389,7 +13389,7 @@
           }
         },
         {
-          "id": "8333cb0e-b668-402a-9e96-240a75542159",
+          "id": "ad98ce1e-4f1e-4b80-a6aa-a8d3fdd41f3d",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13431,7 +13431,7 @@
           },
           "response": [
             {
-              "id": "caa65647-ae0e-4f7b-b827-f6d33286c6f3",
+              "id": "737bd6b7-8b0c-47da-b96e-325c9a6c74b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13495,7 +13495,7 @@
           }
         },
         {
-          "id": "b8bdb874-95da-44b6-ad00-af76721a3ad7",
+          "id": "74c6b84e-64b6-4eb6-8a7a-4c75eb282114",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13548,7 +13548,7 @@
           },
           "response": [
             {
-              "id": "c8ab8d16-1d96-4adc-b789-1657a36684b0",
+              "id": "f4610fb7-527b-449a-96cc-d145a9b4069f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13623,7 +13623,7 @@
           }
         },
         {
-          "id": "465eb26e-b3e2-494e-a28e-b68e80fa8cdb",
+          "id": "979bd090-63ad-410b-87b2-1223b28a775e",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13667,7 +13667,7 @@
           },
           "response": [
             {
-              "id": "23fda246-c123-4346-9f6b-0e3f2e011a0b",
+              "id": "31d99659-911b-4bc4-ab4a-72e80ee1ec59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13722,7 +13722,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13733,7 +13733,7 @@
           }
         },
         {
-          "id": "18162d42-6834-4165-9848-05c86c39e207",
+          "id": "be8f6e04-b1b3-4823-9b8c-46f170f38975",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13777,7 +13777,7 @@
           },
           "response": [
             {
-              "id": "3615f695-cf00-46d8-8e18-15324f704326",
+              "id": "19a0c18c-3593-4ec4-a4d3-c778705be75e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13832,7 +13832,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13849,7 +13849,7 @@
       "description": "",
       "item": [
         {
-          "id": "09f87f5c-f343-4f31-9acb-0a018c75fc3c",
+          "id": "6f43bf40-6543-48f8-adaf-70dc1a50a144",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13891,7 +13891,7 @@
           },
           "response": [
             {
-              "id": "e14086a7-14f1-4a09-99af-58f92d66e255",
+              "id": "ce9796a2-1fd4-4752-a5b8-b11a5c523844",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13940,7 +13940,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3473f5ec-6050-4020-a247-010fc28d39b5",
+              "id": "808bb87f-5999-402d-9428-8c1aad46f345",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13995,7 +13995,7 @@
           }
         },
         {
-          "id": "06edea87-a3bf-4368-8ed0-81c6b0ce8df3",
+          "id": "2a9267ac-ad83-485b-8f14-4163a5abe862",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -14041,7 +14041,7 @@
           },
           "response": [
             {
-              "id": "96d61143-b4e3-45db-8949-2828346a31fa",
+              "id": "f56bc304-2fc7-4a42-ba6a-0e7efa21f93f",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -14100,7 +14100,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a26826e0-62aa-42eb-88e1-c4847476a4c2",
+              "id": "3ea06590-9f0b-4a98-8b3e-14546eab345d",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -14165,7 +14165,7 @@
           }
         },
         {
-          "id": "7ab1f83c-ae59-4c3b-bf0b-1d6a4e26e65f",
+          "id": "2d6ec7a1-d87b-4674-8e5a-126ac9bbce93",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14211,7 +14211,7 @@
           },
           "response": [
             {
-              "id": "0faa228b-f44a-47b2-af69-6176698c5bc9",
+              "id": "cebbf3af-50a6-444d-8c09-6faf6d3f3092",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14270,7 +14270,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1484603f-d4a5-4690-85dd-21ad369e943e",
+              "id": "6e02746a-506c-4626-8936-e38cda98a069",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14335,7 +14335,7 @@
           }
         },
         {
-          "id": "bc9b8db9-11a7-43b4-a9da-28c3c6c779f7",
+          "id": "7c5d5538-34c1-4155-94f3-d342474e9593",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14377,7 +14377,7 @@
           },
           "response": [
             {
-              "id": "8b5d415a-e9a7-45c8-b98d-1d30e1431056",
+              "id": "e3058e7f-78e0-4578-85ab-b9bb74f66c35",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14438,7 +14438,7 @@
       "description": "",
       "item": [
         {
-          "id": "be8dee71-bfb5-4b3b-bc9c-777cd34adaa9",
+          "id": "37bf8071-63ac-4fe2-b03d-bb7091da7c63",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14487,7 +14487,7 @@
           },
           "response": [
             {
-              "id": "dedd0efb-e3da-49f8-bfd2-f93a9845b664",
+              "id": "e82531d9-c6c1-423c-a755-93bf9659286f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14547,7 +14547,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 9302.475911937629\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14558,7 +14558,7 @@
           }
         },
         {
-          "id": "c412504f-9f43-4894-bc0f-f4902780109d",
+          "id": "263b9629-18db-4c65-83ce-1198d30b1128",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14607,7 +14607,7 @@
           },
           "response": [
             {
-              "id": "72db9d98-8ddf-4132-95dd-f65df91f8c1b",
+              "id": "d32bff6c-88b2-44e4-8fd7-f4eede558035",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14678,7 +14678,7 @@
           }
         },
         {
-          "id": "f2a7ff9e-3b00-459f-bb49-2ed31742d4de",
+          "id": "a4cbe41c-5c33-4e10-9914-64cb51b79f89",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14727,7 +14727,7 @@
           },
           "response": [
             {
-              "id": "3513e9ab-261b-4352-835f-68ecde7f5e8f",
+              "id": "56499123-ea33-4314-b354-36a4a5b3b903",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14798,7 +14798,7 @@
           }
         },
         {
-          "id": "12cfd609-85bb-46fd-8060-2b2f9f1c87c5",
+          "id": "315d91c0-f99d-4c66-a961-8d18bd13e27d",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14847,7 +14847,7 @@
           },
           "response": [
             {
-              "id": "ed229802-8bc9-4c4a-bf00-75a4f7d9cf73",
+              "id": "f1717b31-09de-4af9-99c7-77b42b075805",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14924,7 +14924,7 @@
       "description": "",
       "item": [
         {
-          "id": "34f1eb7b-dc2c-441e-b9c0-482bbee6935f",
+          "id": "a472a761-74a8-4d00-9d0a-e4a1390217f6",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14964,7 +14964,7 @@
           },
           "response": [
             {
-              "id": "8037f59d-a72a-4051-a62d-fc34ad8da404",
+              "id": "bd1b19f9-df57-4b9c-a5e2-88c61640ae84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15026,7 +15026,7 @@
           }
         },
         {
-          "id": "5a142780-86af-4a0b-9f77-c0d6cc994d18",
+          "id": "aa1c8046-bc2f-49b0-9096-bb2bd47c4fdd",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -15056,7 +15056,7 @@
           },
           "response": [
             {
-              "id": "9fac6049-5f71-4fb4-85bc-5d3631ab9bb5",
+              "id": "e6cfafe1-d904-4791-bce3-5e854c3cb267",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15097,7 +15097,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 9302.475911937629\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15108,7 +15108,7 @@
           }
         },
         {
-          "id": "41d93da9-ecb0-47f5-b3d1-16a0a4836896",
+          "id": "e68cf46b-b253-4a23-8251-a33bd94bfe15",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -15160,7 +15160,7 @@
           },
           "response": [
             {
-              "id": "0f76bdda-f42d-45c6-bfa9-44ea77457280",
+              "id": "6f3641c3-f296-4bce-b24c-3ba87b4f11e5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15240,7 +15240,7 @@
       "description": "",
       "item": [
         {
-          "id": "111ca295-5107-423e-bb71-b982b829e7d9",
+          "id": "121783ae-477c-4829-9385-2b75f2343159",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15269,7 +15269,7 @@
           },
           "response": [
             {
-              "id": "28709310-60b9-4a10-aa4f-b78275cfa3f2",
+              "id": "faf38b24-de69-4cd0-accf-4d11f59c6cba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15320,7 +15320,7 @@
           }
         },
         {
-          "id": "f80fbcdc-cbd4-43af-b684-1e769eab43b0",
+          "id": "b7bd26af-aebd-46d3-96dc-466724460e71",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15361,7 +15361,7 @@
           },
           "response": [
             {
-              "id": "df7683ed-1441-4d41-b276-52592e4f9a06",
+              "id": "e17f663e-ab1a-4d79-8d11-6d57072c3fd0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15430,7 +15430,7 @@
       "description": "",
       "item": [
         {
-          "id": "28504684-6547-4c29-bbca-3bd12750cb93",
+          "id": "50ae0765-8e26-40b2-8c5b-0da9e63c80f7",
           "name": "health",
           "request": {
             "name": "health",
@@ -15459,7 +15459,7 @@
           },
           "response": [
             {
-              "id": "f4eb0e5c-860e-4cb4-9071-8f56f474717d",
+              "id": "fbb6084f-1d1f-4631-bdf7-c495e91cf985",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15499,7 +15499,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2211,\n  \"key_1\": true,\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 9302.475911937629\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15516,7 +15516,7 @@
       "description": "",
       "item": [
         {
-          "id": "dcea8d3e-beef-4101-a5cf-504f71736993",
+          "id": "aa2401a4-0946-49f4-9d9a-3200ab062820",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15568,7 +15568,7 @@
           },
           "response": [
             {
-              "id": "2cc4abdc-2a4e-4d1b-88b2-a123ed134cbe",
+              "id": "6935c78d-9306-47e6-a977-28acc366e5ff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15642,7 +15642,7 @@
           }
         },
         {
-          "id": "b96cc567-3d8a-4508-9c34-672e2be35e4b",
+          "id": "7cbf329d-bbea-449e-8ab0-d18b9c0d71ad",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15683,7 +15683,7 @@
           },
           "response": [
             {
-              "id": "4a29dd3c-21b5-4de0-a2d1-16d650bf95d1",
+              "id": "e475a398-7e56-4270-9c5e-e19ef3f2bafe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15735,7 +15735,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15746,7 +15746,7 @@
           }
         },
         {
-          "id": "dbae3d1e-a67e-44cc-9e06-da2f75da3b4a",
+          "id": "57350b31-5350-4074-90fb-b89d5c6ee7c1",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15776,7 +15776,7 @@
           },
           "response": [
             {
-              "id": "52b860ab-964f-4fea-b9b8-99a032da5e03",
+              "id": "eb089880-6833-4fa6-b61d-d2c54d555f14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15817,7 +15817,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15848,9 +15848,9 @@
     }
   ],
   "info": {
-    "_postman_id": "badbaf6e-212b-4e8c-af84-8ff28d2da413",
+    "_postman_id": "c14d8f1a-222e-45d8-b29a-345a7913aa0a",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-30 23:20 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-30 23:23 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "9aab9086-0706-43c5-ba5f-6010eb5797cd",
+          "id": "86dc6c7d-39aa-43f9-8c82-4e7d3392830b",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "6bc90b01-2b2a-4a8e-8e12-2dbc070cf16f",
+              "id": "58c8e337-0415-42d4-b918-36a19add5bba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "177cc0e9-6899-4a8e-958d-d0bffc3a6efc",
+          "id": "a78f17a3-5bcf-4e30-a451-c1b3abd38eac",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "5920f258-b08d-45c3-9d3a-125ea7536f05",
+              "id": "28a44ea1-21fd-48fd-b856-1853d4934882",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "4d1a157c-1573-4f74-9ee2-09fe8d9b3e20",
+          "id": "abd0830a-27a1-4a20-8fc7-8a9b23288573",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "b55beff8-aa37-481a-a504-1ab0ba80bf52",
+              "id": "c31d4fe4-b408-495d-8c00-6a769e85641c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "8d417ddf-3fa5-4a85-b2d5-d026079ce759",
+          "id": "5c447d2d-09f4-47b0-83da-5d789409ae37",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "4ee662d1-13db-4c02-876d-11b26422ce10",
+              "id": "6682a4d9-88f8-4c75-b6c4-98623ee71e6b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "9a8c2830-eb19-4d2d-8078-7fc98e46fe42",
+          "id": "165c06ca-d36a-49ce-9f99-66d3659495ff",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "65135795-0a90-4c57-a33c-bbaf64ddb8ef",
+              "id": "ffe1fb91-594d-49dd-8077-56ce564033c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "949a3393-3389-4c89-aa94-180b23d29e81",
+          "id": "bc6ccd21-6570-41cd-bcf1-a4f1d3d31295",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "99f78b40-7500-4e4a-976a-309c8d3b72cd",
+              "id": "68544319-45c8-4b59-9c59-8852bb093e8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "60065a96-8db8-480a-83d8-4f69ab9486c9",
+          "id": "aed69f8c-b28c-4776-88fe-4b3edc27aedf",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "4140ce6e-3794-4c00-aec0-5a3d88dfe79b",
+              "id": "3cb03ed5-3c1e-4cfe-8f6d-9619b9f758a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "5050d5ff-f294-4641-acdc-5fa916762546",
+          "id": "dfb8c350-476f-4009-a3aa-c92fd13c0e4c",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "da4d1865-69e7-40df-9988-2d59214c3998",
+              "id": "441b0a3b-b2e0-4d6c-9876-d8af94460e82",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "03614a7a-0911-4c29-b6e1-e12816c6e56d",
+          "id": "a5dcf45a-64e0-43db-88dd-bcc53d76742c",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "67015339-493f-42c4-b6ac-c6bcd61766f8",
+              "id": "715fec81-ceeb-4c5e-9e5b-411359ec9982",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "19a7b109-b8db-4277-90cb-69fa4c581e3a",
+          "id": "14604480-c36f-44cd-b850-9f320fe8e47d",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "54a85335-2f79-4ce6-b90e-4459441320f2",
+              "id": "87a5e661-e32a-4a2d-9453-6869bd28a06d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "d24670c0-35d3-40a3-be5f-1e8c5bfdf9ab",
+          "id": "01cbd19c-6707-42c7-b0cc-3e29b640204f",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "fde9636a-b325-43aa-b45e-5f949e81c66c",
+              "id": "f49f68e7-c4b8-44d4-b7f8-1f44189a4c61",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "7989dbb9-24cb-4925-bfe6-df2a1ae7fddb",
+          "id": "a9113950-09f6-46c0-811f-97da7807e82a",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "28236137-9809-4bb0-87fe-b6a7385af385",
+              "id": "2ee85a68-85c4-4b17-b354-7515377b4b43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "3092d071-11fd-4958-ac4b-07a7b33b8992",
+          "id": "b8a3969e-3627-47ee-be03-a95f5ff5f297",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "ca201157-257d-4b9d-a3f1-129a33d9421e",
+              "id": "2a2b2509-07db-4873-b1fd-e4c8dbeba76a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "2a82e09c-55c0-4f5b-9f7f-ad8e4f81d12c",
+          "id": "d1900adc-0f0d-4a97-af7b-1447372b0659",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "67f0aef2-522b-4436-a0ea-b285f0c743e7",
+              "id": "442f44c1-1de1-4c95-9f94-c941af7b9535",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "4323199d-f214-4fd2-861c-a82c84e609ce",
+          "id": "601740bc-7e2e-4f94-ae7a-13933d4ddc13",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "3b679521-7dab-4480-841f-cf5703ce63ea",
+              "id": "e4ee4e15-c079-4eff-b078-81303975d436",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "1b8319f4-9b57-445d-8d79-37ae1fb91dee",
+          "id": "02ca6d72-6b89-46bf-a627-5453f310ad50",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "23d990d0-b809-4332-8d1f-6ad6134152a7",
+              "id": "9b5163d2-3ee8-46b5-bc88-b082017a8a40",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "3c42adb3-0883-4c93-b1fe-a5ce0354f315",
+          "id": "03474c18-1e8f-4774-9e3a-8074076c78b6",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -1879,7 +1879,7 @@
           },
           "response": [
             {
-              "id": "683f18f0-6a73-4da4-8189-95eec930d93c",
+              "id": "c54aaf82-e988-43dd-af26-8e18c2497b77",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1933,7 +1933,7 @@
           }
         },
         {
-          "id": "cc6485da-20a9-423a-8698-bbf5ddf79f16",
+          "id": "ee3e07cb-5295-47d0-9c4d-5c21d597c5a6",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -1976,7 +1976,7 @@
           },
           "response": [
             {
-              "id": "226d745b-dc79-4f08-8f30-79b3e65cb5f2",
+              "id": "e9884b8c-4bdf-48e7-b7e9-e800f567df7c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "237dc569-aae0-4456-bbb1-e6269e2a1f88",
+          "id": "9de7f826-caa5-4364-bec9-7ef7ea5fbc23",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -2088,7 +2088,7 @@
           },
           "response": [
             {
-              "id": "dd9dc639-fd22-43f0-9d01-87c973ef76ac",
+              "id": "819c48d6-3604-46f3-8649-0650264ed30c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2163,7 +2163,7 @@
           }
         },
         {
-          "id": "844e8973-c16c-43d6-828c-c91a7b7bd746",
+          "id": "8a98e184-1ace-4578-9ed7-0f4817cd5c99",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "2f043186-4664-4bfa-a772-9477d3620992",
+              "id": "0b75cfab-54ab-4b63-883f-3ec31d4ed45c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2317,7 +2317,7 @@
           }
         },
         {
-          "id": "168fd61b-0d95-4b72-aa82-11b0f8287e85",
+          "id": "a7425e6c-9c6d-4cf2-88e2-4b663facb4c4",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2364,7 +2364,7 @@
           },
           "response": [
             {
-              "id": "1a4feb8f-35fb-4bbc-842d-8758f384c208",
+              "id": "8e5c6e47-2226-40ae-a287-4bf9a92ee561",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2429,7 +2429,7 @@
           }
         },
         {
-          "id": "2c7d59c8-4e2d-4ecb-a7d7-2e69b8d3e9ed",
+          "id": "84663b8b-3198-4bab-afb6-0073f546e883",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2471,7 +2471,7 @@
           },
           "response": [
             {
-              "id": "15ea8f38-3f3a-482a-aa68-73c18ad9c5f7",
+              "id": "1a8967d2-3cb3-455c-ada8-1b4b074573eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2535,7 +2535,7 @@
           }
         },
         {
-          "id": "94e07ae7-771c-45f8-8647-943012d033aa",
+          "id": "2410c509-f185-456d-8a39-2d126deb6a48",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2590,7 +2590,7 @@
           },
           "response": [
             {
-              "id": "01f9bcf9-cfac-45df-8536-310b53982552",
+              "id": "cc7d36a3-436c-4cc2-9117-76267909b069",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2667,7 +2667,7 @@
           }
         },
         {
-          "id": "0c6d6b55-3501-4361-95e6-a60c098ee809",
+          "id": "845dc6f1-bdee-401e-b4c6-93ebfb77a03a",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2731,7 +2731,7 @@
           },
           "response": [
             {
-              "id": "f26692a0-d8c0-4b18-97b8-593039434a1d",
+              "id": "f8cd4627-fd3b-44df-a226-c1e040358328",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2823,7 +2823,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "69262e33-1d99-4799-b80e-10cdc5efd7f8",
+          "id": "9dc68930-aaf2-4505-acd5-8814ec21991d",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2865,7 +2865,7 @@
           },
           "response": [
             {
-              "id": "37e960c2-a036-4d18-8b0e-6552910558ea",
+              "id": "547fb6b4-34d0-4726-9bf0-fd51ff46492e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2929,7 +2929,7 @@
           }
         },
         {
-          "id": "dc256468-5c30-4c4e-b25e-7898215b5736",
+          "id": "bd8a08f5-ca77-45d7-9efe-a21ba0a9769d",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2972,7 +2972,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aaBF27\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#75E52E\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2984,7 +2984,7 @@
           },
           "response": [
             {
-              "id": "7f7a1223-1268-4be1-9f5d-45b556356817",
+              "id": "c5b8807a-9681-413c-a2ae-42b039b2068c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3033,7 +3033,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aaBF27\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#75E52E\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3061,7 +3061,7 @@
           }
         },
         {
-          "id": "fbe80fd7-92c3-4f43-8609-f7a8f6f9b6b9",
+          "id": "2855fd80-7aa1-484e-b6af-13e0bf07257c",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -3097,7 +3097,7 @@
           },
           "response": [
             {
-              "id": "62f4e447-1567-43d2-a438-6cbcd051e859",
+              "id": "b6231d94-0385-4b12-ac00-1f9b8e11750b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
           }
         },
         {
-          "id": "b3065ac9-95e6-4326-9efc-7cea47f4d9db",
+          "id": "c2b7d5e4-8bea-4a58-80bc-5d8095013b8f",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -3181,7 +3181,7 @@
           },
           "response": [
             {
-              "id": "adee6a66-7ba4-48cf-8e66-c761dd28c5a7",
+              "id": "008965f4-b8cd-4866-b94f-ee2a49488bce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3233,7 +3233,7 @@
           }
         },
         {
-          "id": "d55bd3e0-819d-4025-b344-be18dc73e237",
+          "id": "73f90da5-f19e-44c2-9c73-806baf38f35d",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3264,7 +3264,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A48dba\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aE9Aff\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3276,7 +3276,7 @@
           },
           "response": [
             {
-              "id": "f3b034bc-ea88-443d-a815-577a9b634889",
+              "id": "5851f371-0d72-462b-babd-40b9ca127f2b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3313,7 +3313,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A48dba\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aE9Aff\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3341,7 +3341,7 @@
           }
         },
         {
-          "id": "1fb59e7a-cb8b-46c3-8411-d5d9d81b303c",
+          "id": "15fd275d-0cd9-47fd-9a3d-ae6cef748ed4",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3372,7 +3372,7 @@
           },
           "response": [
             {
-              "id": "df5c1bc2-2404-4357-a80c-e53ecdff3a00",
+              "id": "a64377f3-a35f-4d89-8f94-210611d189f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3431,7 +3431,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "0061376b-ccf4-4833-a8c0-e5b133708818",
+          "id": "47d6433c-1492-409c-a83a-bbef8db4789a",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3473,7 +3473,7 @@
           },
           "response": [
             {
-              "id": "5b646d6d-409c-4a70-8190-ce1c9c39fa99",
+              "id": "935d8c2d-9dc4-4bba-a6af-f537655dce12",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
           }
         },
         {
-          "id": "3d1a938c-47d8-4153-a47b-163a17529c48",
+          "id": "b3010e28-f87a-4319-a199-645f9112c0d6",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3592,7 +3592,7 @@
           },
           "response": [
             {
-              "id": "bce1ab6c-8185-4db6-8624-00bb21cafedb",
+              "id": "c9e0d26b-865a-4cc4-adc4-c2766bad6025",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3669,7 +3669,7 @@
           }
         },
         {
-          "id": "09f07e64-ae24-47ff-81cb-ea64f0dffb68",
+          "id": "d48686ff-6e00-442e-abdf-aa173e73d325",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3711,7 +3711,7 @@
           },
           "response": [
             {
-              "id": "cc0a625b-a446-4d92-9a29-5cc1e16c2393",
+              "id": "8ebd35e1-7c46-407b-95f2-2c48f658572f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3775,7 +3775,7 @@
           }
         },
         {
-          "id": "96955a54-9ad3-4c9f-a7fc-83d5b96c274f",
+          "id": "51f6a431-e452-4197-9de7-65dd2fcc65f6",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3805,7 +3805,7 @@
           },
           "response": [
             {
-              "id": "e03b8d02-a8b2-45ce-b84f-0cae5356a24b",
+              "id": "6a039d31-fa39-475d-8688-ac2ad3c1b831",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3857,7 +3857,7 @@
           }
         },
         {
-          "id": "78590fbb-268b-4109-a961-52f5be04da8e",
+          "id": "2533e9d5-a04d-470f-a35b-e8a39ca6354d",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3900,7 +3900,7 @@
           },
           "response": [
             {
-              "id": "3a0c6171-afdc-4ded-83d2-f8f05a0db124",
+              "id": "1880f0a1-8e2a-478a-a758-c0eccadac172",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3965,7 +3965,7 @@
           }
         },
         {
-          "id": "b0139fd6-d668-467f-b376-2f24225c6abb",
+          "id": "163a3023-efc2-4ced-afd5-0da1fb0362fc",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -4018,7 +4018,7 @@
           },
           "response": [
             {
-              "id": "9c5f613e-2b99-49fc-b3c6-7ca8257edf09",
+              "id": "c7e424b8-2e7a-49cb-9694-a2d95e011457",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4082,7 +4082,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9302.475911937629\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -4093,7 +4093,7 @@
           }
         },
         {
-          "id": "f31f710a-0d5d-4e21-98f5-70fd3719f343",
+          "id": "c5758dac-8551-4b08-90f2-e83f1cfa1262",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -4136,7 +4136,7 @@
           },
           "response": [
             {
-              "id": "ab9b87d3-11a5-4a12-8df5-b9ff4f3478de",
+              "id": "e4f486e2-2fa3-4478-8d5c-8470f44cb3dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4201,7 +4201,7 @@
           }
         },
         {
-          "id": "11560841-3f45-420a-a0fc-8dba9d7ddc98",
+          "id": "85d59c5f-15f8-4f57-9e45-ae96cb2243d7",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4232,7 +4232,7 @@
           },
           "response": [
             {
-              "id": "f1c56d5c-004f-4a1c-b661-2f5f6b36b19e",
+              "id": "596546cf-c351-4406-8d98-0dc53aa4c1fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4291,7 +4291,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "51062dcf-ee1e-4105-a75b-62735e6e588d",
+          "id": "ed85f4ca-be3e-4854-8524-90ad9a52bccb",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4333,7 +4333,7 @@
           },
           "response": [
             {
-              "id": "21edb9e8-da8c-4cc5-b91a-4adb610ef436",
+              "id": "c38778e8-3dcf-48ac-9cb6-584828f92245",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4397,7 +4397,7 @@
           }
         },
         {
-          "id": "814d3eff-2584-4a4d-9f7d-405f04037241",
+          "id": "faf61d83-c47c-4905-8838-51ae457c6e02",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4440,7 +4440,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4452,7 +4452,7 @@
           },
           "response": [
             {
-              "id": "4af913fb-e8f8-44db-80e6-4c924d035551",
+              "id": "2efc7bc2-d2fd-4712-97c0-15b2455f2bd5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4501,7 +4501,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4529,7 +4529,7 @@
           }
         },
         {
-          "id": "63057a7d-0c1a-4846-bdc3-a1e5c0a249ed",
+          "id": "a65d3d5f-3da3-4d15-9666-617a0a006883",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4565,7 +4565,7 @@
           },
           "response": [
             {
-              "id": "7da9cd43-128f-4b57-9179-fda40d17b899",
+              "id": "23aa4066-7e56-4bd4-bb35-202b0f949c0f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4619,7 +4619,7 @@
           }
         },
         {
-          "id": "f8e4f2e4-07fc-48ad-a6f8-6bf4c9f2c0d0",
+          "id": "302e60e6-a6e1-4f64-84ae-9f67f64db8d9",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4668,7 +4668,7 @@
           },
           "response": [
             {
-              "id": "4356accf-ed12-4d97-b949-333ddc46d687",
+              "id": "9e91fa93-83d6-43c5-80af-2a3398a93687",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "22fd6fb8-e68a-47c8-ac11-c552a7816370",
+          "id": "fb9fe2b3-7565-44e4-b6af-e018770e6722",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4770,7 +4770,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4782,7 +4782,7 @@
           },
           "response": [
             {
-              "id": "d625910b-11bb-4034-b8e2-ea613effb814",
+              "id": "05e95d7f-c620-4187-b4a4-c1af3113783a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4819,7 +4819,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4847,7 +4847,7 @@
           }
         },
         {
-          "id": "3e18e620-abaa-42f3-9df7-63916eb4c363",
+          "id": "adf566f3-b4a7-4678-89c3-2f5a6f3fe783",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4890,7 +4890,7 @@
           },
           "response": [
             {
-              "id": "36ac4994-0955-4084-a55b-3c9da9bf68b0",
+              "id": "568c5744-2f77-4d63-80a1-dbc201c408e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4955,7 +4955,7 @@
           }
         },
         {
-          "id": "86b900e5-c161-406f-80d3-7e4fa129914a",
+          "id": "0e4854d8-0e62-4414-bb27-00789f57e361",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4998,7 +4998,7 @@
           },
           "response": [
             {
-              "id": "f115192f-ecc4-453b-a4ea-03f643a9d33f",
+              "id": "e51ac41f-fb9c-438f-b8ef-a2af0424a927",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5063,7 +5063,7 @@
           }
         },
         {
-          "id": "d5650914-2816-4fda-9221-a0f4abdbd133",
+          "id": "b9c20d91-a578-4e8f-9629-e7e3de43020d",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -5094,7 +5094,7 @@
           },
           "response": [
             {
-              "id": "a5628a57-6391-493d-892b-c2ea7b3a3b39",
+              "id": "0d5bffc9-ebe5-49d8-92dd-3a1844aa9457",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5147,7 +5147,7 @@
           }
         },
         {
-          "id": "c26bc560-dc6e-4989-94e3-6033cdf5c00d",
+          "id": "fcb870b4-45e1-4fad-beea-225ad7c8737c",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -5178,7 +5178,7 @@
           },
           "response": [
             {
-              "id": "7a8b9397-ef80-4acc-94e9-16b55d225ca7",
+              "id": "514e5bf4-f27e-4cee-a5a1-71d940865dbc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5237,7 +5237,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "2a32acdf-2b68-4506-9302-9cea512e785b",
+          "id": "2cce64d9-1fb4-4aab-8bd8-ceb4303a5568",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5279,7 +5279,7 @@
           },
           "response": [
             {
-              "id": "47bfd37b-4603-43f1-8875-18817d965d72",
+              "id": "d1924f32-e663-4d02-bc1f-56e85bf4e336",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5343,7 +5343,7 @@
           }
         },
         {
-          "id": "6253bc92-f50a-46db-9325-0e3fea87cfe6",
+          "id": "d10ea1dc-2fc0-465b-adfd-8f2f1600e200",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5398,7 +5398,7 @@
           },
           "response": [
             {
-              "id": "fa88c4c1-05cd-4552-ae6f-4f28f169358b",
+              "id": "24b94676-f41e-4591-9bc5-d1d18c91b711",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5475,7 +5475,7 @@
           }
         },
         {
-          "id": "1d58e7ee-5538-435f-b49f-1cd36d497160",
+          "id": "0a8d9413-a650-4302-b2a9-8dac4d97bd2b",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5511,7 +5511,7 @@
           },
           "response": [
             {
-              "id": "70502220-b804-4f08-b34e-b451d930ebcf",
+              "id": "6a70416a-b148-4ab3-a39a-e9e0872abd32",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5565,7 +5565,7 @@
           }
         },
         {
-          "id": "cf810664-a9b4-4423-80af-0b31b123bad2",
+          "id": "4a802ba8-7f33-44ac-b275-007bc206dd41",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5595,7 +5595,7 @@
           },
           "response": [
             {
-              "id": "191add19-2b2e-48c5-b488-5d767d9b565e",
+              "id": "ed009797-b044-4842-aaae-3d02f6646600",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5647,7 +5647,7 @@
           }
         },
         {
-          "id": "18e44225-8581-4004-b558-d9a92db8d21d",
+          "id": "63d7400d-7784-411a-bc29-3f6ea907336a",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5690,7 +5690,7 @@
           },
           "response": [
             {
-              "id": "3a5f2fa8-2f86-4346-a009-ce25dfb41fd9",
+              "id": "4bf4e6a6-504b-4a21-b5ce-f84ca17e6f3d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5761,7 +5761,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "e528ae92-3004-4913-bfc4-ce4beb581880",
+          "id": "e3644065-f3fc-4cbb-ad21-7576f1be533d",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5814,7 +5814,7 @@
           },
           "response": [
             {
-              "id": "2f0755a1-8390-4069-a4c7-f9ee18c5095e",
+              "id": "9d2d1a4b-8049-4638-9460-e2cbe2025bf5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5889,7 +5889,7 @@
           }
         },
         {
-          "id": "08ad35cd-2b78-4ee9-831d-3a83554becb4",
+          "id": "671e8b35-5374-48e1-8f1c-fecbbb574f86",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5955,7 +5955,7 @@
           },
           "response": [
             {
-              "id": "5d675932-c63c-4c87-947b-6e51d291d8a0",
+              "id": "4f4a1f61-f06d-4838-8084-f308f88d398c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6043,7 +6043,7 @@
           }
         },
         {
-          "id": "b76d3b0f-2fcb-4c0f-abcf-24dbba42dd40",
+          "id": "ae6fee46-ae23-4581-9de7-810383f2c47a",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -6090,7 +6090,7 @@
           },
           "response": [
             {
-              "id": "9897009a-898a-4f64-94c6-23ff7fed1688",
+              "id": "35ba4261-81de-4fcb-a745-3f2fa7bf7958",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6155,7 +6155,7 @@
           }
         },
         {
-          "id": "daff58aa-5c44-46f3-9667-6b5ee44528f3",
+          "id": "12b59065-fc49-45ae-8571-69529f402435",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -6197,7 +6197,7 @@
           },
           "response": [
             {
-              "id": "a0c91196-7214-4234-9237-10fe56e6ed1f",
+              "id": "bfd520c7-327c-41a4-9975-d86a8f4dbccf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6261,7 +6261,7 @@
           }
         },
         {
-          "id": "dfecbbec-2661-44e3-bf59-820d8f522790",
+          "id": "0d66dae9-f91c-4518-bb30-a1c7061c3824",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6316,7 +6316,7 @@
           },
           "response": [
             {
-              "id": "475e6e6c-50b9-48dc-a39c-84ab12a2000b",
+              "id": "3dc28a53-63bb-43db-be0a-c69aa5c72abb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6393,7 +6393,7 @@
           }
         },
         {
-          "id": "6b451879-6354-459a-aaf5-90ad624dcbd3",
+          "id": "b35d5aac-54be-43e6-a24d-6f479aac6e45",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6460,7 +6460,7 @@
           },
           "response": [
             {
-              "id": "cc98bea6-a8ac-42cb-8a09-8a9aa8be0899",
+              "id": "3e0433a6-bfd8-4387-b3ec-95e9afc10a7c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6549,7 +6549,7 @@
           }
         },
         {
-          "id": "c0dba5c6-ec5f-4dfe-9506-2b067c64f602",
+          "id": "4686d3bf-c139-43d0-ae73-a2e0d720f126",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6603,7 +6603,7 @@
           },
           "response": [
             {
-              "id": "84f6b960-6894-47ee-a383-6651fe76c7c0",
+              "id": "b6fa4e0f-5e4f-4aa4-804a-1f9d1152e826",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6685,7 +6685,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "a617e5bb-70cd-45e1-ad36-1b197f7617b9",
+          "id": "36515aa6-3886-4510-9413-ba28e6819e71",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6738,7 +6738,7 @@
           },
           "response": [
             {
-              "id": "571cdf3e-b0ae-44e1-ab3f-b5b99c49fbf5",
+              "id": "26951eae-43c7-40d2-bbda-09c0c8ca6508",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6813,7 +6813,7 @@
           }
         },
         {
-          "id": "5145a076-3c63-4c0b-9cc7-6adf48a66d23",
+          "id": "ef9c11c4-011d-4d15-a3b1-fd53ba00b712",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6879,7 +6879,7 @@
           },
           "response": [
             {
-              "id": "afd432dc-687b-4f44-be38-a710ff95f175",
+              "id": "aa924fa0-c167-4ee4-aa7b-2189591d5a5c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6967,7 +6967,7 @@
           }
         },
         {
-          "id": "712cc50b-35b7-45a6-a900-6241df17f49f",
+          "id": "22f8fad7-c73f-4b82-b9d2-0de136d61979",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -7014,7 +7014,7 @@
           },
           "response": [
             {
-              "id": "23b02c52-6bc3-4232-9c02-1024b09dc31e",
+              "id": "a5b30be1-3541-4d14-9630-72334641c62b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7079,7 +7079,7 @@
           }
         },
         {
-          "id": "1f295faf-27ca-42dd-8d53-532ec5ba7450",
+          "id": "e63b6d88-1ccd-464d-9959-86433fb48fe7",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -7121,7 +7121,7 @@
           },
           "response": [
             {
-              "id": "1e01105c-45ad-4ae6-a42c-dcaf672a4d59",
+              "id": "c1cf00d5-e6ad-432c-97ed-afed15adcc1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7185,7 +7185,7 @@
           }
         },
         {
-          "id": "0ec764f6-7a15-48af-8f9d-55925a3e085b",
+          "id": "9879b763-907a-44a7-a450-40964277a835",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7240,7 +7240,7 @@
           },
           "response": [
             {
-              "id": "0c371f43-19a0-4759-b5a5-d9d47189aeaa",
+              "id": "e826541a-4864-4dc6-baa6-186ab0594ed1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7323,7 +7323,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "b51ad564-7c3d-4e1c-9c83-4868b1ac9add",
+          "id": "23d42132-1f9c-447a-9d2f-c16b4cb80895",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7364,7 +7364,7 @@
           },
           "response": [
             {
-              "id": "600af707-8d15-48d8-a46e-f0084118f7f9",
+              "id": "c92f1463-a48b-4409-835e-5ea029e028b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7427,7 +7427,7 @@
           }
         },
         {
-          "id": "a76e8ed6-fee0-422b-a516-9ebf2a8e2984",
+          "id": "14ac66c2-cb43-44c4-8a5f-6198523f8fe5",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7481,7 +7481,7 @@
           },
           "response": [
             {
-              "id": "f318e078-2848-4189-8e6d-ac3a570f427f",
+              "id": "a2f7919e-2a4a-4c83-8367-942b1dd02db5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7557,7 +7557,7 @@
           }
         },
         {
-          "id": "c3974a62-9a1d-4105-b76b-5ef6ec129e24",
+          "id": "b9189a17-a9ed-4795-a19e-32e8ed5dca09",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7592,7 +7592,7 @@
           },
           "response": [
             {
-              "id": "7ddec63e-8008-40e3-924e-8ab5ef706f9d",
+              "id": "c3628632-6707-4b79-9e8c-eb0711345bf3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7645,7 +7645,7 @@
           }
         },
         {
-          "id": "854fa2d0-cd30-4874-84f1-2c2020f2061a",
+          "id": "971a60d1-5b33-4c4c-8871-98dd6d533b39",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7702,7 +7702,7 @@
           },
           "response": [
             {
-              "id": "31a2e716-5fc8-4954-a769-7955cfecb434",
+              "id": "2dbaf7a9-7653-4d60-a50e-25cc3feb7b5c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7781,7 +7781,7 @@
           }
         },
         {
-          "id": "8638d724-63bc-43c7-b58c-a596de23a6f6",
+          "id": "6694c367-b6ad-4919-9eea-316f6818415b",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7823,7 +7823,7 @@
           },
           "response": [
             {
-              "id": "5fbad19b-dfe2-4e9f-96fc-0043a0cdc990",
+              "id": "a478c7f4-0030-43e7-8929-08f1dc97c75f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "c57796a3-25c1-4741-9144-5b73c3662ea3",
+          "id": "b1d785a7-a508-45c5-ba39-93b0189a2df9",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7946,7 +7946,7 @@
           },
           "response": [
             {
-              "id": "24bfd3f8-0e7b-4a41-bafe-b957e1f11551",
+              "id": "be4b2256-287b-434c-9b4d-5f8c4546da4b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8021,7 +8021,7 @@
           }
         },
         {
-          "id": "eedfc3f9-628c-45d9-9bd5-c416185c75f1",
+          "id": "986908d5-d637-4053-96ea-151065fbe6f1",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -8087,7 +8087,7 @@
           },
           "response": [
             {
-              "id": "fcf46126-0e00-41f1-ab69-e69ce5a676ce",
+              "id": "1923a761-39df-4ef1-bb4f-8486a9722342",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8175,7 +8175,7 @@
           }
         },
         {
-          "id": "d9d21893-17f5-4dcc-b9f5-fec3472789e2",
+          "id": "9e52b77f-7a7a-470f-89f2-e2eeae51f1cc",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8222,7 +8222,7 @@
           },
           "response": [
             {
-              "id": "3d415274-50ed-49a2-b2f7-e17bf1864439",
+              "id": "3cb9ae9e-6352-4d7c-b05b-302dc20fdda7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8287,7 +8287,7 @@
           }
         },
         {
-          "id": "d1819ee2-7adc-439c-8818-c0630ce611cc",
+          "id": "eccf3c92-d42b-4d04-bdb9-f1646d39b3c0",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8329,7 +8329,7 @@
           },
           "response": [
             {
-              "id": "7eed6f9a-90e6-4108-9060-77406d75c7c5",
+              "id": "8b99fdd7-cd07-408b-93d7-42380b5a49f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8393,7 +8393,7 @@
           }
         },
         {
-          "id": "c7d889d2-e7ef-47dd-99da-2a29822036e8",
+          "id": "263bcea5-9ae6-4770-a87c-820ae7417eac",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8448,7 +8448,7 @@
           },
           "response": [
             {
-              "id": "f248f526-86c5-4409-94f8-3c1da3ee7b73",
+              "id": "46da0328-6a58-4ef6-b66d-d44ee4b47ff3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8531,7 +8531,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "8793ff5d-d20e-41f3-add8-32f5c33ce184",
+          "id": "e46f9c7c-e395-4bba-8f31-6cae06cd156e",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8573,7 +8573,7 @@
           },
           "response": [
             {
-              "id": "0e48ddad-9298-458e-8371-f605b89912ad",
+              "id": "f60e2fad-6977-424b-9298-fbd8584425de",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "f7f5310a-5c7a-41c7-bff3-a7b994b8993e",
+          "id": "abdaa544-4e84-48d7-9fe8-c502d74f3603",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8692,7 +8692,7 @@
           },
           "response": [
             {
-              "id": "09cf3304-fbf7-424a-a234-0b8af5e5dca1",
+              "id": "da48dabb-6476-4205-a2d2-0ddf97f06663",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8769,7 +8769,7 @@
           }
         },
         {
-          "id": "2ee6c648-f89f-4ed7-8aa6-7d14003ad66c",
+          "id": "e6dc1522-dd83-449b-87c7-ffac27096be5",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8805,7 +8805,7 @@
           },
           "response": [
             {
-              "id": "68144796-1859-4fcf-8cad-a934359c430e",
+              "id": "ce89ca38-4266-4fc1-8081-c6d0f2dada80",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8859,7 +8859,7 @@
           }
         },
         {
-          "id": "405d3bf2-2189-43bc-b65d-450007aa47cf",
+          "id": "537052ee-b640-41e6-973e-a1afa67759bd",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8889,7 +8889,7 @@
           },
           "response": [
             {
-              "id": "a76e40a1-97fc-4dd1-a440-d4f565cb524c",
+              "id": "b6a7e4f6-4e4b-4eed-a776-89b2fe0ce8ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8941,7 +8941,7 @@
           }
         },
         {
-          "id": "ebedabbb-43fb-4a89-8db7-6efcf62ac802",
+          "id": "b78b582f-e85b-4bf4-9d32-a6c823cb62cf",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8984,7 +8984,7 @@
           },
           "response": [
             {
-              "id": "0266b360-77af-4ba6-b727-ac6c3c9d05bc",
+              "id": "7134329c-bdf8-4d0d-8410-9df71e311f9d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9055,7 +9055,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "b2824b22-58e5-467a-8904-2f23659bae08",
+          "id": "cfe39c8f-c47f-44fa-aeb5-333eacad83a2",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -9097,7 +9097,7 @@
           },
           "response": [
             {
-              "id": "414885b4-ae66-4630-a160-d58bd45dc2ce",
+              "id": "96acef2c-3f7f-4204-a538-e67b1f3cc8ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9155,7 +9155,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ee917602-42ca-469b-a2e1-1fb66d061874",
+              "id": "43971439-cb9d-432a-9d91-18133e39ad7c",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9219,7 +9219,7 @@
           }
         },
         {
-          "id": "61ba457e-a5ad-46b2-82ae-1b6398ec453f",
+          "id": "62315d27-bbb6-4420-a1bc-b2565de2b964",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9274,7 +9274,7 @@
           },
           "response": [
             {
-              "id": "94a564ad-692d-45f9-98ab-62599be990e7",
+              "id": "d39e78fb-3d7e-46ee-8e50-6d5b15e65edc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9345,7 +9345,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "87825282-a9be-4509-9ce0-93fac4451f41",
+              "id": "efcaba17-001e-4580-8c9a-c2368d26eadd",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9416,7 +9416,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "434d747d-accc-4e16-a5eb-e60864ac18e5",
+              "id": "3115703b-4c79-4c87-ba2f-dc7fe2886d2e",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9493,7 +9493,7 @@
           }
         },
         {
-          "id": "ebdb87bc-fd65-4646-90e2-be90e350e9d7",
+          "id": "c3c3dda8-d815-4974-b5ff-ea49d51c6b14",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9529,7 +9529,7 @@
           },
           "response": [
             {
-              "id": "105a3e8e-2a26-4736-9757-1774f326df76",
+              "id": "383e9f73-8a13-41b2-a35f-bc6873bd2e8e",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9577,7 +9577,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "60509c10-438e-4158-85d1-3d7bebf690fc",
+              "id": "a4e7c65c-9586-4a2c-a8d5-90c9cfc05e38",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9625,7 +9625,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d13310c0-9079-43ac-89d2-00b238d9911e",
+              "id": "fdc8c7a3-04ff-401a-80d4-4d1c4fc836c5",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9679,7 +9679,7 @@
           }
         },
         {
-          "id": "20de40e0-ef94-4d66-b61b-c29b7cf24089",
+          "id": "64ce72d3-a20c-444f-bc37-8fc65286a737",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9709,7 +9709,7 @@
           },
           "response": [
             {
-              "id": "7a56b604-2c40-4e80-8071-dcebb5eaa158",
+              "id": "74a04349-c4fd-4c08-81a5-90885105f846",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9761,7 +9761,7 @@
           }
         },
         {
-          "id": "4acba6e7-4d21-460b-a16b-e7d56aac462f",
+          "id": "f3b252cd-154b-4af3-9ec4-1ee760e2793e",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9804,7 +9804,7 @@
           },
           "response": [
             {
-              "id": "7de54419-937c-4bb9-9e52-232328ef4d4e",
+              "id": "805d679b-d12e-4f57-b777-0e9c42b1bc8e",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9863,7 +9863,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c0002cad-2db9-4a31-8f58-9f9952404803",
+              "id": "2be08357-ee52-4927-a5de-a26e5f98eacb",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9934,7 +9934,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "dba8ddab-a93b-47e2-9d21-559ddbb64a5d",
+          "id": "351e9a71-6638-46ae-ba7d-825900c0019f",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -10000,7 +10000,7 @@
           },
           "response": [
             {
-              "id": "5a286f87-ba09-4d3a-bbe7-f94845dab1fa",
+              "id": "b766c870-762f-43c0-a56c-c7e51de522e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10074,7 +10074,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9302.475911937629\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -10091,7 +10091,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "dd34dc22-06a4-47c0-87dd-bdfed1e7d0fb",
+          "id": "33eb89dd-a232-48c5-8c6f-9fc671d77bc1",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -10133,7 +10133,7 @@
           },
           "response": [
             {
-              "id": "e0645223-1c6b-49f6-ac11-ef1bb12dcc9b",
+              "id": "3e8dc9bb-a089-4400-8703-22daafbcc4d7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10203,7 +10203,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "3b34e7d4-37c1-4d69-85fb-93defea36009",
+          "id": "d4ede0d2-15b1-4a2c-93e1-29840d46d0d7",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10245,7 +10245,7 @@
           },
           "response": [
             {
-              "id": "b6c6c8ba-56ca-4d63-9a24-78b671b18ff4",
+              "id": "4077f02a-1149-476d-afd1-a9e674525d18",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10309,7 +10309,7 @@
           }
         },
         {
-          "id": "9d253cca-fa4b-44fc-af3d-c0789a104132",
+          "id": "750747fd-48d5-451c-a2d2-c32414428c48",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10352,7 +10352,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#c9eaD8\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#eEDB1E\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10364,7 +10364,7 @@
           },
           "response": [
             {
-              "id": "c1752992-97b4-473e-ac8c-369627628ed8",
+              "id": "6cd7af6b-d0dc-4594-b482-246d908b34a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10413,7 +10413,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#c9eaD8\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#eEDB1E\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10441,7 +10441,7 @@
           }
         },
         {
-          "id": "78e27873-3a6a-44a6-ade5-3a604cdd049d",
+          "id": "041885d0-aa5f-4b2b-ac33-6d7ec9c68313",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10477,7 +10477,7 @@
           },
           "response": [
             {
-              "id": "362ab7a3-130c-40ba-a963-cf57293ce1b8",
+              "id": "21630900-9196-403d-abef-67d648f58384",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10531,7 +10531,7 @@
           }
         },
         {
-          "id": "262776e2-d90c-4cfa-95b7-29c64f7ed2fb",
+          "id": "ccda7f83-09e8-4f5d-aa5c-129422506d17",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10561,7 +10561,7 @@
           },
           "response": [
             {
-              "id": "e2a634a2-6913-4418-bd7a-79ac5c373f45",
+              "id": "006148eb-e7c7-4639-8996-b92b654260a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10613,7 +10613,7 @@
           }
         },
         {
-          "id": "d179c60e-4a50-4732-9b4b-d8629b51f708",
+          "id": "ecabc1a3-a1c3-4f64-be5a-ea7724f93af2",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10644,7 +10644,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#B96d2B\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#CDdB7F\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10656,7 +10656,7 @@
           },
           "response": [
             {
-              "id": "fc3ba072-cc76-4716-b4cd-2b9b1e2c4914",
+              "id": "84df983d-0677-4c9c-b94b-41794a6fedbe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10693,7 +10693,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#B96d2B\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#CDdB7F\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10721,7 +10721,7 @@
           }
         },
         {
-          "id": "7c77e599-50ab-4f0d-aabc-09269775e4cb",
+          "id": "58b5e719-e04f-4df0-9881-0729a0608760",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10752,7 +10752,7 @@
           },
           "response": [
             {
-              "id": "c06190f4-6dd6-4c83-9328-19b53fcbabb0",
+              "id": "bc360931-af3b-493b-9744-eb26523c61c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "effa0307-9e65-49c6-b3a3-ea869927ed1c",
+          "id": "d78b7c36-5f5a-4a81-9bec-8633cd39ed8a",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10864,7 +10864,7 @@
           },
           "response": [
             {
-              "id": "e6dd49e2-34e9-4718-95f5-8d64bba17366",
+              "id": "686bc0e6-e9c7-4bc3-a543-f0b7fdb1d6e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10939,7 +10939,7 @@
           }
         },
         {
-          "id": "50dcab57-5ac7-4e36-8761-b165715c43c4",
+          "id": "d62e3773-0de6-4ec5-8f0b-c1de232ff147",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -11005,7 +11005,7 @@
           },
           "response": [
             {
-              "id": "05021c93-9c6c-4399-b049-b8bb75c8079f",
+              "id": "ed74242b-7a01-4784-be1a-2c71b1e412f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11093,7 +11093,7 @@
           }
         },
         {
-          "id": "506baa8a-cc21-482a-9ff7-6640e5b7ba25",
+          "id": "6f6e1e26-7529-4740-9ee4-36ccf039dfc8",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -11140,7 +11140,7 @@
           },
           "response": [
             {
-              "id": "988b462b-a0cd-45c6-9447-c9c434ef2a2f",
+              "id": "748e7089-81cc-4016-b1b1-7c2a9495e8d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11205,7 +11205,7 @@
           }
         },
         {
-          "id": "6e5dec9a-d1cb-4ffb-b8e9-5c3f9bd66058",
+          "id": "d3921a1d-8ce2-4aa1-b0db-fe289ee3d3c6",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11247,7 +11247,7 @@
           },
           "response": [
             {
-              "id": "e31636a1-80ba-4699-92da-d138218175d4",
+              "id": "c62633a4-7236-490d-a7ee-893a10ca28aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11311,7 +11311,7 @@
           }
         },
         {
-          "id": "a7a3e739-31c9-48bc-ae44-5166a296d07e",
+          "id": "2801fbe6-ee59-4a0f-9d48-46f4c05cd21d",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11366,7 +11366,7 @@
           },
           "response": [
             {
-              "id": "f30607c2-9488-40e0-8b16-24a5e8924ec9",
+              "id": "f0400a5a-2c37-4633-ace4-cf3a2b2441b4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11443,7 +11443,7 @@
           }
         },
         {
-          "id": "af54b460-590d-46df-ac0c-4ea16c2ff4e2",
+          "id": "7769969a-98b8-495f-933a-1f8c22dbdd3f",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11497,7 +11497,7 @@
           },
           "response": [
             {
-              "id": "cbaa6559-5f24-4dde-b147-bc5f0fe34028",
+              "id": "be773fdc-0345-4df7-bc44-f61194021bcb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11573,7 +11573,7 @@
           }
         },
         {
-          "id": "0a9e3023-c97c-4399-b669-717f6a8b5508",
+          "id": "8211c332-067c-4ed6-b849-c11ffd87e60d",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11639,7 +11639,7 @@
           },
           "response": [
             {
-              "id": "f9b16478-3f79-46ee-85b1-58fbccf8e750",
+              "id": "374d5067-6eff-4ba6-bfdf-9e35f4f89eaa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11727,7 +11727,7 @@
           }
         },
         {
-          "id": "d3b21d8f-5c66-4c8c-95a9-d1817968e0ae",
+          "id": "ed534ecc-1336-4942-afaf-4da064e1be54",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11805,7 +11805,7 @@
           },
           "response": [
             {
-              "id": "d07275fa-e7b6-47cd-870e-cb1a565b6f83",
+              "id": "0755cda0-beb3-4bbc-94ba-36b69483924b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11905,7 +11905,7 @@
           }
         },
         {
-          "id": "58f6966f-d85a-493e-9f24-51afd0830506",
+          "id": "2b8a47d7-6eff-4a2b-94b4-8c8df702b467",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11971,7 +11971,7 @@
           },
           "response": [
             {
-              "id": "c0d0b539-81c2-4001-a675-0712a0a5b6b1",
+              "id": "64db72bc-f4ef-4314-b4d7-1cad58bbe86a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12059,7 +12059,7 @@
           }
         },
         {
-          "id": "4b94c997-1de4-494d-9570-9dccf2fa0d41",
+          "id": "9aa3357d-d802-4077-8bce-adb191c5e883",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -12114,7 +12114,7 @@
           },
           "response": [
             {
-              "id": "13445d6d-08e9-4d0d-9abf-a162f309d1ca",
+              "id": "fb2c3b79-096f-4194-b1d3-6c04f45b8002",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12197,7 +12197,7 @@
       "description": "",
       "item": [
         {
-          "id": "3a818d82-fe58-45b7-a32b-cca6908b8980",
+          "id": "a18f3683-ee18-4964-97f7-639d9b9226f4",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12238,7 +12238,7 @@
           },
           "response": [
             {
-              "id": "1833b1ad-1a08-49e3-be2c-601daa045414",
+              "id": "27866487-c246-44fb-bd3a-44dd9f95d92f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12290,7 +12290,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"sectorCode\": \"<string>\",\n  \"alertTypeId\": \"<integer>\",\n  \"alertTypeName\": \"<string>\",\n  \"severityId\": \"<integer>\",\n  \"severityName\": \"<string>\",\n  \"severityLevel\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"resolvedByUserName\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12301,7 +12301,7 @@
           }
         },
         {
-          "id": "efd3f81c-9ea4-42c7-9053-ab599462deaf",
+          "id": "932e4540-188e-4c6d-b2f5-ebc3f16cc6df",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12355,7 +12355,7 @@
           },
           "response": [
             {
-              "id": "e1bc1864-0a9f-4a46-9190-88c6f925c2b9",
+              "id": "4fee0f12-1b48-4897-b481-b3b864633031",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12420,7 +12420,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"sectorCode\": \"<string>\",\n  \"alertTypeId\": \"<integer>\",\n  \"alertTypeName\": \"<string>\",\n  \"severityId\": \"<integer>\",\n  \"severityName\": \"<string>\",\n  \"severityLevel\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"resolvedByUserName\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12431,7 +12431,7 @@
           }
         },
         {
-          "id": "42d906aa-f63e-4904-881a-5cfc52e596c5",
+          "id": "3be975a1-2524-45c9-838a-d754b18ff5c3",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12466,7 +12466,7 @@
           },
           "response": [
             {
-              "id": "6354f723-c436-4f83-9ff2-f127b5eecb31",
+              "id": "dd121526-ab87-4774-9014-bb3f3dc12639",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12519,7 +12519,7 @@
           }
         },
         {
-          "id": "e07ec449-71fa-4e45-86f1-68e0a1a06674",
+          "id": "2c73964c-cc4f-4796-b547-0cd57e01a07c",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12580,7 +12580,7 @@
           },
           "response": [
             {
-              "id": "b3fc22d4-78d7-49c6-b075-c355eeef2d3d",
+              "id": "acd6fe11-694e-4204-ade0-c29b0961de96",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12652,7 +12652,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"sectorCode\": \"<string>\",\n  \"alertTypeId\": \"<integer>\",\n  \"alertTypeName\": \"<string>\",\n  \"severityId\": \"<integer>\",\n  \"severityName\": \"<string>\",\n  \"severityLevel\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"resolvedByUserName\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12663,7 +12663,7 @@
           }
         },
         {
-          "id": "0da6e793-cd40-4ca1-839c-2af53ba7bf7b",
+          "id": "ccbf4596-acc7-48a5-8d31-7f4137db0886",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12705,7 +12705,7 @@
           },
           "response": [
             {
-              "id": "d8957073-4b34-46de-8cf1-e67709a1ba09",
+              "id": "0f13337f-c51b-4ca2-8366-b29a9e1aa690",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12758,7 +12758,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"sectorCode\": \"<string>\",\n  \"alertTypeId\": \"<integer>\",\n  \"alertTypeName\": \"<string>\",\n  \"severityId\": \"<integer>\",\n  \"severityName\": \"<string>\",\n  \"severityLevel\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"resolvedByUserName\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12769,7 +12769,7 @@
           }
         },
         {
-          "id": "b6b06a61-39cc-46e4-bdc0-b4917474e0ef",
+          "id": "7f17a5cd-f8c3-4aa0-b3df-ab1901e7c633",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12844,7 +12844,7 @@
           },
           "response": [
             {
-              "id": "e66fc26c-0172-4b41-81db-03bcb2a11d31",
+              "id": "b9754eb4-aad1-43e1-bebf-5bf5eaa8ef8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12930,7 +12930,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12941,7 +12941,7 @@
           }
         },
         {
-          "id": "2a2ffb84-b6a9-44b0-9184-d031e2616546",
+          "id": "024dc079-4ed2-4181-ba89-69eefae20a42",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12983,7 +12983,7 @@
           },
           "response": [
             {
-              "id": "e1c394d3-9024-4b92-9278-de7be71c6153",
+              "id": "1a3d52b7-9d7f-4302-9433-24569f19c8c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13036,7 +13036,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"alertTypeId\": \"<integer>\",\n  \"severityId\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"tenant\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"greenhouses\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"name\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"users\": [\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      },\n      {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"passwordHash\": \"<string>\",\n        \"role\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"username\": \"<string>\",\n        \"id\": \"<long>\",\n        \"lastLogin\": \"<dateTime>\",\n        \"resetPasswordToken\": \"<string>\",\n        \"resetPasswordTokenExpiry\": \"<dateTime>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    ],\n    \"id\": \"<long>\",\n    \"isActive\": \"<boolean>\",\n    \"province\": \"<string>\",\n    \"country\": \"<string>\",\n    \"phone\": \"<string>\",\n    \"location\": {\n      \"lat\": \"<double>\",\n      \"lon\": \"<double>\"\n    }\n  },\n  \"sector\": {\n    \"code\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"id\": \"<long>\",\n    \"name\": \"<string>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"greenhouse\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"isActive\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"id\": \"<long>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      },\n      \"areaM2\": \"<number>\",\n      \"timezone\": \"<string>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    }\n  },\n  \"resolvedByUser\": {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"email\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"passwordHash\": \"<string>\",\n    \"role\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"id\": \"<long>\",\n    \"lastLogin\": \"<dateTime>\",\n    \"resetPasswordToken\": \"<string>\",\n    \"resetPasswordTokenExpiry\": \"<dateTime>\",\n    \"tenant\": {\n      \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n    }\n  },\n  \"alertType\": {\n    \"name\": \"<string>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\"\n  },\n  \"severity\": {\n    \"createdAt\": \"<dateTime>\",\n    \"level\": \"<integer>\",\n    \"name\": \"<string>\",\n    \"notificationDelayMinutes\": \"<integer>\",\n    \"notifyPush\": \"<boolean>\",\n    \"requiresAction\": \"<boolean>\",\n    \"id\": \"<integer>\",\n    \"description\": \"<string>\",\n    \"color\": \"<string>\"\n  }\n}",
+              "body": "{\n  \"code\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"id\": \"<long>\",\n  \"isResolved\": \"<boolean>\",\n  \"sectorId\": \"<long>\",\n  \"tenantId\": \"<long>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"sectorCode\": \"<string>\",\n  \"alertTypeId\": \"<integer>\",\n  \"alertTypeName\": \"<string>\",\n  \"severityId\": \"<integer>\",\n  \"severityName\": \"<string>\",\n  \"severityLevel\": \"<integer>\",\n  \"message\": \"<string>\",\n  \"description\": \"<string>\",\n  \"clientName\": \"<string>\",\n  \"resolvedAt\": \"<dateTime>\",\n  \"resolvedByUserId\": \"<long>\",\n  \"resolvedByUserName\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13047,7 +13047,7 @@
           }
         },
         {
-          "id": "f243df2c-d73c-4537-95b6-5ace827d4a79",
+          "id": "8b556c01-8c15-45d5-8f57-a941f9eb0a47",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -13090,7 +13090,7 @@
           },
           "response": [
             {
-              "id": "da377687-5c98-4403-8524-00cf58b50d29",
+              "id": "1fd40938-f521-47b7-bf44-312aa11afde7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13144,7 +13144,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13155,7 +13155,7 @@
           }
         },
         {
-          "id": "09083264-efa4-4a1f-9518-586c65e1d50c",
+          "id": "6421edae-26ff-43d7-a53c-00e5bfd2a205",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "db840003-6ece-461d-adb5-e6d4c5e1c25c",
+              "id": "a1e9853e-7fa8-469c-8d15-9592cdc90b20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13252,7 +13252,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13263,7 +13263,7 @@
           }
         },
         {
-          "id": "049a0629-0153-45a4-bb43-7509fdd0f3e3",
+          "id": "d0575f0e-0225-4d6d-99c0-0ffaee23864c",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13315,7 +13315,7 @@
           },
           "response": [
             {
-              "id": "3e0b101a-568b-4017-a69a-fb8010110059",
+              "id": "ba93d474-6e09-41ee-8779-570951ac24c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13378,7 +13378,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13389,7 +13389,7 @@
           }
         },
         {
-          "id": "ad98ce1e-4f1e-4b80-a6aa-a8d3fdd41f3d",
+          "id": "bbd8bc24-96c8-46e4-b2ed-9fea008b6240",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13431,7 +13431,7 @@
           },
           "response": [
             {
-              "id": "737bd6b7-8b0c-47da-b96e-325c9a6c74b0",
+              "id": "e6d28db0-8060-490c-af5b-3ab111694395",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13484,7 +13484,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13495,7 +13495,7 @@
           }
         },
         {
-          "id": "74c6b84e-64b6-4eb6-8a7a-4c75eb282114",
+          "id": "30a03ca4-9cbc-495a-81c5-efbfa5a544a8",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13548,7 +13548,7 @@
           },
           "response": [
             {
-              "id": "f4610fb7-527b-449a-96cc-d145a9b4069f",
+              "id": "a30d714f-30f5-49ab-88f1-c1bac4c32827",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13612,7 +13612,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"alertTypeId\": \"<integer>\",\n    \"severityId\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"tenant\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"greenhouses\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"isActive\": \"<boolean>\",\n          \"name\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"id\": \"<long>\",\n          \"location\": {\n            \"lat\": \"<double>\",\n            \"lon\": \"<double>\"\n          },\n          \"areaM2\": \"<number>\",\n          \"timezone\": \"<string>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"name\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"users\": [\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        },\n        {\n          \"code\": \"<string>\",\n          \"createdAt\": \"<dateTime>\",\n          \"email\": \"<string>\",\n          \"isActive\": \"<boolean>\",\n          \"passwordHash\": \"<string>\",\n          \"role\": \"<string>\",\n          \"tenantId\": \"<long>\",\n          \"updatedAt\": \"<dateTime>\",\n          \"username\": \"<string>\",\n          \"id\": \"<long>\",\n          \"lastLogin\": \"<dateTime>\",\n          \"resetPasswordToken\": \"<string>\",\n          \"resetPasswordTokenExpiry\": \"<dateTime>\",\n          \"tenant\": {\n            \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n          }\n        }\n      ],\n      \"id\": \"<long>\",\n      \"isActive\": \"<boolean>\",\n      \"province\": \"<string>\",\n      \"country\": \"<string>\",\n      \"phone\": \"<string>\",\n      \"location\": {\n        \"lat\": \"<double>\",\n        \"lon\": \"<double>\"\n      }\n    },\n    \"sector\": {\n      \"code\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"tenantId\": \"<long>\",\n      \"id\": \"<long>\",\n      \"name\": \"<string>\",\n      \"tenant\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"email\": \"<string>\",\n        \"greenhouses\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"isActive\": \"<boolean>\",\n            \"name\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"id\": \"<long>\",\n            \"location\": {\n              \"lat\": \"<double>\",\n              \"lon\": \"<double>\"\n            },\n            \"areaM2\": \"<number>\",\n            \"timezone\": \"<string>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"name\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"users\": [\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          },\n          {\n            \"code\": \"<string>\",\n            \"createdAt\": \"<dateTime>\",\n            \"email\": \"<string>\",\n            \"isActive\": \"<boolean>\",\n            \"passwordHash\": \"<string>\",\n            \"role\": \"<string>\",\n            \"tenantId\": \"<long>\",\n            \"updatedAt\": \"<dateTime>\",\n            \"username\": \"<string>\",\n            \"id\": \"<long>\",\n            \"lastLogin\": \"<dateTime>\",\n            \"resetPasswordToken\": \"<string>\",\n            \"resetPasswordTokenExpiry\": \"<dateTime>\",\n            \"tenant\": {\n              \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n            }\n          }\n        ],\n        \"id\": \"<long>\",\n        \"isActive\": \"<boolean>\",\n        \"province\": \"<string>\",\n        \"country\": \"<string>\",\n        \"phone\": \"<string>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        }\n      },\n      \"greenhouse\": {\n        \"code\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"isActive\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"tenantId\": \"<long>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"id\": \"<long>\",\n        \"location\": {\n          \"lat\": \"<double>\",\n          \"lon\": \"<double>\"\n        },\n        \"areaM2\": \"<number>\",\n        \"timezone\": \"<string>\",\n        \"tenant\": {\n          \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n        }\n      }\n    },\n    \"resolvedByUser\": {\n      \"code\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"email\": \"<string>\",\n      \"isActive\": \"<boolean>\",\n      \"passwordHash\": \"<string>\",\n      \"role\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"username\": \"<string>\",\n      \"id\": \"<long>\",\n      \"lastLogin\": \"<dateTime>\",\n      \"resetPasswordToken\": \"<string>\",\n      \"resetPasswordTokenExpiry\": \"<dateTime>\",\n      \"tenant\": {\n        \"value\": \"<Circular reference to #/components/schemas/Tenant detected>\"\n      }\n    },\n    \"alertType\": {\n      \"name\": \"<string>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\"\n    },\n    \"severity\": {\n      \"createdAt\": \"<dateTime>\",\n      \"level\": \"<integer>\",\n      \"name\": \"<string>\",\n      \"notificationDelayMinutes\": \"<integer>\",\n      \"notifyPush\": \"<boolean>\",\n      \"requiresAction\": \"<boolean>\",\n      \"id\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"color\": \"<string>\"\n    }\n  }\n]",
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13623,7 +13623,7 @@
           }
         },
         {
-          "id": "979bd090-63ad-410b-87b2-1223b28a775e",
+          "id": "2885e60b-b33c-42fb-a87b-2ddbe57b29ea",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13667,7 +13667,7 @@
           },
           "response": [
             {
-              "id": "31d99659-911b-4bc4-ab4a-72e80ee1ec59",
+              "id": "87852525-0887-43bb-95bb-33339b6fd51b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13733,7 +13733,7 @@
           }
         },
         {
-          "id": "be8f6e04-b1b3-4823-9b8c-46f170f38975",
+          "id": "1e1fdb25-28cf-4334-9175-d19b601df7cc",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13777,7 +13777,7 @@
           },
           "response": [
             {
-              "id": "19a0c18c-3593-4ec4-a4d3-c778705be75e",
+              "id": "8c6a74e6-197f-488a-b216-a7d94af413df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13849,7 +13849,7 @@
       "description": "",
       "item": [
         {
-          "id": "6f43bf40-6543-48f8-adaf-70dc1a50a144",
+          "id": "8fee11f1-18be-4b6b-9f12-32c593cf6ca9",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13891,7 +13891,7 @@
           },
           "response": [
             {
-              "id": "ce9796a2-1fd4-4752-a5b8-b11a5c523844",
+              "id": "c41b7bf1-295b-44cc-be66-eda3b581c939",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13940,7 +13940,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "808bb87f-5999-402d-9428-8c1aad46f345",
+              "id": "945c17ce-39cd-4478-8cce-6e20504d81e0",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13995,7 +13995,7 @@
           }
         },
         {
-          "id": "2a9267ac-ad83-485b-8f14-4163a5abe862",
+          "id": "4cff6c87-eb5c-4e61-a8f8-19bc6a266319",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -14041,7 +14041,7 @@
           },
           "response": [
             {
-              "id": "f56bc304-2fc7-4a42-ba6a-0e7efa21f93f",
+              "id": "0f47e3fd-edfd-447b-89f0-b5f4b60bf52b",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -14100,7 +14100,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3ea06590-9f0b-4a98-8b3e-14546eab345d",
+              "id": "112b790d-1dbb-4e88-afbe-2d282218d83d",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -14165,7 +14165,7 @@
           }
         },
         {
-          "id": "2d6ec7a1-d87b-4674-8e5a-126ac9bbce93",
+          "id": "9a959791-dc37-4455-946b-34e4ac87f989",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14211,7 +14211,7 @@
           },
           "response": [
             {
-              "id": "cebbf3af-50a6-444d-8c09-6faf6d3f3092",
+              "id": "61a26f32-2a58-45a8-a45b-6f6439ad82a2",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14270,7 +14270,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6e02746a-506c-4626-8936-e38cda98a069",
+              "id": "284ca51b-cbc9-483c-adf9-30d29f3c8727",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14335,7 +14335,7 @@
           }
         },
         {
-          "id": "7c5d5538-34c1-4155-94f3-d342474e9593",
+          "id": "ed930134-6b51-4d8d-a5b8-653f596dc1ff",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14377,7 +14377,7 @@
           },
           "response": [
             {
-              "id": "e3058e7f-78e0-4578-85ab-b9bb74f66c35",
+              "id": "866c2378-7d6b-4a09-8216-420478d4c1f7",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14438,7 +14438,7 @@
       "description": "",
       "item": [
         {
-          "id": "37bf8071-63ac-4fe2-b03d-bb7091da7c63",
+          "id": "fb669c9b-46ff-4037-8b0f-17565020d609",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14487,7 +14487,7 @@
           },
           "response": [
             {
-              "id": "e82531d9-c6c1-423c-a755-93bf9659286f",
+              "id": "a60b9203-d733-4221-b249-e0be6d6e6dc0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14547,7 +14547,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9302.475911937629\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14558,7 +14558,7 @@
           }
         },
         {
-          "id": "263b9629-18db-4c65-83ce-1198d30b1128",
+          "id": "ae5a5a17-75a5-4075-8b22-fcf30aa94a2a",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14607,7 +14607,7 @@
           },
           "response": [
             {
-              "id": "d32bff6c-88b2-44e4-8fd7-f4eede558035",
+              "id": "a941d57e-7293-4648-bc3a-f2306e88ab7c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14678,7 +14678,7 @@
           }
         },
         {
-          "id": "a4cbe41c-5c33-4e10-9914-64cb51b79f89",
+          "id": "9b471c76-cd4e-4d96-b66d-d87b2d32ad98",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14727,7 +14727,7 @@
           },
           "response": [
             {
-              "id": "56499123-ea33-4314-b354-36a4a5b3b903",
+              "id": "9d974d16-fe73-45d6-a1d6-e362580c19a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14798,7 +14798,7 @@
           }
         },
         {
-          "id": "315d91c0-f99d-4c66-a961-8d18bd13e27d",
+          "id": "5357b9ee-98a5-4dfe-a8ef-5eba3c877472",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14847,7 +14847,7 @@
           },
           "response": [
             {
-              "id": "f1717b31-09de-4af9-99c7-77b42b075805",
+              "id": "8e565377-01de-442b-bb2f-a682f3fbd2b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14924,7 +14924,7 @@
       "description": "",
       "item": [
         {
-          "id": "a472a761-74a8-4d00-9d0a-e4a1390217f6",
+          "id": "bbac15c7-ab82-49fb-95f9-dcd9b9aff23b",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14964,7 +14964,7 @@
           },
           "response": [
             {
-              "id": "bd1b19f9-df57-4b9c-a5e2-88c61640ae84",
+              "id": "11672a36-7da2-4157-8231-9d9bbfa6fac6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15026,7 +15026,7 @@
           }
         },
         {
-          "id": "aa1c8046-bc2f-49b0-9096-bb2bd47c4fdd",
+          "id": "9aab2809-829a-48f3-b723-5fcfe157a6fc",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -15056,7 +15056,7 @@
           },
           "response": [
             {
-              "id": "e6cfafe1-d904-4791-bce3-5e854c3cb267",
+              "id": "a39dbeea-0175-4e99-bb40-e4db8606fec4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15097,7 +15097,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9302.475911937629\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15108,7 +15108,7 @@
           }
         },
         {
-          "id": "e68cf46b-b253-4a23-8251-a33bd94bfe15",
+          "id": "63c160fc-5dc0-44aa-8c56-721d7f9e9e66",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -15160,7 +15160,7 @@
           },
           "response": [
             {
-              "id": "6f3641c3-f296-4bce-b24c-3ba87b4f11e5",
+              "id": "a23ac331-b33a-4a0a-b40a-1701e89fd9a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15240,7 +15240,7 @@
       "description": "",
       "item": [
         {
-          "id": "121783ae-477c-4829-9385-2b75f2343159",
+          "id": "03b45b58-d6ea-476e-ba63-a3653e65722e",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15269,7 +15269,7 @@
           },
           "response": [
             {
-              "id": "faf38b24-de69-4cd0-accf-4d11f59c6cba",
+              "id": "188b596e-ee5d-495d-b59b-653a4a605ffe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15320,7 +15320,7 @@
           }
         },
         {
-          "id": "b7bd26af-aebd-46d3-96dc-466724460e71",
+          "id": "588956e2-ab16-415c-9119-4a6e8c801b35",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15361,7 +15361,7 @@
           },
           "response": [
             {
-              "id": "e17f663e-ab1a-4d79-8d11-6d57072c3fd0",
+              "id": "53091188-c200-4037-9cdd-983c7f526ded",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15430,7 +15430,7 @@
       "description": "",
       "item": [
         {
-          "id": "50ae0765-8e26-40b2-8c5b-0da9e63c80f7",
+          "id": "e72e0441-3fc0-467a-a221-ab3e0396b8b2",
           "name": "health",
           "request": {
             "name": "health",
@@ -15459,7 +15459,7 @@
           },
           "response": [
             {
-              "id": "fbb6084f-1d1f-4631-bdf7-c495e91cf985",
+              "id": "da2ce6e0-6c90-49e2-a5f0-3fcccbfaca3b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15499,7 +15499,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 9302.475911937629\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15516,7 +15516,7 @@
       "description": "",
       "item": [
         {
-          "id": "aa2401a4-0946-49f4-9d9a-3200ab062820",
+          "id": "4f7ae265-44c8-4897-86a0-eef800cdca23",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15568,7 +15568,7 @@
           },
           "response": [
             {
-              "id": "6935c78d-9306-47e6-a977-28acc366e5ff",
+              "id": "18ab65ad-bcf9-42a1-8989-b8cba2e70d7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15642,7 +15642,7 @@
           }
         },
         {
-          "id": "7cbf329d-bbea-449e-8ab0-d18b9c0d71ad",
+          "id": "2f429cf6-dce4-48e9-9019-7054dd32d075",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15683,7 +15683,7 @@
           },
           "response": [
             {
-              "id": "e475a398-7e56-4270-9c5e-e19ef3f2bafe",
+              "id": "76157259-8adc-47b4-b1f0-91262c59fb41",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15735,7 +15735,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15746,7 +15746,7 @@
           }
         },
         {
-          "id": "57350b31-5350-4074-90fb-b89d5c6ee7c1",
+          "id": "1d15f422-9e26-4164-9a8a-039fcda96404",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15776,7 +15776,7 @@
           },
           "response": [
             {
-              "id": "eb089880-6833-4fa6-b61d-d2c54d555f14",
+              "id": "f88c707b-f424-4408-966e-e4f2810c44ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15817,7 +15817,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15848,9 +15848,9 @@
     }
   ],
   "info": {
-    "_postman_id": "c14d8f1a-222e-45d8-b29a-345a7913aa0a",
+    "_postman_id": "fda6e60a-13f8-415b-9b01-32eb2493ec48",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-04-30 23:23 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 00:17 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1785,7 +1785,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/Alert"
+                  "$ref": "#/components/schemas/AlertResponse"
                 }
               }
             }
@@ -1824,7 +1824,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/Alert"
+                  "$ref": "#/components/schemas/AlertResponse"
                 }
               }
             }
@@ -1894,7 +1894,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/Alert"
+                  "$ref": "#/components/schemas/AlertResponse"
                 }
               }
             }
@@ -1925,7 +1925,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/Alert"
+                  "$ref": "#/components/schemas/AlertResponse"
                 }
               }
             }
@@ -3357,7 +3357,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Alert"
+                    "$ref": "#/components/schemas/AlertResponse"
                   }
                 }
               }
@@ -3386,7 +3386,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/Alert"
+                  "$ref": "#/components/schemas/AlertResponse"
                 }
               }
             }
@@ -4607,7 +4607,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Alert"
+                    "$ref": "#/components/schemas/AlertResponse"
                   }
                 }
               }
@@ -4641,7 +4641,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Alert"
+                    "$ref": "#/components/schemas/AlertResponse"
                   }
                 }
               }
@@ -4685,7 +4685,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Alert"
+                    "$ref": "#/components/schemas/AlertResponse"
                   }
                 }
               }
@@ -4719,7 +4719,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Alert"
+                    "$ref": "#/components/schemas/AlertResponse"
                   }
                 }
               }
@@ -4763,7 +4763,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Alert"
+                    "$ref": "#/components/schemas/AlertResponse"
                   }
                 }
               }
@@ -6059,6 +6059,108 @@
           "username"
         ]
       },
+      "AlertResponse": {
+        "type": "object",
+        "description": "Respuesta que representa una Alerta del sistema",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "ID unico de la alerta"
+          },
+          "code": {
+            "type": "string",
+            "description": "Codigo unico legible de la alerta",
+            "example": "ALT-00001"
+          },
+          "tenantId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "ID del tenant propietario"
+          },
+          "sectorId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "ID del sector donde ocurrio la alerta"
+          },
+          "sectorCode": {
+            "type": "string",
+            "description": "Codigo del sector"
+          },
+          "alertTypeId": {
+            "type": "integer",
+            "format": "int32",
+            "description": "ID del tipo de alerta"
+          },
+          "alertTypeName": {
+            "type": "string",
+            "description": "Nombre del tipo de alerta"
+          },
+          "severityId": {
+            "type": "integer",
+            "format": "int32",
+            "description": "ID de la severidad"
+          },
+          "severityName": {
+            "type": "string",
+            "description": "Nombre de la severidad (INFO, WARNING, ERROR, CRITICAL)"
+          },
+          "severityLevel": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Nivel de severidad (1-4)"
+          },
+          "message": {
+            "type": "string",
+            "description": "Mensaje descriptivo de la alerta"
+          },
+          "description": {
+            "type": "string",
+            "description": "Descripcion detallada de la alerta"
+          },
+          "clientName": {
+            "type": "string",
+            "description": "Nombre visible para el usuario en el frontend"
+          },
+          "isResolved": {
+            "type": "boolean",
+            "description": "Indica si la alerta esta resuelta"
+          },
+          "resolvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Fecha/hora de resolucion"
+          },
+          "resolvedByUserId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "ID del usuario que resolvio la alerta"
+          },
+          "resolvedByUserName": {
+            "type": "string",
+            "description": "Nombre del usuario que resolvio"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Fecha de creacion"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Fecha de ultima actualizacion"
+          }
+        },
+        "required": [
+          "code",
+          "createdAt",
+          "id",
+          "isResolved",
+          "sectorId",
+          "tenantId",
+          "updatedAt"
+        ]
+      },
       "TenantCreateRequest": {
         "type": "object",
         "description": "Solicitud para crear un nuevo Tenant",
@@ -7296,108 +7398,6 @@
           "createdAt",
           "deviceId",
           "id"
-        ]
-      },
-      "AlertResponse": {
-        "type": "object",
-        "description": "Respuesta que representa una Alerta del sistema",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "ID unico de la alerta"
-          },
-          "code": {
-            "type": "string",
-            "description": "Codigo unico legible de la alerta",
-            "example": "ALT-00001"
-          },
-          "tenantId": {
-            "type": "integer",
-            "format": "int64",
-            "description": "ID del tenant propietario"
-          },
-          "sectorId": {
-            "type": "integer",
-            "format": "int64",
-            "description": "ID del sector donde ocurrio la alerta"
-          },
-          "sectorCode": {
-            "type": "string",
-            "description": "Codigo del sector"
-          },
-          "alertTypeId": {
-            "type": "integer",
-            "format": "int32",
-            "description": "ID del tipo de alerta"
-          },
-          "alertTypeName": {
-            "type": "string",
-            "description": "Nombre del tipo de alerta"
-          },
-          "severityId": {
-            "type": "integer",
-            "format": "int32",
-            "description": "ID de la severidad"
-          },
-          "severityName": {
-            "type": "string",
-            "description": "Nombre de la severidad (INFO, WARNING, ERROR, CRITICAL)"
-          },
-          "severityLevel": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Nivel de severidad (1-4)"
-          },
-          "message": {
-            "type": "string",
-            "description": "Mensaje descriptivo de la alerta"
-          },
-          "description": {
-            "type": "string",
-            "description": "Descripcion detallada de la alerta"
-          },
-          "clientName": {
-            "type": "string",
-            "description": "Nombre visible para el usuario en el frontend"
-          },
-          "isResolved": {
-            "type": "boolean",
-            "description": "Indica si la alerta esta resuelta"
-          },
-          "resolvedAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Fecha/hora de resolucion"
-          },
-          "resolvedByUserId": {
-            "type": "integer",
-            "format": "int64",
-            "description": "ID del usuario que resolvio la alerta"
-          },
-          "resolvedByUserName": {
-            "type": "string",
-            "description": "Nombre del usuario que resolvio"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Fecha de creacion"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Fecha de ultima actualizacion"
-          }
-        },
-        "required": [
-          "code",
-          "createdAt",
-          "id",
-          "isResolved",
-          "sectorId",
-          "tenantId",
-          "updatedAt"
         ]
       },
       "SensorStatisticsHourlyDto": {

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.*
  * - GET /api/v1/alerts/actuator/{actuatorId} - Alertas por actuador
  * - GET /api/v1/alerts/unresolved/tenant/{tenantId} - Alertas no resueltas por tenant
  * - GET /api/v1/alerts/unresolved/sector/{sectorId} - Alertas no resueltas por sector
+ * - GET /api/v1/alerts/history/tenant/{tenantId} - Histórico completo (activas + resueltas) de un tenant
  * - GET /api/v1/alerts/count/unresolved/tenant/{tenantId} - Cuenta alertas no resueltas
  * - GET /api/v1/alerts/count/critical/tenant/{tenantId} - Cuenta alertas críticas
  * - POST /api/v1/alerts - Crear nueva alerta
@@ -247,6 +248,33 @@ class AlertController(
             ResponseEntity.ok(alerts)
         } catch (e: Exception) {
             logger.error("Error getting recent alerts for tenant: $tenantId", e)
+            ResponseEntity.internalServerError().build()
+        }
+    }
+
+    /**
+     * GET /api/alerts/history/tenant/{tenantId}
+     *
+     * Histórico completo de alertas del tenant: incluye tanto activas como resueltas,
+     * ordenadas por createdAt DESC. Es lo que la app móvil consume en su pantalla
+     * "Histórico" — a diferencia del filtro `?isResolved=true`, este endpoint no
+     * limita por estado de resolución.
+     *
+     * Query params:
+     * - limit: Número de alertas (default: 100)
+     */
+    @GetMapping("/history/tenant/{tenantId}")
+    fun getHistoryByTenant(
+        @PathVariable tenantId: Long,
+        @RequestParam(required = false, defaultValue = "100") limit: Int
+    ): ResponseEntity<List<AlertResponse>> {
+        logger.debug("GET /api/alerts/history/tenant/$tenantId?limit=$limit")
+
+        return try {
+            val alerts = alertService.getHistoryByTenant(tenantId, limit).map { it.toResponse() }
+            ResponseEntity.ok(alerts)
+        } catch (e: Exception) {
+            logger.error("Error getting alert history for tenant: $tenantId", e)
             ResponseEntity.internalServerError().build()
         }
     }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertService.kt
@@ -156,6 +156,18 @@ class AlertService(
     }
 
     /**
+     * Histórico completo de alertas de un tenant: incluye activas y resueltas,
+     * ordenadas por createdAt DESC. Pensado para la pantalla "Histórico" de la
+     * app móvil, donde el usuario quiere ver todo el feed independientemente de
+     * si una alerta sigue activa o ya está resuelta.
+     */
+    @Transactional("postgreSQLTransactionManager", readOnly = true)
+    fun getHistoryByTenant(tenantId: Long, limit: Int = 100): List<Alert> {
+        logger.debug("Getting alert history for tenant: $tenantId (limit=$limit)")
+        return alertRepository.findRecentByTenant(tenantId, limit)
+    }
+
+    /**
      * Busca una alerta por ID
      */
     @Transactional("postgreSQLTransactionManager", readOnly = true)


### PR DESCRIPTION
## Summary

Adds a dedicated endpoint that returns the full history of alerts for a tenant — both active and resolved — ordered by `createdAt DESC`. The mobile app `GreenhouseFronts` will switch its "Histórico" tab from `?isResolved=true` (which only returns resolved alerts and was returning `[]` because no alert had been resolved yet) to this new endpoint, so the tab shows every alert the tenant has ever produced regardless of resolution state.

### Why a new endpoint instead of just dropping `isResolved`?
The legacy filter is kept intact so the "Activas" tab (`?isResolved=false`) keeps working without changes. Adding `/history/tenant/{id}` makes the semantic explicit at the URL level, so any future client doesn't have to know that "no `isResolved` parameter" implicitly means "give me everything".

### Implementation

- `AlertController.kt`: new `GET /api/v1/alerts/history/tenant/{tenantId}?limit=100`, returns `List<AlertResponse>` (DTO mapping pattern from PR #106 — zero `LazyInitializationException` risk).
- `AlertService.kt`: new `getHistoryByTenant(tenantId, limit)`, reuses the existing `AlertRepository.findRecentByTenant` (already orders by `createdAt DESC`, already uses `@EntityGraph("Alert.context")`).
- No new repository query, no schema change, no other endpoint touched.

## Includes

- `01e4b4d` — the new endpoint.
- `2d70f72` + `7aaee4c` — merge of main (#106 commit + auto-docs) into develop, keeping develop's Postman per repo convention (matches `dd77bc2` and `7740f42`).

## Test plan

- [x] `./gradlew compileKotlin` clean.
- [x] `./gradlew test` full suite green.
- [x] Dev rolled out: pod healthy, `/actuator/health` 200, new route returns 403 (Spring Security) — proof the controller is registered (would be 404 otherwise).
- [ ] Prod rollout after merge.
- [ ] Mobile (GreenhouseFronts) flips its `AlertApiService` URL to consume `/history/tenant/{id}` — pending Alberto pushing his local feature/alert-notifications branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)