### PR TITLE
feat(ws): server-side broadcast (STOMP JWT auth + Redis pub/sub + 3 sources)

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "86dc6c7d-39aa-43f9-8c82-4e7d3392830b",
+          "id": "1d1be62e-c584-4048-b836-2022b36e3112",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "58c8e337-0415-42d4-b918-36a19add5bba",
+              "id": "b2a83757-adbb-4949-b0a6-6c47cf145b8d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "a78f17a3-5bcf-4e30-a451-c1b3abd38eac",
+          "id": "2db3b9be-a267-45cb-a160-803efa131d2d",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "28a44ea1-21fd-48fd-b856-1853d4934882",
+              "id": "badaacf1-9d29-49a2-9c2d-4fc74a459de8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "abd0830a-27a1-4a20-8fc7-8a9b23288573",
+          "id": "e6d014a4-8938-403d-91b4-ca160ff7a71d",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "c31d4fe4-b408-495d-8c00-6a769e85641c",
+              "id": "ff0f64f9-ef2f-491d-9c70-694a2f02850c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "5c447d2d-09f4-47b0-83da-5d789409ae37",
+          "id": "842343a3-83a2-4db8-b73e-6dead51e6f8c",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "6682a4d9-88f8-4c75-b6c4-98623ee71e6b",
+              "id": "a6b2ae5b-f982-4e25-813e-34106c000f87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "165c06ca-d36a-49ce-9f99-66d3659495ff",
+          "id": "acc8be55-5512-4f44-8aa6-d03b821c18fe",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "ffe1fb91-594d-49dd-8077-56ce564033c3",
+              "id": "f41854bb-d4c8-46cc-98ad-8b81f3e315f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "bc6ccd21-6570-41cd-bcf1-a4f1d3d31295",
+          "id": "6514b204-7f57-47bf-b390-58495a151cea",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "68544319-45c8-4b59-9c59-8852bb093e8c",
+              "id": "a4a3b303-9b00-4f53-987c-f9466c6ff392",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "aed69f8c-b28c-4776-88fe-4b3edc27aedf",
+          "id": "3c356abc-2c89-4312-b3eb-a872d9fd101e",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "3cb03ed5-3c1e-4cfe-8f6d-9619b9f758a6",
+              "id": "cf67dc55-6e3e-4af9-9b38-44b2b4bb531f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "dfb8c350-476f-4009-a3aa-c92fd13c0e4c",
+          "id": "412ab009-746f-4c9c-82af-9c0dc70f9c73",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "441b0a3b-b2e0-4d6c-9876-d8af94460e82",
+              "id": "12e2bee7-c914-47db-a1af-507e07119bc9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "a5dcf45a-64e0-43db-88dd-bcc53d76742c",
+          "id": "7bb7c7fb-7063-435b-8818-6e54fb28406b",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "715fec81-ceeb-4c5e-9e5b-411359ec9982",
+              "id": "a1ea13d4-ae4b-4809-bb5e-fc0bea50e7d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "14604480-c36f-44cd-b850-9f320fe8e47d",
+          "id": "a839ee42-7b39-4db2-81a1-6adc0640119a",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "87a5e661-e32a-4a2d-9453-6869bd28a06d",
+              "id": "80dd9e4d-0716-4272-9101-d9270abe4f33",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "01cbd19c-6707-42c7-b0cc-3e29b640204f",
+          "id": "53778796-6726-4194-a08f-4b868d1810dc",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "f49f68e7-c4b8-44d4-b7f8-1f44189a4c61",
+              "id": "832ca569-de9c-481d-837b-a2fb4618a445",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "a9113950-09f6-46c0-811f-97da7807e82a",
+          "id": "c3cdb81c-017a-4dfe-9a81-6aa327c3f044",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "2ee85a68-85c4-4b17-b354-7515377b4b43",
+              "id": "5ccd770f-bcc6-4dca-abab-f553e064e310",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "b8a3969e-3627-47ee-be03-a95f5ff5f297",
+          "id": "4d57be71-c139-41ea-91d9-1fc27a239e32",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "2a2b2509-07db-4873-b1fd-e4c8dbeba76a",
+              "id": "cc071f7d-b284-4db1-849c-56ffe9c01995",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "d1900adc-0f0d-4a97-af7b-1447372b0659",
+          "id": "c7e7c776-c3e9-4f9c-a850-844935750c2a",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "442f44c1-1de1-4c95-9f94-c941af7b9535",
+              "id": "53ad6c4e-ce7b-43c9-b1d9-823646a91f7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "601740bc-7e2e-4f94-ae7a-13933d4ddc13",
+          "id": "f006080b-7777-43b5-8035-ee2a07ea4af8",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "e4ee4e15-c079-4eff-b078-81303975d436",
+              "id": "3e56fcab-eb32-48a6-b329-bd77c0e56a92",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "02ca6d72-6b89-46bf-a627-5453f310ad50",
+          "id": "a0a866ec-4400-4982-b13c-f81fa0e821f5",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "9b5163d2-3ee8-46b5-bc88-b082017a8a40",
+              "id": "c8f1be81-c91f-4af9-ba42-872596aea38d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "03474c18-1e8f-4774-9e3a-8074076c78b6",
+          "id": "23b9670b-f6ed-490a-847d-127f8c091c11",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -1859,7 +1859,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -1879,7 +1879,7 @@
           },
           "response": [
             {
-              "id": "c54aaf82-e988-43dd-af26-8e18c2497b77",
+              "id": "7be0f154-24ed-49f4-a4dd-f80637194c72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1911,7 +1911,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1933,7 +1933,7 @@
           }
         },
         {
-          "id": "ee3e07cb-5295-47d0-9c4d-5c21d597c5a6",
+          "id": "23a3caf3-2b72-4bb5-9163-1220b5e5328c",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -1976,7 +1976,7 @@
           },
           "response": [
             {
-              "id": "e9884b8c-4bdf-48e7-b7e9-e800f567df7c",
+              "id": "00c8a6c9-fc85-4eb5-a1be-e61f2c614dc5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "9de7f826-caa5-4364-bec9-7ef7ea5fbc23",
+          "id": "f57f809f-e347-4ff8-82d1-3bcce1c8e8c2",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -2088,7 +2088,7 @@
           },
           "response": [
             {
-              "id": "819c48d6-3604-46f3-8649-0650264ed30c",
+              "id": "b251340c-c3cc-40b3-b135-f0193a3f73d7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2163,7 +2163,7 @@
           }
         },
         {
-          "id": "8a98e184-1ace-4578-9ed7-0f4817cd5c99",
+          "id": "783c6ede-48f4-4fe4-9a73-305a1f2ca270",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "0b75cfab-54ab-4b63-883f-3ec31d4ed45c",
+              "id": "e63ece70-6b07-4b0d-9524-d610924eebad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2317,7 +2317,7 @@
           }
         },
         {
-          "id": "a7425e6c-9c6d-4cf2-88e2-4b663facb4c4",
+          "id": "f2b56730-12ae-4618-b09c-6f29c8a8ec14",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2364,7 +2364,7 @@
           },
           "response": [
             {
-              "id": "8e5c6e47-2226-40ae-a287-4bf9a92ee561",
+              "id": "dec35608-8925-41dc-99ce-cb35ae64dcb1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2429,7 +2429,7 @@
           }
         },
         {
-          "id": "84663b8b-3198-4bab-afb6-0073f546e883",
+          "id": "77512b55-7c91-4f61-a013-1ca022fd5c02",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2471,7 +2471,7 @@
           },
           "response": [
             {
-              "id": "1a8967d2-3cb3-455c-ada8-1b4b074573eb",
+              "id": "76d80947-f2c8-4049-8c19-b212515426ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2535,7 +2535,7 @@
           }
         },
         {
-          "id": "2410c509-f185-456d-8a39-2d126deb6a48",
+          "id": "6876b1f1-4b05-499f-b173-249418f74a43",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2590,7 +2590,7 @@
           },
           "response": [
             {
-              "id": "cc7d36a3-436c-4cc2-9117-76267909b069",
+              "id": "5737c68a-1034-4c47-a8a3-ceaa2dcbe71f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2667,7 +2667,7 @@
           }
         },
         {
-          "id": "845dc6f1-bdee-401e-b4c6-93ebfb77a03a",
+          "id": "fa691a1d-25b9-4461-bf04-96bbbb47ca47",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2731,7 +2731,7 @@
           },
           "response": [
             {
-              "id": "f8cd4627-fd3b-44df-a226-c1e040358328",
+              "id": "6cd73dd0-70c0-449e-bcf7-2ea5da2ccfb6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2823,7 +2823,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "9dc68930-aaf2-4505-acd5-8814ec21991d",
+          "id": "16faa3ef-19c0-4620-93c5-ab5644e92928",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2865,7 +2865,7 @@
           },
           "response": [
             {
-              "id": "547fb6b4-34d0-4726-9bf0-fd51ff46492e",
+              "id": "4c226110-f189-4b15-be3e-806740f079bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2929,7 +2929,7 @@
           }
         },
         {
-          "id": "bd8a08f5-ca77-45d7-9efe-a21ba0a9769d",
+          "id": "294cd91f-d86a-405b-9151-2b025de797ce",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2972,7 +2972,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#75E52E\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#BdFA84\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2984,7 +2984,7 @@
           },
           "response": [
             {
-              "id": "c5b8807a-9681-413c-a2ae-42b039b2068c",
+              "id": "4266efff-43f7-4019-a99c-d5490dd5e1cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3033,7 +3033,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#75E52E\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#BdFA84\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3061,7 +3061,7 @@
           }
         },
         {
-          "id": "2855fd80-7aa1-484e-b6af-13e0bf07257c",
+          "id": "a5ec4599-f7ba-4bd0-930c-b293ffa3229d",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -3097,7 +3097,7 @@
           },
           "response": [
             {
-              "id": "b6231d94-0385-4b12-ac00-1f9b8e11750b",
+              "id": "a1653a5e-219d-485d-8407-e39fb77f0ef7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
           }
         },
         {
-          "id": "c2b7d5e4-8bea-4a58-80bc-5d8095013b8f",
+          "id": "25450fbc-38ae-4285-8ff8-c13676186e94",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -3181,7 +3181,7 @@
           },
           "response": [
             {
-              "id": "008965f4-b8cd-4866-b94f-ee2a49488bce",
+              "id": "9b5e12c5-466b-4916-be41-cfbec6d55fb9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3233,7 +3233,7 @@
           }
         },
         {
-          "id": "73f90da5-f19e-44c2-9c73-806baf38f35d",
+          "id": "2e8fc62b-1c81-4053-88ef-b2b181002d25",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3264,7 +3264,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aE9Aff\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9aae7E\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3276,7 +3276,7 @@
           },
           "response": [
             {
-              "id": "5851f371-0d72-462b-babd-40b9ca127f2b",
+              "id": "4662c409-205e-4d16-ad05-e4a18261e380",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3313,7 +3313,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#aE9Aff\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9aae7E\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3341,7 +3341,7 @@
           }
         },
         {
-          "id": "15fd275d-0cd9-47fd-9a3d-ae6cef748ed4",
+          "id": "7139f1f1-c710-439e-8a5b-af152d317145",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3372,7 +3372,7 @@
           },
           "response": [
             {
-              "id": "a64377f3-a35f-4d89-8f94-210611d189f6",
+              "id": "e6bb00b9-7d3a-40a2-bdc4-73a07682351d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3431,7 +3431,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "47d6433c-1492-409c-a83a-bbef8db4789a",
+          "id": "a5aec917-4271-42a0-a828-24172e585c0b",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3473,7 +3473,7 @@
           },
           "response": [
             {
-              "id": "935d8c2d-9dc4-4bba-a6af-f537655dce12",
+              "id": "3c7a7089-142c-4c06-92bb-e30e619ac216",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
           }
         },
         {
-          "id": "b3010e28-f87a-4319-a199-645f9112c0d6",
+          "id": "c966abe7-597f-46d6-b819-afae0f9a0153",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3592,7 +3592,7 @@
           },
           "response": [
             {
-              "id": "c9e0d26b-865a-4cc4-adc4-c2766bad6025",
+              "id": "c47b67b3-836c-48eb-b84b-6d7db3018526",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3669,7 +3669,7 @@
           }
         },
         {
-          "id": "d48686ff-6e00-442e-abdf-aa173e73d325",
+          "id": "197ca322-1820-4e66-b9e4-975140c6862e",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3711,7 +3711,7 @@
           },
           "response": [
             {
-              "id": "8ebd35e1-7c46-407b-95f2-2c48f658572f",
+              "id": "485e82ff-45cb-4c56-9e5c-3b516641a619",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3775,7 +3775,7 @@
           }
         },
         {
-          "id": "51f6a431-e452-4197-9de7-65dd2fcc65f6",
+          "id": "78c508e4-f697-4dc8-a5a1-d23f2f31591f",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3805,7 +3805,7 @@
           },
           "response": [
             {
-              "id": "6a039d31-fa39-475d-8688-ac2ad3c1b831",
+              "id": "7da226b8-353f-4133-9149-6d1b083ee6d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3857,7 +3857,7 @@
           }
         },
         {
-          "id": "2533e9d5-a04d-470f-a35b-e8a39ca6354d",
+          "id": "7de3857b-ea90-438b-9784-f815cbcbf12d",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3900,7 +3900,7 @@
           },
           "response": [
             {
-              "id": "1880f0a1-8e2a-478a-a758-c0eccadac172",
+              "id": "2e447e4d-3306-496d-a76c-b966fa468c56",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3965,7 +3965,7 @@
           }
         },
         {
-          "id": "163a3023-efc2-4ced-afd5-0da1fb0362fc",
+          "id": "634fbe80-ec5a-452d-b05a-5bbce1fdfd2b",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -4018,7 +4018,7 @@
           },
           "response": [
             {
-              "id": "c7e424b8-2e7a-49cb-9694-a2d95e011457",
+              "id": "c9b3d625-26c1-4e5d-ab7e-1affbd695287",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4082,7 +4082,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -4093,7 +4093,7 @@
           }
         },
         {
-          "id": "c5758dac-8551-4b08-90f2-e83f1cfa1262",
+          "id": "a1a541eb-1228-49be-aebe-aedd19b0688a",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -4136,7 +4136,7 @@
           },
           "response": [
             {
-              "id": "e4f486e2-2fa3-4478-8d5c-8470f44cb3dd",
+              "id": "a81f51e2-46ec-49a1-9659-a9bb1f05f424",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4201,7 +4201,7 @@
           }
         },
         {
-          "id": "85d59c5f-15f8-4f57-9e45-ae96cb2243d7",
+          "id": "a1f1debc-9512-45ad-a7fc-1ce884160128",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4232,7 +4232,7 @@
           },
           "response": [
             {
-              "id": "596546cf-c351-4406-8d98-0dc53aa4c1fc",
+              "id": "169517ca-4bf4-45f3-90e4-edf8dae8e9bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4291,7 +4291,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "ed85f4ca-be3e-4854-8524-90ad9a52bccb",
+          "id": "a9cab971-33a9-49b9-b606-283dea50add0",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4333,7 +4333,7 @@
           },
           "response": [
             {
-              "id": "c38778e8-3dcf-48ac-9cb6-584828f92245",
+              "id": "aef13722-7ea9-4d3f-b40d-ea3ca8c984ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4397,7 +4397,7 @@
           }
         },
         {
-          "id": "faf61d83-c47c-4905-8838-51ae457c6e02",
+          "id": "b52fcd44-e6e3-4938-a207-0f872ab01ec6",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4440,7 +4440,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4452,7 +4452,7 @@
           },
           "response": [
             {
-              "id": "2efc7bc2-d2fd-4712-97c0-15b2455f2bd5",
+              "id": "943190c3-eab3-4b06-8ea3-1b8da52e20e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4501,7 +4501,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4529,7 +4529,7 @@
           }
         },
         {
-          "id": "a65d3d5f-3da3-4d15-9666-617a0a006883",
+          "id": "17af2cfe-414d-44ab-b9ea-8aa2e99be015",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4565,7 +4565,7 @@
           },
           "response": [
             {
-              "id": "23aa4066-7e56-4bd4-bb35-202b0f949c0f",
+              "id": "269dd2df-43d2-474d-893d-485f4d860cb5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4619,7 +4619,7 @@
           }
         },
         {
-          "id": "302e60e6-a6e1-4f64-84ae-9f67f64db8d9",
+          "id": "7a0b1bd1-2481-4c31-b144-21ee604f62dc",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4668,7 +4668,7 @@
           },
           "response": [
             {
-              "id": "9e91fa93-83d6-43c5-80af-2a3398a93687",
+              "id": "4e73378e-30ee-4282-82bc-2cfc822b2da0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "fb9fe2b3-7565-44e4-b6af-e018770e6722",
+          "id": "a705e5d7-5ee2-4ee3-92f2-ee95c728abf4",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4782,7 +4782,7 @@
           },
           "response": [
             {
-              "id": "05e95d7f-c620-4187-b4a4-c1af3113783a",
+              "id": "20b5881f-e500-4633-a3c4-f1f59fd84d0c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4847,7 +4847,7 @@
           }
         },
         {
-          "id": "adf566f3-b4a7-4678-89c3-2f5a6f3fe783",
+          "id": "6407c255-1ff3-4a98-8ff1-61cbf15d53e3",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4890,7 +4890,7 @@
           },
           "response": [
             {
-              "id": "568c5744-2f77-4d63-80a1-dbc201c408e3",
+              "id": "a7816d4e-8667-4066-8aaf-76283314f2ff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4955,7 +4955,7 @@
           }
         },
         {
-          "id": "0e4854d8-0e62-4414-bb27-00789f57e361",
+          "id": "46888846-5751-41de-8184-a9fe8ff499a3",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4998,7 +4998,7 @@
           },
           "response": [
             {
-              "id": "e51ac41f-fb9c-438f-b8ef-a2af0424a927",
+              "id": "b0f850b1-4118-42af-9cdf-bcc5f773e57a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5063,7 +5063,7 @@
           }
         },
         {
-          "id": "b9c20d91-a578-4e8f-9629-e7e3de43020d",
+          "id": "4de092fb-d8d2-4501-a771-5a67f0e1fccc",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -5094,7 +5094,7 @@
           },
           "response": [
             {
-              "id": "0d5bffc9-ebe5-49d8-92dd-3a1844aa9457",
+              "id": "65627313-a7be-4dea-8bbe-029a14f39165",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5147,7 +5147,7 @@
           }
         },
         {
-          "id": "fcb870b4-45e1-4fad-beea-225ad7c8737c",
+          "id": "b338b8b1-8acd-46e7-9e26-de93acd5ce7e",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -5178,7 +5178,7 @@
           },
           "response": [
             {
-              "id": "514e5bf4-f27e-4cee-a5a1-71d940865dbc",
+              "id": "0deb27a3-e1c3-409e-b8cc-1365fbcaa517",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5237,7 +5237,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "2cce64d9-1fb4-4aab-8bd8-ceb4303a5568",
+          "id": "3b61f3da-5151-4fd5-bddb-80c7b167ce8c",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5279,7 +5279,7 @@
           },
           "response": [
             {
-              "id": "d1924f32-e663-4d02-bc1f-56e85bf4e336",
+              "id": "426e157f-33b3-42c1-8690-7e7daa2d0734",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5343,7 +5343,7 @@
           }
         },
         {
-          "id": "d10ea1dc-2fc0-465b-adfd-8f2f1600e200",
+          "id": "fe941f71-ea0a-448e-8021-d89da7c3fd35",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5398,7 +5398,7 @@
           },
           "response": [
             {
-              "id": "24b94676-f41e-4591-9bc5-d1d18c91b711",
+              "id": "5ca64510-b491-4735-9a93-38e23758d28e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5475,7 +5475,7 @@
           }
         },
         {
-          "id": "0a8d9413-a650-4302-b2a9-8dac4d97bd2b",
+          "id": "60fb31b4-5433-4b6b-a0d8-17937c597ff6",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5511,7 +5511,7 @@
           },
           "response": [
             {
-              "id": "6a70416a-b148-4ab3-a39a-e9e0872abd32",
+              "id": "f352bc0a-16a8-4802-96fa-1317ee196261",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5565,7 +5565,7 @@
           }
         },
         {
-          "id": "4a802ba8-7f33-44ac-b275-007bc206dd41",
+          "id": "ac36ecb8-ebdf-4eac-af1b-f2ed1333bab7",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5595,7 +5595,7 @@
           },
           "response": [
             {
-              "id": "ed009797-b044-4842-aaae-3d02f6646600",
+              "id": "ebe0c3bc-f9a5-4ab1-80f9-da4eb232b551",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5647,7 +5647,7 @@
           }
         },
         {
-          "id": "63d7400d-7784-411a-bc29-3f6ea907336a",
+          "id": "87325d3b-2d18-445a-87ce-ffc56b702ffa",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5690,7 +5690,7 @@
           },
           "response": [
             {
-              "id": "4bf4e6a6-504b-4a21-b5ce-f84ca17e6f3d",
+              "id": "e8369707-4fba-4aea-b051-b905739454c0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5761,7 +5761,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "e3644065-f3fc-4cbb-ad21-7576f1be533d",
+          "id": "9c9f1fae-60d7-4bba-abd3-a709a5430d24",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5814,7 +5814,7 @@
           },
           "response": [
             {
-              "id": "9d2d1a4b-8049-4638-9460-e2cbe2025bf5",
+              "id": "f68aad7a-9f63-4b3c-baaa-1c650dff375c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5889,7 +5889,7 @@
           }
         },
         {
-          "id": "671e8b35-5374-48e1-8f1c-fecbbb574f86",
+          "id": "96f62ca5-5ae6-40a5-acb8-8e379867589c",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5955,7 +5955,7 @@
           },
           "response": [
             {
-              "id": "4f4a1f61-f06d-4838-8084-f308f88d398c",
+              "id": "4744ebd6-830b-43dd-b809-f0f4e9f0ccdd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6043,7 +6043,7 @@
           }
         },
         {
-          "id": "ae6fee46-ae23-4581-9de7-810383f2c47a",
+          "id": "f5d9a655-6713-45cd-b09b-02694f7561ad",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -6090,7 +6090,7 @@
           },
           "response": [
             {
-              "id": "35ba4261-81de-4fcb-a745-3f2fa7bf7958",
+              "id": "990a57a7-db12-4e67-8939-14f6eda44110",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6155,7 +6155,7 @@
           }
         },
         {
-          "id": "12b59065-fc49-45ae-8571-69529f402435",
+          "id": "680cee42-5cff-4268-8483-2c731c2295c1",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -6197,7 +6197,7 @@
           },
           "response": [
             {
-              "id": "bfd520c7-327c-41a4-9975-d86a8f4dbccf",
+              "id": "0483181e-f346-4e17-b2cc-5dc1073071b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6261,7 +6261,7 @@
           }
         },
         {
-          "id": "0d66dae9-f91c-4518-bb30-a1c7061c3824",
+          "id": "563962a9-8d3e-4a53-9c59-a23f39d65c2f",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6316,7 +6316,7 @@
           },
           "response": [
             {
-              "id": "3dc28a53-63bb-43db-be0a-c69aa5c72abb",
+              "id": "78fd4fc4-752e-4b8d-8233-d98492734404",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6393,7 +6393,7 @@
           }
         },
         {
-          "id": "b35d5aac-54be-43e6-a24d-6f479aac6e45",
+          "id": "54c51e73-b15b-40f9-9c8c-fd3fbcef6756",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6460,7 +6460,7 @@
           },
           "response": [
             {
-              "id": "3e0433a6-bfd8-4387-b3ec-95e9afc10a7c",
+              "id": "8add8014-d42d-4353-8106-5d79c1be189b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6549,7 +6549,7 @@
           }
         },
         {
-          "id": "4686d3bf-c139-43d0-ae73-a2e0d720f126",
+          "id": "a0f9a115-e83e-4c00-a7d9-8f6fbe6f562d",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6603,7 +6603,7 @@
           },
           "response": [
             {
-              "id": "b6fa4e0f-5e4f-4aa4-804a-1f9d1152e826",
+              "id": "0d59813a-c3ea-4bdc-bff9-3872736a04a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6685,7 +6685,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "36515aa6-3886-4510-9413-ba28e6819e71",
+          "id": "0d93ffe5-3989-41e4-9f28-519f3c23f88e",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6738,7 +6738,7 @@
           },
           "response": [
             {
-              "id": "26951eae-43c7-40d2-bbda-09c0c8ca6508",
+              "id": "6f4e94c2-d06d-4dc5-8dad-6bd5c372deeb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6813,7 +6813,7 @@
           }
         },
         {
-          "id": "ef9c11c4-011d-4d15-a3b1-fd53ba00b712",
+          "id": "48ab46b9-a211-4351-8648-ba88f508b4cd",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6879,7 +6879,7 @@
           },
           "response": [
             {
-              "id": "aa924fa0-c167-4ee4-aa7b-2189591d5a5c",
+              "id": "23757d51-5d8c-4078-883e-09c347377b3f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6967,7 +6967,7 @@
           }
         },
         {
-          "id": "22f8fad7-c73f-4b82-b9d2-0de136d61979",
+          "id": "422214b5-f479-41f5-8326-201750c953ef",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -7014,7 +7014,7 @@
           },
           "response": [
             {
-              "id": "a5b30be1-3541-4d14-9630-72334641c62b",
+              "id": "dbb4d8a1-718d-4786-8ea5-566a0e90f703",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7079,7 +7079,7 @@
           }
         },
         {
-          "id": "e63b6d88-1ccd-464d-9959-86433fb48fe7",
+          "id": "229c1d07-6a61-41eb-bb09-1febc8af76de",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -7121,7 +7121,7 @@
           },
           "response": [
             {
-              "id": "c1cf00d5-e6ad-432c-97ed-afed15adcc1c",
+              "id": "2de94243-21ae-4bf4-9a87-ed3e12e2cba5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7185,7 +7185,7 @@
           }
         },
         {
-          "id": "9879b763-907a-44a7-a450-40964277a835",
+          "id": "fc8a18a0-3fdc-4bbb-ac12-5172f890fb9d",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7240,7 +7240,7 @@
           },
           "response": [
             {
-              "id": "e826541a-4864-4dc6-baa6-186ab0594ed1",
+              "id": "5475785e-41f6-45fb-ba9a-b74156ad4f10",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7323,7 +7323,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "23d42132-1f9c-447a-9d2f-c16b4cb80895",
+          "id": "e562c4ac-0813-4000-b1c4-5c164e52b0ae",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7364,7 +7364,7 @@
           },
           "response": [
             {
-              "id": "c92f1463-a48b-4409-835e-5ea029e028b2",
+              "id": "db2c1af9-9137-4cd6-9605-e41ec015ddab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7427,7 +7427,7 @@
           }
         },
         {
-          "id": "14ac66c2-cb43-44c4-8a5f-6198523f8fe5",
+          "id": "83953b17-0e98-4da4-a945-143b4508e002",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7481,7 +7481,7 @@
           },
           "response": [
             {
-              "id": "a2f7919e-2a4a-4c83-8367-942b1dd02db5",
+              "id": "09972714-7d72-4ac3-96b9-b3c6be1f9b86",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7557,7 +7557,7 @@
           }
         },
         {
-          "id": "b9189a17-a9ed-4795-a19e-32e8ed5dca09",
+          "id": "abeb453a-40c8-496b-a158-9f8bd47aeb5f",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7592,7 +7592,7 @@
           },
           "response": [
             {
-              "id": "c3628632-6707-4b79-9e8c-eb0711345bf3",
+              "id": "cfb240d6-2f75-49c1-96f4-4bbcd942d6af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7645,7 +7645,7 @@
           }
         },
         {
-          "id": "971a60d1-5b33-4c4c-8871-98dd6d533b39",
+          "id": "c17f1d46-9f1e-421a-837f-bae4d549372a",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7702,7 +7702,7 @@
           },
           "response": [
             {
-              "id": "2dbaf7a9-7653-4d60-a50e-25cc3feb7b5c",
+              "id": "090b8e44-1f81-44c1-a63b-0398a75a95a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7781,7 +7781,7 @@
           }
         },
         {
-          "id": "6694c367-b6ad-4919-9eea-316f6818415b",
+          "id": "7d925383-8752-4920-bb15-c8b489754471",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7823,7 +7823,7 @@
           },
           "response": [
             {
-              "id": "a478c7f4-0030-43e7-8929-08f1dc97c75f",
+              "id": "abfa6f2d-4b01-4cbb-bbb0-4dfd1c0251f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "b1d785a7-a508-45c5-ba39-93b0189a2df9",
+          "id": "1c4820b1-cec6-43c8-a39d-cd1b15d4ee98",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7946,7 +7946,7 @@
           },
           "response": [
             {
-              "id": "be4b2256-287b-434c-9b4d-5f8c4546da4b",
+              "id": "9cf41487-1bfc-40cc-9ebd-3aa42bab3a4c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8021,7 +8021,7 @@
           }
         },
         {
-          "id": "986908d5-d637-4053-96ea-151065fbe6f1",
+          "id": "922ff293-f5b2-4ac2-8d9e-a233305bf55f",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -8087,7 +8087,7 @@
           },
           "response": [
             {
-              "id": "1923a761-39df-4ef1-bb4f-8486a9722342",
+              "id": "e0602874-2415-449b-9fea-59ca0bdb502d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8175,7 +8175,7 @@
           }
         },
         {
-          "id": "9e52b77f-7a7a-470f-89f2-e2eeae51f1cc",
+          "id": "d8fadc62-5aad-48f5-9014-4d5bfb987ac6",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8222,7 +8222,7 @@
           },
           "response": [
             {
-              "id": "3cb9ae9e-6352-4d7c-b05b-302dc20fdda7",
+              "id": "899ebed4-3d23-412c-b3c5-5134534ee6ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8287,7 +8287,7 @@
           }
         },
         {
-          "id": "eccf3c92-d42b-4d04-bdb9-f1646d39b3c0",
+          "id": "341f2341-1644-486e-a21e-349a9e11de49",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8329,7 +8329,7 @@
           },
           "response": [
             {
-              "id": "8b99fdd7-cd07-408b-93d7-42380b5a49f6",
+              "id": "e6f750b5-4ff5-4dbb-aa53-0fcf6caa56d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8393,7 +8393,7 @@
           }
         },
         {
-          "id": "263bcea5-9ae6-4770-a87c-820ae7417eac",
+          "id": "77fddbca-e334-47d7-beea-4bdebb7765c0",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8448,7 +8448,7 @@
           },
           "response": [
             {
-              "id": "46da0328-6a58-4ef6-b66d-d44ee4b47ff3",
+              "id": "13bc34ac-4e2a-4b97-bf0c-90c87e5e1897",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8531,7 +8531,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "e46f9c7c-e395-4bba-8f31-6cae06cd156e",
+          "id": "8a3c5b2a-3215-48e3-9d20-10b0088cd57e",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8573,7 +8573,7 @@
           },
           "response": [
             {
-              "id": "f60e2fad-6977-424b-9298-fbd8584425de",
+              "id": "cccbc982-a22b-4e10-9590-375a4915fbcd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "abdaa544-4e84-48d7-9fe8-c502d74f3603",
+          "id": "45ea3374-cc8a-42f0-b35e-c8a93ea1807d",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8692,7 +8692,7 @@
           },
           "response": [
             {
-              "id": "da48dabb-6476-4205-a2d2-0ddf97f06663",
+              "id": "b791a482-9fb1-4852-8f76-dfce556b7eff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8769,7 +8769,7 @@
           }
         },
         {
-          "id": "e6dc1522-dd83-449b-87c7-ffac27096be5",
+          "id": "03eaff26-183e-4f2d-b75e-caa8550561b0",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8805,7 +8805,7 @@
           },
           "response": [
             {
-              "id": "ce89ca38-4266-4fc1-8081-c6d0f2dada80",
+              "id": "52f5a1e5-368f-47c6-a1a8-3d68822e7ffc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8859,7 +8859,7 @@
           }
         },
         {
-          "id": "537052ee-b640-41e6-973e-a1afa67759bd",
+          "id": "68cc83e0-6928-439a-9823-398bcfd5a257",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8889,7 +8889,7 @@
           },
           "response": [
             {
-              "id": "b6a7e4f6-4e4b-4eed-a776-89b2fe0ce8ed",
+              "id": "06560782-7150-4b4b-b1ec-4456fa94c6ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8941,7 +8941,7 @@
           }
         },
         {
-          "id": "b78b582f-e85b-4bf4-9d32-a6c823cb62cf",
+          "id": "f4554520-a734-4719-9e07-7a01fe82260e",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8984,7 +8984,7 @@
           },
           "response": [
             {
-              "id": "7134329c-bdf8-4d0d-8410-9df71e311f9d",
+              "id": "9395e184-3096-48ec-89f1-8fbda52df5aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9055,7 +9055,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "cfe39c8f-c47f-44fa-aeb5-333eacad83a2",
+          "id": "6e79e7ef-29f6-419d-8f4a-dd2f78007fd5",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -9097,7 +9097,7 @@
           },
           "response": [
             {
-              "id": "96acef2c-3f7f-4204-a538-e67b1f3cc8ed",
+              "id": "82fc4f85-ab31-4a3c-af3c-bc6b84b91604",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9155,7 +9155,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "43971439-cb9d-432a-9d91-18133e39ad7c",
+              "id": "93dedf34-d635-4925-b76d-7c9fa6cdde65",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9219,7 +9219,7 @@
           }
         },
         {
-          "id": "62315d27-bbb6-4420-a1bc-b2565de2b964",
+          "id": "3d3e13c2-f12a-443c-9891-e3b82087b34e",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9274,7 +9274,7 @@
           },
           "response": [
             {
-              "id": "d39e78fb-3d7e-46ee-8e50-6d5b15e65edc",
+              "id": "47cecd83-7d59-4fb6-8fc4-db26c67f809f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9345,7 +9345,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "efcaba17-001e-4580-8c9a-c2368d26eadd",
+              "id": "20020bc3-5067-43bc-b760-84c370db0cc1",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9416,7 +9416,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3115703b-4c79-4c87-ba2f-dc7fe2886d2e",
+              "id": "0404faad-b174-4a77-ab6e-2f3c111dd691",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9493,7 +9493,7 @@
           }
         },
         {
-          "id": "c3c3dda8-d815-4974-b5ff-ea49d51c6b14",
+          "id": "379a96e1-86a4-4506-adbc-b3bbe8a782dd",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9529,7 +9529,7 @@
           },
           "response": [
             {
-              "id": "383e9f73-8a13-41b2-a35f-bc6873bd2e8e",
+              "id": "69542fa5-5320-4a9e-bcde-128ec354beab",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9577,7 +9577,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a4e7c65c-9586-4a2c-a8d5-90c9cfc05e38",
+              "id": "086e485e-ecdb-4c72-bbbc-0f09aa4bc47d",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9625,7 +9625,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "fdc8c7a3-04ff-401a-80d4-4d1c4fc836c5",
+              "id": "db866747-7165-46b2-b06a-e9ddd5e7662f",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9679,7 +9679,7 @@
           }
         },
         {
-          "id": "64ce72d3-a20c-444f-bc37-8fc65286a737",
+          "id": "1f56f8cb-9966-4d5d-a750-0571f3b9ebf3",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9709,7 +9709,7 @@
           },
           "response": [
             {
-              "id": "74a04349-c4fd-4c08-81a5-90885105f846",
+              "id": "9705721a-1c00-48de-bf5a-6006338ebaab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9761,7 +9761,7 @@
           }
         },
         {
-          "id": "f3b252cd-154b-4af3-9ec4-1ee760e2793e",
+          "id": "84629170-91ce-444f-aa5a-25b52be62d83",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9804,7 +9804,7 @@
           },
           "response": [
             {
-              "id": "805d679b-d12e-4f57-b777-0e9c42b1bc8e",
+              "id": "9cfdb10a-c7e2-474a-9f43-30bc37bfa93b",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9863,7 +9863,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "2be08357-ee52-4927-a5de-a26e5f98eacb",
+              "id": "c2627c15-e55a-47cb-ac86-77acb812529f",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9934,7 +9934,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "351e9a71-6638-46ae-ba7d-825900c0019f",
+          "id": "f53843ab-2eab-4bb1-a606-136572d58acd",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -10000,7 +10000,7 @@
           },
           "response": [
             {
-              "id": "b766c870-762f-43c0-a56c-c7e51de522e8",
+              "id": "ab07af5d-6eaf-4ba2-aec3-274fd72929ee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10074,7 +10074,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -10091,7 +10091,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "33eb89dd-a232-48c5-8c6f-9fc671d77bc1",
+          "id": "37666264-2896-4cdf-9b02-6e6fc8ab7f18",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -10133,7 +10133,7 @@
           },
           "response": [
             {
-              "id": "3e8dc9bb-a089-4400-8703-22daafbcc4d7",
+              "id": "d70c8d6f-cf3d-48cd-a844-80da96ea464f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10203,7 +10203,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "d4ede0d2-15b1-4a2c-93e1-29840d46d0d7",
+          "id": "cb2081fd-7ff1-4277-8f53-e0b1b48eb85e",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10245,7 +10245,7 @@
           },
           "response": [
             {
-              "id": "4077f02a-1149-476d-afd1-a9e674525d18",
+              "id": "a1c97d35-4783-4693-a568-f5d785ecb479",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10309,7 +10309,7 @@
           }
         },
         {
-          "id": "750747fd-48d5-451c-a2d2-c32414428c48",
+          "id": "4f6fcac6-2c59-4c2d-9204-41babbef5893",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10352,7 +10352,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#eEDB1E\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5Dfb54\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10364,7 +10364,7 @@
           },
           "response": [
             {
-              "id": "6cd7af6b-d0dc-4594-b482-246d908b34a3",
+              "id": "5e82aa60-1259-479c-948c-98832cdd12a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10413,7 +10413,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#eEDB1E\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5Dfb54\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10441,7 +10441,7 @@
           }
         },
         {
-          "id": "041885d0-aa5f-4b2b-ac33-6d7ec9c68313",
+          "id": "31556096-f12f-4d95-b937-f1bc77e784d0",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10477,7 +10477,7 @@
           },
           "response": [
             {
-              "id": "21630900-9196-403d-abef-67d648f58384",
+              "id": "77a1edbd-0f81-419b-b430-1a2abc00c2ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10531,7 +10531,7 @@
           }
         },
         {
-          "id": "ccda7f83-09e8-4f5d-aa5c-129422506d17",
+          "id": "dca3abc4-083b-4f2a-a73c-4dd8fd2d3ee6",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10561,7 +10561,7 @@
           },
           "response": [
             {
-              "id": "006148eb-e7c7-4639-8996-b92b654260a5",
+              "id": "95601359-6d6c-410a-aa16-1420cecbf68c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10613,7 +10613,7 @@
           }
         },
         {
-          "id": "ecabc1a3-a1c3-4f64-be5a-ea7724f93af2",
+          "id": "62294e70-2973-4fd8-9128-c3610fb6ea5d",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10644,7 +10644,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#CDdB7F\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#18aACC\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10656,7 +10656,7 @@
           },
           "response": [
             {
-              "id": "84df983d-0677-4c9c-b94b-41794a6fedbe",
+              "id": "b975c4bd-1236-421a-8fa0-c583a708f6f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10693,7 +10693,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#CDdB7F\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#18aACC\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10721,7 +10721,7 @@
           }
         },
         {
-          "id": "58b5e719-e04f-4df0-9881-0729a0608760",
+          "id": "f52fe788-4286-42db-a095-f05f580c0e1e",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10752,7 +10752,7 @@
           },
           "response": [
             {
-              "id": "bc360931-af3b-493b-9744-eb26523c61c9",
+              "id": "56ccaa9b-1bdd-4afd-bb8a-fcbb662b79eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "d78b7c36-5f5a-4a81-9bec-8633cd39ed8a",
+          "id": "e49d0251-27f6-45e7-9424-9f99722b87b7",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10864,7 +10864,7 @@
           },
           "response": [
             {
-              "id": "686bc0e6-e9c7-4bc3-a543-f0b7fdb1d6e1",
+              "id": "66c48ee8-0e38-4df3-ada8-ac8cf1801cb2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10939,7 +10939,7 @@
           }
         },
         {
-          "id": "d62e3773-0de6-4ec5-8f0b-c1de232ff147",
+          "id": "169e57cd-87c8-4acc-b184-565fecd6e011",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -11005,7 +11005,7 @@
           },
           "response": [
             {
-              "id": "ed74242b-7a01-4784-be1a-2c71b1e412f1",
+              "id": "adb67093-6bf4-45ae-ad44-331457e5b64b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11093,7 +11093,7 @@
           }
         },
         {
-          "id": "6f6e1e26-7529-4740-9ee4-36ccf039dfc8",
+          "id": "f72c562f-5ae9-4785-8ee2-d6823cbddad6",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -11140,7 +11140,7 @@
           },
           "response": [
             {
-              "id": "748e7089-81cc-4016-b1b1-7c2a9495e8d0",
+              "id": "590bd9ec-fa0f-453d-bd99-8744ee934037",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11205,7 +11205,7 @@
           }
         },
         {
-          "id": "d3921a1d-8ce2-4aa1-b0db-fe289ee3d3c6",
+          "id": "21d27d8b-209f-4f76-9d79-509358511194",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11247,7 +11247,7 @@
           },
           "response": [
             {
-              "id": "c62633a4-7236-490d-a7ee-893a10ca28aa",
+              "id": "09f22a9e-f245-47f3-963d-3bff1e307339",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11311,7 +11311,7 @@
           }
         },
         {
-          "id": "2801fbe6-ee59-4a0f-9d48-46f4c05cd21d",
+          "id": "8379ed73-4813-4ace-a8fc-bf5f91949fde",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11366,7 +11366,7 @@
           },
           "response": [
             {
-              "id": "f0400a5a-2c37-4633-ace4-cf3a2b2441b4",
+              "id": "8cb4d66d-ead9-4781-98ff-4fa74b7f1c4b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11443,7 +11443,7 @@
           }
         },
         {
-          "id": "7769969a-98b8-495f-933a-1f8c22dbdd3f",
+          "id": "0e876c81-ea3b-4d0e-87c6-a19004d6d6f1",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11497,7 +11497,7 @@
           },
           "response": [
             {
-              "id": "be773fdc-0345-4df7-bc44-f61194021bcb",
+              "id": "a8a18e2d-a498-4bba-b74e-88a13a0f88bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11573,7 +11573,7 @@
           }
         },
         {
-          "id": "8211c332-067c-4ed6-b849-c11ffd87e60d",
+          "id": "57bdb4c4-3709-441a-b2a1-e04093ba023f",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11639,7 +11639,7 @@
           },
           "response": [
             {
-              "id": "374d5067-6eff-4ba6-bfdf-9e35f4f89eaa",
+              "id": "98bda81b-7b67-4b12-a334-191c386352c0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11727,7 +11727,7 @@
           }
         },
         {
-          "id": "ed534ecc-1336-4942-afaf-4da064e1be54",
+          "id": "01f8b6f1-8541-4957-8f45-e8c3176bd165",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11805,7 +11805,7 @@
           },
           "response": [
             {
-              "id": "0755cda0-beb3-4bbc-94ba-36b69483924b",
+              "id": "2a00185e-66e6-46d8-8ae4-5808969499f5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11905,7 +11905,7 @@
           }
         },
         {
-          "id": "2b8a47d7-6eff-4a2b-94b4-8c8df702b467",
+          "id": "ada82c3d-95a8-4ba6-89fe-d110656cebba",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11971,7 +11971,7 @@
           },
           "response": [
             {
-              "id": "64db72bc-f4ef-4314-b4d7-1cad58bbe86a",
+              "id": "6fb49600-270c-4fae-9ef2-daa83cff3f34",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12059,7 +12059,7 @@
           }
         },
         {
-          "id": "9aa3357d-d802-4077-8bce-adb191c5e883",
+          "id": "75dda59d-a758-4b34-a4c5-7e83a62e2833",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -12114,7 +12114,7 @@
           },
           "response": [
             {
-              "id": "fb2c3b79-096f-4194-b1d3-6c04f45b8002",
+              "id": "efa90203-e740-432c-8750-540bbac5910c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12197,7 +12197,7 @@
       "description": "",
       "item": [
         {
-          "id": "a18f3683-ee18-4964-97f7-639d9b9226f4",
+          "id": "8138fd94-4dc1-4eeb-aefe-cf0e88c87046",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12238,7 +12238,7 @@
           },
           "response": [
             {
-              "id": "27866487-c246-44fb-bd3a-44dd9f95d92f",
+              "id": "3946b78e-8e24-4d92-aa1a-5eb745779579",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12301,7 +12301,7 @@
           }
         },
         {
-          "id": "932e4540-188e-4c6d-b2f5-ebc3f16cc6df",
+          "id": "8d5d4101-cf88-4500-90a8-e98471499461",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12355,7 +12355,7 @@
           },
           "response": [
             {
-              "id": "4fee0f12-1b48-4897-b481-b3b864633031",
+              "id": "45af6597-5d57-4d61-8b71-cab2228f728f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12431,7 +12431,7 @@
           }
         },
         {
-          "id": "3be975a1-2524-45c9-838a-d754b18ff5c3",
+          "id": "8dee2f07-fccf-4544-9d59-7cc3dc6a47c1",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12466,7 +12466,7 @@
           },
           "response": [
             {
-              "id": "dd121526-ab87-4774-9014-bb3f3dc12639",
+              "id": "075a01db-8962-44e2-a1fd-b4182c147909",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12519,7 +12519,7 @@
           }
         },
         {
-          "id": "2c73964c-cc4f-4796-b547-0cd57e01a07c",
+          "id": "36f93295-fb7d-4d40-af5d-27953fa37cf2",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12580,7 +12580,7 @@
           },
           "response": [
             {
-              "id": "acd6fe11-694e-4204-ade0-c29b0961de96",
+              "id": "97e07394-3b5d-410c-8583-ad0efae93dd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12663,7 +12663,7 @@
           }
         },
         {
-          "id": "ccbf4596-acc7-48a5-8d31-7f4137db0886",
+          "id": "488be303-f9d2-4c9a-8428-5b6b8256b8c6",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12705,7 +12705,7 @@
           },
           "response": [
             {
-              "id": "0f13337f-c51b-4ca2-8366-b29a9e1aa690",
+              "id": "6a93682e-0c57-4fae-816a-1cf25d993415",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12769,7 +12769,7 @@
           }
         },
         {
-          "id": "7f17a5cd-f8c3-4aa0-b3df-ab1901e7c633",
+          "id": "79e6be0a-7696-4d03-9016-aea8e36dab6b",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12844,7 +12844,7 @@
           },
           "response": [
             {
-              "id": "b9754eb4-aad1-43e1-bebf-5bf5eaa8ef8f",
+              "id": "ba6e9b0e-9007-438e-a605-c9f7d195ba59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12941,7 +12941,7 @@
           }
         },
         {
-          "id": "024dc079-4ed2-4181-ba89-69eefae20a42",
+          "id": "92b4ab64-b741-462d-b494-33e3595f0b6c",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12983,7 +12983,7 @@
           },
           "response": [
             {
-              "id": "1a3d52b7-9d7f-4302-9433-24569f19c8c3",
+              "id": "3a6c0f0a-1b02-4bbc-88bf-53311f276253",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13047,7 +13047,7 @@
           }
         },
         {
-          "id": "8b556c01-8c15-45d5-8f57-a941f9eb0a47",
+          "id": "a59d31b9-1a20-471a-a227-a971f0ecd004",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -13090,7 +13090,7 @@
           },
           "response": [
             {
-              "id": "1fd40938-f521-47b7-bf44-312aa11afde7",
+              "id": "47338797-85de-49fb-8826-d23502990340",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13155,7 +13155,7 @@
           }
         },
         {
-          "id": "6421edae-26ff-43d7-a53c-00e5bfd2a205",
+          "id": "6cbab471-d7fb-45d1-827e-a8b0c24e2016",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "a1e9853e-7fa8-469c-8d15-9592cdc90b20",
+              "id": "526cf3d9-9939-446e-9b8d-260186da1cd4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13263,7 +13263,7 @@
           }
         },
         {
-          "id": "d0575f0e-0225-4d6d-99c0-0ffaee23864c",
+          "id": "65e38158-7ff4-4119-9627-ee23bc7415fc",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13315,7 +13315,7 @@
           },
           "response": [
             {
-              "id": "ba93d474-6e09-41ee-8779-570951ac24c2",
+              "id": "4683de3d-4de4-4022-8a9c-a7c6889d3e7a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13389,7 +13389,7 @@
           }
         },
         {
-          "id": "bbd8bc24-96c8-46e4-b2ed-9fea008b6240",
+          "id": "8350118b-dac2-4c4b-a547-26ca45b2a08a",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13431,7 +13431,7 @@
           },
           "response": [
             {
-              "id": "e6d28db0-8060-490c-af5b-3ab111694395",
+              "id": "78375306-3af8-48a3-afa3-62a01ce2ad04",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13495,7 +13495,7 @@
           }
         },
         {
-          "id": "30a03ca4-9cbc-495a-81c5-efbfa5a544a8",
+          "id": "bcc2a79b-4dea-4874-a51a-f6c114616b7d",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13548,7 +13548,7 @@
           },
           "response": [
             {
-              "id": "a30d714f-30f5-49ab-88f1-c1bac4c32827",
+              "id": "42d234c7-05c2-4dca-b2ae-4a175c3fb7df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13623,7 +13623,135 @@
           }
         },
         {
-          "id": "2885e60b-b33c-42fb-a87b-2ddbe57b29ea",
+          "id": "270ebbd6-2f5b-499c-9c17-911cb3caa680",
+          "name": "get History By Tenant",
+          "request": {
+            "name": "get History By Tenant",
+            "description": {},
+            "url": {
+              "path": [
+                "api",
+                "v1",
+                "alerts",
+                "history",
+                "tenant",
+                ":tenantId"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "disabled": false,
+                  "description": {
+                    "content": "",
+                    "type": "text/plain"
+                  },
+                  "key": "limit",
+                  "value": "100"
+                }
+              ],
+              "variable": [
+                {
+                  "type": "any",
+                  "value": "<long>",
+                  "key": "tenantId",
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) ",
+                    "type": "text/plain"
+                  }
+                }
+              ]
+            },
+            "header": [
+              {
+                "key": "Accept",
+                "value": "*/*"
+              }
+            ],
+            "method": "GET",
+            "body": {},
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "275d3ea1-db72-44f4-afd4-43d366c81d5f",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "v1",
+                    "alerts",
+                    "history",
+                    "tenant",
+                    ":tenantId"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "limit",
+                      "value": "100"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) ",
+                        "type": "text/plain"
+                      },
+                      "type": "any",
+                      "value": "<long>",
+                      "key": "tenantId"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "*/*"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: bearer",
+                      "type": "text/plain"
+                    },
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "*/*"
+                }
+              ],
+              "body": "[\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  },\n  {\n    \"code\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"id\": \"<long>\",\n    \"isResolved\": \"<boolean>\",\n    \"sectorId\": \"<long>\",\n    \"tenantId\": \"<long>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"sectorCode\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"message\": \"<string>\",\n    \"description\": \"<string>\",\n    \"clientName\": \"<string>\",\n    \"resolvedAt\": \"<dateTime>\",\n    \"resolvedByUserId\": \"<long>\",\n    \"resolvedByUserName\": \"<string>\"\n  }\n]",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": [],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "id": "b09cc04b-b2b8-4fef-b37b-976e791ff0c7",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13667,7 +13795,7 @@
           },
           "response": [
             {
-              "id": "87852525-0887-43bb-95bb-33339b6fd51b",
+              "id": "d0568ff9-a748-4cfb-8363-b450a0010f8e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13722,7 +13850,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13733,7 +13861,7 @@
           }
         },
         {
-          "id": "1e1fdb25-28cf-4334-9175-d19b601df7cc",
+          "id": "e0e69898-da41-4d7a-8f6e-49801d19f810",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13777,7 +13905,7 @@
           },
           "response": [
             {
-              "id": "8c6a74e6-197f-488a-b216-a7d94af413df",
+              "id": "d3366e6f-60ff-4d3b-9284-268a1ed3aca4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13832,7 +13960,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13849,7 +13977,7 @@
       "description": "",
       "item": [
         {
-          "id": "8fee11f1-18be-4b6b-9f12-32c593cf6ca9",
+          "id": "be093eab-805b-44df-bb43-83bbb01a920d",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -13891,7 +14019,7 @@
           },
           "response": [
             {
-              "id": "c41b7bf1-295b-44cc-be66-eda3b581c939",
+              "id": "942d4cab-9126-4d65-b8e4-beeaf2f9bf8e",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -13940,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "945c17ce-39cd-4478-8cce-6e20504d81e0",
+              "id": "ce58011f-6763-474c-87ee-e70b9db1ad0e",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -13995,7 +14123,7 @@
           }
         },
         {
-          "id": "4cff6c87-eb5c-4e61-a8f8-19bc6a266319",
+          "id": "e15869ae-831f-426b-b2ba-ddd09bb42367",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -14041,7 +14169,7 @@
           },
           "response": [
             {
-              "id": "0f47e3fd-edfd-447b-89f0-b5f4b60bf52b",
+              "id": "a36ab3bb-065f-4610-a945-a4724b7e798a",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -14100,7 +14228,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "112b790d-1dbb-4e88-afbe-2d282218d83d",
+              "id": "6032a7dd-5900-4346-9d00-80eb10736a64",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -14165,7 +14293,7 @@
           }
         },
         {
-          "id": "9a959791-dc37-4455-946b-34e4ac87f989",
+          "id": "ffdda9a9-14c8-4b4d-8937-36271bd35a2f",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14211,7 +14339,7 @@
           },
           "response": [
             {
-              "id": "61a26f32-2a58-45a8-a45b-6f6439ad82a2",
+              "id": "06240da3-f01b-40ca-b746-77489e5a8f8d",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14270,7 +14398,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "284ca51b-cbc9-483c-adf9-30d29f3c8727",
+              "id": "495e20ca-3742-4193-8c49-fec367746f71",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14335,7 +14463,7 @@
           }
         },
         {
-          "id": "ed930134-6b51-4d8d-a5b8-653f596dc1ff",
+          "id": "d5582b1b-a426-422a-954b-9f91a23e189c",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14377,7 +14505,7 @@
           },
           "response": [
             {
-              "id": "866c2378-7d6b-4a09-8216-420478d4c1f7",
+              "id": "f656d13b-350c-4939-b2f1-bd6db810dae7",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14438,7 +14566,7 @@
       "description": "",
       "item": [
         {
-          "id": "fb669c9b-46ff-4037-8b0f-17565020d609",
+          "id": "49c811af-689c-450a-83aa-b32785c3198d",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14487,7 +14615,7 @@
           },
           "response": [
             {
-              "id": "a60b9203-d733-4221-b249-e0be6d6e6dc0",
+              "id": "c968b855-08ab-4563-bed9-2c6840165970",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14547,7 +14675,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14558,7 +14686,7 @@
           }
         },
         {
-          "id": "ae5a5a17-75a5-4075-8b22-fcf30aa94a2a",
+          "id": "dd390275-4406-44cc-8c63-da1ba47e5e7b",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14607,7 +14735,7 @@
           },
           "response": [
             {
-              "id": "a941d57e-7293-4648-bc3a-f2306e88ab7c",
+              "id": "39672ed0-3be9-415e-a7f4-4163ec3ff418",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14678,7 +14806,7 @@
           }
         },
         {
-          "id": "9b471c76-cd4e-4d96-b66d-d87b2d32ad98",
+          "id": "b6187e7c-ba1e-427b-a247-01b494ffbc90",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14727,7 +14855,7 @@
           },
           "response": [
             {
-              "id": "9d974d16-fe73-45d6-a1d6-e362580c19a3",
+              "id": "8d426675-9b81-4f46-b604-fe5181a37bdc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14798,7 +14926,7 @@
           }
         },
         {
-          "id": "5357b9ee-98a5-4dfe-a8ef-5eba3c877472",
+          "id": "7f84791d-8adc-46eb-9623-8fdb8d02b6b2",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14847,7 +14975,7 @@
           },
           "response": [
             {
-              "id": "8e565377-01de-442b-bb2f-a682f3fbd2b0",
+              "id": "80432ec1-db74-4fad-8fdc-4fb8628a2d25",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14924,7 +15052,7 @@
       "description": "",
       "item": [
         {
-          "id": "bbac15c7-ab82-49fb-95f9-dcd9b9aff23b",
+          "id": "6b8ab0e6-6f8c-4006-a879-7db37bdb3fed",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -14964,7 +15092,7 @@
           },
           "response": [
             {
-              "id": "11672a36-7da2-4157-8231-9d9bbfa6fac6",
+              "id": "5e7f3c25-24b2-4d30-9bc2-510ba5c4c930",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15026,7 +15154,7 @@
           }
         },
         {
-          "id": "9aab2809-829a-48f3-b723-5fcfe157a6fc",
+          "id": "b3c1b018-0139-4e97-95c5-09f0bf74e7bf",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -15056,7 +15184,7 @@
           },
           "response": [
             {
-              "id": "a39dbeea-0175-4e99-bb40-e4db8606fec4",
+              "id": "d79ff9b3-a910-4017-8f88-32e029a2ea5b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15097,7 +15225,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15108,7 +15236,7 @@
           }
         },
         {
-          "id": "63c160fc-5dc0-44aa-8c56-721d7f9e9e66",
+          "id": "16ca0aa7-6b9d-4ae5-b6cd-cd42f262a53e",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -15160,7 +15288,7 @@
           },
           "response": [
             {
-              "id": "a23ac331-b33a-4a0a-b40a-1701e89fd9a4",
+              "id": "947a0340-7c47-446f-9282-acc3a1502bd5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15240,7 +15368,7 @@
       "description": "",
       "item": [
         {
-          "id": "03b45b58-d6ea-476e-ba63-a3653e65722e",
+          "id": "120d0712-0340-4bfe-a1ca-b6e7d0b8b6d9",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15269,7 +15397,7 @@
           },
           "response": [
             {
-              "id": "188b596e-ee5d-495d-b59b-653a4a605ffe",
+              "id": "6057025e-e71f-4206-8486-c8ac35f93ad5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15320,7 +15448,7 @@
           }
         },
         {
-          "id": "588956e2-ab16-415c-9119-4a6e8c801b35",
+          "id": "fe9e7dcf-4122-47ea-98ed-9be9063848d2",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15361,7 +15489,7 @@
           },
           "response": [
             {
-              "id": "53091188-c200-4037-9cdd-983c7f526ded",
+              "id": "d6ee0c3b-7185-44b5-b481-a6be93f70c85",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15430,7 +15558,7 @@
       "description": "",
       "item": [
         {
-          "id": "e72e0441-3fc0-467a-a221-ab3e0396b8b2",
+          "id": "319aaf32-d61b-492e-8af1-9e8240b8966f",
           "name": "health",
           "request": {
             "name": "health",
@@ -15459,7 +15587,7 @@
           },
           "response": [
             {
-              "id": "da2ce6e0-6c90-49e2-a5f0-3fcccbfaca3b",
+              "id": "b5347156-41a1-430b-8abf-334464dcd0d2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15499,7 +15627,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15516,7 +15644,7 @@
       "description": "",
       "item": [
         {
-          "id": "4f7ae265-44c8-4897-86a0-eef800cdca23",
+          "id": "bbb8d254-f749-4b98-aa8f-e9f505dc48f5",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15568,7 +15696,7 @@
           },
           "response": [
             {
-              "id": "18ab65ad-bcf9-42a1-8989-b8cba2e70d7e",
+              "id": "3b5bc1d9-692d-44f5-8306-db76a8bf7a93",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15642,7 +15770,7 @@
           }
         },
         {
-          "id": "2f429cf6-dce4-48e9-9019-7054dd32d075",
+          "id": "b83afd30-5420-4ac7-a7ec-8d90bb619990",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15683,7 +15811,7 @@
           },
           "response": [
             {
-              "id": "76157259-8adc-47b4-b1f0-91262c59fb41",
+              "id": "dd3e74b8-bec4-4c74-98dd-c7bf62a49c56",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15735,7 +15863,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15746,7 +15874,7 @@
           }
         },
         {
-          "id": "1d15f422-9e26-4164-9a8a-039fcda96404",
+          "id": "483cf0d9-4051-4d0f-adb0-9b86427057ab",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15776,7 +15904,7 @@
           },
           "response": [
             {
-              "id": "f88c707b-f424-4408-966e-e4f2810c44ab",
+              "id": "9ec19f4f-22d2-4829-9a28-2774dbe2f298",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15817,7 +15945,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15848,9 +15976,9 @@
     }
   ],
   "info": {
-    "_postman_id": "fda6e60a-13f8-415b-9b01-32eb2493ec48",
+    "_postman_id": "ba6946e0-5111-4e5b-8e11-5923fd591b46",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 00:17 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 00:21 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "1d1be62e-c584-4048-b836-2022b36e3112",
+          "id": "e37b4be2-8aba-4628-81cb-2718bb1e6f0f",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "b2a83757-adbb-4949-b0a6-6c47cf145b8d",
+              "id": "202603d7-8ad7-48ca-9f19-0c1845bf1ae1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "2db3b9be-a267-45cb-a160-803efa131d2d",
+          "id": "6afbfbfc-2bd0-441d-8cd3-52e2a991f1ef",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "badaacf1-9d29-49a2-9c2d-4fc74a459de8",
+              "id": "1e89715f-193f-405d-92e0-9ebd00d82cf5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "e6d014a4-8938-403d-91b4-ca160ff7a71d",
+          "id": "1e69759b-2327-47a7-a488-8ee3270d8720",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "ff0f64f9-ef2f-491d-9c70-694a2f02850c",
+              "id": "0fdca6cb-6c7a-4ef9-b10c-ca4295deb092",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "842343a3-83a2-4db8-b73e-6dead51e6f8c",
+          "id": "234a4bdb-8b33-4aa2-b519-65ca21961daf",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "a6b2ae5b-f982-4e25-813e-34106c000f87",
+              "id": "e524e84f-a66a-4e5e-9b8d-33f2b3913d73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "acc8be55-5512-4f44-8aa6-d03b821c18fe",
+          "id": "b63e4c41-6043-46e5-8335-b99980fcc604",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "f41854bb-d4c8-46cc-98ad-8b81f3e315f0",
+              "id": "25fd8c78-1322-45c3-b4d4-9543f1b5f4d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "6514b204-7f57-47bf-b390-58495a151cea",
+          "id": "f91365c3-7cdd-4626-8a76-86097ae5f99d",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "a4a3b303-9b00-4f53-987c-f9466c6ff392",
+              "id": "a236218f-2292-4e00-b056-6bd6a3bc874b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "3c356abc-2c89-4312-b3eb-a872d9fd101e",
+          "id": "a179e6c5-e837-4336-aa93-80fd3a1d7633",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "cf67dc55-6e3e-4af9-9b38-44b2b4bb531f",
+              "id": "60fd36f9-853d-44fb-8058-b736479597bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "412ab009-746f-4c9c-82af-9c0dc70f9c73",
+          "id": "25277b63-127d-473a-9415-6a5c470a919a",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "12e2bee7-c914-47db-a1af-507e07119bc9",
+              "id": "069f29c2-1708-49e2-b8f8-932c1a6d299e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "7bb7c7fb-7063-435b-8818-6e54fb28406b",
+          "id": "50e5b600-5b90-49bf-9725-78d95da65bd1",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "a1ea13d4-ae4b-4809-bb5e-fc0bea50e7d4",
+              "id": "d0974488-a4d3-49fc-8851-b2c4f094235d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "a839ee42-7b39-4db2-81a1-6adc0640119a",
+          "id": "a8d1d2ac-1415-479a-81f4-02f922f08ccd",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "80dd9e4d-0716-4272-9101-d9270abe4f33",
+              "id": "65801012-8ab7-4206-ad75-f967cf9a6d23",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "53778796-6726-4194-a08f-4b868d1810dc",
+          "id": "bb4cb99f-b95c-4c0e-9910-2e5b4efc3efe",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "832ca569-de9c-481d-837b-a2fb4618a445",
+              "id": "160d2f68-aca1-424d-92d6-b74374116233",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "c3cdb81c-017a-4dfe-9a81-6aa327c3f044",
+          "id": "388c790d-0675-4ded-9e9b-23309e921012",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "5ccd770f-bcc6-4dca-abab-f553e064e310",
+              "id": "bd4bcb68-ab22-48d5-956a-ad22bc76aaa8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "4d57be71-c139-41ea-91d9-1fc27a239e32",
+          "id": "bab503e5-ab3b-478e-876d-0af4b8253af2",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "cc071f7d-b284-4db1-849c-56ffe9c01995",
+              "id": "e6f9a03e-6be8-43d1-97b1-78f4e7b08fd2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "c7e7c776-c3e9-4f9c-a850-844935750c2a",
+          "id": "85e8b11a-1dd6-4882-8a8b-a17b7aad4c28",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "53ad6c4e-ce7b-43c9-b1d9-823646a91f7e",
+              "id": "c12a095c-d99b-4338-8ecd-20e7c38cc82b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "f006080b-7777-43b5-8035-ee2a07ea4af8",
+          "id": "8bb51e1b-7701-497c-8f50-eeffc2e7b2e9",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "3e56fcab-eb32-48a6-b329-bd77c0e56a92",
+              "id": "a228cf81-7c41-4068-8d67-db5c3db84cbf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "a0a866ec-4400-4982-b13c-f81fa0e821f5",
+          "id": "6693dc6b-f3b7-4e5f-9cd1-19272c0d5724",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "c8f1be81-c91f-4af9-ba42-872596aea38d",
+              "id": "62f1a14f-a1b2-4770-9475-120ea90d9639",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "23b9670b-f6ed-490a-847d-127f8c091c11",
+          "id": "294b5cbf-7a94-471b-973f-3c20530b7ac2",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -1859,7 +1859,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -1879,7 +1879,7 @@
           },
           "response": [
             {
-              "id": "7be0f154-24ed-49f4-a4dd-f80637194c72",
+              "id": "b85a204b-612e-4ad4-9f3e-ca65ef685baa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1911,7 +1911,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1933,7 +1933,7 @@
           }
         },
         {
-          "id": "23a3caf3-2b72-4bb5-9163-1220b5e5328c",
+          "id": "3546ffb4-ee91-42da-8e3c-926637173457",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -1976,7 +1976,7 @@
           },
           "response": [
             {
-              "id": "00c8a6c9-fc85-4eb5-a1be-e61f2c614dc5",
+              "id": "fb8b4cdb-0378-45b1-9c8d-951a4701273b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "f57f809f-e347-4ff8-82d1-3bcce1c8e8c2",
+          "id": "646b7202-6269-4c5c-8c90-1bfa035bc715",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -2088,7 +2088,7 @@
           },
           "response": [
             {
-              "id": "b251340c-c3cc-40b3-b135-f0193a3f73d7",
+              "id": "0129a8c6-0875-414c-a666-bccef04c8e15",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2163,7 +2163,7 @@
           }
         },
         {
-          "id": "783c6ede-48f4-4fe4-9a73-305a1f2ca270",
+          "id": "d5e09225-4f30-41b5-9b76-e3b8b364c575",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "e63ece70-6b07-4b0d-9524-d610924eebad",
+              "id": "bf6a6ab4-31b6-4332-b74e-42a8ac48368e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2317,7 +2317,7 @@
           }
         },
         {
-          "id": "f2b56730-12ae-4618-b09c-6f29c8a8ec14",
+          "id": "768aaa23-8c8d-4d49-b5e6-b3a9dfdc960b",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2364,7 +2364,7 @@
           },
           "response": [
             {
-              "id": "dec35608-8925-41dc-99ce-cb35ae64dcb1",
+              "id": "d026d885-2ac4-4367-94a5-47d7d536cf9e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2429,7 +2429,7 @@
           }
         },
         {
-          "id": "77512b55-7c91-4f61-a013-1ca022fd5c02",
+          "id": "2947fb59-8b10-4aac-8896-43c4593a1e06",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2471,7 +2471,7 @@
           },
           "response": [
             {
-              "id": "76d80947-f2c8-4049-8c19-b212515426ef",
+              "id": "061af62c-0788-4bb4-8083-b3764d38d5fd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2535,7 +2535,7 @@
           }
         },
         {
-          "id": "6876b1f1-4b05-499f-b173-249418f74a43",
+          "id": "5b474b7b-e5fd-40b8-be48-e47511db85b5",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2590,7 +2590,7 @@
           },
           "response": [
             {
-              "id": "5737c68a-1034-4c47-a8a3-ceaa2dcbe71f",
+              "id": "706bf8cc-8dba-455e-9041-560cb2f21be0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2667,7 +2667,7 @@
           }
         },
         {
-          "id": "fa691a1d-25b9-4461-bf04-96bbbb47ca47",
+          "id": "1ce24797-ac5d-4530-959d-2a8276ddf4f4",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2731,7 +2731,7 @@
           },
           "response": [
             {
-              "id": "6cd73dd0-70c0-449e-bcf7-2ea5da2ccfb6",
+              "id": "586b8a29-72d1-4308-8e71-14b796d60a7d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2823,7 +2823,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "16faa3ef-19c0-4620-93c5-ab5644e92928",
+          "id": "dd2d7da1-c08e-47a3-ac73-fc5ee01cdea2",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2865,7 +2865,7 @@
           },
           "response": [
             {
-              "id": "4c226110-f189-4b15-be3e-806740f079bb",
+              "id": "4066111e-7c9b-482f-9453-a34ff8891209",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2929,7 +2929,7 @@
           }
         },
         {
-          "id": "294cd91f-d86a-405b-9151-2b025de797ce",
+          "id": "d1b10758-181d-40c7-9f84-cc82843059d9",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2972,7 +2972,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#BdFA84\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3CcD86\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2984,7 +2984,7 @@
           },
           "response": [
             {
-              "id": "4266efff-43f7-4019-a99c-d5490dd5e1cc",
+              "id": "11ea1041-d78b-48df-af54-664ce6dae973",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3033,7 +3033,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#BdFA84\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3CcD86\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3061,7 +3061,7 @@
           }
         },
         {
-          "id": "a5ec4599-f7ba-4bd0-930c-b293ffa3229d",
+          "id": "a04ab08f-fd12-4ed2-b2a5-d2822ca41e1c",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -3097,7 +3097,7 @@
           },
           "response": [
             {
-              "id": "a1653a5e-219d-485d-8407-e39fb77f0ef7",
+              "id": "01234903-5281-48c1-bf74-d060264ef8c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
           }
         },
         {
-          "id": "25450fbc-38ae-4285-8ff8-c13676186e94",
+          "id": "3f0caaea-ad8b-405f-a4a3-3a3f6b75ce26",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -3181,7 +3181,7 @@
           },
           "response": [
             {
-              "id": "9b5e12c5-466b-4916-be41-cfbec6d55fb9",
+              "id": "46106809-5357-4cbf-9f29-2053871f236f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3233,7 +3233,7 @@
           }
         },
         {
-          "id": "2e8fc62b-1c81-4053-88ef-b2b181002d25",
+          "id": "9007659a-5bee-4616-95e1-6a42e073d7a2",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3264,7 +3264,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9aae7E\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e2d304\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3276,7 +3276,7 @@
           },
           "response": [
             {
-              "id": "4662c409-205e-4d16-ad05-e4a18261e380",
+              "id": "881de86a-ff8c-4e79-a524-9ea98a243207",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3313,7 +3313,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9aae7E\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e2d304\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3341,7 +3341,7 @@
           }
         },
         {
-          "id": "7139f1f1-c710-439e-8a5b-af152d317145",
+          "id": "28115765-f536-46b7-a4bf-11934f26626b",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3372,7 +3372,7 @@
           },
           "response": [
             {
-              "id": "e6bb00b9-7d3a-40a2-bdc4-73a07682351d",
+              "id": "7224863f-8b02-4f92-b6df-09b081037184",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3431,7 +3431,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "a5aec917-4271-42a0-a828-24172e585c0b",
+          "id": "38f21df7-03c3-4fd4-b913-cd8c696fe6d1",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3473,7 +3473,7 @@
           },
           "response": [
             {
-              "id": "3c7a7089-142c-4c06-92bb-e30e619ac216",
+              "id": "c0f1e43f-1f6a-4e48-9bcd-b47afc77f8f4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
           }
         },
         {
-          "id": "c966abe7-597f-46d6-b819-afae0f9a0153",
+          "id": "5e5c5cd4-d6b5-4e0e-b10b-7b89af1837ec",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3592,7 +3592,7 @@
           },
           "response": [
             {
-              "id": "c47b67b3-836c-48eb-b84b-6d7db3018526",
+              "id": "1e5e3121-a3e5-4255-af39-7fa91157e0ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3669,7 +3669,7 @@
           }
         },
         {
-          "id": "197ca322-1820-4e66-b9e4-975140c6862e",
+          "id": "4f14e20a-e02e-40ac-ad24-b66d4675ab2f",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3711,7 +3711,7 @@
           },
           "response": [
             {
-              "id": "485e82ff-45cb-4c56-9e5c-3b516641a619",
+              "id": "f59b8116-c293-4ced-be15-1bea5a3543de",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3775,7 +3775,7 @@
           }
         },
         {
-          "id": "78c508e4-f697-4dc8-a5a1-d23f2f31591f",
+          "id": "b26a8a82-e837-46a6-a4cc-2a92ea24ba95",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3805,7 +3805,7 @@
           },
           "response": [
             {
-              "id": "7da226b8-353f-4133-9149-6d1b083ee6d4",
+              "id": "8e582ae8-1b84-495b-8bc2-6547b50ec27a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3857,7 +3857,7 @@
           }
         },
         {
-          "id": "7de3857b-ea90-438b-9784-f815cbcbf12d",
+          "id": "91323eef-eec9-4896-bd2d-5a157881c783",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3900,7 +3900,7 @@
           },
           "response": [
             {
-              "id": "2e447e4d-3306-496d-a76c-b966fa468c56",
+              "id": "a0e388aa-3c53-4388-bd6c-42211f65d5e2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3965,7 +3965,7 @@
           }
         },
         {
-          "id": "634fbe80-ec5a-452d-b05a-5bbce1fdfd2b",
+          "id": "82ab56fa-8012-4aef-8ca1-bc8b2bd1dedd",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -4018,7 +4018,7 @@
           },
           "response": [
             {
-              "id": "c9b3d625-26c1-4e5d-ab7e-1affbd695287",
+              "id": "66aae97f-8fcc-4b08-be99-c15560cf2fae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4082,7 +4082,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -4093,7 +4093,7 @@
           }
         },
         {
-          "id": "a1a541eb-1228-49be-aebe-aedd19b0688a",
+          "id": "8eb483c4-97b8-4ff6-96d4-a891ceb748b7",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -4136,7 +4136,7 @@
           },
           "response": [
             {
-              "id": "a81f51e2-46ec-49a1-9659-a9bb1f05f424",
+              "id": "1c26cbd6-3c9b-410b-8792-256f282e287b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4201,7 +4201,7 @@
           }
         },
         {
-          "id": "a1f1debc-9512-45ad-a7fc-1ce884160128",
+          "id": "1f67075c-6789-44ba-a5d9-124c3a357dd5",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4232,7 +4232,7 @@
           },
           "response": [
             {
-              "id": "169517ca-4bf4-45f3-90e4-edf8dae8e9bb",
+              "id": "bd0721f8-e81e-404b-a9c8-a38aaa770ac4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4291,7 +4291,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "a9cab971-33a9-49b9-b606-283dea50add0",
+          "id": "566cb5bb-f2ff-4773-96de-21cd8ea8f58e",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4333,7 +4333,7 @@
           },
           "response": [
             {
-              "id": "aef13722-7ea9-4d3f-b40d-ea3ca8c984ac",
+              "id": "25c5b3f1-e11d-420f-8fbc-5bf7c8b98d79",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4397,7 +4397,7 @@
           }
         },
         {
-          "id": "b52fcd44-e6e3-4938-a207-0f872ab01ec6",
+          "id": "1446d971-4ff0-4095-afd0-689f1faada4e",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4440,7 +4440,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4452,7 +4452,7 @@
           },
           "response": [
             {
-              "id": "943190c3-eab3-4b06-8ea3-1b8da52e20e3",
+              "id": "b3d56adb-79b8-4c7a-bb04-9bd45a0e6737",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4501,7 +4501,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4529,7 +4529,7 @@
           }
         },
         {
-          "id": "17af2cfe-414d-44ab-b9ea-8aa2e99be015",
+          "id": "ba495ae3-8b12-40b9-9488-7c2d68913a3c",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4565,7 +4565,7 @@
           },
           "response": [
             {
-              "id": "269dd2df-43d2-474d-893d-485f4d860cb5",
+              "id": "5436715f-27fd-40b6-85de-3d112fce801b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4619,7 +4619,7 @@
           }
         },
         {
-          "id": "7a0b1bd1-2481-4c31-b144-21ee604f62dc",
+          "id": "ffbfd14f-f88a-4b10-8eb3-4b1f41cbb786",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4668,7 +4668,7 @@
           },
           "response": [
             {
-              "id": "4e73378e-30ee-4282-82bc-2cfc822b2da0",
+              "id": "9b420e8f-758e-4c4b-897b-9c6a785ed682",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "a705e5d7-5ee2-4ee3-92f2-ee95c728abf4",
+          "id": "09eec8ec-6a84-4a72-8c91-d21d7c0f88b6",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4770,7 +4770,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4782,7 +4782,7 @@
           },
           "response": [
             {
-              "id": "20b5881f-e500-4633-a3c4-f1f59fd84d0c",
+              "id": "d3a76cba-4fc6-402a-b04b-44c962efe6c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4819,7 +4819,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4847,7 +4847,7 @@
           }
         },
         {
-          "id": "6407c255-1ff3-4a98-8ff1-61cbf15d53e3",
+          "id": "10977676-1602-4488-a318-85f356439895",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4890,7 +4890,7 @@
           },
           "response": [
             {
-              "id": "a7816d4e-8667-4066-8aaf-76283314f2ff",
+              "id": "a8930dde-4942-4a35-be1f-a4fc78eab77b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4955,7 +4955,7 @@
           }
         },
         {
-          "id": "46888846-5751-41de-8184-a9fe8ff499a3",
+          "id": "c8eae701-7e04-4a47-bd00-90c618c5f692",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4998,7 +4998,7 @@
           },
           "response": [
             {
-              "id": "b0f850b1-4118-42af-9cdf-bcc5f773e57a",
+              "id": "7ecd7fd7-5d81-439e-94b8-1a764a99b0e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5063,7 +5063,7 @@
           }
         },
         {
-          "id": "4de092fb-d8d2-4501-a771-5a67f0e1fccc",
+          "id": "3db8498c-1673-497b-a785-a77bf1005bf8",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -5094,7 +5094,7 @@
           },
           "response": [
             {
-              "id": "65627313-a7be-4dea-8bbe-029a14f39165",
+              "id": "292bde1b-1734-459b-8b8d-676767cc9a33",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5147,7 +5147,7 @@
           }
         },
         {
-          "id": "b338b8b1-8acd-46e7-9e26-de93acd5ce7e",
+          "id": "95472d25-6169-41e4-9912-88528277073e",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -5178,7 +5178,7 @@
           },
           "response": [
             {
-              "id": "0deb27a3-e1c3-409e-b8cc-1365fbcaa517",
+              "id": "108c5ef9-01e0-4120-a379-fdbaa55c7e95",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5237,7 +5237,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "3b61f3da-5151-4fd5-bddb-80c7b167ce8c",
+          "id": "7f5a6e14-34ae-48f5-bcde-1bc62744aed0",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5279,7 +5279,7 @@
           },
           "response": [
             {
-              "id": "426e157f-33b3-42c1-8690-7e7daa2d0734",
+              "id": "86c70f82-0c0a-4d57-9e09-6df6cc6c28fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5343,7 +5343,7 @@
           }
         },
         {
-          "id": "fe941f71-ea0a-448e-8021-d89da7c3fd35",
+          "id": "671163ed-86b1-4e1d-971f-22361f1921d5",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5398,7 +5398,7 @@
           },
           "response": [
             {
-              "id": "5ca64510-b491-4735-9a93-38e23758d28e",
+              "id": "c62315d6-bfd8-4825-9926-41e41fe4af65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5475,7 +5475,7 @@
           }
         },
         {
-          "id": "60fb31b4-5433-4b6b-a0d8-17937c597ff6",
+          "id": "1688a9df-21af-452f-95f2-a55554e50db4",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5511,7 +5511,7 @@
           },
           "response": [
             {
-              "id": "f352bc0a-16a8-4802-96fa-1317ee196261",
+              "id": "f505a07d-3930-4a3c-ae53-12d47c854972",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5565,7 +5565,7 @@
           }
         },
         {
-          "id": "ac36ecb8-ebdf-4eac-af1b-f2ed1333bab7",
+          "id": "741d98b8-8e63-4f07-b4bc-4ecccdde16f0",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5595,7 +5595,7 @@
           },
           "response": [
             {
-              "id": "ebe0c3bc-f9a5-4ab1-80f9-da4eb232b551",
+              "id": "d9936240-8f4d-474f-9980-f67e3e73b3c8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5647,7 +5647,7 @@
           }
         },
         {
-          "id": "87325d3b-2d18-445a-87ce-ffc56b702ffa",
+          "id": "477b54bb-35b9-4db3-9829-3617192f8c4e",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5690,7 +5690,7 @@
           },
           "response": [
             {
-              "id": "e8369707-4fba-4aea-b051-b905739454c0",
+              "id": "c915b0ca-89fd-4d2e-8cb5-36ba264cea80",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5761,7 +5761,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "9c9f1fae-60d7-4bba-abd3-a709a5430d24",
+          "id": "2f5dfcd7-cdeb-4344-8bbf-9443d799f8b6",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5814,7 +5814,7 @@
           },
           "response": [
             {
-              "id": "f68aad7a-9f63-4b3c-baaa-1c650dff375c",
+              "id": "868edc26-dbeb-468f-a34d-1a29d446058d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5889,7 +5889,7 @@
           }
         },
         {
-          "id": "96f62ca5-5ae6-40a5-acb8-8e379867589c",
+          "id": "dae989b5-3541-4fa2-8ffc-500f5bfc2be5",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5955,7 +5955,7 @@
           },
           "response": [
             {
-              "id": "4744ebd6-830b-43dd-b809-f0f4e9f0ccdd",
+              "id": "4f131ca0-7a14-42b7-bef5-b9ccd3142f21",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6043,7 +6043,7 @@
           }
         },
         {
-          "id": "f5d9a655-6713-45cd-b09b-02694f7561ad",
+          "id": "f3795ee0-7335-49f7-81aa-a09fa9f90b09",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -6090,7 +6090,7 @@
           },
           "response": [
             {
-              "id": "990a57a7-db12-4e67-8939-14f6eda44110",
+              "id": "1521414d-274e-42b0-92fd-49faf3356518",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6155,7 +6155,7 @@
           }
         },
         {
-          "id": "680cee42-5cff-4268-8483-2c731c2295c1",
+          "id": "68e27dba-71a2-4c34-aeec-196bfc7223d4",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -6197,7 +6197,7 @@
           },
           "response": [
             {
-              "id": "0483181e-f346-4e17-b2cc-5dc1073071b8",
+              "id": "a9f7faa6-a887-4155-b26a-0fe22254eb18",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6261,7 +6261,7 @@
           }
         },
         {
-          "id": "563962a9-8d3e-4a53-9c59-a23f39d65c2f",
+          "id": "8938cb48-4763-485a-9d0a-72318b1386f1",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6316,7 +6316,7 @@
           },
           "response": [
             {
-              "id": "78fd4fc4-752e-4b8d-8233-d98492734404",
+              "id": "b8b68229-86c3-4f45-8350-228e3ec7af81",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6393,7 +6393,7 @@
           }
         },
         {
-          "id": "54c51e73-b15b-40f9-9c8c-fd3fbcef6756",
+          "id": "7ef0f539-693f-4000-a05a-e271ace8a000",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6460,7 +6460,7 @@
           },
           "response": [
             {
-              "id": "8add8014-d42d-4353-8106-5d79c1be189b",
+              "id": "6c7e62a9-d37a-4886-99e8-a1297ca1f817",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6549,7 +6549,7 @@
           }
         },
         {
-          "id": "a0f9a115-e83e-4c00-a7d9-8f6fbe6f562d",
+          "id": "841b1ccd-e961-497b-961b-e91ab8fca68c",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6603,7 +6603,7 @@
           },
           "response": [
             {
-              "id": "0d59813a-c3ea-4bdc-bff9-3872736a04a0",
+              "id": "da904e44-a321-4589-b7fb-7d2719d4e29c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6685,7 +6685,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "0d93ffe5-3989-41e4-9f28-519f3c23f88e",
+          "id": "ff9a0a9b-4780-4c31-947e-01ee971be4e6",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6738,7 +6738,7 @@
           },
           "response": [
             {
-              "id": "6f4e94c2-d06d-4dc5-8dad-6bd5c372deeb",
+              "id": "fdb9b8a4-b8a9-4fa4-b63e-7f70868a10ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6813,7 +6813,7 @@
           }
         },
         {
-          "id": "48ab46b9-a211-4351-8648-ba88f508b4cd",
+          "id": "8eb157d2-0241-4529-be58-6b62967968ac",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6879,7 +6879,7 @@
           },
           "response": [
             {
-              "id": "23757d51-5d8c-4078-883e-09c347377b3f",
+              "id": "6cf47670-4aa1-4294-a535-bd03625aa77c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6967,7 +6967,7 @@
           }
         },
         {
-          "id": "422214b5-f479-41f5-8326-201750c953ef",
+          "id": "8dcc8a4f-5042-475f-a12d-d21d7e7eb0e0",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -7014,7 +7014,7 @@
           },
           "response": [
             {
-              "id": "dbb4d8a1-718d-4786-8ea5-566a0e90f703",
+              "id": "2b1f9960-a58f-419c-8483-9e26657c7b61",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7079,7 +7079,7 @@
           }
         },
         {
-          "id": "229c1d07-6a61-41eb-bb09-1febc8af76de",
+          "id": "07e18f3c-c361-44a3-a29a-b96c4624f327",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -7121,7 +7121,7 @@
           },
           "response": [
             {
-              "id": "2de94243-21ae-4bf4-9a87-ed3e12e2cba5",
+              "id": "3b910646-5204-4d70-bd92-cf227d8cd523",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7185,7 +7185,7 @@
           }
         },
         {
-          "id": "fc8a18a0-3fdc-4bbb-ac12-5172f890fb9d",
+          "id": "32a3af9b-218b-4a1a-9668-9d4986c2677d",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7240,7 +7240,7 @@
           },
           "response": [
             {
-              "id": "5475785e-41f6-45fb-ba9a-b74156ad4f10",
+              "id": "42ae7ebc-198d-485e-a26b-312758b182c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7323,7 +7323,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "e562c4ac-0813-4000-b1c4-5c164e52b0ae",
+          "id": "1cd71648-8d2d-4149-9522-a239ed3902ec",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7364,7 +7364,7 @@
           },
           "response": [
             {
-              "id": "db2c1af9-9137-4cd6-9605-e41ec015ddab",
+              "id": "c7961604-0121-4cbf-99db-118f070d5076",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7427,7 +7427,7 @@
           }
         },
         {
-          "id": "83953b17-0e98-4da4-a945-143b4508e002",
+          "id": "2a92b997-72ba-49dd-82a3-5a62f5b8d830",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7481,7 +7481,7 @@
           },
           "response": [
             {
-              "id": "09972714-7d72-4ac3-96b9-b3c6be1f9b86",
+              "id": "ea98e4e7-35b8-4094-87ca-afde30345c3c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7557,7 +7557,7 @@
           }
         },
         {
-          "id": "abeb453a-40c8-496b-a158-9f8bd47aeb5f",
+          "id": "47da71e9-6f68-4621-9cdb-af374d8e3963",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7592,7 +7592,7 @@
           },
           "response": [
             {
-              "id": "cfb240d6-2f75-49c1-96f4-4bbcd942d6af",
+              "id": "403a7d21-dff7-4389-b3b7-427bbaebcb2c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7645,7 +7645,7 @@
           }
         },
         {
-          "id": "c17f1d46-9f1e-421a-837f-bae4d549372a",
+          "id": "15724610-0016-416c-a932-170afb7b856a",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7702,7 +7702,7 @@
           },
           "response": [
             {
-              "id": "090b8e44-1f81-44c1-a63b-0398a75a95a5",
+              "id": "f7c4464b-235d-4901-907d-8e4d67812a46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7781,7 +7781,7 @@
           }
         },
         {
-          "id": "7d925383-8752-4920-bb15-c8b489754471",
+          "id": "64cbf444-24de-4f09-9022-8234d0e70042",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7823,7 +7823,7 @@
           },
           "response": [
             {
-              "id": "abfa6f2d-4b01-4cbb-bbb0-4dfd1c0251f1",
+              "id": "54211c88-23cd-4325-b8fa-7d8d141f0437",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "1c4820b1-cec6-43c8-a39d-cd1b15d4ee98",
+          "id": "c5717802-933e-4722-a375-fcde8761c842",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7946,7 +7946,7 @@
           },
           "response": [
             {
-              "id": "9cf41487-1bfc-40cc-9ebd-3aa42bab3a4c",
+              "id": "09bc4b14-fd93-46b7-a866-438eae7603ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8021,7 +8021,7 @@
           }
         },
         {
-          "id": "922ff293-f5b2-4ac2-8d9e-a233305bf55f",
+          "id": "1e18be1d-8dcc-43f5-a470-25e5184e5975",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -8087,7 +8087,7 @@
           },
           "response": [
             {
-              "id": "e0602874-2415-449b-9fea-59ca0bdb502d",
+              "id": "245c4bda-ad72-4add-9016-9504d669ef49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8175,7 +8175,7 @@
           }
         },
         {
-          "id": "d8fadc62-5aad-48f5-9014-4d5bfb987ac6",
+          "id": "cb3830cd-07b6-4158-a5e6-cb2bd86b2689",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8222,7 +8222,7 @@
           },
           "response": [
             {
-              "id": "899ebed4-3d23-412c-b3c5-5134534ee6ef",
+              "id": "c6b0934f-287b-4aac-8ada-d7d12062f56b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8287,7 +8287,7 @@
           }
         },
         {
-          "id": "341f2341-1644-486e-a21e-349a9e11de49",
+          "id": "90aefd7a-6f1c-40aa-ac7f-e9f7fa614d7d",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8329,7 +8329,7 @@
           },
           "response": [
             {
-              "id": "e6f750b5-4ff5-4dbb-aa53-0fcf6caa56d9",
+              "id": "649106df-9185-4790-8a8f-f9f1e05782ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8393,7 +8393,7 @@
           }
         },
         {
-          "id": "77fddbca-e334-47d7-beea-4bdebb7765c0",
+          "id": "073a4fec-b275-46dd-bf19-5313043b6d7b",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8448,7 +8448,7 @@
           },
           "response": [
             {
-              "id": "13bc34ac-4e2a-4b97-bf0c-90c87e5e1897",
+              "id": "1c849a62-823e-44df-9022-dc51bf6a80da",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8531,7 +8531,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "8a3c5b2a-3215-48e3-9d20-10b0088cd57e",
+          "id": "17f67647-178c-42fa-8aa1-f5c6b01bb48c",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8573,7 +8573,7 @@
           },
           "response": [
             {
-              "id": "cccbc982-a22b-4e10-9590-375a4915fbcd",
+              "id": "9dc15ea9-15d0-4154-9fb0-e9346c03cf79",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "45ea3374-cc8a-42f0-b35e-c8a93ea1807d",
+          "id": "1c846749-af4d-40d1-87d7-c2842eda9fe6",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8692,7 +8692,7 @@
           },
           "response": [
             {
-              "id": "b791a482-9fb1-4852-8f76-dfce556b7eff",
+              "id": "de92c2ad-d6d3-439d-9f05-3abaa689cda7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8769,7 +8769,7 @@
           }
         },
         {
-          "id": "03eaff26-183e-4f2d-b75e-caa8550561b0",
+          "id": "f5b0a998-dd80-46aa-bb77-75740537629a",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8805,7 +8805,7 @@
           },
           "response": [
             {
-              "id": "52f5a1e5-368f-47c6-a1a8-3d68822e7ffc",
+              "id": "3c6d393e-8156-4f5d-ab74-792667c57d6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8859,7 +8859,7 @@
           }
         },
         {
-          "id": "68cc83e0-6928-439a-9823-398bcfd5a257",
+          "id": "5d9c6a13-15c6-4227-9984-7c0fb08ec680",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8889,7 +8889,7 @@
           },
           "response": [
             {
-              "id": "06560782-7150-4b4b-b1ec-4456fa94c6ba",
+              "id": "5f5919df-d194-4114-a516-49c93ad451fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8941,7 +8941,7 @@
           }
         },
         {
-          "id": "f4554520-a734-4719-9e07-7a01fe82260e",
+          "id": "5b7c178e-3a86-4cbf-9aec-3bf52c72712f",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8984,7 +8984,7 @@
           },
           "response": [
             {
-              "id": "9395e184-3096-48ec-89f1-8fbda52df5aa",
+              "id": "12010277-8d4b-41ed-9183-eb52ce63fbd4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9055,7 +9055,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "6e79e7ef-29f6-419d-8f4a-dd2f78007fd5",
+          "id": "3582d9e7-bde0-4ad5-92a9-8a8237cbfebe",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -9097,7 +9097,7 @@
           },
           "response": [
             {
-              "id": "82fc4f85-ab31-4a3c-af3c-bc6b84b91604",
+              "id": "70ee2047-d33a-46e3-b701-3e723849336b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9155,7 +9155,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "93dedf34-d635-4925-b76d-7c9fa6cdde65",
+              "id": "3f6f78a3-e1b9-4478-88ce-be0fb8ab7683",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9219,7 +9219,7 @@
           }
         },
         {
-          "id": "3d3e13c2-f12a-443c-9891-e3b82087b34e",
+          "id": "667398df-2e04-4ade-9be6-38dc1e4fba78",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9274,7 +9274,7 @@
           },
           "response": [
             {
-              "id": "47cecd83-7d59-4fb6-8fc4-db26c67f809f",
+              "id": "7d5b4164-b1f5-40fd-8b9d-58cc0b5a94a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9345,7 +9345,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "20020bc3-5067-43bc-b760-84c370db0cc1",
+              "id": "73eb27d8-c36d-49b0-b80f-e49b3982fa96",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9416,7 +9416,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0404faad-b174-4a77-ab6e-2f3c111dd691",
+              "id": "b9827437-36d8-43d6-a6bc-e06a07cec3a3",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9493,7 +9493,7 @@
           }
         },
         {
-          "id": "379a96e1-86a4-4506-adbc-b3bbe8a782dd",
+          "id": "a854b93b-bc9d-4d60-901c-4743f8f2263b",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9529,7 +9529,7 @@
           },
           "response": [
             {
-              "id": "69542fa5-5320-4a9e-bcde-128ec354beab",
+              "id": "fceddc2e-9134-45da-ab30-8a6fe3cc4a63",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9577,7 +9577,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "086e485e-ecdb-4c72-bbbc-0f09aa4bc47d",
+              "id": "bf0c1c8f-021f-4be1-9f9c-0ca170852b77",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9625,7 +9625,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "db866747-7165-46b2-b06a-e9ddd5e7662f",
+              "id": "b0a8e4c9-e6c5-44e1-b35b-7d8ba4db3e95",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9679,7 +9679,7 @@
           }
         },
         {
-          "id": "1f56f8cb-9966-4d5d-a750-0571f3b9ebf3",
+          "id": "de237e55-e011-4bd3-955c-80a7b0f67e68",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9709,7 +9709,7 @@
           },
           "response": [
             {
-              "id": "9705721a-1c00-48de-bf5a-6006338ebaab",
+              "id": "4a710b04-2b76-4695-885c-49647bd7bd76",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9761,7 +9761,7 @@
           }
         },
         {
-          "id": "84629170-91ce-444f-aa5a-25b52be62d83",
+          "id": "24abcb20-e945-4226-a401-cfc4613da3d6",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9804,7 +9804,7 @@
           },
           "response": [
             {
-              "id": "9cfdb10a-c7e2-474a-9f43-30bc37bfa93b",
+              "id": "3e875d93-99dd-438e-9e48-6c874bd2e296",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9863,7 +9863,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c2627c15-e55a-47cb-ac86-77acb812529f",
+              "id": "35d0a2a1-6121-4bef-b321-ff3c27d20d41",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9934,7 +9934,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "f53843ab-2eab-4bb1-a606-136572d58acd",
+          "id": "fd0b2595-38ab-4d46-ba9c-3bcd50efaf38",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -10000,7 +10000,7 @@
           },
           "response": [
             {
-              "id": "ab07af5d-6eaf-4ba2-aec3-274fd72929ee",
+              "id": "246772b4-9ff5-4807-abb3-0a7c14eae2a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10074,7 +10074,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -10091,7 +10091,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "37666264-2896-4cdf-9b02-6e6fc8ab7f18",
+          "id": "12e1aa7e-1832-4246-b63f-0ee0fafa71b8",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -10133,7 +10133,7 @@
           },
           "response": [
             {
-              "id": "d70c8d6f-cf3d-48cd-a844-80da96ea464f",
+              "id": "437773a9-f5d6-439e-ab8d-f5baffa89271",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10203,7 +10203,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "cb2081fd-7ff1-4277-8f53-e0b1b48eb85e",
+          "id": "f0a5bdf1-7f88-416f-8565-c50b8547610b",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10245,7 +10245,7 @@
           },
           "response": [
             {
-              "id": "a1c97d35-4783-4693-a568-f5d785ecb479",
+              "id": "9206d265-b9b0-414d-8daf-c562842d06eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10309,7 +10309,7 @@
           }
         },
         {
-          "id": "4f6fcac6-2c59-4c2d-9204-41babbef5893",
+          "id": "dff0d216-c419-4889-af39-8ba1efe03cca",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10352,7 +10352,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5Dfb54\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#b8470D\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10364,7 +10364,7 @@
           },
           "response": [
             {
-              "id": "5e82aa60-1259-479c-948c-98832cdd12a2",
+              "id": "137e7ac7-8c11-4143-ae67-f3375821ec87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10413,7 +10413,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5Dfb54\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#b8470D\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10441,7 +10441,7 @@
           }
         },
         {
-          "id": "31556096-f12f-4d95-b937-f1bc77e784d0",
+          "id": "2c0e5380-5782-407a-a51c-3ffd378db6ae",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10477,7 +10477,7 @@
           },
           "response": [
             {
-              "id": "77a1edbd-0f81-419b-b430-1a2abc00c2ea",
+              "id": "307f6960-d5c4-4631-b524-dd24c8539ee9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10531,7 +10531,7 @@
           }
         },
         {
-          "id": "dca3abc4-083b-4f2a-a73c-4dd8fd2d3ee6",
+          "id": "254bf28d-12c4-4ae6-8a12-15958b76fbd3",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10561,7 +10561,7 @@
           },
           "response": [
             {
-              "id": "95601359-6d6c-410a-aa16-1420cecbf68c",
+              "id": "dc862db9-4ccb-4d32-9a95-75b1b12950f7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10613,7 +10613,7 @@
           }
         },
         {
-          "id": "62294e70-2973-4fd8-9128-c3610fb6ea5d",
+          "id": "b94676fd-bed5-4137-8448-0bcbd8d8645c",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10644,7 +10644,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#18aACC\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#5Ebf31\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10656,7 +10656,7 @@
           },
           "response": [
             {
-              "id": "b975c4bd-1236-421a-8fa0-c583a708f6f9",
+              "id": "196cf5cc-a82a-4c1e-a464-b57e02fe2208",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10693,7 +10693,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#18aACC\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#5Ebf31\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10721,7 +10721,7 @@
           }
         },
         {
-          "id": "f52fe788-4286-42db-a095-f05f580c0e1e",
+          "id": "7172bae8-de0f-44ad-a71d-289463b1f2ae",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10752,7 +10752,7 @@
           },
           "response": [
             {
-              "id": "56ccaa9b-1bdd-4afd-bb8a-fcbb662b79eb",
+              "id": "d2b40703-a5c8-4543-b423-8a5ee62c5720",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "e49d0251-27f6-45e7-9424-9f99722b87b7",
+          "id": "31b7ddfb-e337-4c80-854f-c9fe8e349612",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10864,7 +10864,7 @@
           },
           "response": [
             {
-              "id": "66c48ee8-0e38-4df3-ada8-ac8cf1801cb2",
+              "id": "50de29a0-5da4-4757-893f-90d9bf99639c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10939,7 +10939,7 @@
           }
         },
         {
-          "id": "169e57cd-87c8-4acc-b184-565fecd6e011",
+          "id": "0e554ceb-0c41-4f78-84bd-da034e9e9259",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -11005,7 +11005,7 @@
           },
           "response": [
             {
-              "id": "adb67093-6bf4-45ae-ad44-331457e5b64b",
+              "id": "a9bc6e4a-65cb-4699-94b5-a4c16ffabfe1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11093,7 +11093,7 @@
           }
         },
         {
-          "id": "f72c562f-5ae9-4785-8ee2-d6823cbddad6",
+          "id": "aff31886-a706-4e5b-9c34-6ce7d6ee2ae6",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -11140,7 +11140,7 @@
           },
           "response": [
             {
-              "id": "590bd9ec-fa0f-453d-bd99-8744ee934037",
+              "id": "370b30b7-3845-4586-9bf5-2378c92e5553",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11205,7 +11205,7 @@
           }
         },
         {
-          "id": "21d27d8b-209f-4f76-9d79-509358511194",
+          "id": "9a354812-7e7b-406d-9923-24dbeb6ebf38",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11247,7 +11247,7 @@
           },
           "response": [
             {
-              "id": "09f22a9e-f245-47f3-963d-3bff1e307339",
+              "id": "cb926062-e8db-48cc-9f40-9410a4e8648f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11311,7 +11311,7 @@
           }
         },
         {
-          "id": "8379ed73-4813-4ace-a8fc-bf5f91949fde",
+          "id": "9f52a836-9e5e-4e99-b244-8d09b0b78210",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11366,7 +11366,7 @@
           },
           "response": [
             {
-              "id": "8cb4d66d-ead9-4781-98ff-4fa74b7f1c4b",
+              "id": "8cd530e0-d361-4c58-a92e-3a18feae2d1f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11443,7 +11443,7 @@
           }
         },
         {
-          "id": "0e876c81-ea3b-4d0e-87c6-a19004d6d6f1",
+          "id": "80c8c9e7-798d-4fae-b7eb-4cc1bffbea1b",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11497,7 +11497,7 @@
           },
           "response": [
             {
-              "id": "a8a18e2d-a498-4bba-b74e-88a13a0f88bc",
+              "id": "e29946e8-18a8-4025-92b8-dea58fa78f48",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11573,7 +11573,7 @@
           }
         },
         {
-          "id": "57bdb4c4-3709-441a-b2a1-e04093ba023f",
+          "id": "bc8ee725-1e33-493d-b081-50cf96d7c5f8",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11639,7 +11639,7 @@
           },
           "response": [
             {
-              "id": "98bda81b-7b67-4b12-a334-191c386352c0",
+              "id": "f67c7d11-8662-4616-ab2c-5364fbd9cec4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11727,7 +11727,7 @@
           }
         },
         {
-          "id": "01f8b6f1-8541-4957-8f45-e8c3176bd165",
+          "id": "d412f284-22ea-476b-8f25-1ab5254b916d",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11805,7 +11805,7 @@
           },
           "response": [
             {
-              "id": "2a00185e-66e6-46d8-8ae4-5808969499f5",
+              "id": "3e3f7632-915f-4fe6-80b3-066ec7f68a32",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11905,7 +11905,7 @@
           }
         },
         {
-          "id": "ada82c3d-95a8-4ba6-89fe-d110656cebba",
+          "id": "a2da595c-f148-414e-b51a-71e4ceded0a6",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11971,7 +11971,7 @@
           },
           "response": [
             {
-              "id": "6fb49600-270c-4fae-9ef2-daa83cff3f34",
+              "id": "438abf3f-5db9-4cfc-abe7-42798fcbcb2b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12059,7 +12059,7 @@
           }
         },
         {
-          "id": "75dda59d-a758-4b34-a4c5-7e83a62e2833",
+          "id": "1553f585-e91e-4678-aed1-83c5ad107d09",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -12114,7 +12114,7 @@
           },
           "response": [
             {
-              "id": "efa90203-e740-432c-8750-540bbac5910c",
+              "id": "d4f5af49-9fa6-4659-9b28-030e3ba91df1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12197,7 +12197,7 @@
       "description": "",
       "item": [
         {
-          "id": "8138fd94-4dc1-4eeb-aefe-cf0e88c87046",
+          "id": "2dd4cba2-a6e9-43ff-9f51-25f29cd9d3df",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12238,7 +12238,7 @@
           },
           "response": [
             {
-              "id": "3946b78e-8e24-4d92-aa1a-5eb745779579",
+              "id": "659c2d8b-da44-4260-8a41-e0dae163eae1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12301,7 +12301,7 @@
           }
         },
         {
-          "id": "8d5d4101-cf88-4500-90a8-e98471499461",
+          "id": "181ebd93-679d-4a2f-8d6e-433f598e15c0",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12355,7 +12355,7 @@
           },
           "response": [
             {
-              "id": "45af6597-5d57-4d61-8b71-cab2228f728f",
+              "id": "53112984-cb7f-4825-b7cb-3d9fb46c6e35",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12431,7 +12431,7 @@
           }
         },
         {
-          "id": "8dee2f07-fccf-4544-9d59-7cc3dc6a47c1",
+          "id": "fccfdcd5-d063-471f-bdd9-9f9dbce97987",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12466,7 +12466,7 @@
           },
           "response": [
             {
-              "id": "075a01db-8962-44e2-a1fd-b4182c147909",
+              "id": "11c51d6c-366f-4301-9295-f57b3843e009",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12519,7 +12519,7 @@
           }
         },
         {
-          "id": "36f93295-fb7d-4d40-af5d-27953fa37cf2",
+          "id": "992daaf9-1cab-4981-ade0-58f2927c3bdf",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12580,7 +12580,7 @@
           },
           "response": [
             {
-              "id": "97e07394-3b5d-410c-8583-ad0efae93dd8",
+              "id": "b1ea36d6-4911-4133-a23f-0fcf01f2056a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12663,7 +12663,7 @@
           }
         },
         {
-          "id": "488be303-f9d2-4c9a-8428-5b6b8256b8c6",
+          "id": "7eb383ea-1755-4746-8697-f1b4fdc6325d",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12705,7 +12705,7 @@
           },
           "response": [
             {
-              "id": "6a93682e-0c57-4fae-816a-1cf25d993415",
+              "id": "ddc879b4-4346-4d80-903e-42dfc95f6f2b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12769,7 +12769,7 @@
           }
         },
         {
-          "id": "79e6be0a-7696-4d03-9016-aea8e36dab6b",
+          "id": "68483a6f-3d7a-41b6-884f-9cab900e4524",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12844,7 +12844,7 @@
           },
           "response": [
             {
-              "id": "ba6e9b0e-9007-438e-a605-c9f7d195ba59",
+              "id": "0a3f07a4-a4ff-4b3c-93c8-6971a6f1ebc7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12941,7 +12941,7 @@
           }
         },
         {
-          "id": "92b4ab64-b741-462d-b494-33e3595f0b6c",
+          "id": "53a56b61-1e4c-4514-94e1-f847e03e7f0b",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12983,7 +12983,7 @@
           },
           "response": [
             {
-              "id": "3a6c0f0a-1b02-4bbc-88bf-53311f276253",
+              "id": "526e868f-a7dc-44df-a397-7b76822ddb8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13047,7 +13047,7 @@
           }
         },
         {
-          "id": "a59d31b9-1a20-471a-a227-a971f0ecd004",
+          "id": "5265595a-6930-48cf-a442-6c928f0b2ac7",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -13090,7 +13090,7 @@
           },
           "response": [
             {
-              "id": "47338797-85de-49fb-8826-d23502990340",
+              "id": "73b23260-7c3c-4804-aa04-7844336e2520",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13155,7 +13155,7 @@
           }
         },
         {
-          "id": "6cbab471-d7fb-45d1-827e-a8b0c24e2016",
+          "id": "165863ae-900e-4606-9324-f4dbaa14b6e0",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "526cf3d9-9939-446e-9b8d-260186da1cd4",
+              "id": "b47b2543-ed4e-49cc-938e-87b2649482fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13263,7 +13263,7 @@
           }
         },
         {
-          "id": "65e38158-7ff4-4119-9627-ee23bc7415fc",
+          "id": "d2fda366-c82b-4cd3-9786-b9c8c8b45f45",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13315,7 +13315,7 @@
           },
           "response": [
             {
-              "id": "4683de3d-4de4-4022-8a9c-a7c6889d3e7a",
+              "id": "acaa5bbe-b583-41e6-918b-5f76aaadef2c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13389,7 +13389,7 @@
           }
         },
         {
-          "id": "8350118b-dac2-4c4b-a547-26ca45b2a08a",
+          "id": "09482311-2cf9-4866-902d-df3a8616bdb6",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13431,7 +13431,7 @@
           },
           "response": [
             {
-              "id": "78375306-3af8-48a3-afa3-62a01ce2ad04",
+              "id": "e50789b0-be95-464c-8a3f-2f9a3e733879",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13495,7 +13495,7 @@
           }
         },
         {
-          "id": "bcc2a79b-4dea-4874-a51a-f6c114616b7d",
+          "id": "0d0420a3-4081-40a9-9982-c57b39db0cf4",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13548,7 +13548,7 @@
           },
           "response": [
             {
-              "id": "42d234c7-05c2-4dca-b2ae-4a175c3fb7df",
+              "id": "4d0db79c-d714-400a-a113-7d599ac3e1c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13623,7 +13623,7 @@
           }
         },
         {
-          "id": "270ebbd6-2f5b-499c-9c17-911cb3caa680",
+          "id": "bf14b7a9-0979-49a3-8656-f1e466cceb27",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -13676,7 +13676,7 @@
           },
           "response": [
             {
-              "id": "275d3ea1-db72-44f4-afd4-43d366c81d5f",
+              "id": "b196f1ad-b29e-45b8-b027-ba717bbdb807",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13751,7 +13751,7 @@
           }
         },
         {
-          "id": "b09cc04b-b2b8-4fef-b37b-976e791ff0c7",
+          "id": "aae5b327-2f6c-41a1-b36f-6deb211a834f",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13795,7 +13795,7 @@
           },
           "response": [
             {
-              "id": "d0568ff9-a748-4cfb-8363-b450a0010f8e",
+              "id": "91f31677-6f80-4ee5-b327-5f29ae88d76c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13850,7 +13850,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13861,7 +13861,7 @@
           }
         },
         {
-          "id": "e0e69898-da41-4d7a-8f6e-49801d19f810",
+          "id": "5c823125-3da4-4e9e-8041-6dd300cca4aa",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13905,7 +13905,7 @@
           },
           "response": [
             {
-              "id": "d3366e6f-60ff-4d3b-9284-268a1ed3aca4",
+              "id": "16c9f269-3b30-4303-a2bc-5c898b6d20b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13960,7 +13960,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13977,7 +13977,7 @@
       "description": "",
       "item": [
         {
-          "id": "be093eab-805b-44df-bb43-83bbb01a920d",
+          "id": "83e45be4-d7cd-4855-a577-315a04428cda",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -14019,7 +14019,7 @@
           },
           "response": [
             {
-              "id": "942d4cab-9126-4d65-b8e4-beeaf2f9bf8e",
+              "id": "433023f6-d685-4008-abe5-98ada53c0baa",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ce58011f-6763-474c-87ee-e70b9db1ad0e",
+              "id": "1e78c089-f869-4856-8373-e702e5b7c7e0",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -14123,7 +14123,7 @@
           }
         },
         {
-          "id": "e15869ae-831f-426b-b2ba-ddd09bb42367",
+          "id": "d9a57a1e-d4f9-4308-83b2-ca503c52f651",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -14169,7 +14169,7 @@
           },
           "response": [
             {
-              "id": "a36ab3bb-065f-4610-a945-a4724b7e798a",
+              "id": "a4adb18f-1bec-46ed-b9bb-9fa6d344a773",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -14228,7 +14228,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6032a7dd-5900-4346-9d00-80eb10736a64",
+              "id": "897a23a4-7d43-46b5-a420-164db2206035",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -14293,7 +14293,7 @@
           }
         },
         {
-          "id": "ffdda9a9-14c8-4b4d-8937-36271bd35a2f",
+          "id": "cb2e72ab-9fbe-439e-b4d4-e886690551bc",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14339,7 +14339,7 @@
           },
           "response": [
             {
-              "id": "06240da3-f01b-40ca-b746-77489e5a8f8d",
+              "id": "794c8dcf-13c2-467b-a86f-264e65053da6",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14398,7 +14398,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "495e20ca-3742-4193-8c49-fec367746f71",
+              "id": "68e9099a-e695-448c-a212-f39f4e8e270f",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14463,7 +14463,7 @@
           }
         },
         {
-          "id": "d5582b1b-a426-422a-954b-9f91a23e189c",
+          "id": "9e85033d-d4de-4c6c-a509-ee8396bbab6a",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14505,7 +14505,7 @@
           },
           "response": [
             {
-              "id": "f656d13b-350c-4939-b2f1-bd6db810dae7",
+              "id": "fccc9263-7816-4322-8fc9-a185fbb1a557",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14566,7 +14566,7 @@
       "description": "",
       "item": [
         {
-          "id": "49c811af-689c-450a-83aa-b32785c3198d",
+          "id": "b78d9593-0199-4881-bfd6-6672c7b57d17",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14615,7 +14615,7 @@
           },
           "response": [
             {
-              "id": "c968b855-08ab-4563-bed9-2c6840165970",
+              "id": "7decd331-b9bb-4a23-bc12-340caec128e9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14675,7 +14675,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14686,7 +14686,7 @@
           }
         },
         {
-          "id": "dd390275-4406-44cc-8c63-da1ba47e5e7b",
+          "id": "0b91e8ba-0710-44a8-895a-e03efd745ce2",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14735,7 +14735,7 @@
           },
           "response": [
             {
-              "id": "39672ed0-3be9-415e-a7f4-4163ec3ff418",
+              "id": "1fcea666-aafa-4c3f-918c-366d41b33674",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14806,7 +14806,7 @@
           }
         },
         {
-          "id": "b6187e7c-ba1e-427b-a247-01b494ffbc90",
+          "id": "8688b525-5487-4447-9ef9-dc174524e6df",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14855,7 +14855,7 @@
           },
           "response": [
             {
-              "id": "8d426675-9b81-4f46-b604-fe5181a37bdc",
+              "id": "676b7ed0-60c3-418e-87a3-38a3b2052551",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14926,7 +14926,7 @@
           }
         },
         {
-          "id": "7f84791d-8adc-46eb-9623-8fdb8d02b6b2",
+          "id": "8f913713-9e7d-4333-bf85-5adcef356942",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14975,7 +14975,7 @@
           },
           "response": [
             {
-              "id": "80432ec1-db74-4fad-8fdc-4fb8628a2d25",
+              "id": "88756837-16d6-44d9-8643-2f22e1d200c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15052,7 +15052,7 @@
       "description": "",
       "item": [
         {
-          "id": "6b8ab0e6-6f8c-4006-a879-7db37bdb3fed",
+          "id": "8b3f6095-ceaa-4ef2-b83e-a4d96bc98de0",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -15092,7 +15092,7 @@
           },
           "response": [
             {
-              "id": "5e7f3c25-24b2-4d30-9bc2-510ba5c4c930",
+              "id": "609b291f-4a25-40ac-9ca4-ee9786e50ca5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15154,7 +15154,7 @@
           }
         },
         {
-          "id": "b3c1b018-0139-4e97-95c5-09f0bf74e7bf",
+          "id": "2af28e97-803f-49b2-8298-3cb53c41e567",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -15184,7 +15184,7 @@
           },
           "response": [
             {
-              "id": "d79ff9b3-a910-4017-8f88-32e029a2ea5b",
+              "id": "e2bfb99d-cfa1-4f25-ba87-4d44f4354826",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15225,7 +15225,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15236,7 +15236,7 @@
           }
         },
         {
-          "id": "16ca0aa7-6b9d-4ae5-b6cd-cd42f262a53e",
+          "id": "a3149f19-c3ca-427f-8612-cd96eae8443e",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -15288,7 +15288,7 @@
           },
           "response": [
             {
-              "id": "947a0340-7c47-446f-9282-acc3a1502bd5",
+              "id": "44523e2f-e693-4bcd-930f-26b8df96fcd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15368,7 +15368,7 @@
       "description": "",
       "item": [
         {
-          "id": "120d0712-0340-4bfe-a1ca-b6e7d0b8b6d9",
+          "id": "5a8a574d-726d-469d-bb05-f9e2e93b00da",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15397,7 +15397,7 @@
           },
           "response": [
             {
-              "id": "6057025e-e71f-4206-8486-c8ac35f93ad5",
+              "id": "17790c37-2874-4b9d-86bb-766111bab491",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15448,7 +15448,7 @@
           }
         },
         {
-          "id": "fe9e7dcf-4122-47ea-98ed-9be9063848d2",
+          "id": "415660be-4232-4d2d-bb45-a18956b3b2e2",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15489,7 +15489,7 @@
           },
           "response": [
             {
-              "id": "d6ee0c3b-7185-44b5-b481-a6be93f70c85",
+              "id": "24c574d4-5bf0-4cc1-add3-967005270d96",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15558,7 +15558,7 @@
       "description": "",
       "item": [
         {
-          "id": "319aaf32-d61b-492e-8af1-9e8240b8966f",
+          "id": "fe142421-6961-45fa-853d-32c84a4c694f",
           "name": "health",
           "request": {
             "name": "health",
@@ -15587,7 +15587,7 @@
           },
           "response": [
             {
-              "id": "b5347156-41a1-430b-8abf-334464dcd0d2",
+              "id": "b858af94-10d4-4181-b72f-4c2960829536",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15627,7 +15627,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15644,7 +15644,7 @@
       "description": "",
       "item": [
         {
-          "id": "bbb8d254-f749-4b98-aa8f-e9f505dc48f5",
+          "id": "8baac1cb-894c-4a1b-bdfd-bd12af5fd5f8",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15696,7 +15696,7 @@
           },
           "response": [
             {
-              "id": "3b5bc1d9-692d-44f5-8306-db76a8bf7a93",
+              "id": "bc1e1cef-4775-4a64-b442-4af0b64ef0fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15770,7 +15770,7 @@
           }
         },
         {
-          "id": "b83afd30-5420-4ac7-a7ec-8d90bb619990",
+          "id": "94994651-105d-408c-9f99-1ac588cb06c1",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15811,7 +15811,7 @@
           },
           "response": [
             {
-              "id": "dd3e74b8-bec4-4c74-98dd-c7bf62a49c56",
+              "id": "5783d755-56f7-4cea-8abc-86d973ceb535",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15863,7 +15863,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_3\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15874,7 +15874,7 @@
           }
         },
         {
-          "id": "483cf0d9-4051-4d0f-adb0-9b86427057ab",
+          "id": "6e89d42c-e328-4510-b231-9f448f404c40",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15904,7 +15904,7 @@
           },
           "response": [
             {
-              "id": "9ec19f4f-22d2-4829-9a28-2774dbe2f298",
+              "id": "48d527e1-bc12-4cc9-ae88-7c4d66e1692d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15976,9 +15976,9 @@
     }
   ],
   "info": {
-    "_postman_id": "ba6946e0-5111-4e5b-8e11-5923fd591b46",
+    "_postman_id": "99fc4e91-56ce-44df-a756-ded963951a38",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 00:21 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 01:59 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/docs/MOBILE_HISTORY_ENDPOINT_PROMPT.md
+++ b/docs/MOBILE_HISTORY_ENDPOINT_PROMPT.md
@@ -1,0 +1,539 @@
+# Prompt técnico para Claude Code en Android Studio (`GreenhouseFronts`)
+
+**Pásale a tu Claude Code en Android Studio TODO este documento (el bloque entre `=== INICIO PROMPT ===` y `=== FIN PROMPT ===`). Es autosuficiente.**
+
+---
+
+```text
+=== INICIO PROMPT PARA CLAUDE CODE EN apptolast/GreenhouseFronts ===
+
+# Conectar la pantalla "Histórico de alertas" al nuevo endpoint
+# /api/v1/alerts/history/tenant/{tenantId} del backend
+
+## Contexto
+
+El backend `apptolast/InvernaderosAPI` acaba de añadir un endpoint nuevo, ya
+desplegado en dev (https://inverapi-dev.apptolast.com) y prod
+(https://inverapi-prod.apptolast.com), pensado específicamente para la pantalla
+"Histórico" de esta app móvil:
+
+    GET /api/v1/alerts/history/tenant/{tenantId}?limit=100
+
+Devuelve **todas** las alertas que han existido para ese tenant (activas y
+resueltas), ordenadas por `createdAt DESC`. El bug que arregla: la pantalla
+"Histórico" llamaba a `GET /api/v1/alerts?tenantId=X&isResolved=true&limit=100`
+y por construcción solo devolvía las alertas que ya se hubieran resuelto. Como
+en producción real apenas se ha resuelto ninguna alerta todavía, el usuario veía
+`[]` y la pantalla salía vacía a pesar de tener alertas activas. Decisión de
+producto: "Histórico" debe mostrar el feed completo (activas + resueltas).
+
+La URL de la pestaña **"Activas"** sigue siendo correcta y NO se toca:
+
+    GET /api/v1/alerts?tenantId={tenantId}&isResolved=false&limit=100
+
+(Si el cliente actualmente usa `/api/v1/alerts/unresolved/tenant/{tenantId}` para
+contar las alertas activas en las cards de invernadero — visible en
+`GreenhouseApiService.getUnresolvedAlerts` — eso TAMPOCO se toca.)
+
+## Contrato del endpoint nuevo (verificado contra dev y prod)
+
+**URL**: `${baseUrl}/alerts/history/tenant/{tenantId}` donde `baseUrl` es
+`Environment.current.baseUrl` + `/api/v1` (igual que el resto de servicios del
+repo — ver `util/Environment.kt` y `data/remote/KtorClient.kt`).
+
+**Método**: `GET`
+**Auth**: Bearer JWT (el `AUTHENTICATED_CLIENT` de Koin ya lo inyecta).
+**Path param**: `tenantId: Long`
+**Query param**: `limit: Int` (opcional, default `100` en backend; recomendado
+mandarlo desde cliente para ser explícito).
+**Response 200**: `application/json`, array de objetos `AlertResponse` (forma
+literal traída del logcat real contra dev):
+
+```json
+[
+  {
+    "id": 823997985639380207,
+    "code": "ALT-00010",
+    "tenantId": 814997898604790412,
+    "sectorId": 820685609276048132,
+    "sectorCode": "SEC-00033",
+    "alertTypeId": 3,
+    "alertTypeName": "ACTUATOR FAILURE",
+    "severityId": 4,
+    "severityName": "CRITICAL",
+    "severityLevel": 4,
+    "message": "Vaya movida de calor",
+    "description": null,
+    "clientName": "Temperatura muy alta",
+    "isResolved": false,
+    "resolvedAt": null,
+    "resolvedByUserId": null,
+    "resolvedByUserName": null,
+    "createdAt": "2026-03-23T19:13:48.628792Z",
+    "updatedAt": "2026-04-30T23:52:38.919178Z"
+  }
+]
+```
+
+**Tipos exactos del backend** (verificados contra `AlertResponse.kt` del repo
+del backend):
+
+| Campo                | Tipo            | Notas                                              |
+| -------------------- | --------------- | -------------------------------------------------- |
+| `id`                 | `Long`          | Siempre presente.                                  |
+| `code`               | `String`        | Ej. `"ALT-00010"`. Siempre presente.               |
+| `tenantId`           | `Long`          | Siempre presente.                                  |
+| `sectorId`           | `Long`          | Siempre presente.                                  |
+| `sectorCode`         | `String?`       | Puede venir `null` si el sector no tiene código.   |
+| `alertTypeId`        | `Short?`        | Nullable.                                          |
+| `alertTypeName`      | `String?`       | Nullable.                                          |
+| `severityId`         | `Short?`        | Nullable.                                          |
+| `severityName`       | `String?`       | `"INFO" | "WARNING" | "ERROR" | "CRITICAL"` o null.|
+| `severityLevel`      | `Short?`        | 1..4 o null.                                       |
+| `message`            | `String?`       | Nullable.                                          |
+| `description`        | `String?`       | Nullable.                                          |
+| `clientName`         | `String?`       | Nombre legible para el usuario final.              |
+| `isResolved`         | `Boolean`       | Siempre presente.                                  |
+| `resolvedAt`         | `String?`       | ISO-8601 UTC, null si no resuelta.                 |
+| `resolvedByUserId`   | `Long?`         | Nullable.                                          |
+| `resolvedByUserName` | `String?`       | Nullable.                                          |
+| `createdAt`          | `String`        | ISO-8601 UTC. Siempre presente.                    |
+| `updatedAt`          | `String`        | ISO-8601 UTC. Siempre presente.                    |
+
+> **Sobre `Short` en KMP**: el backend serializa estos como números pequeños.
+> En el cliente puedes usar `Short?` o `Int?` indistintamente — kotlinx
+> serialization los acepta y la app ya tiene `coerceInputValues = true`,
+> `ignoreUnknownKeys = true` y `isLenient = true` configurados en
+> `di/DataModule.kt`. Recomendado: `Int?` para evitar tener que castear en UI.
+
+## Acción concreta que tienes que ejecutar
+
+### Paso 0 — Detecta el estado actual de tu rama
+
+Estás en `feature/alert-notifications` (rama remota). El usuario probablemente
+tiene **commits locales encima** con la pantalla de Histórico medio hecha
+(donde está el bug de `?isResolved=true`). Antes de tocar nada:
+
+1. `git status` — para ver el árbol de trabajo.
+2. `git log feature/alert-notifications..HEAD --oneline` — para ver los commits
+   locales.
+3. **Lista todos los archivos `*Alert*` del repo** y enséñame su ruta. Esto
+   incluye al menos:
+   - `composeApp/src/commonMain/kotlin/com/apptolast/greenhousefronts/data/model/greenhouse/GreenhouseDtos.kt`
+     (ya tiene un `AlertResponse` recortado con solo `id`, `sectorId`,
+     `clientName`, `isResolved` — usado para contar alertas en las cards).
+   - Cualquier `AlertApiService`, `AlertRepository`, `AlertHistoryViewModel`,
+     `AlertsScreen` o `AlertHistoryScreen` que el usuario haya creado
+     localmente.
+
+Sin esto **no toques código**. Pídeme la lista y espera.
+
+### Paso 1 — Modelo de datos
+
+Revisa el `AlertResponse` actual en
+`composeApp/src/commonMain/kotlin/com/apptolast/greenhousefronts/data/model/greenhouse/GreenhouseDtos.kt`:
+
+```kotlin
+@Serializable
+data class AlertResponse(
+    val id: Long,
+    val sectorId: Long,
+    val clientName: String? = null,
+    val isResolved: Boolean = false,
+)
+```
+
+Este DTO está pensado solo para contar/agrupar (lo usa
+`GreenhouseRepositoryImpl` para los counters de las cards). **NO lo modifiques
+en el sitio actual** — romperías la suposición de los counters. En su lugar:
+
+**Opción A (recomendada y mínima)**. Crea un DTO nuevo dedicado al detalle:
+
+```kotlin
+// composeApp/src/commonMain/kotlin/com/apptolast/greenhousefronts/data/model/alert/AlertDetailResponse.kt
+package com.apptolast.greenhousefronts.data.model.alert
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Response for endpoints that return the full alert payload:
+ *  - GET /api/v1/alerts/history/tenant/{tenantId}
+ *  - GET /api/v1/alerts/{id}
+ *  - GET /api/v1/alerts/unresolved/tenant/{tenantId} (legacy, returns the same shape)
+ *
+ * Mirrors AlertResponse on the backend. Field order matches the Kotlin record
+ * exposed by AlertController. JSON config (`ignoreUnknownKeys = true`) tolerates
+ * future field additions on the server.
+ */
+@Serializable
+data class AlertDetailResponse(
+    val id: Long,
+    val code: String,
+    val tenantId: Long,
+    val sectorId: Long,
+    val sectorCode: String? = null,
+    val alertTypeId: Int? = null,
+    val alertTypeName: String? = null,
+    val severityId: Int? = null,
+    val severityName: String? = null,
+    val severityLevel: Int? = null,
+    val message: String? = null,
+    val description: String? = null,
+    val clientName: String? = null,
+    val isResolved: Boolean = false,
+    val resolvedAt: String? = null,
+    val resolvedByUserId: Long? = null,
+    val resolvedByUserName: String? = null,
+    val createdAt: String,
+    val updatedAt: String,
+)
+```
+
+> Si el usuario ya tiene un DTO equivalente creado localmente con otro nombre,
+> **úsalo en su lugar** y reporta cuál has detectado. No dupliques.
+
+### Paso 2 — API service
+
+El repo ya tiene un `GreenhouseApiService` con un método para alertas no
+resueltas (lo usa el counter):
+
+```kotlin
+suspend fun getUnresolvedAlerts(tenantId: Long): List<AlertResponse> {
+    return httpClient.get("$baseUrl/alerts/unresolved/tenant/$tenantId").body()
+}
+```
+
+Añade un método nuevo en el **mismo `GreenhouseApiService`** (no crees uno nuevo
+si no es necesario — sigue el patrón del repo), o en un `AlertApiService`
+dedicado si el usuario ya lo ha creado en su rama local. La firma:
+
+```kotlin
+import com.apptolast.greenhousefronts.data.model.alert.AlertDetailResponse
+import io.ktor.client.request.parameter
+
+/**
+ * Full alert history for a tenant: includes both active and resolved alerts,
+ * ordered by createdAt DESC. Backed by GET /api/v1/alerts/history/tenant/{id}
+ * — the dedicated endpoint for the mobile "Histórico" tab. The legacy filter
+ * `?isResolved=true` is intentionally NOT used here because it would only
+ * return resolved alerts, leaving the tab empty until something gets resolved.
+ */
+suspend fun getAlertsHistory(
+    tenantId: Long,
+    limit: Int = 100,
+): List<AlertDetailResponse> {
+    return httpClient.get("$baseUrl/alerts/history/tenant/$tenantId") {
+        parameter("limit", limit)
+    }.body()
+}
+```
+
+Notas:
+- `$baseUrl` es la propiedad `val baseUrl: String` definida en
+  `data/remote/KtorClient.kt` (devuelve `Environment.current.baseUrl`, que ya
+  incluye el prefijo `/api/v1`).
+- El cliente `httpClient` es el `AUTHENTICATED_CLIENT` (inyectado vía Koin en
+  `di/DataModule.kt`). Bearer token automático.
+- `import io.ktor.client.request.parameter` — el patrón con `parameter("...")`
+  es el estándar Ktor para query strings; usa este en vez de concatenar
+  manualmente.
+- `expectSuccess = true` está activo: cualquier respuesta 4xx/5xx tira
+  `ResponseException`. La capa repository ya lo maneja con `Result.failure`.
+
+### Paso 3 — Repository
+
+El cliente ya devuelve `Result<...>` desde la capa repositorio. Sigue el
+patrón de `GreenhouseRepositoryImpl`:
+
+```kotlin
+// domain/repository/AlertRepository.kt (si no existe ya, créalo)
+interface AlertRepository {
+    /**
+     * Returns the full alert history for the current tenant
+     * (active + resolved), ordered by createdAt DESC.
+     */
+    suspend fun getAlertHistory(limit: Int = 100): Result<List<AlertDetail>>
+}
+```
+
+```kotlin
+// data/repository/AlertRepositoryImpl.kt
+class AlertRepositoryImpl(
+    private val apiService: GreenhouseApiService, // o AlertApiService si existe
+    private val tokenStorage: TokenStorage,
+) : AlertRepository {
+
+    override suspend fun getAlertHistory(limit: Int): Result<List<AlertDetail>> {
+        val tenantId = tokenStorage.getTenantId()
+            ?: return Result.failure(Exception("No se encontró el ID del tenant"))
+
+        return try {
+            val dtos = apiService.getAlertsHistory(tenantId, limit)
+            Result.success(dtos.map { it.toDomain() })
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+```
+
+Si Alberto tiene ya su propio modelo `domain/model/AlertDetail.kt` (o lo llama
+`Alert`), úsalo. Si no, crea uno mínimo con solo los campos que la pantalla
+Histórico necesita pintar.
+
+Ejemplo de mapper en `data/model/alert/AlertMappers.kt` (extension function,
+patrón consistente con el resto del repo):
+
+```kotlin
+fun AlertDetailResponse.toDomain(): AlertDetail = AlertDetail(
+    id = id,
+    code = code,
+    sectorCode = sectorCode,
+    severity = severityName,
+    severityLevel = severityLevel,
+    title = clientName ?: message ?: code,
+    message = message,
+    description = description,
+    isResolved = isResolved,
+    createdAt = createdAt,
+    resolvedAt = resolvedAt,
+)
+```
+
+### Paso 4 — ViewModel
+
+Crea (o adapta el existente) un `AlertHistoryViewModel` siguiendo el patrón
+de los demás ViewModels del repo (todos están en
+`composeApp/src/commonMain/kotlin/com/apptolast/greenhousefronts/presentation/viewmodel/`):
+
+```kotlin
+class AlertHistoryViewModel(
+    private val alertRepository: AlertRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AlertHistoryUiState())
+    val uiState: StateFlow<AlertHistoryUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun load() = viewModelScope.launch {
+        _uiState.update { it.copy(isLoading = true, error = null) }
+        alertRepository.getAlertHistory().fold(
+            onSuccess = { list ->
+                _uiState.update {
+                    it.copy(isLoading = false, alerts = list, error = null)
+                }
+            },
+            onFailure = { e ->
+                _uiState.update {
+                    it.copy(isLoading = false, error = e.message ?: "Error desconocido")
+                }
+            },
+        )
+    }
+}
+
+data class AlertHistoryUiState(
+    val isLoading: Boolean = false,
+    val alerts: List<AlertDetail> = emptyList(),
+    val error: String? = null,
+)
+```
+
+### Paso 5 — Pantalla
+
+Localiza la pantalla actual de Histórico (probablemente en
+`presentation/ui/AlertsScreen.kt` o similar). Hoy debe estar llamando a algo
+como `apiService.getAlerts(tenantId, isResolved = true, limit = 100)` o
+construyendo manualmente la URL `?isResolved=true`. Sustitúyelo por una llamada
+al nuevo `alertHistoryViewModel.uiState`.
+
+Renderizado mínimo (Compose Multiplatform):
+- Lista (LazyColumn) de tarjetas con: severidad (chip de color), `clientName`
+  o `message`, fecha (formatear `createdAt`), y un badge **"Activa"** o
+  **"Resuelta"** según `isResolved`.
+- Si `error != null`, mostrar texto rojo con un botón Reintentar que llame a
+  `viewModel.load()`.
+- Si `isLoading && alerts.isEmpty()`, mostrar `CircularProgressIndicator`.
+- Si la lista está vacía y no hay error, mostrar copy:
+  *"Aún no se han generado alertas para este invernadero."*
+
+### Paso 6 — Koin DI
+
+Registra repository y viewmodel en los módulos correspondientes
+(`di/DataModule.kt` y `di/PresentationModule.kt`):
+
+```kotlin
+// di/DataModule.kt — añadir junto al resto de repos
+singleOf(::AlertRepositoryImpl) bind AlertRepository::class
+```
+
+```kotlin
+// di/PresentationModule.kt — añadir junto a los demás VMs
+viewModelOf(::AlertHistoryViewModel)
+```
+
+Si el usuario en su rama local **ya** ha registrado uno con otro nombre,
+detéctalo y reúsa lo que tenga (no dupliques bindings).
+
+### Paso 7 — Tests
+
+El repo no tiene una cobertura amplia (solo
+`composeApp/src/commonTest/kotlin/com/apptolast/greenhousefronts/ComposeAppCommonTest.kt`).
+**No añadas tests de integración**, pero **sí** un test unitario del VM con
+MockK / Turbine si ya están en el classpath (mirar
+`gradle/libs.versions.toml`):
+
+```kotlin
+class AlertHistoryViewModelTest {
+    @Test
+    fun `loads alerts on init`() = runTest {
+        val repo = mockk<AlertRepository>()
+        coEvery { repo.getAlertHistory(any()) } returns Result.success(listOf(/* fake AlertDetail */))
+        val vm = AlertHistoryViewModel(repo)
+        vm.uiState.test {
+            // assertions
+        }
+    }
+}
+```
+
+Si Turbine / MockK no están en el `libs.versions.toml`, **no los añadas** —
+solo dilo en tu reporte y deja el test fuera. Confirma que la app sigue
+compilando para los 4 targets:
+
+```bash
+./gradlew :composeApp:assembleDebug                    # Android
+./gradlew :composeApp:run                              # Desktop (JVM)
+./gradlew :composeApp:wasmJsBrowserDevelopmentRun      # Web (Wasm)
+```
+
+## Restricciones (estas son no-negociables)
+
+- **NO** modifiques el `AlertResponse` recortado existente en
+  `data/model/greenhouse/GreenhouseDtos.kt`. Si otro código lo usa para contar
+  alertas (`GreenhouseRepositoryImpl.getGreenhouses` y `getGreenhouseDetail`),
+  ese flujo debe seguir intacto.
+- **NO** cambies la URL de la pestaña "Activas" (sigue siendo
+  `?isResolved=false&limit=100` o el `getUnresolvedAlerts` actual del
+  `GreenhouseApiService`).
+- **NO** añadas un `AlertResponse` con el mismo nombre en otro paquete — usa
+  un nombre distinto (`AlertDetailResponse` recomendado) para evitar
+  ambigüedad de imports.
+- **NO** desactives `isLenient`, `ignoreUnknownKeys`, ni `coerceInputValues`
+  en `di/DataModule.kt`. Esa configuración es la que permite que el cliente
+  tolere campos extra que el backend pueda añadir en el futuro.
+- **NO** asumas que el path `/api/v1/alerts/history/...` está en algún
+  documento OpenAPI local del repo cliente. **No lo está**. Confía en este
+  documento — el endpoint está vivo en dev y prod (verificable con la URL
+  pública).
+- **Comentarios técnicos en inglés**, copy de UI en español (regla del
+  CLAUDE.md del repo).
+- **NO** alucines nada. Si te falta un dato (un nombre de archivo, un
+  parámetro), pregúntale al usuario antes de inventar.
+
+## Verificación
+
+1. Build local:
+   ```bash
+   ./gradlew :composeApp:assembleDebug
+   ```
+   Sin warnings ni errores de Kotlin/serialization.
+
+2. Ejecutar la app contra DEV (`Environment.current = Environment.DEV`),
+   loguearse, ir a la pestaña "Histórico" del invernadero. Esperado:
+
+   - **Antes** (bug actual): `[]` → pantalla vacía aunque haya alertas activas.
+   - **Después** (con este fix): la lista contiene `ALT-00010` con badge
+     "Activa" (porque `isResolved=false`). Si en el futuro alguien resuelve
+     una alerta, también aparecerá con badge "Resuelta".
+
+3. Logcat / consola del cliente:
+   ```
+   HttpClient: REQUEST: https://inverapi-dev.apptolast.com/api/v1/alerts/history/tenant/<ID>?limit=100
+   HttpClient: RESPONSE: 200 OK
+   BODY: [{"id":..., "code":"ALT-00010", "isResolved":false, ...}]
+   ```
+   Una sola petición. Sin 404, sin 500.
+
+4. La pestaña **"Activas"** sigue mostrando lo mismo que antes (la misma
+   alerta `ALT-00010` con badge crítico).
+
+## Acceptance criteria
+
+- [ ] Existe un DTO con todos los campos del response (`AlertDetailResponse` o
+      el que el usuario ya tenga local).
+- [ ] Hay un método `getAlertsHistory(tenantId, limit)` en `GreenhouseApiService`
+      (o equivalente) que llama a `GET /alerts/history/tenant/{id}?limit=...`.
+- [ ] Hay un `AlertRepository` (o un método nuevo en el existente) que devuelve
+      `Result<List<AlertDetail>>`.
+- [ ] Hay un `AlertHistoryViewModel` registrado en Koin.
+- [ ] La pantalla "Histórico" consume el ViewModel y pinta la lista — no llama
+      directamente al API.
+- [ ] Pantalla "Activas" intacta.
+- [ ] `./gradlew :composeApp:assembleDebug` pasa.
+- [ ] Logcat muestra petición a `/alerts/history/tenant/{id}?limit=100` con
+      200 y body no vacío en DEV.
+- [ ] Yarn lock actualizado si añadiste deps (`./gradlew kotlinUpgradeYarnLock`
+      y `./gradlew kotlinWasmUpgradeYarnLock`).
+
+## Si encuentras algo distinto a lo descrito aquí
+
+Detente y reporta. No reescribas la arquitectura del repo. Este prompt asume:
+- MVVM + Repository (ya existente).
+- Koin DI (ya existente).
+- Ktor client autenticado (ya existente).
+- kotlinx.serialization con `ignoreUnknownKeys` (ya configurado).
+
+Si algo de eso ha cambiado, los snippets de arriba pueden no encajar 1:1 —
+consulta antes de adaptar.
+
+=== FIN PROMPT PARA CLAUDE CODE EN apptolast/GreenhouseFronts ===
+```
+
+---
+
+## Anexos para Pablo (no para Alberto)
+
+### A. Estado del backend (confirmado por mí)
+
+- Commit que añade el endpoint: `01e4b4d` en `develop`.
+- PR a main: https://github.com/apptolast/InvernaderosAPI/pull/107 (MERGED).
+- Imágenes Docker:
+  - `apptolast/invernaderos-api:develop` desplegado en
+    `apptolast-invernadero-api-dev/invernaderos-api` (1 réplica), health 200.
+  - `apptolast/invernaderos-api:latest` desplegado en
+    `apptolast-invernadero-api-prod/invernaderos-api` (2 réplicas), health 200.
+- Endpoint disponible en:
+  - https://inverapi-dev.apptolast.com/api/v1/alerts/history/tenant/{id}
+  - https://inverapi-prod.apptolast.com/api/v1/alerts/history/tenant/{id}
+- Sin filtro `isResolved` (incluye activas y resueltas).
+- Orden: `createdAt DESC`.
+- Default `limit = 100`.
+- Cero `LazyInitializationException` en logs tras rollout.
+
+### B. Patrones del repo `GreenhouseFronts` que cito en el prompt
+
+Verificados leyendo la rama `feature/alert-notifications` (HEAD `d81f181`):
+
+- `composeApp/src/commonMain/kotlin/com/apptolast/greenhousefronts/data/remote/api/GreenhouseApiService.kt`
+  — patrón Ktor: `httpClient.get("$baseUrl/path/$param").body()`.
+- `composeApp/src/commonMain/kotlin/com/apptolast/greenhousefronts/data/remote/KtorClient.kt`
+  — `baseUrl` y `createAuthenticatedHttpClient`.
+- `composeApp/src/commonMain/kotlin/com/apptolast/greenhousefronts/di/DataModule.kt`
+  — config JSON con `ignoreUnknownKeys = true`, registro Koin.
+- `composeApp/src/commonMain/kotlin/com/apptolast/greenhousefronts/di/PresentationModule.kt`
+  — `viewModelOf(...)`.
+- `composeApp/src/commonMain/kotlin/com/apptolast/greenhousefronts/data/repository/GreenhouseRepositoryImpl.kt`
+  — patrón `Result<T>` + tokenStorage para tenantId.
+- `CLAUDE.md` raíz — reglas "no inventar", build commands, yarn lock.
+
+### C. Cosas que NO he tocado y NO debe tocar Claude Code en el cliente
+
+- `GreenhouseApiService.getUnresolvedAlerts` — sigue usándose para contar
+  alertas en las cards.
+- `AlertResponse` recortado en `GreenhouseDtos.kt` — sigue siendo el DTO de
+  los counters.
+- Pestaña "Activas" — su URL sigue funcionando con el fix del 500 (PR #106).
+- `spring.jpa.open-in-view`, LAZY annotations, `@JsonIgnore`, `@NamedEntityGraph`
+  en backend — sin cambios.

--- a/openapi.json
+++ b/openapi.json
@@ -4772,6 +4772,50 @@
         }
       }
     },
+    "/api/v1/alerts/history/tenant/{tenantId}": {
+      "get": {
+        "tags": [
+          "alert-controller"
+        ],
+        "operationId": "getHistoryByTenant",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlertResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/alerts/count/unresolved/tenant/{tenantId}": {
       "get": {
         "tags": [

--- a/src/main/kotlin/com/apptolast/invernaderos/config/StompJwtAuthInterceptor.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/StompJwtAuthInterceptor.kt
@@ -1,0 +1,82 @@
+package com.apptolast.invernaderos.config
+
+import com.apptolast.invernaderos.core.security.JwtService
+import org.slf4j.LoggerFactory
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Component
+
+/**
+ * STOMP CONNECT interceptor that extracts a Bearer JWT from the native
+ * `Authorization` header, validates it with [JwtService], and attaches the
+ * authenticated user as the STOMP session [java.security.Principal].
+ *
+ * Once attached, [org.springframework.messaging.simp.SimpMessagingTemplate.convertAndSendToUser]
+ * can route messages to a specific username via `/user/{username}/queue/...`,
+ * which is required for the future server-side broadcast path.
+ *
+ * **Backwards-compatible by design**: if the CONNECT frame omits the header,
+ * brings a malformed/expired token, or the user lookup fails, the interceptor
+ * leaves the session principal unset. Spring then falls back to the
+ * sessionId-based anonymous principal, preserving today's behaviour for
+ * clients that do not yet send the JWT during STOMP handshake. The connection
+ * is **never** rejected here — auth failures degrade gracefully into "no
+ * targeted broadcasts for this session", which is exactly what we want for
+ * a no-downtime rollout.
+ *
+ * Errors during JWT parsing are absorbed and only logged at DEBUG; we do not
+ * want a malformed token to surface as a STOMP CONNECT failure for paying
+ * clients who will inevitably hit transient validation hiccups.
+ */
+@Component
+class StompJwtAuthInterceptor(
+    private val jwtService: JwtService,
+    private val userDetailsService: UserDetailsService
+) : ChannelInterceptor {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun preSend(message: Message<*>, channel: MessageChannel): Message<*> {
+        val accessor = StompHeaderAccessor.wrap(message)
+        if (accessor.command != StompCommand.CONNECT) return message
+
+        val authHeader = accessor.getFirstNativeHeader("Authorization")
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            logger.debug("STOMP CONNECT without Bearer token — anonymous session")
+            return message
+        }
+
+        val token = authHeader.substring("Bearer ".length).trim()
+        if (token.isEmpty()) {
+            logger.debug("STOMP CONNECT with empty Bearer token — anonymous session")
+            return message
+        }
+
+        try {
+            val username = jwtService.extractUsername(token)
+            val userDetails = userDetailsService.loadUserByUsername(username)
+            if (!jwtService.isTokenValid(token, userDetails)) {
+                logger.debug("STOMP CONNECT JWT failed validation for {} — anonymous session", username)
+                return message
+            }
+            val auth = UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.authorities
+            )
+            accessor.user = auth
+            logger.debug("STOMP CONNECT authenticated user={} sessionId={}", username, accessor.sessionId)
+        } catch (e: Exception) {
+            // Defensive: malformed/expired token, unknown user, etc. Never
+            // reject the CONNECT — fall through to anonymous so polling
+            // clients keep working during the rollout.
+            logger.debug("STOMP CONNECT JWT parsing failed: {} — anonymous session", e.message)
+        }
+        return message
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/config/WebSocketBroadcastAsyncConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/WebSocketBroadcastAsyncConfig.kt
@@ -1,0 +1,42 @@
+package com.apptolast.invernaderos.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.ThreadPoolExecutor
+
+/**
+ * Dedicated executor for WebSocket broadcast tasks. Kept isolated from any
+ * other `@Async` use case in the codebase so a stuck broadcast can't impact
+ * unrelated work — and vice versa.
+ *
+ * Sizing assumes the natural rate of 1 broadcast/s/tenant from the sensor
+ * flush plus rare CRUD/alert events. With small payloads and short
+ * `convertAndSendToUser` latencies (≤10 ms locally), 2–4 threads cover
+ * dozens of tenants comfortably.
+ *
+ * `DiscardOldestPolicy` is intentional: a snapshot is idempotent — the
+ * newest one always supersedes older ones. If pressure spikes momentarily
+ * the queue sheds the oldest pending task and keeps the most recent state
+ * flowing to clients. Combined with the queue capacity of 200 this gives a
+ * hard upper bound on memory while preserving correctness under load.
+ */
+@Configuration
+@EnableAsync
+class WebSocketBroadcastAsyncConfig {
+
+    @Bean(name = ["wsBroadcastExecutor"], destroyMethod = "shutdown")
+    fun wsBroadcastExecutor(): ThreadPoolTaskExecutor {
+        return ThreadPoolTaskExecutor().apply {
+            corePoolSize = 2
+            maxPoolSize = 4
+            queueCapacity = 200
+            setThreadNamePrefix("ws-broadcast-")
+            setRejectedExecutionHandler(ThreadPoolExecutor.DiscardOldestPolicy())
+            setWaitForTasksToCompleteOnShutdown(true)
+            setAwaitTerminationSeconds(30)
+            initialize()
+        }
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/WebSocketConfig.kt
@@ -2,6 +2,7 @@ package com.apptolast.invernaderos.config
 
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.ChannelRegistration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry
@@ -24,9 +25,20 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
  */
 @Configuration
 @EnableWebSocketMessageBroker
-class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+class WebSocketConfig(
+    private val stompJwtAuthInterceptor: StompJwtAuthInterceptor
+) : WebSocketMessageBrokerConfigurer {
 
     private val logger = LoggerFactory.getLogger(WebSocketConfig::class.java)
+
+    override fun configureClientInboundChannel(registration: ChannelRegistration) {
+        // Backwards-compatible JWT auth on STOMP CONNECT. See
+        // StompJwtAuthInterceptor for behaviour on missing/invalid tokens
+        // (sessions stay anonymous, never rejected) — required so that the
+        // upcoming server-side broadcast path can target users by username
+        // via convertAndSendToUser.
+        registration.interceptors(stompJwtAuthInterceptor)
+    }
 
     override fun configureMessageBroker(registry: MessageBrokerRegistry) {
         logger.info("Configurando Message Broker para WebSocket")

--- a/src/main/kotlin/com/apptolast/invernaderos/features/device/application/usecase/CreateDeviceUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/device/application/usecase/CreateDeviceUseCaseImpl.kt
@@ -8,12 +8,15 @@ import com.apptolast.invernaderos.features.device.domain.port.output.DeviceCodeG
 import com.apptolast.invernaderos.features.device.domain.port.output.DeviceRepositoryPort
 import com.apptolast.invernaderos.features.device.domain.port.output.SectorExistencePort
 import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 
 class CreateDeviceUseCaseImpl(
     private val repository: DeviceRepositoryPort,
     private val codeGenerator: DeviceCodeGenerator,
-    private val sectorExistence: SectorExistencePort
+    private val sectorExistence: SectorExistencePort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : CreateDeviceUseCase {
 
     override fun execute(command: CreateDeviceCommand): Either<DeviceError, Device> {
@@ -41,6 +44,10 @@ class CreateDeviceUseCaseImpl(
             updatedAt = now
         )
 
-        return Either.Right(repository.save(device))
+        val saved = repository.save(device)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.DEVICE_CRUD)
+        )
+        return Either.Right(saved)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/device/application/usecase/DeleteDeviceUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/device/application/usecase/DeleteDeviceUseCaseImpl.kt
@@ -6,9 +6,12 @@ import com.apptolast.invernaderos.features.device.domain.port.output.DeviceRepos
 import com.apptolast.invernaderos.features.shared.domain.Either
 import com.apptolast.invernaderos.features.shared.domain.model.DeviceId
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 
 class DeleteDeviceUseCaseImpl(
-    private val repository: DeviceRepositoryPort
+    private val repository: DeviceRepositoryPort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : DeleteDeviceUseCase {
 
     override fun execute(id: DeviceId, tenantId: TenantId): Either<DeviceError, Unit> {
@@ -16,6 +19,9 @@ class DeleteDeviceUseCaseImpl(
             return Either.Left(DeviceError.NotFound(id, tenantId))
         }
         repository.delete(id, tenantId)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(tenantId.value, TenantStatusChangedEvent.Source.DEVICE_CRUD)
+        )
         return Either.Right(Unit)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/device/application/usecase/UpdateDeviceUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/device/application/usecase/UpdateDeviceUseCaseImpl.kt
@@ -7,11 +7,14 @@ import com.apptolast.invernaderos.features.device.domain.port.input.UpdateDevice
 import com.apptolast.invernaderos.features.device.domain.port.output.DeviceRepositoryPort
 import com.apptolast.invernaderos.features.device.domain.port.output.SectorExistencePort
 import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 
 class UpdateDeviceUseCaseImpl(
     private val repository: DeviceRepositoryPort,
-    private val sectorExistence: SectorExistencePort
+    private val sectorExistence: SectorExistencePort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : UpdateDeviceUseCase {
 
     override fun execute(command: UpdateDeviceCommand): Either<DeviceError, Device> {
@@ -37,6 +40,10 @@ class UpdateDeviceUseCaseImpl(
             updatedAt = Instant.now()
         )
 
-        return Either.Right(repository.save(updated))
+        val saved = repository.save(updated)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.DEVICE_CRUD)
+        )
+        return Either.Right(saved)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/device/infrastructure/config/DeviceModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/device/infrastructure/config/DeviceModuleConfig.kt
@@ -14,6 +14,7 @@ import com.apptolast.invernaderos.features.device.domain.port.output.CommandHist
 import com.apptolast.invernaderos.features.device.domain.port.output.DeviceCodeGenerator
 import com.apptolast.invernaderos.features.device.domain.port.output.DeviceRepositoryPort
 import com.apptolast.invernaderos.features.device.domain.port.output.SectorExistencePort
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -24,8 +25,9 @@ class DeviceModuleConfig {
     fun createDeviceUseCase(
         repository: DeviceRepositoryPort,
         codeGenerator: DeviceCodeGenerator,
-        sectorExistence: SectorExistencePort
-    ): CreateDeviceUseCase = CreateDeviceUseCaseImpl(repository, codeGenerator, sectorExistence)
+        sectorExistence: SectorExistencePort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): CreateDeviceUseCase = CreateDeviceUseCaseImpl(repository, codeGenerator, sectorExistence, applicationEventPublisher)
 
     @Bean
     fun findDeviceUseCase(
@@ -35,13 +37,15 @@ class DeviceModuleConfig {
     @Bean
     fun updateDeviceUseCase(
         repository: DeviceRepositoryPort,
-        sectorExistence: SectorExistencePort
-    ): UpdateDeviceUseCase = UpdateDeviceUseCaseImpl(repository, sectorExistence)
+        sectorExistence: SectorExistencePort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): UpdateDeviceUseCase = UpdateDeviceUseCaseImpl(repository, sectorExistence, applicationEventPublisher)
 
     @Bean
     fun deleteDeviceUseCase(
-        repository: DeviceRepositoryPort
-    ): DeleteDeviceUseCase = DeleteDeviceUseCaseImpl(repository)
+        repository: DeviceRepositoryPort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): DeleteDeviceUseCase = DeleteDeviceUseCaseImpl(repository, applicationEventPublisher)
 
     @Bean
     fun findCommandHistoryUseCase(

--- a/src/main/kotlin/com/apptolast/invernaderos/features/greenhouse/application/usecase/CreateGreenhouseUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/greenhouse/application/usecase/CreateGreenhouseUseCaseImpl.kt
@@ -7,11 +7,14 @@ import com.apptolast.invernaderos.features.greenhouse.domain.port.input.CreateGr
 import com.apptolast.invernaderos.features.greenhouse.domain.port.output.GreenhouseCodeGenerator
 import com.apptolast.invernaderos.features.greenhouse.domain.port.output.GreenhouseRepositoryPort
 import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 
 class CreateGreenhouseUseCaseImpl(
     private val repository: GreenhouseRepositoryPort,
-    private val codeGenerator: GreenhouseCodeGenerator
+    private val codeGenerator: GreenhouseCodeGenerator,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : CreateGreenhouseUseCase {
 
     override fun execute(command: CreateGreenhouseCommand): Either<GreenhouseError, Greenhouse> {
@@ -33,6 +36,10 @@ class CreateGreenhouseUseCaseImpl(
             updatedAt = now
         )
 
-        return Either.Right(repository.save(greenhouse))
+        val saved = repository.save(greenhouse)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.GREENHOUSE_CRUD)
+        )
+        return Either.Right(saved)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/greenhouse/application/usecase/DeleteGreenhouseUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/greenhouse/application/usecase/DeleteGreenhouseUseCaseImpl.kt
@@ -6,9 +6,12 @@ import com.apptolast.invernaderos.features.greenhouse.domain.port.input.DeleteGr
 import com.apptolast.invernaderos.features.greenhouse.domain.port.output.GreenhouseRepositoryPort
 import com.apptolast.invernaderos.features.shared.domain.Either
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 
 class DeleteGreenhouseUseCaseImpl(
-    private val repository: GreenhouseRepositoryPort
+    private val repository: GreenhouseRepositoryPort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : DeleteGreenhouseUseCase {
 
     override fun execute(id: GreenhouseId, tenantId: TenantId): Either<GreenhouseError, Unit> {
@@ -16,6 +19,9 @@ class DeleteGreenhouseUseCaseImpl(
             return Either.Left(GreenhouseError.NotFound(id, tenantId))
         }
         repository.delete(id, tenantId)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(tenantId.value, TenantStatusChangedEvent.Source.GREENHOUSE_CRUD)
+        )
         return Either.Right(Unit)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/greenhouse/application/usecase/UpdateGreenhouseUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/greenhouse/application/usecase/UpdateGreenhouseUseCaseImpl.kt
@@ -6,10 +6,13 @@ import com.apptolast.invernaderos.features.greenhouse.domain.port.input.UpdateGr
 import com.apptolast.invernaderos.features.greenhouse.domain.port.input.UpdateGreenhouseUseCase
 import com.apptolast.invernaderos.features.greenhouse.domain.port.output.GreenhouseRepositoryPort
 import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 
 class UpdateGreenhouseUseCaseImpl(
-    private val repository: GreenhouseRepositoryPort
+    private val repository: GreenhouseRepositoryPort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : UpdateGreenhouseUseCase {
 
     override fun execute(command: UpdateGreenhouseCommand): Either<GreenhouseError, Greenhouse> {
@@ -32,6 +35,10 @@ class UpdateGreenhouseUseCaseImpl(
             updatedAt = Instant.now()
         )
 
-        return Either.Right(repository.save(updated))
+        val saved = repository.save(updated)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.GREENHOUSE_CRUD)
+        )
+        return Either.Right(saved)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/greenhouse/infrastructure/config/GreenhouseModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/greenhouse/infrastructure/config/GreenhouseModuleConfig.kt
@@ -10,6 +10,7 @@ import com.apptolast.invernaderos.features.greenhouse.domain.port.input.FindGree
 import com.apptolast.invernaderos.features.greenhouse.domain.port.input.UpdateGreenhouseUseCase
 import com.apptolast.invernaderos.features.greenhouse.domain.port.output.GreenhouseCodeGenerator
 import com.apptolast.invernaderos.features.greenhouse.domain.port.output.GreenhouseRepositoryPort
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -19,8 +20,9 @@ class GreenhouseModuleConfig {
     @Bean
     fun createGreenhouseUseCase(
         repository: GreenhouseRepositoryPort,
-        codeGenerator: GreenhouseCodeGenerator
-    ): CreateGreenhouseUseCase = CreateGreenhouseUseCaseImpl(repository, codeGenerator)
+        codeGenerator: GreenhouseCodeGenerator,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): CreateGreenhouseUseCase = CreateGreenhouseUseCaseImpl(repository, codeGenerator, applicationEventPublisher)
 
     @Bean
     fun findGreenhouseUseCase(
@@ -29,11 +31,13 @@ class GreenhouseModuleConfig {
 
     @Bean
     fun updateGreenhouseUseCase(
-        repository: GreenhouseRepositoryPort
-    ): UpdateGreenhouseUseCase = UpdateGreenhouseUseCaseImpl(repository)
+        repository: GreenhouseRepositoryPort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): UpdateGreenhouseUseCase = UpdateGreenhouseUseCaseImpl(repository, applicationEventPublisher)
 
     @Bean
     fun deleteGreenhouseUseCase(
-        repository: GreenhouseRepositoryPort
-    ): DeleteGreenhouseUseCase = DeleteGreenhouseUseCaseImpl(repository)
+        repository: GreenhouseRepositoryPort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): DeleteGreenhouseUseCase = DeleteGreenhouseUseCaseImpl(repository, applicationEventPublisher)
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/sector/application/usecase/CreateSectorUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/sector/application/usecase/CreateSectorUseCaseImpl.kt
@@ -8,11 +8,14 @@ import com.apptolast.invernaderos.features.sector.domain.port.output.GreenhouseE
 import com.apptolast.invernaderos.features.sector.domain.port.output.SectorCodeGenerator
 import com.apptolast.invernaderos.features.sector.domain.port.output.SectorRepositoryPort
 import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 
 class CreateSectorUseCaseImpl(
     private val repository: SectorRepositoryPort,
     private val codeGenerator: SectorCodeGenerator,
-    private val greenhouseExistence: GreenhouseExistencePort
+    private val greenhouseExistence: GreenhouseExistencePort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : CreateSectorUseCase {
 
     override fun execute(command: CreateSectorCommand): Either<SectorError, Sector> {
@@ -29,6 +32,10 @@ class CreateSectorUseCaseImpl(
             name = command.name
         )
 
-        return Either.Right(repository.save(sector))
+        val saved = repository.save(sector)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.SECTOR_CRUD)
+        )
+        return Either.Right(saved)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/sector/application/usecase/DeleteSectorUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/sector/application/usecase/DeleteSectorUseCaseImpl.kt
@@ -6,9 +6,12 @@ import com.apptolast.invernaderos.features.sector.domain.port.output.SectorRepos
 import com.apptolast.invernaderos.features.shared.domain.Either
 import com.apptolast.invernaderos.features.shared.domain.model.SectorId
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 
 class DeleteSectorUseCaseImpl(
-    private val repository: SectorRepositoryPort
+    private val repository: SectorRepositoryPort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : DeleteSectorUseCase {
 
     override fun execute(id: SectorId, tenantId: TenantId): Either<SectorError, Unit> {
@@ -16,6 +19,9 @@ class DeleteSectorUseCaseImpl(
             return Either.Left(SectorError.NotFound(id, tenantId))
         }
         repository.delete(id, tenantId)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(tenantId.value, TenantStatusChangedEvent.Source.SECTOR_CRUD)
+        )
         return Either.Right(Unit)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/sector/application/usecase/UpdateSectorUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/sector/application/usecase/UpdateSectorUseCaseImpl.kt
@@ -7,10 +7,13 @@ import com.apptolast.invernaderos.features.sector.domain.port.input.UpdateSector
 import com.apptolast.invernaderos.features.sector.domain.port.output.GreenhouseExistencePort
 import com.apptolast.invernaderos.features.sector.domain.port.output.SectorRepositoryPort
 import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 
 class UpdateSectorUseCaseImpl(
     private val repository: SectorRepositoryPort,
-    private val greenhouseExistence: GreenhouseExistencePort
+    private val greenhouseExistence: GreenhouseExistencePort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : UpdateSectorUseCase {
 
     override fun execute(command: UpdateSectorCommand): Either<SectorError, Sector> {
@@ -30,6 +33,10 @@ class UpdateSectorUseCaseImpl(
             name = command.name ?: existing.name
         )
 
-        return Either.Right(repository.save(updated))
+        val saved = repository.save(updated)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.SECTOR_CRUD)
+        )
+        return Either.Right(saved)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/sector/infrastructure/config/SectorModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/sector/infrastructure/config/SectorModuleConfig.kt
@@ -11,6 +11,7 @@ import com.apptolast.invernaderos.features.sector.domain.port.input.UpdateSector
 import com.apptolast.invernaderos.features.sector.domain.port.output.GreenhouseExistencePort
 import com.apptolast.invernaderos.features.sector.domain.port.output.SectorCodeGenerator
 import com.apptolast.invernaderos.features.sector.domain.port.output.SectorRepositoryPort
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -21,8 +22,9 @@ class SectorModuleConfig {
     fun createSectorUseCase(
         repository: SectorRepositoryPort,
         codeGenerator: SectorCodeGenerator,
-        greenhouseExistence: GreenhouseExistencePort
-    ): CreateSectorUseCase = CreateSectorUseCaseImpl(repository, codeGenerator, greenhouseExistence)
+        greenhouseExistence: GreenhouseExistencePort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): CreateSectorUseCase = CreateSectorUseCaseImpl(repository, codeGenerator, greenhouseExistence, applicationEventPublisher)
 
     @Bean
     fun findSectorUseCase(
@@ -32,11 +34,13 @@ class SectorModuleConfig {
     @Bean
     fun updateSectorUseCase(
         repository: SectorRepositoryPort,
-        greenhouseExistence: GreenhouseExistencePort
-    ): UpdateSectorUseCase = UpdateSectorUseCaseImpl(repository, greenhouseExistence)
+        greenhouseExistence: GreenhouseExistencePort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): UpdateSectorUseCase = UpdateSectorUseCaseImpl(repository, greenhouseExistence, applicationEventPublisher)
 
     @Bean
     fun deleteSectorUseCase(
-        repository: SectorRepositoryPort
-    ): DeleteSectorUseCase = DeleteSectorUseCaseImpl(repository)
+        repository: SectorRepositoryPort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): DeleteSectorUseCase = DeleteSectorUseCaseImpl(repository, applicationEventPublisher)
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/setting/application/usecase/CreateSettingUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/setting/application/usecase/CreateSettingUseCaseImpl.kt
@@ -8,12 +8,15 @@ import com.apptolast.invernaderos.features.setting.domain.port.output.SettingCod
 import com.apptolast.invernaderos.features.setting.domain.port.output.SettingRepositoryPort
 import com.apptolast.invernaderos.features.setting.domain.port.output.SettingSectorValidationPort
 import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 
 class CreateSettingUseCaseImpl(
     private val repository: SettingRepositoryPort,
     private val codeGenerator: SettingCodeGenerator,
-    private val sectorValidation: SettingSectorValidationPort
+    private val sectorValidation: SettingSectorValidationPort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : CreateSettingUseCase {
 
     override fun execute(command: CreateSettingCommand): Either<SettingError, Setting> {
@@ -41,6 +44,10 @@ class CreateSettingUseCaseImpl(
             updatedAt = now
         )
 
-        return Either.Right(repository.save(setting))
+        val saved = repository.save(setting)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.SETTING_CRUD)
+        )
+        return Either.Right(saved)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/setting/application/usecase/DeleteSettingUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/setting/application/usecase/DeleteSettingUseCaseImpl.kt
@@ -6,9 +6,12 @@ import com.apptolast.invernaderos.features.setting.domain.port.output.SettingRep
 import com.apptolast.invernaderos.features.shared.domain.Either
 import com.apptolast.invernaderos.features.shared.domain.model.SettingId
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 
 class DeleteSettingUseCaseImpl(
-    private val repository: SettingRepositoryPort
+    private val repository: SettingRepositoryPort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : DeleteSettingUseCase {
 
     override fun execute(id: SettingId, tenantId: TenantId): Either<SettingError, Unit> {
@@ -16,6 +19,9 @@ class DeleteSettingUseCaseImpl(
             return Either.Left(SettingError.NotFound(id, tenantId))
         }
         repository.delete(id, tenantId)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(tenantId.value, TenantStatusChangedEvent.Source.SETTING_CRUD)
+        )
         return Either.Right(Unit)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/setting/application/usecase/UpdateSettingUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/setting/application/usecase/UpdateSettingUseCaseImpl.kt
@@ -7,11 +7,14 @@ import com.apptolast.invernaderos.features.setting.domain.port.input.UpdateSetti
 import com.apptolast.invernaderos.features.setting.domain.port.output.SettingRepositoryPort
 import com.apptolast.invernaderos.features.setting.domain.port.output.SettingSectorValidationPort
 import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 
 class UpdateSettingUseCaseImpl(
     private val repository: SettingRepositoryPort,
-    private val sectorValidation: SettingSectorValidationPort
+    private val sectorValidation: SettingSectorValidationPort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : UpdateSettingUseCase {
 
     override fun execute(command: UpdateSettingCommand): Either<SettingError, Setting> {
@@ -37,6 +40,10 @@ class UpdateSettingUseCaseImpl(
             updatedAt = Instant.now()
         )
 
-        return Either.Right(repository.save(updated))
+        val saved = repository.save(updated)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.SETTING_CRUD)
+        )
+        return Either.Right(saved)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/setting/infrastructure/config/SettingModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/setting/infrastructure/config/SettingModuleConfig.kt
@@ -11,6 +11,7 @@ import com.apptolast.invernaderos.features.setting.domain.port.input.UpdateSetti
 import com.apptolast.invernaderos.features.setting.domain.port.output.SettingCodeGenerator
 import com.apptolast.invernaderos.features.setting.domain.port.output.SettingRepositoryPort
 import com.apptolast.invernaderos.features.setting.domain.port.output.SettingSectorValidationPort
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -21,8 +22,9 @@ class SettingModuleConfig {
     fun createSettingUseCase(
         repository: SettingRepositoryPort,
         codeGenerator: SettingCodeGenerator,
-        sectorValidation: SettingSectorValidationPort
-    ): CreateSettingUseCase = CreateSettingUseCaseImpl(repository, codeGenerator, sectorValidation)
+        sectorValidation: SettingSectorValidationPort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): CreateSettingUseCase = CreateSettingUseCaseImpl(repository, codeGenerator, sectorValidation, applicationEventPublisher)
 
     @Bean
     fun findSettingUseCase(
@@ -32,11 +34,13 @@ class SettingModuleConfig {
     @Bean
     fun updateSettingUseCase(
         repository: SettingRepositoryPort,
-        sectorValidation: SettingSectorValidationPort
-    ): UpdateSettingUseCase = UpdateSettingUseCaseImpl(repository, sectorValidation)
+        sectorValidation: SettingSectorValidationPort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): UpdateSettingUseCase = UpdateSettingUseCaseImpl(repository, sectorValidation, applicationEventPublisher)
 
     @Bean
     fun deleteSettingUseCase(
-        repository: SettingRepositoryPort
-    ): DeleteSettingUseCase = DeleteSettingUseCaseImpl(repository)
+        repository: SettingRepositoryPort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): DeleteSettingUseCase = DeleteSettingUseCaseImpl(repository, applicationEventPublisher)
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/user/UserRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/user/UserRepository.kt
@@ -9,6 +9,7 @@ interface UserRepository : JpaRepository<User, Long> {
     @EntityGraph(value = "User.tenant") fun findByUsername(username: String): User?
     @EntityGraph(value = "User.tenant") fun findByEmail(email: String): User?
     @EntityGraph(value = "User.tenant") fun findByTenantId(tenantId: Long): List<User>
+    @EntityGraph(value = "User.tenant") fun findByTenantIdAndIsActiveTrue(tenantId: Long): List<User>
     @EntityGraph(value = "User.tenant") fun findByIdAndTenantId(id: Long, tenantId: Long): User?
     fun existsByUsername(username: String): Boolean
     fun existsByEmail(email: String): Boolean

--- a/src/main/kotlin/com/apptolast/invernaderos/features/user/application/usecase/CreateUserUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/user/application/usecase/CreateUserUseCaseImpl.kt
@@ -9,12 +9,15 @@ import com.apptolast.invernaderos.features.user.domain.port.input.CreateUserUseC
 import com.apptolast.invernaderos.features.user.domain.port.output.PasswordHasher
 import com.apptolast.invernaderos.features.user.domain.port.output.UserCodeGenerator
 import com.apptolast.invernaderos.features.user.domain.port.output.UserRepositoryPort
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 
 class CreateUserUseCaseImpl(
     private val repository: UserRepositoryPort,
     private val codeGenerator: UserCodeGenerator,
-    private val passwordHasher: PasswordHasher
+    private val passwordHasher: PasswordHasher,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : CreateUserUseCase {
 
     override fun execute(command: CreateUserCommand): Either<UserError, User> {
@@ -44,7 +47,11 @@ class CreateUserUseCaseImpl(
             updatedAt = now
         )
 
-        return Either.Right(repository.save(user, passwordHash))
+        val saved = repository.save(user, passwordHash)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.USER_CRUD)
+        )
+        return Either.Right(saved)
     }
 
     private fun parseRole(role: String): UserRole? =

--- a/src/main/kotlin/com/apptolast/invernaderos/features/user/application/usecase/DeleteUserUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/user/application/usecase/DeleteUserUseCaseImpl.kt
@@ -5,9 +5,12 @@ import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import com.apptolast.invernaderos.features.user.domain.error.UserError
 import com.apptolast.invernaderos.features.user.domain.port.input.DeleteUserUseCase
 import com.apptolast.invernaderos.features.user.domain.port.output.UserRepositoryPort
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 
 class DeleteUserUseCaseImpl(
-    private val repository: UserRepositoryPort
+    private val repository: UserRepositoryPort,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : DeleteUserUseCase {
 
     override fun execute(id: Long, tenantId: TenantId): Either<UserError, Unit> {
@@ -15,6 +18,9 @@ class DeleteUserUseCaseImpl(
             ?: return Either.Left(UserError.NotFound(id, tenantId))
 
         repository.delete(exists.id!!, tenantId)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(tenantId.value, TenantStatusChangedEvent.Source.USER_CRUD)
+        )
         return Either.Right(Unit)
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/user/application/usecase/UpdateUserUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/user/application/usecase/UpdateUserUseCaseImpl.kt
@@ -8,11 +8,14 @@ import com.apptolast.invernaderos.features.user.domain.port.input.UpdateUserComm
 import com.apptolast.invernaderos.features.user.domain.port.input.UpdateUserUseCase
 import com.apptolast.invernaderos.features.user.domain.port.output.PasswordHasher
 import com.apptolast.invernaderos.features.user.domain.port.output.UserRepositoryPort
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 
 class UpdateUserUseCaseImpl(
     private val repository: UserRepositoryPort,
-    private val passwordHasher: PasswordHasher
+    private val passwordHasher: PasswordHasher,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : UpdateUserUseCase {
 
     override fun execute(command: UpdateUserCommand): Either<UserError, User> {
@@ -44,7 +47,11 @@ class UpdateUserUseCaseImpl(
         )
 
         val newPasswordHash = command.passwordRaw?.let { passwordHasher.hash(it) }
-        return Either.Right(repository.save(updatedUser, newPasswordHash))
+        val saved = repository.save(updatedUser, newPasswordHash)
+        applicationEventPublisher.publishEvent(
+            TenantStatusChangedEvent(command.tenantId.value, TenantStatusChangedEvent.Source.USER_CRUD)
+        )
+        return Either.Right(saved)
     }
 
     private fun parseRole(role: String): UserRole? =

--- a/src/main/kotlin/com/apptolast/invernaderos/features/user/infrastructure/config/UserModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/user/infrastructure/config/UserModuleConfig.kt
@@ -11,6 +11,7 @@ import com.apptolast.invernaderos.features.user.domain.port.input.UpdateUserUseC
 import com.apptolast.invernaderos.features.user.domain.port.output.PasswordHasher
 import com.apptolast.invernaderos.features.user.domain.port.output.UserCodeGenerator
 import com.apptolast.invernaderos.features.user.domain.port.output.UserRepositoryPort
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -21,8 +22,9 @@ class UserModuleConfig {
     fun createUserUseCase(
         repository: UserRepositoryPort,
         codeGenerator: UserCodeGenerator,
-        passwordHasher: PasswordHasher
-    ): CreateUserUseCase = CreateUserUseCaseImpl(repository, codeGenerator, passwordHasher)
+        passwordHasher: PasswordHasher,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): CreateUserUseCase = CreateUserUseCaseImpl(repository, codeGenerator, passwordHasher, applicationEventPublisher)
 
     @Bean
     fun findUserUseCase(
@@ -32,11 +34,13 @@ class UserModuleConfig {
     @Bean
     fun updateUserUseCase(
         repository: UserRepositoryPort,
-        passwordHasher: PasswordHasher
-    ): UpdateUserUseCase = UpdateUserUseCaseImpl(repository, passwordHasher)
+        passwordHasher: PasswordHasher,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): UpdateUserUseCase = UpdateUserUseCaseImpl(repository, passwordHasher, applicationEventPublisher)
 
     @Bean
     fun deleteUserUseCase(
-        repository: UserRepositoryPort
-    ): DeleteUserUseCase = DeleteUserUseCaseImpl(repository)
+        repository: UserRepositoryPort,
+        applicationEventPublisher: ApplicationEventPublisher
+    ): DeleteUserUseCase = DeleteUserUseCaseImpl(repository, applicationEventPublisher)
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssembler.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusAssembler.kt
@@ -52,49 +52,88 @@ class GreenhouseStatusAssembler(
     fun assembleFullStatus(): GreenhouseStatusResponse {
         val startTime = System.currentTimeMillis()
 
-        // 1. Obtener ultimos valores de device_current_values (tabla tiny, sin DISTINCT ON)
-        val latestReadings = deviceCurrentValueRepository.findAll()
-        val readingsMap = latestReadings.associateBy { it.code }
+        val readingsMap = loadReadingsMap()
 
-        logger.debug("Loaded {} current values from device_current_values", latestReadings.size)
-
-        // 2. Cargar todos los tenants activos
+        // Cargar todos los tenants activos y ensamblar cada rama
         val tenants = tenantRepository.findByIsActive(true)
-
-        // 3. Ensamblar la jerarquia para cada tenant
-        val tenantResponses = tenants.map { tenant ->
-            val tenantId = tenant.id!!
-
-            // Cargar usuarios del tenant
-            val users = userRepository.findByTenantId(tenantId)
-
-            // Cargar greenhouses del tenant
-            val greenhouses = greenhouseRepository.findByTenantId(tenantId)
-
-            // Para cada greenhouse, cargar sectores y sus hijos
-            val greenhouseResponses = greenhouses.map { greenhouse ->
-                val sectors = sectorRepository.findByGreenhouseId(greenhouse.id!!)
-
-                val sectorResponses = sectors.map { sector ->
-                    assembleSector(sector, readingsMap)
-                }
-
-                greenhouse.toResponse(sectors = sectorResponses)
-            }
-
-            tenant.toResponse(
-                users = users.map { it.toResponse() },
-                greenhouses = greenhouseResponses
-            )
-        }
+        val tenantResponses = tenants.map { tenant -> assembleTenantBranch(tenant, readingsMap) }
 
         val duration = System.currentTimeMillis() - startTime
         logger.info("Assembled full status: {} tenants, {} readings in {}ms",
-            tenantResponses.size, latestReadings.size, duration)
+            tenantResponses.size, readingsMap.size, duration)
 
         return GreenhouseStatusResponse(
             timestamp = Instant.now(),
             tenants = tenantResponses
+        )
+    }
+
+    /**
+     * Snapshot enriquecido de un único tenant. Mantiene el mismo envelope
+     * `GreenhouseStatusResponse` que `assembleFullStatus()` (con `tenants`
+     * conteniendo un solo elemento) para que los clientes no tengan que
+     * cambiar el contrato — solo cambia la ruta de invocación.
+     *
+     * Pensado para el broadcast push tras un cambio que afecta sólo a un
+     * tenant (sensor flush, alert state change, CRUD admin); evita el coste
+     * de re-ensamblar todos los tenants cuando solo uno ha cambiado.
+     *
+     * Devuelve un envelope con `tenants = []` cuando el tenant no existe o
+     * está inactivo, por idempotencia frente al broadcast: el listener no
+     * tiene que conocer la regla de "tenants activos" para decidir si publica.
+     */
+    @Transactional("metadataTransactionManager", readOnly = true)
+    fun assembleStatusForTenant(tenantId: Long): GreenhouseStatusResponse {
+        val startTime = System.currentTimeMillis()
+
+        val tenant = tenantRepository.findById(tenantId).orElse(null)
+        val readingsMap = loadReadingsMap()
+
+        val tenantResponses = if (tenant == null || tenant.isActive != true) {
+            emptyList()
+        } else {
+            listOf(assembleTenantBranch(tenant, readingsMap))
+        }
+
+        val duration = System.currentTimeMillis() - startTime
+        logger.debug("Assembled tenant status: tenantId={} hits={} readings={} in {}ms",
+            tenantId, tenantResponses.size, readingsMap.size, duration)
+
+        return GreenhouseStatusResponse(
+            timestamp = Instant.now(),
+            tenants = tenantResponses
+        )
+    }
+
+    /** Carga la tabla `device_current_values` y devuelve un mapa code → row. */
+    private fun loadReadingsMap(): Map<String, DeviceCurrentValue> {
+        val latestReadings = deviceCurrentValueRepository.findAll()
+        logger.debug("Loaded {} current values from device_current_values", latestReadings.size)
+        return latestReadings.associateBy { it.code }
+    }
+
+    /**
+     * Ensambla la rama completa de un tenant: usuarios, invernaderos,
+     * sectores y sus children (devices, settings, alerts) con `currentValue`
+     * embebido cuando lo hay.
+     */
+    private fun assembleTenantBranch(
+        tenant: com.apptolast.invernaderos.features.tenant.Tenant,
+        readingsMap: Map<String, DeviceCurrentValue>
+    ): com.apptolast.invernaderos.features.websocket.dto.TenantResponse {
+        val tenantId = tenant.id!!
+        val users = userRepository.findByTenantId(tenantId)
+        val greenhouses = greenhouseRepository.findByTenantId(tenantId)
+
+        val greenhouseResponses = greenhouses.map { greenhouse ->
+            val sectors = sectorRepository.findByGreenhouseId(greenhouse.id!!)
+            val sectorResponses = sectors.map { sector -> assembleSector(sector, readingsMap) }
+            greenhouse.toResponse(sectors = sectorResponses)
+        }
+
+        return tenant.toResponse(
+            users = users.map { it.toResponse() },
+            greenhouses = greenhouseResponses
         )
     }
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/TenantStatusBroadcastListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/TenantStatusBroadcastListener.kt
@@ -1,0 +1,85 @@
+package com.apptolast.invernaderos.features.websocket.broadcast
+
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.output.AlertStateChangedEvent
+import com.apptolast.invernaderos.features.websocket.event.DeviceCurrentValuesFlushedEvent
+import com.apptolast.invernaderos.features.websocket.event.TenantStatusChangedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * Single fan-in listener for every event that should produce a per-tenant
+ * WebSocket push. Today there are three sources:
+ *
+ *  1. [DeviceCurrentValuesFlushedEvent] — emitted by `DeviceStatusProcessor`
+ *     after the Timescale flush commits a batch of `device_current_values`
+ *     upserts. Carries the set of tenant ids whose state changed.
+ *  2. [AlertStateChangedEvent] — already published by the alert use cases.
+ *     We add this listener alongside the existing
+ *     [com.apptolast.invernaderos.features.push.infrastructure.adapter.output.AlertActivationPushListener]
+ *     (which handles FCM). Spring delivers the event to both — they have
+ *     unrelated responsibilities.
+ *  3. [TenantStatusChangedEvent] — emitted by CRUD use cases (greenhouses,
+ *     sectors, devices, settings, users) when admin-side mutations change
+ *     the tenant's catalog.
+ *
+ * **AFTER_COMMIT** for events tied to a database transaction: avoids
+ * publishing a snapshot the database will roll back. The
+ * [AlertStateChangedEvent] listener is also AFTER_COMMIT because the
+ * publisher (`AlertStateChangedEventPublisherAdapter`) sits inside the
+ * use case's `@Transactional`.
+ *
+ * **No coalescing** is implemented here. The natural rate from the sensor
+ * flush is ≤1 event/s/tenant, CRUD/alert events are rare. The downstream
+ * `wsBroadcastExecutor` queue with `DiscardOldestPolicy` shields against
+ * unforeseen bursts — the *newest* snapshot always wins.
+ */
+@Component
+class TenantStatusBroadcastListener(
+    private val wsBroadcaster: WsBroadcaster
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    fun onDeviceCurrentValuesFlushed(event: DeviceCurrentValuesFlushedEvent) {
+        if (event.tenantIds.isEmpty()) return
+        logger.debug("DeviceCurrentValuesFlushedEvent received for {} tenants", event.tenantIds.size)
+        event.tenantIds.forEach { tenantId ->
+            try {
+                wsBroadcaster.broadcastTenantStatus(tenantId)
+            } catch (e: Exception) {
+                // Async submit can fail under extreme pressure
+                // (DiscardOldestPolicy never throws here, but defensive in
+                // case the executor is shutting down).
+                logger.warn("Failed to enqueue WS broadcast for tenantId={}: {}",
+                    tenantId, e.message)
+            }
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    fun onAlertStateChanged(event: AlertStateChangedEvent) {
+        val tenantId = event.alert.tenantId.value
+        logger.debug("AlertStateChangedEvent → broadcast tenantId={} alertCode={} toResolved={}",
+            tenantId, event.alert.code, event.change.toResolved)
+        try {
+            wsBroadcaster.broadcastTenantStatus(tenantId)
+        } catch (e: Exception) {
+            logger.warn("Failed to enqueue WS broadcast for tenantId={}: {}", tenantId, e.message)
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    fun onTenantStatusChanged(event: TenantStatusChangedEvent) {
+        logger.debug("TenantStatusChangedEvent received: tenantId={} source={}",
+            event.tenantId, event.source)
+        try {
+            wsBroadcaster.broadcastTenantStatus(event.tenantId)
+        } catch (e: Exception) {
+            logger.warn("Failed to enqueue WS broadcast for tenantId={}: {}",
+                event.tenantId, e.message)
+        }
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsBroadcaster.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsBroadcaster.kt
@@ -1,0 +1,138 @@
+package com.apptolast.invernaderos.features.websocket.broadcast
+
+import com.apptolast.invernaderos.features.user.UserRepository
+import com.apptolast.invernaderos.features.websocket.GreenhouseStatusAssembler
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.messaging.simp.user.SimpUserRegistry
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+/**
+ * Routes a fresh per-tenant snapshot to every active user of the tenant
+ * across the cluster. Two entry points:
+ *
+ *  - [broadcastTenantStatus]: invoked by `@TransactionalEventListener
+ *    (AFTER_COMMIT)`. Delivers locally **and** republishes via Redis pub/sub
+ *    so other pods deliver to their own connected sessions. Async on the
+ *    [wsBroadcastExecutor] so a slow `convertAndSendToUser` never blocks
+ *    the listener thread.
+ *  - [deliverLocallyOnly]: invoked by `WsRedisListener` after receiving
+ *    a Redis pub/sub message. Skips the Redis hop on purpose to avoid an
+ *    infinite loop. Also async (every pod handles its own users in parallel).
+ *
+ * **No-op fast path**: when `findByTenantIdAndIsActiveTrue` ∩
+ * `simpUserRegistry.users` is empty (no active user of this tenant has a
+ * STOMP session on this pod) the method returns without re-assembling the
+ * snapshot — Redis fan-out will reach the right pod. This keeps the cost
+ * negligible on pods that don't host the targeted users.
+ *
+ * **Error isolation**: every step is wrapped in try/catch. A serialisation
+ * failure or a closed STOMP session on one user must not stop delivery to
+ * the others. Errors are logged and swallowed (the next flush carries the
+ * fresh state anyway). Mirrors the pattern in [com.apptolast.invernaderos
+ * .features.push.infrastructure.adapter.output.AlertActivationPushListener].
+ */
+@Component
+class WsBroadcaster(
+    private val assembler: GreenhouseStatusAssembler,
+    private val userRepository: UserRepository,
+    private val simpUserRegistry: SimpUserRegistry,
+    private val messagingTemplate: SimpMessagingTemplate,
+    @Qualifier("redisTemplate") private val redisTemplate: RedisTemplate<String, Any>,
+    @Qualifier("wsBroadcastChannel") private val redisChannel: String
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        const val USER_QUEUE_DESTINATION = "/queue/status/response"
+    }
+
+    /**
+     * Broadcast originated locally (event listener). Publishes to Redis so
+     * peer pods can deliver to their users, **and** delivers locally for
+     * users connected to this pod.
+     */
+    @Async("wsBroadcastExecutor")
+    open fun broadcastTenantStatus(tenantId: Long) {
+        publishToRedis(tenantId)
+        deliverLocally(tenantId)
+    }
+
+    /**
+     * Broadcast forwarded from another pod via Redis. Delivers locally only,
+     * never re-publishes — that would loop.
+     */
+    @Async("wsBroadcastExecutor")
+    open fun deliverLocallyOnly(tenantId: Long) {
+        deliverLocally(tenantId)
+    }
+
+    private fun publishToRedis(tenantId: Long) {
+        try {
+            redisTemplate.convertAndSend(redisChannel, tenantId)
+        } catch (e: Exception) {
+            logger.warn("Redis publish failed for tenantId={} channel={}: {}",
+                tenantId, redisChannel, e.message)
+        }
+    }
+
+    private fun deliverLocally(tenantId: Long) {
+        val targetUsers = try {
+            resolveLocalRecipients(tenantId)
+        } catch (e: Exception) {
+            logger.warn("Failed to resolve recipients for tenantId={}: {}", tenantId, e.message)
+            return
+        }
+        if (targetUsers.isEmpty()) {
+            logger.trace("No local recipients for tenantId={}", tenantId)
+            return
+        }
+
+        val snapshot = try {
+            assembler.assembleStatusForTenant(tenantId)
+        } catch (e: Exception) {
+            logger.error("Failed to assemble snapshot for tenantId={}: {}", tenantId, e.message, e)
+            return
+        }
+
+        var delivered = 0
+        targetUsers.forEach { username ->
+            try {
+                messagingTemplate.convertAndSendToUser(username, USER_QUEUE_DESTINATION, snapshot)
+                delivered++
+            } catch (e: Exception) {
+                logger.warn("convertAndSendToUser failed user={} tenantId={}: {}",
+                    username, tenantId, e.message)
+            }
+        }
+        logger.info("WS broadcast tenantId={} usersTargeted={} delivered={} tenants-in-payload={}",
+            tenantId, targetUsers.size, delivered, snapshot.tenants.size)
+    }
+
+    /**
+     * Active users of this tenant ∩ users with at least one STOMP session
+     * on this pod. The intersection avoids serialisation work for offline
+     * users (their `convertAndSendToUser` would be a no-op anyway, but a
+     * costly one — Spring still serialises and resolves the destination).
+     *
+     * **Identity convention**: Spring Security maps each `User.email` to
+     * `userDetails.username` (see [CustomUserDetailsService]). The JWT
+     * carries the email as subject; [com.apptolast.invernaderos.config
+     * .StompJwtAuthInterceptor] uses that as the STOMP session principal
+     * name. We therefore key recipients by **email**, not by the optional
+     * `User.username` display name.
+     */
+    private fun resolveLocalRecipients(tenantId: Long): Set<String> {
+        val activeTenantEmails = userRepository.findByTenantIdAndIsActiveTrue(tenantId)
+            .map { it.email }
+            .toSet()
+        if (activeTenantEmails.isEmpty()) return emptySet()
+
+        val connectedPrincipalNames = simpUserRegistry.users.mapNotNull { it.name }.toSet()
+        return activeTenantEmails intersect connectedPrincipalNames
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsRedisBridgeConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsRedisBridgeConfig.kt
@@ -1,0 +1,53 @@
+package com.apptolast.invernaderos.features.websocket.broadcast
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.data.redis.listener.Topic
+import org.springframework.data.redis.listener.ChannelTopic
+
+/**
+ * Wires the Redis pub/sub channel that fans WebSocket broadcasts across
+ * pods. The [RedisConnectionFactory] / [RedisTemplate] beans come from the
+ * existing [com.apptolast.invernaderos.config.RedisConfig] — we only add a
+ * dedicated [RedisMessageListenerContainer] tied to one channel.
+ *
+ * **Channel naming is environment-prefixed** because Redis pub/sub channels
+ * live at the server level, not per-database. Without the prefix a dev pod
+ * publishing on the same Redis instance would deliver broadcasts to prod
+ * subscribers — a tenant-leakage bug. We pick the prefix from the active
+ * Spring profile (`dev`, `prod`, …) so the channel becomes e.g.
+ * `inverapi:dev:ws:tenant-status`.
+ */
+@Configuration
+class WsRedisBridgeConfig(
+    @param:Value("\${spring.profiles.active:default}") private val activeProfile: String
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Bean(name = ["wsBroadcastChannel"])
+    fun wsBroadcastChannel(): String {
+        val channel = "inverapi:${activeProfile}:ws:tenant-status"
+        logger.info("WS broadcast Redis channel = {}", channel)
+        return channel
+    }
+
+    @Bean(name = ["wsBroadcastTopic"])
+    fun wsBroadcastTopic(): Topic = ChannelTopic(wsBroadcastChannel())
+
+    @Bean(name = ["wsBroadcastListenerContainer"], destroyMethod = "destroy")
+    fun wsBroadcastListenerContainer(
+        connectionFactory: RedisConnectionFactory,
+        listener: WsRedisListener,
+        wsBroadcastTopic: Topic
+    ): RedisMessageListenerContainer {
+        val container = RedisMessageListenerContainer()
+        container.setConnectionFactory(connectionFactory)
+        container.addMessageListener(listener, wsBroadcastTopic)
+        return container
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsRedisListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsRedisListener.kt
@@ -1,0 +1,48 @@
+package com.apptolast.invernaderos.features.websocket.broadcast
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.stereotype.Component
+
+/**
+ * Bridge between Redis pub/sub and the local pod's [WsBroadcaster].
+ *
+ * Why Redis pub/sub specifically:
+ *  - Spring's `enableSimpleBroker` keeps STOMP sessions in-memory per pod.
+ *    When prod runs ≥2 replicas, a `convertAndSendToUser(email, …)` only
+ *    reaches the pod where that user's session lives. A broadcast triggered
+ *    on the wrong pod is silently dropped.
+ *  - Redis pub/sub is **fire-and-forget** with no persistence. If a pod is
+ *    down when the message is published it loses that message — and that's
+ *    desirable here because the snapshot is idempotent: the next sensor
+ *    flush (≤1 s away) carries the up-to-date state. Streams or queues
+ *    would over-engineer this with backlogs we don't want.
+ *
+ * Loop prevention: this listener calls [WsBroadcaster.deliverLocallyOnly]
+ * (NOT `broadcastTenantStatus`) so we do not re-publish the same tenantId
+ * we just received.
+ */
+@Component
+class WsRedisListener(
+    private val wsBroadcaster: WsBroadcaster
+) : MessageListener {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun onMessage(message: Message, pattern: ByteArray?) {
+        val raw = String(message.body).trim().trim('"')
+        val tenantId = raw.toLongOrNull() ?: run {
+            logger.warn("Ignoring Redis pub/sub message with non-numeric body: '{}'", raw)
+            return
+        }
+        try {
+            wsBroadcaster.deliverLocallyOnly(tenantId)
+        } catch (e: Exception) {
+            // Defensive: deliverLocallyOnly is itself try/catch'd, but
+            // a Redis listener that throws is silently dropped from the
+            // container by some Spring versions. Belt-and-suspenders.
+            logger.error("WsRedisListener failed for tenantId={}: {}", tenantId, e.message, e)
+        }
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/event/DeviceCurrentValuesFlushedEvent.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/event/DeviceCurrentValuesFlushedEvent.kt
@@ -1,0 +1,20 @@
+package com.apptolast.invernaderos.features.websocket.event
+
+/**
+ * ApplicationEvent published from `DeviceStatusProcessor.flushPendingChanges`
+ * after the Timescale transaction commits a batch of `device_current_values`
+ * upserts. Carries the set of tenant ids whose state may have changed in the
+ * last second.
+ *
+ * Consumed by `TenantStatusBroadcastListener` to fan out a WebSocket push to
+ * each affected tenant. The listener is `@TransactionalEventListener
+ * (AFTER_COMMIT)` so a Timescale rollback does not leak ghost broadcasts.
+ *
+ * Set semantics — never empty when published; the publisher only fires when
+ * the affected set is non-empty. A single event per flush minimises bus
+ * pressure and is enough for the UI (the broadcast carries a fresh snapshot
+ * either way).
+ */
+data class DeviceCurrentValuesFlushedEvent(
+    val tenantIds: Set<Long>
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/event/TenantStatusChangedEvent.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/event/TenantStatusChangedEvent.kt
@@ -1,0 +1,28 @@
+package com.apptolast.invernaderos.features.websocket.event
+
+/**
+ * ApplicationEvent published from CRUD use cases (greenhouses, sectors,
+ * devices, settings, users) and from any other writer that affects the
+ * shape or content of the snapshot served by
+ * `GreenhouseStatusAssembler.assembleStatusForTenant`.
+ *
+ * The `source` enum is for observability only — listeners do not branch on
+ * it. Logs and metrics correlate broadcasts with the originating use case.
+ *
+ * Published from inside the use case's `@Transactional`; the consumer is
+ * a `@TransactionalEventListener(AFTER_COMMIT)` to avoid emitting events
+ * that the database will roll back.
+ */
+data class TenantStatusChangedEvent(
+    val tenantId: Long,
+    val source: Source
+) {
+    enum class Source {
+        ALERT,
+        GREENHOUSE_CRUD,
+        SECTOR_CRUD,
+        DEVICE_CRUD,
+        SETTING_CRUD,
+        USER_CRUD
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/mqtt/service/CodeToTenantCache.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/mqtt/service/CodeToTenantCache.kt
@@ -1,0 +1,67 @@
+package com.apptolast.invernaderos.mqtt.service
+
+import com.apptolast.invernaderos.features.device.DeviceRepository
+import com.apptolast.invernaderos.features.setting.SettingRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory cache that resolves a hardware/setting code (e.g. `DEV-00012`,
+ * `SET-00036`) to its owning `tenantId`. Used by `DeviceStatusProcessor`
+ * to attach a tenant id to each `device_current_values` flush so the
+ * downstream broadcaster knows which tenant to target.
+ *
+ * **Bounded by the device+setting catalog size** — a few thousand entries
+ * at most. Hot path is O(1) hash lookup; cold path issues one metadata
+ * query per never-seen code.
+ *
+ * **Fail-safe**: if the metadata lookup throws (DB hiccup, missing row,
+ * etc.), `resolve` returns `null` and the calling flush continues without
+ * that code. The Timescale write **never aborts** because of a cache miss.
+ *
+ * **Thread-safe**: `ConcurrentHashMap` and idempotent puts (the same code
+ * always resolves to the same tenant id; concurrent puts are harmless).
+ *
+ * **Invalidation**: not implemented intentionally. A code's owning tenant
+ * is stable for its lifetime — devices and settings get reassigned by
+ * deleting + recreating with a new code, never by editing the old one.
+ * If that invariant ever changes, add explicit invalidation on the CRUD
+ * use cases.
+ */
+@Component
+class CodeToTenantCache(
+    private val deviceRepository: DeviceRepository,
+    private val settingRepository: SettingRepository
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val cache = ConcurrentHashMap<String, Long>()
+
+    /**
+     * Returns the `tenantId` that owns the given hardware/setting code, or
+     * `null` if it cannot be resolved (unknown code, DB error, etc.).
+     */
+    fun resolve(code: String): Long? {
+        cache[code]?.let { return it }
+
+        val resolved = try {
+            lookup(code)
+        } catch (e: Exception) {
+            logger.warn("Failed to resolve tenantId for code={}: {}", code, e.message)
+            null
+        }
+        if (resolved != null) cache[code] = resolved
+        return resolved
+    }
+
+    @Transactional("metadataTransactionManager", readOnly = true)
+    private fun lookup(code: String): Long? {
+        return when {
+            code.startsWith("DEV-") -> deviceRepository.findByCode(code)?.tenantId
+            code.startsWith("SET-") -> settingRepository.findByCode(code)?.tenantId
+            else -> null
+        }
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/mqtt/service/DeviceStatusProcessor.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/mqtt/service/DeviceStatusProcessor.kt
@@ -6,7 +6,9 @@ import com.apptolast.invernaderos.features.telemetry.timescaledb.entities.Sensor
 import com.apptolast.invernaderos.features.telemetry.timeseries.DeviceCurrentValueRepository
 import com.apptolast.invernaderos.features.telemetry.timeseries.SensorReadingRawRepository
 import com.apptolast.invernaderos.features.telemetry.timeseries.SensorReadingRepository
+import com.apptolast.invernaderos.features.websocket.event.DeviceCurrentValuesFlushedEvent
 import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,7 +32,9 @@ class DeviceStatusProcessor(
     private val sensorReadingRawRepository: SensorReadingRawRepository,
     private val deviceCurrentValueRepository: DeviceCurrentValueRepository,
     private val deduplicationService: SensorDeduplicationService,
-    private val alertMqttInboundAdapter: AlertMqttInboundAdapter
+    private val alertMqttInboundAdapter: AlertMqttInboundAdapter,
+    private val codeToTenantCache: CodeToTenantCache,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -119,6 +123,22 @@ class DeviceStatusProcessor(
         }
 
         logger.debug("Upserted {} current values", updates.size)
+
+        // Resolve which tenants are affected and publish an event so the
+        // WebSocket broadcaster can fan out a fresh snapshot to their users.
+        // Codes that fail to resolve (unknown / DB hiccup) are silently
+        // skipped — the persistence path above is already committed and
+        // must not be impacted by a downstream broadcast issue. Spring
+        // delivers the event to `@TransactionalEventListener(AFTER_COMMIT)`
+        // listeners only when the surrounding Timescale transaction commits.
+        val affectedTenants = updates.keys
+            .mapNotNull { code -> codeToTenantCache.resolve(code) }
+            .toSet()
+        if (affectedTenants.isNotEmpty()) {
+            applicationEventPublisher.publishEvent(
+                DeviceCurrentValuesFlushedEvent(tenantIds = affectedTenants)
+            )
+        }
     }
 
     private fun flushRawReadings() {

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertMqttSignalIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertMqttSignalIntegrationTest.kt
@@ -47,13 +47,19 @@ class AlertMqttSignalIntegrationTest {
     private val deviceCurrentValueRepository = mockk<DeviceCurrentValueRepository>(relaxed = true)
     private val deduplicationService = mockk<SensorDeduplicationService>()
     private val alertMqttInboundAdapter = mockk<AlertMqttInboundAdapter>()
+    private val codeToTenantCache =
+        mockk<com.apptolast.invernaderos.mqtt.service.CodeToTenantCache>(relaxed = true)
+    private val applicationEventPublisher =
+        mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
 
     private val processor = DeviceStatusProcessor(
         sensorReadingRepository = sensorReadingRepository,
         sensorReadingRawRepository = sensorReadingRawRepository,
         deviceCurrentValueRepository = deviceCurrentValueRepository,
         deduplicationService = deduplicationService,
-        alertMqttInboundAdapter = alertMqttInboundAdapter
+        alertMqttInboundAdapter = alertMqttInboundAdapter,
+        codeToTenantCache = codeToTenantCache,
+        applicationEventPublisher = applicationEventPublisher
     )
 
     // ---------------------------------------------------------------------------

--- a/src/test/kotlin/com/apptolast/invernaderos/features/device/domain/usecase/CreateDeviceUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/device/domain/usecase/CreateDeviceUseCaseTest.kt
@@ -22,7 +22,8 @@ class CreateDeviceUseCaseTest {
     private val repository = mockk<DeviceRepositoryPort>()
     private val codeGenerator = mockk<DeviceCodeGenerator>()
     private val sectorExistence = mockk<SectorExistencePort>()
-    private val useCase = CreateDeviceUseCaseImpl(repository, codeGenerator, sectorExistence)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = CreateDeviceUseCaseImpl(repository, codeGenerator, sectorExistence, applicationEventPublisher)
 
     @Test
     fun `should create device when sector belongs to tenant`() {

--- a/src/test/kotlin/com/apptolast/invernaderos/features/device/domain/usecase/DeleteDeviceUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/device/domain/usecase/DeleteDeviceUseCaseTest.kt
@@ -18,7 +18,8 @@ import java.time.Instant
 class DeleteDeviceUseCaseTest {
 
     private val repository = mockk<DeviceRepositoryPort>()
-    private val useCase = DeleteDeviceUseCaseImpl(repository)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = DeleteDeviceUseCaseImpl(repository, applicationEventPublisher)
 
     private val existing = Device(
         id = DeviceId(1L), code = "DEV-00001", tenantId = TenantId(10L), sectorId = SectorId(20L),

--- a/src/test/kotlin/com/apptolast/invernaderos/features/device/domain/usecase/UpdateDeviceUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/device/domain/usecase/UpdateDeviceUseCaseTest.kt
@@ -21,7 +21,8 @@ class UpdateDeviceUseCaseTest {
 
     private val repository = mockk<DeviceRepositoryPort>()
     private val sectorExistence = mockk<SectorExistencePort>()
-    private val useCase = UpdateDeviceUseCaseImpl(repository, sectorExistence)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = UpdateDeviceUseCaseImpl(repository, sectorExistence, applicationEventPublisher)
 
     private val existing = Device(
         id = DeviceId(1L), code = "DEV-00001", tenantId = TenantId(10L), sectorId = SectorId(20L),

--- a/src/test/kotlin/com/apptolast/invernaderos/features/greenhouse/domain/usecase/CreateGreenhouseUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/greenhouse/domain/usecase/CreateGreenhouseUseCaseTest.kt
@@ -20,7 +20,8 @@ class CreateGreenhouseUseCaseTest {
 
     private val repository = mockk<GreenhouseRepositoryPort>()
     private val codeGenerator = mockk<GreenhouseCodeGenerator>()
-    private val useCase = CreateGreenhouseUseCaseImpl(repository, codeGenerator)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = CreateGreenhouseUseCaseImpl(repository, codeGenerator, applicationEventPublisher)
 
     @Test
     fun `should create greenhouse when name is unique`() {

--- a/src/test/kotlin/com/apptolast/invernaderos/features/greenhouse/domain/usecase/DeleteGreenhouseUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/greenhouse/domain/usecase/DeleteGreenhouseUseCaseTest.kt
@@ -18,7 +18,8 @@ import java.time.Instant
 class DeleteGreenhouseUseCaseTest {
 
     private val repository = mockk<GreenhouseRepositoryPort>()
-    private val useCase = DeleteGreenhouseUseCaseImpl(repository)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = DeleteGreenhouseUseCaseImpl(repository, applicationEventPublisher)
 
     private val existing = Greenhouse(
         id = GreenhouseId(1L),

--- a/src/test/kotlin/com/apptolast/invernaderos/features/greenhouse/domain/usecase/UpdateGreenhouseUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/greenhouse/domain/usecase/UpdateGreenhouseUseCaseTest.kt
@@ -19,7 +19,8 @@ import java.time.Instant
 class UpdateGreenhouseUseCaseTest {
 
     private val repository = mockk<GreenhouseRepositoryPort>()
-    private val useCase = UpdateGreenhouseUseCaseImpl(repository)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = UpdateGreenhouseUseCaseImpl(repository, applicationEventPublisher)
 
     private val existing = Greenhouse(
         id = GreenhouseId(1L),

--- a/src/test/kotlin/com/apptolast/invernaderos/features/sector/domain/usecase/CreateSectorUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/sector/domain/usecase/CreateSectorUseCaseTest.kt
@@ -22,7 +22,8 @@ class CreateSectorUseCaseTest {
     private val repository = mockk<SectorRepositoryPort>()
     private val codeGenerator = mockk<SectorCodeGenerator>()
     private val greenhouseExistence = mockk<GreenhouseExistencePort>()
-    private val useCase = CreateSectorUseCaseImpl(repository, codeGenerator, greenhouseExistence)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = CreateSectorUseCaseImpl(repository, codeGenerator, greenhouseExistence, applicationEventPublisher)
 
     @Test
     fun `should create sector when greenhouse belongs to tenant`() {

--- a/src/test/kotlin/com/apptolast/invernaderos/features/sector/domain/usecase/DeleteSectorUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/sector/domain/usecase/DeleteSectorUseCaseTest.kt
@@ -17,7 +17,8 @@ import org.junit.jupiter.api.Test
 class DeleteSectorUseCaseTest {
 
     private val repository = mockk<SectorRepositoryPort>()
-    private val useCase = DeleteSectorUseCaseImpl(repository)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = DeleteSectorUseCaseImpl(repository, applicationEventPublisher)
 
     private val existing = Sector(
         id = SectorId(1L),

--- a/src/test/kotlin/com/apptolast/invernaderos/features/sector/domain/usecase/UpdateSectorUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/sector/domain/usecase/UpdateSectorUseCaseTest.kt
@@ -20,7 +20,8 @@ class UpdateSectorUseCaseTest {
 
     private val repository = mockk<SectorRepositoryPort>()
     private val greenhouseExistence = mockk<GreenhouseExistencePort>()
-    private val useCase = UpdateSectorUseCaseImpl(repository, greenhouseExistence)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = UpdateSectorUseCaseImpl(repository, greenhouseExistence, applicationEventPublisher)
 
     private val existing = Sector(
         id = SectorId(1L),

--- a/src/test/kotlin/com/apptolast/invernaderos/features/setting/domain/usecase/CreateSettingUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/setting/domain/usecase/CreateSettingUseCaseTest.kt
@@ -22,7 +22,8 @@ class CreateSettingUseCaseTest {
     private val repository = mockk<SettingRepositoryPort>()
     private val codeGenerator = mockk<SettingCodeGenerator>()
     private val sectorValidation = mockk<SettingSectorValidationPort>()
-    private val useCase = CreateSettingUseCaseImpl(repository, codeGenerator, sectorValidation)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = CreateSettingUseCaseImpl(repository, codeGenerator, sectorValidation, applicationEventPublisher)
 
     @Test
     fun `should create setting when sector belongs to tenant`() {

--- a/src/test/kotlin/com/apptolast/invernaderos/features/setting/domain/usecase/DeleteSettingUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/setting/domain/usecase/DeleteSettingUseCaseTest.kt
@@ -18,7 +18,8 @@ import java.time.Instant
 class DeleteSettingUseCaseTest {
 
     private val repository = mockk<SettingRepositoryPort>()
-    private val useCase = DeleteSettingUseCaseImpl(repository)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = DeleteSettingUseCaseImpl(repository, applicationEventPublisher)
 
     private val existing = Setting(
         id = SettingId(1L),

--- a/src/test/kotlin/com/apptolast/invernaderos/features/setting/domain/usecase/UpdateSettingUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/setting/domain/usecase/UpdateSettingUseCaseTest.kt
@@ -21,7 +21,8 @@ class UpdateSettingUseCaseTest {
 
     private val repository = mockk<SettingRepositoryPort>()
     private val sectorValidation = mockk<SettingSectorValidationPort>()
-    private val useCase = UpdateSettingUseCaseImpl(repository, sectorValidation)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = UpdateSettingUseCaseImpl(repository, sectorValidation, applicationEventPublisher)
 
     private val existing = Setting(
         id = SettingId(1L),

--- a/src/test/kotlin/com/apptolast/invernaderos/features/user/domain/usecase/CreateUserUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/user/domain/usecase/CreateUserUseCaseTest.kt
@@ -22,7 +22,8 @@ class CreateUserUseCaseTest {
     private val repository = mockk<UserRepositoryPort>()
     private val codeGenerator = mockk<UserCodeGenerator>()
     private val passwordHasher = mockk<PasswordHasher>()
-    private val useCase = CreateUserUseCaseImpl(repository, codeGenerator, passwordHasher)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = CreateUserUseCaseImpl(repository, codeGenerator, passwordHasher, applicationEventPublisher)
 
     private val tenantId = TenantId(1L)
     private val now = Instant.now()

--- a/src/test/kotlin/com/apptolast/invernaderos/features/user/domain/usecase/DeleteUserUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/user/domain/usecase/DeleteUserUseCaseTest.kt
@@ -17,7 +17,8 @@ import java.time.Instant
 class DeleteUserUseCaseTest {
 
     private val repository = mockk<UserRepositoryPort>()
-    private val useCase = DeleteUserUseCaseImpl(repository)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = DeleteUserUseCaseImpl(repository, applicationEventPublisher)
 
     private val tenantId = TenantId(1L)
     private val now = Instant.now()

--- a/src/test/kotlin/com/apptolast/invernaderos/features/user/domain/usecase/UpdateUserUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/user/domain/usecase/UpdateUserUseCaseTest.kt
@@ -20,7 +20,8 @@ class UpdateUserUseCaseTest {
 
     private val repository = mockk<UserRepositoryPort>()
     private val passwordHasher = mockk<PasswordHasher>()
-    private val useCase = UpdateUserUseCaseImpl(repository, passwordHasher)
+    private val applicationEventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+    private val useCase = UpdateUserUseCaseImpl(repository, passwordHasher, applicationEventPublisher)
 
     private val tenantId = TenantId(1L)
     private val now = Instant.now()


### PR DESCRIPTION
## Summary

End-to-end server-push pipeline for the WebSocket. Today the mobile app polls `/app/status/request` every 2 s because the backend doesn't emit spontaneous broadcasts. After this PR + the matching mobile change (`POLL_INTERVAL_MS = 0`), the app gets pure-push updates from any of three sources without polling.

### Verified live in dev (`apptolast-invernadero-api-dev`)

```
01:59:47.379 .a.i.f.w.b.TenantStatusBroadcastListener : DeviceCurrentValuesFlushedEvent received for 1 tenants
01:59:47.379 [ws-broadcast-2] dispatching command AsyncCommand [type=PUBLISH ...]
```

The flush emits the event, the executor `ws-broadcast-` thread picks it up, and the Redis `PUBLISH` lands on `inverapi:dev:ws:tenant-status`. No `LazyInitializationException`, no APM noise (the cluster cleanup is also rolled out — orthogonal but related deuda removed).

### Architecture (single PR, full pipeline)

1. **STOMP JWT auth (backwards compatible)** — `StompJwtAuthInterceptor` reads `Authorization: Bearer …` from the CONNECT frame. Valid token → Principal with the user's email. Missing/invalid token → anonymous Principal (today's behaviour). Reuses `JwtService` + `CustomUserDetailsService`. Polling clients keep working unchanged.

2. **Scoped assembler** — `GreenhouseStatusAssembler.assembleStatusForTenant(tenantId)` returns the same `GreenhouseStatusResponse` envelope but with a single tenant in `tenants`. `assembleFullStatus()` is refactored around the same private helper, public behaviour unchanged.

3. **Three event sources** dispatch into one listener (`TenantStatusBroadcastListener`, `AFTER_COMMIT, fallbackExecution = true`):
   - `DeviceCurrentValuesFlushedEvent` from `DeviceStatusProcessor.flushPendingChanges` (1 event/s/tenant). `CodeToTenantCache` resolves DEV-/SET- codes lazily.
   - `AlertStateChangedEvent` (already published by alert use cases). `AlertActivationPushListener` (FCM) is left untouched.
   - `TenantStatusChangedEvent` published by every Create/Update/Delete use case for greenhouse, sector, device, setting, user (15 use cases × `applicationEventPublisher.publishEvent`).

4. **`WsBroadcaster` async on `wsBroadcastExecutor`** (core 2, max 4, queue 200, `DiscardOldestPolicy`). Two entry points: `broadcastTenantStatus` (Redis publish + local) and `deliverLocallyOnly` (Redis-listener path, no re-publish — loop prevention). Local recipients = `findByTenantIdAndIsActiveTrue` ∩ `SimpUserRegistry.users`.

5. **Redis pub/sub bridge** — `RedisMessageListenerContainer` on channel `inverapi:${profile}:ws:tenant-status` (env-prefixed to avoid dev/prod cross-talk on the same Redis server). Reuses the existing `RedisConnectionFactory`. Fire-and-forget pub/sub: snapshots are idempotent, the next 1 s flush brings the latest state.

### Out of scope (intentionally)

- The mobile change to set `POLL_INTERVAL_MS = 0` (Alberto on `GreenhouseFronts`).
- Coalescing per tenant (the executor's `DiscardOldestPolicy` + 1 evt/s natural rate already cap pressure; can be added in a follow-up PR if logs show spam).
- Command-confirm broadcast — `MqttMessageProcessor.processActuatorStatus` doesn't persist anything yet, so there's no state change to broadcast.

### Test plan

- [x] `./gradlew compileKotlin` clean
- [x] `./gradlew test` full suite green (15 use case tests updated to mock the new `ApplicationEventPublisher`; `AlertMqttSignalIntegrationTest` updated for the new `DeviceStatusProcessor` deps)
- [x] Dev rollout: pod healthy, broadcast events flowing into the `ws-broadcast-` executor and to Redis
- [ ] Prod rollout after merge
- [ ] Mobile flips `POLL_INTERVAL_MS = 0` once dev has soaked

🤖 Generated with [Claude Code](https://claude.com/claude-code)