### PR TITLE
chore(ws): cleaner broadcast logging with cadence + payload metadata

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "5f94ecc6-6b18-442a-81a4-57edde438023",
+          "id": "9751745c-2cdc-4e3d-8c4b-3d0872afc9b4",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "85060b3c-0e3a-47af-a1a3-b0becd189bc7",
+              "id": "e4830762-da9f-407a-9243-542ede3e6851",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "0c912a4a-d65a-4613-aab8-df1ed0ea7f7d",
+          "id": "1d92dff0-ea0f-4354-b340-020f5b4b1223",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "64050b15-7567-4a2f-a1e8-8c94aaf26ff0",
+              "id": "2036dd4b-76c6-439f-b50b-0d780d51b217",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "9f402f33-ddca-4ed0-ac3c-494f4971cd28",
+          "id": "c342f6c8-13c9-4aed-b78a-056e9895ced7",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "3b25b283-ba2c-46c9-b6d5-725cfe0585ef",
+              "id": "57b8b00b-9a67-4136-8d73-5e14a85bde44",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "293588b2-9d8b-49ee-9fa4-cf168f903d0a",
+          "id": "f17f641b-2fbe-46aa-ab79-4af24bd1472e",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "661c32a8-5982-46b6-84e6-2533e45e882c",
+              "id": "5d15990e-5501-4392-bb82-839990b9cecc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "9423a7a5-ee46-4fb4-ae0d-df6e48effa9f",
+          "id": "1d1db14f-4dc0-4158-996c-19a1d494def6",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "600999e5-8bbb-4d17-bed8-35b00fe8f23a",
+              "id": "b1f8d6ed-4d9f-4a0e-9469-9f23ed54f049",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "56251336-2d7a-4506-875e-6bee50c334ba",
+          "id": "7e68d677-c263-41d7-8637-70fa1fc3130d",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "a2ff5cbe-c958-4adf-9e31-877660e9a56d",
+              "id": "7aa69200-6b2d-435d-95e1-db92178fe735",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "310ec74d-96c0-4d87-bbf1-3409e068918b",
+          "id": "4bbab94d-6c02-4403-a6ec-c74bb55fc909",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "85cb4d04-2e1d-4d52-8e44-edd4bfe22bab",
+              "id": "7b81142e-e1e2-4ba7-9fea-2be6d1a18fad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "c10e5183-6f1d-4b44-9319-0321d13071f5",
+          "id": "3bc1fd93-270b-465c-8829-90f1993ab566",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "d15479fd-9cb3-4efe-b589-5f6a0cf3c90c",
+              "id": "e89e4f15-f76f-4c7e-9cea-22572ab77c0b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "67b6d0d0-4255-4dfe-a6f0-f08d6554ed54",
+          "id": "46f4c9f0-6e81-4f0f-bc6c-5348639a2020",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "ba3860a4-c913-4541-ac69-38bb2b469dff",
+              "id": "cf6bdd92-4863-4cfe-9b3e-78d050dc86b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "c4d9cbf1-da6b-4817-84a7-a96fff7fefaa",
+          "id": "1947d9a2-836c-4eb3-be4e-71b8a74dff73",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "ab31bebf-0181-4be0-a563-60ba10d085f3",
+              "id": "52bc7cc0-97f4-496b-9f2b-9edc0ea2c1bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "ec99f1cf-39de-403a-b3ba-cecd530893a4",
+          "id": "43f43957-88bc-4085-a390-fe1a03b21014",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "9e36704c-1641-4ac8-a922-729ab88cfa24",
+              "id": "4917a87d-24f0-4506-8312-993133ac0770",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "2e875379-152d-48bd-b521-d19b2675becb",
+          "id": "f8978c30-c73b-4209-b6bd-f7c926e39838",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "c232e3a1-ff2a-4375-96a0-a1feafe15af3",
+              "id": "c8b5053f-0805-49eb-98d5-5a33db8d8ff8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "4b9c2a18-67a7-4f5a-85a3-1e5b0bd059cc",
+          "id": "1984d236-9721-4bf1-b36d-d7de79756413",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "535860a5-19e7-418a-8626-bcceb3a32f18",
+              "id": "d5bca98b-0981-4bc2-973f-9f190720b0dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "88b3672c-0d7b-4b60-adeb-37ffa1a999bc",
+          "id": "eae0b8d6-b829-41b5-a31e-e6262b0d45d4",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "2b9c4bbf-efb7-43bd-b159-7d8a8fe6e73b",
+              "id": "0ebfbe68-c9d6-4999-8887-f00f98b74260",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "e3cab72e-468f-4d10-90e2-042a16294474",
+          "id": "588122b6-c4a5-44d3-bb36-7f98c5e539e8",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "48c86790-46aa-4fde-8814-97e6fa06ce5a",
+              "id": "64d939ff-b867-4ed1-95c6-40975fb31152",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "e0efef91-bfed-4d42-96f9-f3dcf6b1d327",
+          "id": "8d67a08c-9397-422a-b88d-6ab575e072f8",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "9784b8e7-6114-42d0-9d98-c369774dd0ac",
+              "id": "6252feef-56ed-4e2b-8545-82e518f1ff68",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "2bf0e3c9-d51d-4339-8968-77a3e41ba2e6",
+          "id": "70d15a92-d4a9-474b-a45a-c21c50feaec5",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -1879,7 +1879,7 @@
           },
           "response": [
             {
-              "id": "10f80fb3-09cd-4ab1-b060-fac2203d00fe",
+              "id": "9e818157-1c3f-411c-ab0a-b3a1c6e24d6a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1933,7 +1933,7 @@
           }
         },
         {
-          "id": "d5fa6104-ac50-46ab-a7a1-f78a1fcbd1cd",
+          "id": "28068624-d88c-470e-a3b4-6c356c74ef08",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -1976,7 +1976,7 @@
           },
           "response": [
             {
-              "id": "4f63de70-7049-4a7a-a8ae-b3d82834ee3b",
+              "id": "c5160353-3245-4d8a-bfc6-411258e41b40",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "fac6bdb4-0a87-4316-a0a9-bcaa9f7cecf2",
+          "id": "41d8fc94-90bf-4c0f-9c8b-0eef94c287b1",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -2088,7 +2088,7 @@
           },
           "response": [
             {
-              "id": "5eaf1b65-3a21-4749-a38e-34015afafa2c",
+              "id": "6cd6dbc6-8c1a-4f0f-8650-c99edd375af6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2163,7 +2163,7 @@
           }
         },
         {
-          "id": "ca4fe2a8-339d-489c-a358-3a5536a1c730",
+          "id": "898fd89d-2fca-4346-a61b-f7909b3f6065",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "11c11221-c79d-4154-814f-6f46cf994179",
+              "id": "8cf3592a-32f2-4fd9-aa43-36afdb97a51d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2317,7 +2317,7 @@
           }
         },
         {
-          "id": "2ad36697-cca5-4b92-874c-f86d8baaa712",
+          "id": "85ad5b4c-498c-4cf9-90cf-f53ba8e42818",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2364,7 +2364,7 @@
           },
           "response": [
             {
-              "id": "dcb685a7-a724-4967-89eb-eb787e24a344",
+              "id": "7120a60f-2c03-4be2-bb71-ec12983ecddd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2429,7 +2429,7 @@
           }
         },
         {
-          "id": "4ef73ccf-83da-4654-8922-4176b2b8cf54",
+          "id": "bfcd3897-ac89-4510-a4d3-3ea454a936e6",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2471,7 +2471,7 @@
           },
           "response": [
             {
-              "id": "bbb65f95-04d3-4b07-8de6-4ca4c95e4b16",
+              "id": "d4a11aaf-2861-4bf7-85d6-159c3493dd01",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2535,7 +2535,7 @@
           }
         },
         {
-          "id": "72d76125-5ef2-47a1-9f0b-09b57a30de5c",
+          "id": "55df9d98-7489-4007-a4de-5d79bb1c8dec",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2590,7 +2590,7 @@
           },
           "response": [
             {
-              "id": "f5730b8b-9998-40a4-8665-a14830e18dd3",
+              "id": "9187811b-d8cd-4e27-b80b-773515387090",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2667,7 +2667,7 @@
           }
         },
         {
-          "id": "e32517e7-ff8a-4001-9e4a-ad4050c4129a",
+          "id": "5df495a0-1a1a-41e2-a42d-b12e78a6ec85",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2731,7 +2731,7 @@
           },
           "response": [
             {
-              "id": "e3318e34-18b3-4e3e-bd9f-c0d0ee697455",
+              "id": "e5db0dae-543e-4a19-9f2f-5ccd107044c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2823,7 +2823,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "eeb769a4-d35b-47ac-946d-65279b6ec5c1",
+          "id": "430923c6-5ff8-48b8-b190-fbcd9d910890",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2865,7 +2865,7 @@
           },
           "response": [
             {
-              "id": "edd101dc-0cc5-40d3-975d-6fa29c1119e8",
+              "id": "9ea10119-9fe8-4d11-9e41-4d16014b22a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2929,7 +2929,7 @@
           }
         },
         {
-          "id": "688e7158-d13f-4365-916f-0b6c81bc5e69",
+          "id": "558db603-2bb3-4c4f-980f-66ea45a68aa3",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2972,7 +2972,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#70e366\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#48FFbf\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2984,7 +2984,7 @@
           },
           "response": [
             {
-              "id": "d8ed7cd3-00f5-4cf6-9cab-074d4c78cd53",
+              "id": "82a31bab-db3e-4815-8fbe-81bdfb50947c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3033,7 +3033,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#70e366\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#48FFbf\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3061,7 +3061,7 @@
           }
         },
         {
-          "id": "b2d6014e-20be-4c33-8753-32c44cf83d94",
+          "id": "43144436-6ccd-4ded-bb66-aa8ecc792a71",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -3097,7 +3097,7 @@
           },
           "response": [
             {
-              "id": "5001261e-fd79-488f-9aa6-17c4d9d91d1c",
+              "id": "b690de04-0866-4506-bad0-949470908c94",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
           }
         },
         {
-          "id": "4ed4a939-27ce-40fb-b392-4b1adf300b88",
+          "id": "bc8d78f0-06d4-4508-a40e-b87b746b2e45",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -3181,7 +3181,7 @@
           },
           "response": [
             {
-              "id": "134c586a-f2fd-4964-ba27-b1d7c509a1dd",
+              "id": "45d48f82-70b9-4dac-975f-98bc1d2667e9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3233,7 +3233,7 @@
           }
         },
         {
-          "id": "97567365-d0f7-493b-abd7-62739241e87e",
+          "id": "ba1f2c8d-3c85-40f5-a7ce-1be8d03e2e84",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3264,7 +3264,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#ECa3E9\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#0EDFd0\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3276,7 +3276,7 @@
           },
           "response": [
             {
-              "id": "d538610a-2adb-4b9a-b6ba-a843dcc5e33c",
+              "id": "77dca4a3-d592-40c7-abe1-8020de138fff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3313,7 +3313,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#ECa3E9\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#0EDFd0\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3341,7 +3341,7 @@
           }
         },
         {
-          "id": "b3a47f21-147d-4c8a-a8a8-1fb649707d41",
+          "id": "ce75f6ab-a886-48ed-b820-3754d7d9a18b",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3372,7 +3372,7 @@
           },
           "response": [
             {
-              "id": "2dae52b0-5de4-456c-9ca8-98775de2f7e1",
+              "id": "ec665f97-e563-4ec4-888f-9dd7f233bec9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3431,7 +3431,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "64f1d462-a608-481f-8566-754aff281006",
+          "id": "69767088-25f9-4fe5-bc25-6bded8b3daaa",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3473,7 +3473,7 @@
           },
           "response": [
             {
-              "id": "a2002c6f-4d5d-4e44-87db-9bcd71231ac8",
+              "id": "ad56e7a8-8f8f-4e5a-8152-5962d7bb1a53",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
           }
         },
         {
-          "id": "66a00896-1370-4988-82ae-e138825bda89",
+          "id": "6b77ff75-a9cc-434e-8099-a64306b583b0",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3592,7 +3592,7 @@
           },
           "response": [
             {
-              "id": "2a665b58-8976-432a-a8fe-52d5b030e908",
+              "id": "2ab34104-1430-487c-8cd9-34a4ff7d890a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3669,7 +3669,7 @@
           }
         },
         {
-          "id": "29f36969-25eb-4e8d-9454-566a81d385de",
+          "id": "2fa45276-bfeb-4d00-b9f1-3d479c5282bb",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3711,7 +3711,7 @@
           },
           "response": [
             {
-              "id": "cd0bb42b-617b-453a-a937-06f467dfc3b7",
+              "id": "74d22388-c8c3-46cc-8440-7687d00e36dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3775,7 +3775,7 @@
           }
         },
         {
-          "id": "4a17194a-95cf-4d61-abb2-6f123bbad0e8",
+          "id": "bdd79331-0544-463f-a7f9-8451704d3ddb",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3805,7 +3805,7 @@
           },
           "response": [
             {
-              "id": "a8281199-ab40-4695-b4da-c3cb6f93bb7f",
+              "id": "166b6017-87ba-48e2-b964-2b04c09e8dba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3857,7 +3857,7 @@
           }
         },
         {
-          "id": "55d2aaf5-62d2-4607-8c15-8bf4355a83b7",
+          "id": "ac41e58a-527d-4921-bdea-7ac213cf5d80",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3900,7 +3900,7 @@
           },
           "response": [
             {
-              "id": "422b4bc0-ba43-49ad-908d-519818b87880",
+              "id": "f8df4add-0372-4cf0-af22-39394dec6d88",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3965,7 +3965,7 @@
           }
         },
         {
-          "id": "21a813f7-6280-471b-80dc-560942d667f1",
+          "id": "e9b73ab3-5e5b-49b8-bda4-e4c8e4fcf21b",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -4018,7 +4018,7 @@
           },
           "response": [
             {
-              "id": "965999f4-9bac-435a-8f88-e1a56edc7b43",
+              "id": "8d4c9126-ceb9-4861-9cee-fcef49ef4a6f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4082,7 +4082,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -4093,7 +4093,7 @@
           }
         },
         {
-          "id": "267d6a64-6831-407e-815a-f52b4028b4f0",
+          "id": "5ed375de-eb7d-4e55-be46-1a459c6a64c7",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -4136,7 +4136,7 @@
           },
           "response": [
             {
-              "id": "977862f2-124a-4176-9ff3-b21e1a64fe2c",
+              "id": "9cde39fe-4547-4020-8abb-5ca9f68453ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4201,7 +4201,7 @@
           }
         },
         {
-          "id": "67b4959d-f8a6-47e6-834c-00a52aba9d46",
+          "id": "834e7d5c-74c9-4fe0-a350-d8e95fe3d027",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4232,7 +4232,7 @@
           },
           "response": [
             {
-              "id": "b6deb9d6-bc22-474c-bbec-a88b49d03184",
+              "id": "09080d6e-36fe-48ff-b7c1-0d1ddce9f225",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4291,7 +4291,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "44420113-dc30-4314-89f9-c398bdaad1f9",
+          "id": "349a98cb-b739-40cf-a117-d3c22ad6ea8c",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4333,7 +4333,7 @@
           },
           "response": [
             {
-              "id": "e1b0eba9-278d-4af0-ac6b-6872c1d636e7",
+              "id": "8c21633c-2c78-42f8-a8c0-b58c57569c31",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4397,7 +4397,7 @@
           }
         },
         {
-          "id": "d7c75f4c-617c-4c55-b731-38555c2fc7da",
+          "id": "2b93634d-55c2-4698-80bf-813d27fbff41",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4440,7 +4440,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4452,7 +4452,7 @@
           },
           "response": [
             {
-              "id": "13222dbf-1051-430d-9e8f-e363e0c1ac60",
+              "id": "f010630d-96ff-4c86-813b-3278725c7e32",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4501,7 +4501,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4529,7 +4529,7 @@
           }
         },
         {
-          "id": "9b76528c-a4be-4697-bfc6-d6d3eb27cfd6",
+          "id": "1322883f-647c-4194-9b82-12b6eb706a61",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4565,7 +4565,7 @@
           },
           "response": [
             {
-              "id": "25f1763f-29ff-4037-8a4c-438c33049097",
+              "id": "10d1fbef-a77f-4efc-a484-3534e8926131",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4619,7 +4619,7 @@
           }
         },
         {
-          "id": "677b98ee-179e-4970-af25-5e43b892b9fe",
+          "id": "17ca7e87-4f88-40d1-a96c-3de3c9a85fbc",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4668,7 +4668,7 @@
           },
           "response": [
             {
-              "id": "570e7f3e-0d98-4c27-8636-8285f72c7aef",
+              "id": "7289f0f5-2cf9-431a-b46a-915ef2e6ddca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "1eba255b-7cbd-4d68-af67-f14e0ec0807a",
+          "id": "c5e551bd-ffa9-4964-95d1-545f848eaad7",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4770,7 +4770,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4782,7 +4782,7 @@
           },
           "response": [
             {
-              "id": "a2b80676-682c-49d6-9606-a45d572790c4",
+              "id": "bfe2457f-3770-4588-803d-4bcae7a30ae9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4819,7 +4819,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4847,7 +4847,7 @@
           }
         },
         {
-          "id": "bcbde338-1f1b-4776-8a29-a3abc2a5e629",
+          "id": "4ef39c94-020f-4f5a-9ce2-dfcea224af45",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4890,7 +4890,7 @@
           },
           "response": [
             {
-              "id": "dbf01e3b-cce6-4450-86c1-a419f6b91aac",
+              "id": "a29a4690-bf57-4939-bdab-72cc6c877429",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4955,7 +4955,7 @@
           }
         },
         {
-          "id": "fa0da023-1d66-4db0-b718-0c4c8fbe8b86",
+          "id": "54cd6a0b-3509-4878-8b7a-18c5dfd267f0",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4998,7 +4998,7 @@
           },
           "response": [
             {
-              "id": "3103812d-17e2-41a7-b1ff-dcd4cd0ea2ce",
+              "id": "6b90616e-b789-4ad1-a969-407c1b30cc19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5063,7 +5063,7 @@
           }
         },
         {
-          "id": "20ac26cc-3475-4b0d-8b00-4e4f7f18358d",
+          "id": "5ce439e9-e0e0-4716-b30a-9aed2609e231",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -5094,7 +5094,7 @@
           },
           "response": [
             {
-              "id": "ce10431b-5b98-4026-98e9-f61c79d72274",
+              "id": "f13d2b7b-bb9d-40de-9bb4-682cdb7c4825",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5147,7 +5147,7 @@
           }
         },
         {
-          "id": "2cf7d334-0d31-42b6-a6b0-2441cf65bd3b",
+          "id": "e80f6d2c-2cbd-4ec3-8b73-eb9f2ba0e38a",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -5178,7 +5178,7 @@
           },
           "response": [
             {
-              "id": "b638a6b5-35f0-4de1-8492-29156ffcaa7c",
+              "id": "f2a98f85-9f4b-498c-871c-0c63451fd255",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5237,7 +5237,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "9c77c4d9-5b72-4084-a11c-876d14f941d9",
+          "id": "d7430fc2-1da8-4afd-92dc-2e58d8f9c425",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5279,7 +5279,7 @@
           },
           "response": [
             {
-              "id": "b6253a44-1ba0-4114-b232-3397ff9224a1",
+              "id": "e056141d-4cb6-446b-b6d8-281a700eb4ad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5343,7 +5343,7 @@
           }
         },
         {
-          "id": "9701de44-14d5-4245-9ccd-a642c5421bf5",
+          "id": "6d94f323-f30f-434f-9f30-298d7aec4124",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5398,7 +5398,7 @@
           },
           "response": [
             {
-              "id": "2da596b6-9958-425d-87d0-10f3640c0895",
+              "id": "06d16a21-f5da-4f6c-becb-d420969429cb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5475,7 +5475,7 @@
           }
         },
         {
-          "id": "69c66f52-6fd4-4750-a410-d50130506aa8",
+          "id": "388c60ce-0653-4566-ad6a-38e0f77dd694",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5511,7 +5511,7 @@
           },
           "response": [
             {
-              "id": "fbc9799d-4740-46bd-9ff7-5c66ec432669",
+              "id": "48a65399-32e7-4ca9-9db5-34117529e557",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5565,7 +5565,7 @@
           }
         },
         {
-          "id": "5afa6677-b693-40d9-870d-dbbdbfe46cbc",
+          "id": "934a0878-775c-48ea-9de6-f54a14ac06fb",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5595,7 +5595,7 @@
           },
           "response": [
             {
-              "id": "c17b0e5b-db21-4e6b-91bb-ba1a50003348",
+              "id": "46e91861-6841-499d-b5f5-f1c90cc42997",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5647,7 +5647,7 @@
           }
         },
         {
-          "id": "5708696a-c237-4ac5-9ab2-902461b96c84",
+          "id": "83ecd2e9-1e0f-45a3-81c3-f1dfa3746912",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5690,7 +5690,7 @@
           },
           "response": [
             {
-              "id": "283ad6ac-e923-400d-8f90-66fa4ea75d5d",
+              "id": "cf709fe3-304c-45b2-adc2-6af13f7f9172",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5761,7 +5761,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "996db613-3da2-45a0-9df1-7c3e35ff24c0",
+          "id": "93c7c9b6-0046-4baa-88a5-cc8bffcfbc4c",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5814,7 +5814,7 @@
           },
           "response": [
             {
-              "id": "f0ac97b5-a354-478b-8f12-4529d1b86e67",
+              "id": "895bc7ed-5162-40c9-8b5e-6fb46fb63199",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5889,7 +5889,7 @@
           }
         },
         {
-          "id": "5022afd2-6539-48c1-9bac-6b366e05105d",
+          "id": "7fd4436e-aa3c-4afe-9893-2f0729b1d30c",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5955,7 +5955,7 @@
           },
           "response": [
             {
-              "id": "d375d907-ad1b-4150-bbb5-7f2af58d3474",
+              "id": "50a49aa0-d7af-4e35-a5d3-fd4424db7273",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6043,7 +6043,7 @@
           }
         },
         {
-          "id": "18bb6c8e-0e4e-4e8c-8ee1-bdab22fefc46",
+          "id": "270bc595-0269-4e99-96d4-8f0f15d9f3f0",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -6090,7 +6090,7 @@
           },
           "response": [
             {
-              "id": "552e08cd-97c3-4ab1-a43c-a9e3c32f6cd2",
+              "id": "53d3040f-9e3b-423f-b4a2-62134d8937d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6155,7 +6155,7 @@
           }
         },
         {
-          "id": "82a0c008-fa86-49f7-87b4-ce8d0b1cd9bc",
+          "id": "6e4df614-38cb-469d-a301-f167f8b52a43",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -6197,7 +6197,7 @@
           },
           "response": [
             {
-              "id": "3b3f3389-4b3d-4682-8811-64591838aef9",
+              "id": "20d55ffe-d579-450d-8af8-16b4c0db08bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6261,7 +6261,7 @@
           }
         },
         {
-          "id": "80de6cce-2279-4663-af93-a35c3626dde7",
+          "id": "06a58bb1-23f1-4a4f-b718-c7c356c7f9da",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6316,7 +6316,7 @@
           },
           "response": [
             {
-              "id": "f3098ea3-52e1-411a-b43d-372bf9f53db5",
+              "id": "0ae2ef98-2114-44ab-bba9-4c97e727ada5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6393,7 +6393,7 @@
           }
         },
         {
-          "id": "582c577b-70d7-4623-ac04-105aeaed2745",
+          "id": "83102e8f-4233-4afb-96fb-de88d08a497f",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6460,7 +6460,7 @@
           },
           "response": [
             {
-              "id": "77683434-b1bf-493e-8967-a3476178429e",
+              "id": "ba46b529-8419-4948-b069-a5136a30f4d2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6549,7 +6549,7 @@
           }
         },
         {
-          "id": "1adec691-c864-41b0-acc7-a633f6f6e5b9",
+          "id": "b837a8d0-2b4b-4774-8bfe-daecc1db3dae",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6603,7 +6603,7 @@
           },
           "response": [
             {
-              "id": "c9033f0f-5117-4483-85fd-43e97459fb9e",
+              "id": "03b7d326-086b-4ff6-81c8-f7cd964835b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6685,7 +6685,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "95b13c61-faf1-4675-85bd-8c13a2f40d0c",
+          "id": "14aff2be-5744-4cf7-890a-06cb78778904",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6738,7 +6738,7 @@
           },
           "response": [
             {
-              "id": "88cea40c-fd5a-4006-99a1-e9b0894acecb",
+              "id": "cafeb623-85d2-481a-a189-d207b2617e36",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6813,7 +6813,7 @@
           }
         },
         {
-          "id": "30614271-49c4-4959-9304-9c4bc20e8640",
+          "id": "8890d142-5d5b-48f1-9490-4fb3c8ee2061",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6879,7 +6879,7 @@
           },
           "response": [
             {
-              "id": "33df292b-c908-453e-b22d-243f291dfcf2",
+              "id": "936edade-b2c4-438b-b201-f2375b1bea65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6967,7 +6967,7 @@
           }
         },
         {
-          "id": "f46d08ba-9955-4f87-9587-b1853b38a876",
+          "id": "bcdddef9-b167-4d94-a1a1-5c604fa5d225",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -7014,7 +7014,7 @@
           },
           "response": [
             {
-              "id": "3887a54b-adc0-4e0f-8bf3-efe8a0e0b7b0",
+              "id": "7768554d-3fe8-40cd-a5ed-01a4355cd2a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7079,7 +7079,7 @@
           }
         },
         {
-          "id": "cad32376-3afd-4799-9e2c-e26355898285",
+          "id": "b8a73e4e-d50f-4098-93c4-8976d4c7ea6a",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -7121,7 +7121,7 @@
           },
           "response": [
             {
-              "id": "839d2556-d66e-4d88-af15-aef6b06087d0",
+              "id": "a4439a90-9b88-4843-8494-96ceb9f8a57e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7185,7 +7185,7 @@
           }
         },
         {
-          "id": "10c64d84-af18-45e2-b285-5248f1934ed5",
+          "id": "c1d140a1-dce1-4e69-9d67-03cc9311afcb",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7240,7 +7240,7 @@
           },
           "response": [
             {
-              "id": "c437de61-dac9-4121-8b3a-86510e14bd36",
+              "id": "9c34e1e2-8e5e-43bd-9a46-92b7ea34bb58",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7323,7 +7323,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "9dabc6bf-8c15-402b-93b4-87616e82d9fd",
+          "id": "db11cb4d-94a4-41a7-a531-0a3751478ab4",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7364,7 +7364,7 @@
           },
           "response": [
             {
-              "id": "adae662a-ca77-479a-b448-d65a2a9aad33",
+              "id": "6265fc2e-35b4-4cd5-9ecf-7e5b4a58a3d7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7427,7 +7427,7 @@
           }
         },
         {
-          "id": "d0ba7b56-19e1-46b5-94c2-ba44ca0bb936",
+          "id": "649015b6-5ed3-4214-9e44-868785b6b7ff",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7481,7 +7481,7 @@
           },
           "response": [
             {
-              "id": "a1a8dbbe-58bc-46b2-9664-6b5ebb0a2ab8",
+              "id": "bac37875-07fc-409b-9bb5-bc0e27fc3373",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7557,7 +7557,7 @@
           }
         },
         {
-          "id": "d4f2bc16-c64a-4cf1-a105-56913a0dc6f0",
+          "id": "d0116aef-7dfd-4367-bc99-facbee945e5f",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7592,7 +7592,7 @@
           },
           "response": [
             {
-              "id": "25295144-59ba-4a9f-9310-865e31cef60b",
+              "id": "07e188f3-e5fb-4035-9520-f645c7bca883",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7645,7 +7645,7 @@
           }
         },
         {
-          "id": "ef06498b-2b56-47eb-81f7-aaec5b6f73e8",
+          "id": "1bde880c-ed8e-44c5-94c2-9c30cafb4ec5",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7702,7 +7702,7 @@
           },
           "response": [
             {
-              "id": "b582635c-e86c-4acd-8aca-5b24c2da3222",
+              "id": "b21d061d-8825-4ae8-bba4-f17416703291",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7781,7 +7781,7 @@
           }
         },
         {
-          "id": "33f6f300-792b-487c-803b-a3ffab2c8eda",
+          "id": "d0c49efb-42c0-4d69-ae48-9f6e4d285f79",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7823,7 +7823,7 @@
           },
           "response": [
             {
-              "id": "1bcbaf4b-b56a-439a-8fb7-dabeb23a3211",
+              "id": "0cd89442-db69-4482-aa98-270b487b74e5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "5da9b71a-097c-43aa-9ffb-2c8fd06320bb",
+          "id": "a73c8e54-8181-44c6-8d5b-cc5e07b96148",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7946,7 +7946,7 @@
           },
           "response": [
             {
-              "id": "70bbc2ab-1799-4401-b994-50c1bf4e028d",
+              "id": "da9d0660-640f-49ba-b1e0-05bae7c43cd5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8021,7 +8021,7 @@
           }
         },
         {
-          "id": "d08e4633-f3f0-48db-a791-292db2cdd723",
+          "id": "206f306f-21c0-4c6c-a5f5-a79ca4840e3b",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -8087,7 +8087,7 @@
           },
           "response": [
             {
-              "id": "0a646ebd-e741-432a-aa55-9b5897f40913",
+              "id": "79e5249f-9e78-4e10-bb2f-0a1bbbe1bcde",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8175,7 +8175,7 @@
           }
         },
         {
-          "id": "041fbfc9-ede0-499a-bd05-4e843cccd990",
+          "id": "3bc4019d-1272-4c66-b81f-586116fce085",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8222,7 +8222,7 @@
           },
           "response": [
             {
-              "id": "daa00a1a-baf9-40ee-a12a-9f96e25a2315",
+              "id": "7c171fe3-205c-433b-921b-ede81243d309",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8287,7 +8287,7 @@
           }
         },
         {
-          "id": "4929dfec-2cdb-4c99-bf13-9e55e7aa4bc1",
+          "id": "08df5db7-e10d-4964-a863-fac5137983aa",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8329,7 +8329,7 @@
           },
           "response": [
             {
-              "id": "9f0f84df-8468-4c31-961e-30cae2e7d51c",
+              "id": "5bbb36b0-75eb-4ab7-be1f-66cc1381976f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8393,7 +8393,7 @@
           }
         },
         {
-          "id": "989d6ff2-6ae7-405a-a799-123afcec6ab6",
+          "id": "06830f80-fb80-4a10-b172-95d3f9b9d3ff",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8448,7 +8448,7 @@
           },
           "response": [
             {
-              "id": "0414d6c2-77e4-409d-9db0-e27777fad1ea",
+              "id": "7d653516-45be-4e20-a8c1-75e1a87651d6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8531,7 +8531,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "bc0a22e6-cd9f-4254-a2a4-e46035eae5ff",
+          "id": "bbdb42dd-7001-408d-89e9-5208e740eb2b",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8573,7 +8573,7 @@
           },
           "response": [
             {
-              "id": "c2891226-63ed-4c12-a106-ee93fa6f0add",
+              "id": "8db68343-d2f3-45a5-a3a6-f027863674fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "699e01f3-dcf4-4fe8-9068-f629de4ee750",
+          "id": "e7325bfe-d388-40c8-a6e7-87fc4bf76a6a",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8692,7 +8692,7 @@
           },
           "response": [
             {
-              "id": "c9b0ca41-7c7c-4f73-9e6c-e6c5df9edca2",
+              "id": "4cb2704a-c74a-401a-af98-fa0c6bdc9cde",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8769,7 +8769,7 @@
           }
         },
         {
-          "id": "cc414236-639c-4e95-8d41-fd23e8141149",
+          "id": "4750e70f-3517-4b71-9d29-e0721d85a3ee",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8805,7 +8805,7 @@
           },
           "response": [
             {
-              "id": "50f44ecc-e877-4d4f-a28d-bc15fd04c1e9",
+              "id": "266065f6-829f-4b2a-b856-45ce697587a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8859,7 +8859,7 @@
           }
         },
         {
-          "id": "7ef3f789-a8c2-42d2-b8e7-57ce3bed6076",
+          "id": "435e2f17-0d71-4d3e-a5ab-3ae940ba738b",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8889,7 +8889,7 @@
           },
           "response": [
             {
-              "id": "99c8894f-ba8a-4618-9485-1ff21d74c5cc",
+              "id": "472dea29-b0c2-4af4-897e-29520fe3f4ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8941,7 +8941,7 @@
           }
         },
         {
-          "id": "c34f2de9-1ad1-41f1-82ff-961360ef5722",
+          "id": "7b322783-3148-48a8-aa82-cf132bf827fc",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8984,7 +8984,7 @@
           },
           "response": [
             {
-              "id": "81b34c23-4270-493e-872e-0ca14476bc8c",
+              "id": "9380e661-629c-4d4e-a10e-1dd7e280aff2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9055,7 +9055,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "306795fa-a760-420b-94ad-048441013bc2",
+          "id": "7df01143-e72a-46b8-b44c-1cb5ac9598e3",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -9097,7 +9097,7 @@
           },
           "response": [
             {
-              "id": "1a849ad2-d806-4d33-a3cb-9aa408fc1652",
+              "id": "47cc21a1-f1f0-443b-8e7b-c202466a5fad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9155,7 +9155,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6d60326e-fcd6-4f3c-8c45-72871235f693",
+              "id": "644589eb-d8bf-4895-81c6-edaa7745292c",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9219,7 +9219,7 @@
           }
         },
         {
-          "id": "36257f06-84f5-430f-9e13-3ff7f064ba54",
+          "id": "0017eb0a-f1c2-44bc-ac7a-7a8bee240899",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9274,7 +9274,7 @@
           },
           "response": [
             {
-              "id": "9692fb17-4445-45bb-a712-6ead2b309f8e",
+              "id": "4c87d28b-7269-4f35-932f-ea15229402e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9345,7 +9345,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "cef148b1-2e43-4f06-bc8c-b306d00199b3",
+              "id": "eee8cc7c-318e-42e3-8209-8c17b74aa1cd",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9416,7 +9416,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d5ca96e2-6a4a-404c-855f-b28a054202f5",
+              "id": "1532c9f9-cb5f-46e4-9c1a-7a477dbae6a1",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9493,7 +9493,7 @@
           }
         },
         {
-          "id": "eea534f0-2833-48a2-96ed-9df0b43912b8",
+          "id": "c2889280-fc1f-4d71-8e77-11206eda44ee",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9529,7 +9529,7 @@
           },
           "response": [
             {
-              "id": "37a374db-3d6d-4f55-9951-2098dc3ce6eb",
+              "id": "587835a1-2492-4aed-92e2-43033bec3a11",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9577,7 +9577,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b519bc00-7a4f-4d67-87e0-f96338bb6f30",
+              "id": "0e2b299d-5d93-4b08-88e9-4c808bb96d1b",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9625,7 +9625,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "68ad312f-3304-4d26-8e7e-1019bce4f6d7",
+              "id": "79d875d7-d121-4ba6-a7d8-26d1960b6235",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9679,7 +9679,7 @@
           }
         },
         {
-          "id": "eeda7b5c-6492-4bf8-b1d4-649c19595707",
+          "id": "25b6228e-7dc8-4d54-b555-296163977ad3",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9709,7 +9709,7 @@
           },
           "response": [
             {
-              "id": "5731c187-6046-43dc-b7f4-5839609eb67b",
+              "id": "04cb4d59-7b0d-4d71-b037-45df3d783583",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9761,7 +9761,7 @@
           }
         },
         {
-          "id": "72c153d8-3248-4040-a9c3-2bdc466abd6c",
+          "id": "dd2556fe-ea00-436f-8045-446b393b52ad",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9804,7 +9804,7 @@
           },
           "response": [
             {
-              "id": "50cb1cfc-5b20-4882-bb09-8db9ed0a7c8f",
+              "id": "dc595a6c-d0e5-4f58-bd61-24eeef9123d0",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9863,7 +9863,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "28427e35-5804-4443-b331-f2223248fbb0",
+              "id": "e2b53d73-bdfd-4df1-82a0-a5f0ba785f54",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9934,7 +9934,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "9281ea07-b5b9-48f5-b62e-7c3f83010872",
+          "id": "74f3ca23-8c0d-432c-86de-03e198e54b8c",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -10000,7 +10000,7 @@
           },
           "response": [
             {
-              "id": "71b396ca-38ce-4471-943b-86460ff1074d",
+              "id": "c5e9fb83-3a63-442f-b941-61788843e851",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10074,7 +10074,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -10091,7 +10091,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "df3daed3-fec9-40a0-90c5-2e31c78c2468",
+          "id": "665415b4-fdb2-4c88-95ff-5b6685bd2a15",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -10133,7 +10133,7 @@
           },
           "response": [
             {
-              "id": "74f1e3ff-57d0-47b9-ad12-423cab987b1e",
+              "id": "918457b2-7711-4af0-9f98-ac8225d3cb0f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10203,7 +10203,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "aaabf95d-6f87-4696-954b-6c25fa087d2d",
+          "id": "c26b3f05-ed7a-4c7f-8292-402d59bda023",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10245,7 +10245,7 @@
           },
           "response": [
             {
-              "id": "2ffbe76d-5f5d-459a-aef9-c53615934f80",
+              "id": "a7b7e634-1f71-4fb6-91b2-bad04760aa93",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10309,7 +10309,7 @@
           }
         },
         {
-          "id": "f6fac47f-7910-4a8f-b412-9826a83bdf91",
+          "id": "7710fc7f-45a0-4047-997f-1626107ed745",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10352,7 +10352,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#9D0e50\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#E57D4E\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10364,7 +10364,7 @@
           },
           "response": [
             {
-              "id": "68f7351c-2005-47db-9fa4-4ede3aeea5dc",
+              "id": "3277368b-eedd-461e-ba5f-d15f8507dc06",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10413,7 +10413,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#9D0e50\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#E57D4E\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10441,7 +10441,7 @@
           }
         },
         {
-          "id": "3bb96b84-975a-4743-8139-3c1a6fba5660",
+          "id": "6c8e5ca0-8b7f-438b-9fcb-e84da9b3b76a",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10477,7 +10477,7 @@
           },
           "response": [
             {
-              "id": "c4f2d2e7-5e36-4cbf-89e5-e8a176031b85",
+              "id": "c3d179a2-3275-43eb-8ad0-52fd727abf51",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10531,7 +10531,7 @@
           }
         },
         {
-          "id": "d2b8ca05-8df1-4b58-b2ad-0aa4d1ace16d",
+          "id": "d2903031-a8ee-45bf-b5fb-f5eb01dc46c3",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10561,7 +10561,7 @@
           },
           "response": [
             {
-              "id": "fd40e166-7744-49d3-8943-069377a2cf61",
+              "id": "45fbaaa8-e9b3-423d-a1e4-dfc3d1eab71d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10613,7 +10613,7 @@
           }
         },
         {
-          "id": "841963bb-6d10-45a4-b43f-ba5cd87dcccf",
+          "id": "31d6bc6f-d4dd-4c26-82e9-de71c27dd266",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10644,7 +10644,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#fbCFe2\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3BF4ed\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10656,7 +10656,7 @@
           },
           "response": [
             {
-              "id": "dca83ef2-5a0b-4764-a4a0-c29cd7545298",
+              "id": "bdca337a-8c03-44a5-b9e4-59837eafc4a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10693,7 +10693,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#fbCFe2\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3BF4ed\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10721,7 +10721,7 @@
           }
         },
         {
-          "id": "c6f0c6c6-9f37-42b1-8c29-f10d87be2b79",
+          "id": "d5ba45a2-5c32-4331-8d02-8db10055a4c7",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10752,7 +10752,7 @@
           },
           "response": [
             {
-              "id": "4991e476-a70f-4a3e-ac1c-47fcf2a81aa4",
+              "id": "5d4d7c8f-866c-4a48-b5a2-10c4801f9398",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "ae2f5b29-c4fd-42d8-9fec-57919d1bf2cc",
+          "id": "70524fb3-4c10-46af-923c-b474da934ac3",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10864,7 +10864,7 @@
           },
           "response": [
             {
-              "id": "9f025b50-5038-46ae-a09e-df81eb5683b9",
+              "id": "5383600d-8ebf-4e01-9b6f-2d6443bc7434",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10939,7 +10939,7 @@
           }
         },
         {
-          "id": "5271f429-2327-4aa1-9bcb-7f71fd29a2d4",
+          "id": "b440ef32-9212-4c7e-a19b-039ba8e4a07e",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -11005,7 +11005,7 @@
           },
           "response": [
             {
-              "id": "9b08b6f5-566e-4cfc-a5b6-3f4b62cdda8c",
+              "id": "207c2df6-083d-4bf0-b158-5795a243b3c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11093,7 +11093,7 @@
           }
         },
         {
-          "id": "9cdcb8ce-eb68-4ad9-ad6c-dc2e23a35d22",
+          "id": "5d468dd9-044b-4534-958a-d837f713f715",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -11140,7 +11140,7 @@
           },
           "response": [
             {
-              "id": "ec3c8208-6268-4108-93c3-c3c6e5c14c68",
+              "id": "eaa731b6-8d21-4e86-91bb-d11945e7d075",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11205,7 +11205,7 @@
           }
         },
         {
-          "id": "e3ab85f3-8246-4118-b0ce-7296205cb2e2",
+          "id": "5358a6d0-dabd-4d3b-98c3-3677a7150cdf",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11247,7 +11247,7 @@
           },
           "response": [
             {
-              "id": "fb29e41c-04f8-4232-afcb-5b539265df39",
+              "id": "4be8cc56-4427-413b-aeee-1f5865a9dc51",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11311,7 +11311,7 @@
           }
         },
         {
-          "id": "8dd8caf9-5000-4a0f-9e4e-2d80035e9053",
+          "id": "bb57a8ea-d242-4e26-9c61-5ef0d3d67afe",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11366,7 +11366,7 @@
           },
           "response": [
             {
-              "id": "790d9c53-a483-4c2a-8dc7-ac23f22657d1",
+              "id": "850b8258-ab9f-4cc6-be3f-4b4145db9275",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11443,7 +11443,7 @@
           }
         },
         {
-          "id": "281bbd0d-2f7d-436d-97a1-d36eeb632486",
+          "id": "b43a5fb6-5e96-409b-9bec-79b124aa2457",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11497,7 +11497,7 @@
           },
           "response": [
             {
-              "id": "7033b096-9f22-4f3d-882f-4e0f68d84c97",
+              "id": "a5c1d2bf-4514-4114-b7d8-0e2c1ca0ad95",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11573,7 +11573,7 @@
           }
         },
         {
-          "id": "9955c5b7-1592-476b-82b4-32ae8ae62afe",
+          "id": "97c6e4cd-5991-4092-b7df-0be34aed7db2",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11639,7 +11639,7 @@
           },
           "response": [
             {
-              "id": "f4b24a4b-5781-4e1e-81fe-5323b1e57ea3",
+              "id": "605cdd6c-0c82-4c71-bad6-c05936ffb4d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11727,7 +11727,7 @@
           }
         },
         {
-          "id": "008253c6-3649-4c0c-8ff2-e83c5cccfd76",
+          "id": "4f813af2-5c03-42ff-93a2-881612aa25d1",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11805,7 +11805,7 @@
           },
           "response": [
             {
-              "id": "fc5edbd1-5888-41e8-93a8-05e780007e66",
+              "id": "5687fa84-7000-4e28-b6e8-f8950b19c586",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11905,7 +11905,7 @@
           }
         },
         {
-          "id": "fd8a7b8e-5195-4746-b883-7afc4f9fd2a5",
+          "id": "42859a52-2469-4b09-80a3-82e2a07b575e",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11971,7 +11971,7 @@
           },
           "response": [
             {
-              "id": "b412d02d-4bde-46eb-b093-a2ea25c9073f",
+              "id": "3220de8a-5405-4436-9db0-21f9abf489a9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12059,7 +12059,7 @@
           }
         },
         {
-          "id": "cef9e744-8073-4c06-834e-7bd6e4fe069d",
+          "id": "6decbde5-7d65-4118-9d76-ecb415dbca1b",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -12114,7 +12114,7 @@
           },
           "response": [
             {
-              "id": "38f706fa-0f9e-4a53-a9f0-3d23a41646ba",
+              "id": "deb82c31-fbb3-408f-bf6f-61498cf21700",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12197,7 +12197,7 @@
       "description": "",
       "item": [
         {
-          "id": "fce750e7-93d0-4e0d-89d5-1fcd9abbaa2e",
+          "id": "9d05c8e9-649a-4ef9-ad9c-3b2c42898255",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12238,7 +12238,7 @@
           },
           "response": [
             {
-              "id": "81962813-e93b-4ef9-841a-db725fed8240",
+              "id": "27e041a2-98dd-4c6a-9082-f7413f42e53c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12301,7 +12301,7 @@
           }
         },
         {
-          "id": "2d95d98f-96b6-47de-9223-017e77c21146",
+          "id": "a54b713b-1b31-45d6-80ed-172a301b131a",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12355,7 +12355,7 @@
           },
           "response": [
             {
-              "id": "b10f2c2f-6c6c-474e-8af1-94c585690ef3",
+              "id": "cdb6457b-3927-43c7-873f-e4972a4c9e92",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12431,7 +12431,7 @@
           }
         },
         {
-          "id": "51e7700e-daec-4fca-b2b0-59d40733167b",
+          "id": "3a5070ec-cf96-415b-a2b5-ca4ef1ec444d",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12466,7 +12466,7 @@
           },
           "response": [
             {
-              "id": "2d8494d7-2164-4bd3-a6a8-ed2f90682591",
+              "id": "daca046d-182d-4f08-a937-bba634382125",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12519,7 +12519,7 @@
           }
         },
         {
-          "id": "f51e14ab-d821-47d9-a77e-a970aceee803",
+          "id": "5dd7f472-d5ae-46cf-844a-d880552c8840",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12580,7 +12580,7 @@
           },
           "response": [
             {
-              "id": "ec4f6622-fe66-4a34-b3af-59a6700154a7",
+              "id": "e60a6cb5-2490-4066-9ad3-cc7a5361c846",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12663,7 +12663,7 @@
           }
         },
         {
-          "id": "bd1b4841-e09c-4d44-9047-1995a08c9831",
+          "id": "d1c896f2-eb23-4a0e-b89a-ebe3e0dd15b8",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12705,7 +12705,7 @@
           },
           "response": [
             {
-              "id": "4b876cc1-dbac-4957-8bcb-3178342d402d",
+              "id": "3565e103-e8ec-4fcf-85f6-1fd8d643b253",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12769,7 +12769,7 @@
           }
         },
         {
-          "id": "e5008ea5-b228-4ef5-841b-3334c06a62cd",
+          "id": "9dea9430-a9b4-4726-9d67-7100e6b4d478",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12844,7 +12844,7 @@
           },
           "response": [
             {
-              "id": "e6e28a3a-1561-4c28-a475-3bf4c5b19e40",
+              "id": "548b9794-924c-4eb2-8c5b-accf63c7dc63",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12941,7 +12941,7 @@
           }
         },
         {
-          "id": "b004e589-0550-4d4c-8051-58d3c2fb2608",
+          "id": "b6c96871-c20e-462c-91d9-63f484d6a4b0",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12983,7 +12983,7 @@
           },
           "response": [
             {
-              "id": "56576fe2-54d7-4953-bcbb-a019ed87a875",
+              "id": "a5ec9717-2504-4dd6-9873-36db567098af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13047,7 +13047,7 @@
           }
         },
         {
-          "id": "73c171df-d65b-4185-ad9b-7f79ab91dbae",
+          "id": "fccc4547-5d8a-40e7-851d-4a8fbf2fcc1b",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -13090,7 +13090,7 @@
           },
           "response": [
             {
-              "id": "f5a261ea-f346-46b3-be79-5046113efa0e",
+              "id": "c0fd72e9-e5e0-4d0b-aaf1-ff2a06707f84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13155,7 +13155,7 @@
           }
         },
         {
-          "id": "b18cce34-ea3b-4365-adb6-a72becf16b97",
+          "id": "9324e26d-eee1-48f5-8a26-9043b366c46d",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "87154d87-bac0-4649-b940-bbfa3e709d25",
+              "id": "294d699f-95c6-4ec9-8d82-f0e1143a693d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13263,7 +13263,7 @@
           }
         },
         {
-          "id": "a45795ab-88c5-49ee-8ffd-7cf6846e1089",
+          "id": "d33c6ed3-84a8-432a-aedd-4b4f6fe727f9",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13315,7 +13315,7 @@
           },
           "response": [
             {
-              "id": "1c83f094-d5de-45c6-931d-af513aa5c2c7",
+              "id": "f29c90ab-9eb2-4551-9820-fd7cec2cfe52",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13389,7 +13389,7 @@
           }
         },
         {
-          "id": "bb016e2f-fb1f-43e7-a19b-5ffff37b28dd",
+          "id": "306bc5e6-ed17-42fd-bbaf-0b72fddea95a",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13431,7 +13431,7 @@
           },
           "response": [
             {
-              "id": "f63cb7ad-b57d-48ff-beb0-7aa80f7395f2",
+              "id": "e1f5d8c9-d4f3-4736-9796-54a62a3cb8c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13495,7 +13495,7 @@
           }
         },
         {
-          "id": "6db650d5-c2c0-4bd2-bff4-0301c6fc3d08",
+          "id": "0dd5c4a3-af5c-42ef-9a5c-831b0b38fd78",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13548,7 +13548,7 @@
           },
           "response": [
             {
-              "id": "64bf7e2b-82e0-44a6-a714-c60bf60a3a63",
+              "id": "7f31eb36-df78-44ef-81a6-24e69ffc0dce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13623,7 +13623,7 @@
           }
         },
         {
-          "id": "eabe31b5-b506-48cc-ba3f-6d9bbea57030",
+          "id": "80036332-9ddc-489b-9de8-ad1e2c711b2d",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -13676,7 +13676,7 @@
           },
           "response": [
             {
-              "id": "0044e8e1-bfb0-4438-9575-d5ef8c9c6456",
+              "id": "cd8ea59b-e299-4b12-86d3-6e8939504c3f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13751,7 +13751,7 @@
           }
         },
         {
-          "id": "7dcd507a-1e6e-41c8-81a3-f6ede15474da",
+          "id": "48327162-abd0-4875-bef2-0da4e77f6e0c",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13795,7 +13795,7 @@
           },
           "response": [
             {
-              "id": "abd66e2e-90ce-4ee0-8fda-8867713a812a",
+              "id": "ef579f5e-083f-48da-b215-5cf3fb1bc8d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13861,7 +13861,7 @@
           }
         },
         {
-          "id": "fb8f2fb4-2a65-49f4-a977-11cb2bb56ad3",
+          "id": "32b6feb2-777b-4782-afd6-8d6d0a098fda",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13905,7 +13905,7 @@
           },
           "response": [
             {
-              "id": "55543789-49e9-48a2-9181-137236546ec8",
+              "id": "67efb58b-b9ab-4360-8e9a-b0eff8320cdb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13977,7 +13977,7 @@
       "description": "",
       "item": [
         {
-          "id": "38209b56-8c3b-424d-bd0a-1c223b9220ce",
+          "id": "6d0d3bc2-392d-4bc1-a028-845473facdf1",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -14019,7 +14019,7 @@
           },
           "response": [
             {
-              "id": "a978d0da-c80c-4495-b0e2-cf19961bc3ce",
+              "id": "8abc8709-ef32-4762-add1-ae1a0784ba2e",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ece8c2da-6737-4976-92a5-8be98db5ad26",
+              "id": "0e0451bb-4515-40a7-ba83-624701943461",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -14123,7 +14123,7 @@
           }
         },
         {
-          "id": "1a99a176-a085-4d38-80ec-dbd1d1fb65ca",
+          "id": "2c9dbc9b-42eb-4afd-81f5-c1979f6927e5",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -14169,7 +14169,7 @@
           },
           "response": [
             {
-              "id": "01c67d9d-dc80-4460-afeb-2d965af01e8d",
+              "id": "e283426f-3492-4c57-b0bd-755ea1f1bcc6",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -14228,7 +14228,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d19e07da-9dc7-4d9e-bd0e-a18ef9e09cd6",
+              "id": "d3464976-a650-4ede-8547-903e7f191ff1",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -14293,7 +14293,7 @@
           }
         },
         {
-          "id": "4744bf25-7b06-4b9d-b225-32f854f1e122",
+          "id": "bd74031f-6d95-49e4-b30c-26b4376779ff",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14339,7 +14339,7 @@
           },
           "response": [
             {
-              "id": "8d33dac9-c49c-49bc-bfec-33b928c149ea",
+              "id": "2cb7ee49-aa67-47c0-9e80-de091f83af39",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14398,7 +14398,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f4e19dc9-8aa5-4bdd-b441-d248e9ff345a",
+              "id": "72fc7ca1-98e2-4104-925b-cd2606a0110c",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14463,7 +14463,7 @@
           }
         },
         {
-          "id": "783c6d57-2b5f-4fb2-a016-d17122016a6f",
+          "id": "bf936ad9-3aed-4394-aeb6-ad35cbe21163",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14505,7 +14505,7 @@
           },
           "response": [
             {
-              "id": "7a9e264c-0efc-461e-b653-47c33c96e154",
+              "id": "92336cca-7f72-4182-b2e7-bb9fb0a8fd7a",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14566,7 +14566,7 @@
       "description": "",
       "item": [
         {
-          "id": "904083b3-f2dd-4680-840c-4c2f7598282b",
+          "id": "e3bcddc8-22a2-4844-a5cb-c397609b5b14",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14615,7 +14615,7 @@
           },
           "response": [
             {
-              "id": "9d7072de-1f17-4d39-a3ed-7bef94d47d6f",
+              "id": "db26bd58-7804-4ef0-a909-0b54ca1d217a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14675,7 +14675,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14686,7 +14686,7 @@
           }
         },
         {
-          "id": "61d63344-63fb-4803-b90a-0357f38cf228",
+          "id": "39200bdf-bfb8-4c4b-b990-393eb9957c53",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14735,7 +14735,7 @@
           },
           "response": [
             {
-              "id": "ce54db17-5fa5-40f1-84ef-39b22e497fc9",
+              "id": "fa2bd221-ecbb-4288-8f41-b4298fd64a12",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14806,7 +14806,7 @@
           }
         },
         {
-          "id": "5028a665-e62f-4ffb-8638-02468f9e3716",
+          "id": "d095b12e-993a-4798-b7f8-1ac45a7dce30",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14855,7 +14855,7 @@
           },
           "response": [
             {
-              "id": "765ccdcf-fc86-4c1c-81f8-1848c9b70b87",
+              "id": "e411d10f-30e2-4d6c-9b7b-ef869919dc61",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14926,7 +14926,7 @@
           }
         },
         {
-          "id": "21ef90fb-3d37-49c0-975e-2df6ef208ee4",
+          "id": "41478419-f970-4b40-97ca-d8594c7721da",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14975,7 +14975,7 @@
           },
           "response": [
             {
-              "id": "e5b73269-bffd-44d2-a589-bb08389535a0",
+              "id": "b85cee15-4387-483c-af4d-1f9e18d5c98b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15052,7 +15052,7 @@
       "description": "",
       "item": [
         {
-          "id": "8752643e-bed9-4a57-abe4-14aef8871d13",
+          "id": "e8822c54-2030-479f-9d26-4258d80a6476",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -15092,7 +15092,7 @@
           },
           "response": [
             {
-              "id": "34c87d30-0184-4eda-bcf7-7fb814c88c9f",
+              "id": "5df690fb-7770-4450-bcfc-fc1c7a5fb191",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15154,7 +15154,7 @@
           }
         },
         {
-          "id": "3dc11085-774d-415a-9907-52cb4a1fffd2",
+          "id": "4f240a30-9620-4c48-90fd-1662ef1bd0b7",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -15184,7 +15184,7 @@
           },
           "response": [
             {
-              "id": "5f6f7067-1090-40f3-b833-0dfe1942863b",
+              "id": "b1652ed8-7c0c-4416-a8e6-556f2afdcf6b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15225,7 +15225,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15236,7 +15236,7 @@
           }
         },
         {
-          "id": "93ad2aee-3790-4959-a84b-e95b88bb0fc2",
+          "id": "39c23a45-ea47-46b4-89ac-ff3be0c44e6f",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -15288,7 +15288,7 @@
           },
           "response": [
             {
-              "id": "5e893d69-f47e-48ea-8cd8-913d3685472a",
+              "id": "0c54bbbf-74d7-40b9-8282-8a4cbe17e9e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15368,7 +15368,7 @@
       "description": "",
       "item": [
         {
-          "id": "04338bb6-6231-4dd5-88ad-9eabbb94705e",
+          "id": "1aad1af9-2b3b-4dae-bdb8-043d42d35160",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15397,7 +15397,7 @@
           },
           "response": [
             {
-              "id": "f5643238-90b1-4fac-bdf8-2e44c2e02bad",
+              "id": "99571545-d72d-4d2b-b4d0-92f542e5fa94",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15448,7 +15448,7 @@
           }
         },
         {
-          "id": "9588f854-a3fd-4311-b57a-ce510ce2f506",
+          "id": "1be9e855-9b49-4674-9e45-9832457d2651",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15489,7 +15489,7 @@
           },
           "response": [
             {
-              "id": "b8554654-0454-43ba-9241-2b2b4694e46e",
+              "id": "600e02c9-60ae-4c0e-963a-94607eceebbe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15558,7 +15558,7 @@
       "description": "",
       "item": [
         {
-          "id": "6c31b1a2-bdcd-415c-a999-d9fe3c648902",
+          "id": "2f90213c-747f-461a-9508-a73afb4bfaa2",
           "name": "health",
           "request": {
             "name": "health",
@@ -15587,7 +15587,7 @@
           },
           "response": [
             {
-              "id": "a8e64892-5541-4e09-a153-bde7e72d808e",
+              "id": "2dbd601f-df9c-49f0-bac3-7008fb867112",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15627,7 +15627,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15644,7 +15644,7 @@
       "description": "",
       "item": [
         {
-          "id": "cdfed765-833f-4093-b928-af932c3ed23d",
+          "id": "8f8493d7-4417-43d3-b45c-71d8cbfdb92a",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15696,7 +15696,7 @@
           },
           "response": [
             {
-              "id": "7e873ac2-db0f-4f08-b17d-1182443a5f1d",
+              "id": "f6a4793f-be7a-41fe-ad73-f254e362bd3a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15770,7 +15770,7 @@
           }
         },
         {
-          "id": "09d51d49-420c-44c2-aa7b-347142f7220f",
+          "id": "d09682ce-1b4b-4f09-8aac-45ac949620aa",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15811,7 +15811,7 @@
           },
           "response": [
             {
-              "id": "14ee8714-a577-495a-bb74-8471a1b65a7d",
+              "id": "32704908-7660-4345-bb2c-3c7fab6e320d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15863,7 +15863,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15874,7 +15874,7 @@
           }
         },
         {
-          "id": "9ad4231e-59f8-4366-b850-9b820e43d14d",
+          "id": "2a19fc63-6933-48df-92aa-9315311cff19",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15904,7 +15904,7 @@
           },
           "response": [
             {
-              "id": "2d795122-6b10-408a-ba76-be4bc9dfbf14",
+              "id": "77910eb5-4ede-4782-8c24-e35d04cf53ec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15945,7 +15945,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15976,9 +15976,9 @@
     }
   ],
   "info": {
-    "_postman_id": "a02e9594-ad8e-42c7-840b-e61c083efe8e",
+    "_postman_id": "b2a5fb26-991e-4192-96a2-75b034df47d6",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 02:03 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 02:47 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "e37b4be2-8aba-4628-81cb-2718bb1e6f0f",
+          "id": "5f94ecc6-6b18-442a-81a4-57edde438023",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "202603d7-8ad7-48ca-9f19-0c1845bf1ae1",
+              "id": "85060b3c-0e3a-47af-a1a3-b0becd189bc7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "6afbfbfc-2bd0-441d-8cd3-52e2a991f1ef",
+          "id": "0c912a4a-d65a-4613-aab8-df1ed0ea7f7d",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "1e89715f-193f-405d-92e0-9ebd00d82cf5",
+              "id": "64050b15-7567-4a2f-a1e8-8c94aaf26ff0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "1e69759b-2327-47a7-a488-8ee3270d8720",
+          "id": "9f402f33-ddca-4ed0-ac3c-494f4971cd28",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "0fdca6cb-6c7a-4ef9-b10c-ca4295deb092",
+              "id": "3b25b283-ba2c-46c9-b6d5-725cfe0585ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "234a4bdb-8b33-4aa2-b519-65ca21961daf",
+          "id": "293588b2-9d8b-49ee-9fa4-cf168f903d0a",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "e524e84f-a66a-4e5e-9b8d-33f2b3913d73",
+              "id": "661c32a8-5982-46b6-84e6-2533e45e882c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "b63e4c41-6043-46e5-8335-b99980fcc604",
+          "id": "9423a7a5-ee46-4fb4-ae0d-df6e48effa9f",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "25fd8c78-1322-45c3-b4d4-9543f1b5f4d0",
+              "id": "600999e5-8bbb-4d17-bed8-35b00fe8f23a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "f91365c3-7cdd-4626-8a76-86097ae5f99d",
+          "id": "56251336-2d7a-4506-875e-6bee50c334ba",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "a236218f-2292-4e00-b056-6bd6a3bc874b",
+              "id": "a2ff5cbe-c958-4adf-9e31-877660e9a56d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "a179e6c5-e837-4336-aa93-80fd3a1d7633",
+          "id": "310ec74d-96c0-4d87-bbf1-3409e068918b",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "60fd36f9-853d-44fb-8058-b736479597bb",
+              "id": "85cb4d04-2e1d-4d52-8e44-edd4bfe22bab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "25277b63-127d-473a-9415-6a5c470a919a",
+          "id": "c10e5183-6f1d-4b44-9319-0321d13071f5",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "069f29c2-1708-49e2-b8f8-932c1a6d299e",
+              "id": "d15479fd-9cb3-4efe-b589-5f6a0cf3c90c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "50e5b600-5b90-49bf-9725-78d95da65bd1",
+          "id": "67b6d0d0-4255-4dfe-a6f0-f08d6554ed54",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "d0974488-a4d3-49fc-8851-b2c4f094235d",
+              "id": "ba3860a4-c913-4541-ac69-38bb2b469dff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "a8d1d2ac-1415-479a-81f4-02f922f08ccd",
+          "id": "c4d9cbf1-da6b-4817-84a7-a96fff7fefaa",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "65801012-8ab7-4206-ad75-f967cf9a6d23",
+              "id": "ab31bebf-0181-4be0-a563-60ba10d085f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "bb4cb99f-b95c-4c0e-9910-2e5b4efc3efe",
+          "id": "ec99f1cf-39de-403a-b3ba-cecd530893a4",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "160d2f68-aca1-424d-92d6-b74374116233",
+              "id": "9e36704c-1641-4ac8-a922-729ab88cfa24",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "388c790d-0675-4ded-9e9b-23309e921012",
+          "id": "2e875379-152d-48bd-b521-d19b2675becb",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "bd4bcb68-ab22-48d5-956a-ad22bc76aaa8",
+              "id": "c232e3a1-ff2a-4375-96a0-a1feafe15af3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "bab503e5-ab3b-478e-876d-0af4b8253af2",
+          "id": "4b9c2a18-67a7-4f5a-85a3-1e5b0bd059cc",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "e6f9a03e-6be8-43d1-97b1-78f4e7b08fd2",
+              "id": "535860a5-19e7-418a-8626-bcceb3a32f18",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "85e8b11a-1dd6-4882-8a8b-a17b7aad4c28",
+          "id": "88b3672c-0d7b-4b60-adeb-37ffa1a999bc",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "c12a095c-d99b-4338-8ecd-20e7c38cc82b",
+              "id": "2b9c4bbf-efb7-43bd-b159-7d8a8fe6e73b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "8bb51e1b-7701-497c-8f50-eeffc2e7b2e9",
+          "id": "e3cab72e-468f-4d10-90e2-042a16294474",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "a228cf81-7c41-4068-8d67-db5c3db84cbf",
+              "id": "48c86790-46aa-4fde-8814-97e6fa06ce5a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "6693dc6b-f3b7-4e5f-9cd1-19272c0d5724",
+          "id": "e0efef91-bfed-4d42-96f9-f3dcf6b1d327",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "62f1a14f-a1b2-4770-9475-120ea90d9639",
+              "id": "9784b8e7-6114-42d0-9d98-c369774dd0ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "294b5cbf-7a94-471b-973f-3c20530b7ac2",
+          "id": "2bf0e3c9-d51d-4339-8968-77a3e41ba2e6",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -1859,7 +1859,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -1879,7 +1879,7 @@
           },
           "response": [
             {
-              "id": "b85a204b-612e-4ad4-9f3e-ca65ef685baa",
+              "id": "10f80fb3-09cd-4ab1-b060-fac2203d00fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1911,7 +1911,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1933,7 +1933,7 @@
           }
         },
         {
-          "id": "3546ffb4-ee91-42da-8e3c-926637173457",
+          "id": "d5fa6104-ac50-46ab-a7a1-f78a1fcbd1cd",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -1976,7 +1976,7 @@
           },
           "response": [
             {
-              "id": "fb8b4cdb-0378-45b1-9c8d-951a4701273b",
+              "id": "4f63de70-7049-4a7a-a8ae-b3d82834ee3b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "646b7202-6269-4c5c-8c90-1bfa035bc715",
+          "id": "fac6bdb4-0a87-4316-a0a9-bcaa9f7cecf2",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -2088,7 +2088,7 @@
           },
           "response": [
             {
-              "id": "0129a8c6-0875-414c-a666-bccef04c8e15",
+              "id": "5eaf1b65-3a21-4749-a38e-34015afafa2c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2163,7 +2163,7 @@
           }
         },
         {
-          "id": "d5e09225-4f30-41b5-9b76-e3b8b364c575",
+          "id": "ca4fe2a8-339d-489c-a358-3a5536a1c730",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "bf6a6ab4-31b6-4332-b74e-42a8ac48368e",
+              "id": "11c11221-c79d-4154-814f-6f46cf994179",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2317,7 +2317,7 @@
           }
         },
         {
-          "id": "768aaa23-8c8d-4d49-b5e6-b3a9dfdc960b",
+          "id": "2ad36697-cca5-4b92-874c-f86d8baaa712",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2364,7 +2364,7 @@
           },
           "response": [
             {
-              "id": "d026d885-2ac4-4367-94a5-47d7d536cf9e",
+              "id": "dcb685a7-a724-4967-89eb-eb787e24a344",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2429,7 +2429,7 @@
           }
         },
         {
-          "id": "2947fb59-8b10-4aac-8896-43c4593a1e06",
+          "id": "4ef73ccf-83da-4654-8922-4176b2b8cf54",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2471,7 +2471,7 @@
           },
           "response": [
             {
-              "id": "061af62c-0788-4bb4-8083-b3764d38d5fd",
+              "id": "bbb65f95-04d3-4b07-8de6-4ca4c95e4b16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2535,7 +2535,7 @@
           }
         },
         {
-          "id": "5b474b7b-e5fd-40b8-be48-e47511db85b5",
+          "id": "72d76125-5ef2-47a1-9f0b-09b57a30de5c",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2590,7 +2590,7 @@
           },
           "response": [
             {
-              "id": "706bf8cc-8dba-455e-9041-560cb2f21be0",
+              "id": "f5730b8b-9998-40a4-8665-a14830e18dd3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2667,7 +2667,7 @@
           }
         },
         {
-          "id": "1ce24797-ac5d-4530-959d-2a8276ddf4f4",
+          "id": "e32517e7-ff8a-4001-9e4a-ad4050c4129a",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2731,7 +2731,7 @@
           },
           "response": [
             {
-              "id": "586b8a29-72d1-4308-8e71-14b796d60a7d",
+              "id": "e3318e34-18b3-4e3e-bd9f-c0d0ee697455",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2823,7 +2823,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "dd2d7da1-c08e-47a3-ac73-fc5ee01cdea2",
+          "id": "eeb769a4-d35b-47ac-946d-65279b6ec5c1",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2865,7 +2865,7 @@
           },
           "response": [
             {
-              "id": "4066111e-7c9b-482f-9453-a34ff8891209",
+              "id": "edd101dc-0cc5-40d3-975d-6fa29c1119e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2929,7 +2929,7 @@
           }
         },
         {
-          "id": "d1b10758-181d-40c7-9f84-cc82843059d9",
+          "id": "688e7158-d13f-4365-916f-0b6c81bc5e69",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2972,7 +2972,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3CcD86\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#70e366\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2984,7 +2984,7 @@
           },
           "response": [
             {
-              "id": "11ea1041-d78b-48df-af54-664ce6dae973",
+              "id": "d8ed7cd3-00f5-4cf6-9cab-074d4c78cd53",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3033,7 +3033,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3CcD86\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#70e366\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3061,7 +3061,7 @@
           }
         },
         {
-          "id": "a04ab08f-fd12-4ed2-b2a5-d2822ca41e1c",
+          "id": "b2d6014e-20be-4c33-8753-32c44cf83d94",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -3097,7 +3097,7 @@
           },
           "response": [
             {
-              "id": "01234903-5281-48c1-bf74-d060264ef8c1",
+              "id": "5001261e-fd79-488f-9aa6-17c4d9d91d1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
           }
         },
         {
-          "id": "3f0caaea-ad8b-405f-a4a3-3a3f6b75ce26",
+          "id": "4ed4a939-27ce-40fb-b392-4b1adf300b88",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -3181,7 +3181,7 @@
           },
           "response": [
             {
-              "id": "46106809-5357-4cbf-9f29-2053871f236f",
+              "id": "134c586a-f2fd-4964-ba27-b1d7c509a1dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3233,7 +3233,7 @@
           }
         },
         {
-          "id": "9007659a-5bee-4616-95e1-6a42e073d7a2",
+          "id": "97567365-d0f7-493b-abd7-62739241e87e",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3264,7 +3264,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e2d304\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#ECa3E9\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3276,7 +3276,7 @@
           },
           "response": [
             {
-              "id": "881de86a-ff8c-4e79-a524-9ea98a243207",
+              "id": "d538610a-2adb-4b9a-b6ba-a843dcc5e33c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3313,7 +3313,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e2d304\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#ECa3E9\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3341,7 +3341,7 @@
           }
         },
         {
-          "id": "28115765-f536-46b7-a4bf-11934f26626b",
+          "id": "b3a47f21-147d-4c8a-a8a8-1fb649707d41",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3372,7 +3372,7 @@
           },
           "response": [
             {
-              "id": "7224863f-8b02-4f92-b6df-09b081037184",
+              "id": "2dae52b0-5de4-456c-9ca8-98775de2f7e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3431,7 +3431,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "38f21df7-03c3-4fd4-b913-cd8c696fe6d1",
+          "id": "64f1d462-a608-481f-8566-754aff281006",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3473,7 +3473,7 @@
           },
           "response": [
             {
-              "id": "c0f1e43f-1f6a-4e48-9bcd-b47afc77f8f4",
+              "id": "a2002c6f-4d5d-4e44-87db-9bcd71231ac8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
           }
         },
         {
-          "id": "5e5c5cd4-d6b5-4e0e-b10b-7b89af1837ec",
+          "id": "66a00896-1370-4988-82ae-e138825bda89",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3592,7 +3592,7 @@
           },
           "response": [
             {
-              "id": "1e5e3121-a3e5-4255-af39-7fa91157e0ca",
+              "id": "2a665b58-8976-432a-a8fe-52d5b030e908",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3669,7 +3669,7 @@
           }
         },
         {
-          "id": "4f14e20a-e02e-40ac-ad24-b66d4675ab2f",
+          "id": "29f36969-25eb-4e8d-9454-566a81d385de",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3711,7 +3711,7 @@
           },
           "response": [
             {
-              "id": "f59b8116-c293-4ced-be15-1bea5a3543de",
+              "id": "cd0bb42b-617b-453a-a937-06f467dfc3b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3775,7 +3775,7 @@
           }
         },
         {
-          "id": "b26a8a82-e837-46a6-a4cc-2a92ea24ba95",
+          "id": "4a17194a-95cf-4d61-abb2-6f123bbad0e8",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3805,7 +3805,7 @@
           },
           "response": [
             {
-              "id": "8e582ae8-1b84-495b-8bc2-6547b50ec27a",
+              "id": "a8281199-ab40-4695-b4da-c3cb6f93bb7f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3857,7 +3857,7 @@
           }
         },
         {
-          "id": "91323eef-eec9-4896-bd2d-5a157881c783",
+          "id": "55d2aaf5-62d2-4607-8c15-8bf4355a83b7",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3900,7 +3900,7 @@
           },
           "response": [
             {
-              "id": "a0e388aa-3c53-4388-bd6c-42211f65d5e2",
+              "id": "422b4bc0-ba43-49ad-908d-519818b87880",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3965,7 +3965,7 @@
           }
         },
         {
-          "id": "82ab56fa-8012-4aef-8ca1-bc8b2bd1dedd",
+          "id": "21a813f7-6280-471b-80dc-560942d667f1",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -4018,7 +4018,7 @@
           },
           "response": [
             {
-              "id": "66aae97f-8fcc-4b08-be99-c15560cf2fae",
+              "id": "965999f4-9bac-435a-8f88-e1a56edc7b43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4082,7 +4082,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -4093,7 +4093,7 @@
           }
         },
         {
-          "id": "8eb483c4-97b8-4ff6-96d4-a891ceb748b7",
+          "id": "267d6a64-6831-407e-815a-f52b4028b4f0",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -4136,7 +4136,7 @@
           },
           "response": [
             {
-              "id": "1c26cbd6-3c9b-410b-8792-256f282e287b",
+              "id": "977862f2-124a-4176-9ff3-b21e1a64fe2c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4201,7 +4201,7 @@
           }
         },
         {
-          "id": "1f67075c-6789-44ba-a5d9-124c3a357dd5",
+          "id": "67b4959d-f8a6-47e6-834c-00a52aba9d46",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4232,7 +4232,7 @@
           },
           "response": [
             {
-              "id": "bd0721f8-e81e-404b-a9c8-a38aaa770ac4",
+              "id": "b6deb9d6-bc22-474c-bbec-a88b49d03184",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4291,7 +4291,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "566cb5bb-f2ff-4773-96de-21cd8ea8f58e",
+          "id": "44420113-dc30-4314-89f9-c398bdaad1f9",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4333,7 +4333,7 @@
           },
           "response": [
             {
-              "id": "25c5b3f1-e11d-420f-8fbc-5bf7c8b98d79",
+              "id": "e1b0eba9-278d-4af0-ac6b-6872c1d636e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4397,7 +4397,7 @@
           }
         },
         {
-          "id": "1446d971-4ff0-4095-afd0-689f1faada4e",
+          "id": "d7c75f4c-617c-4c55-b731-38555c2fc7da",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4440,7 +4440,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4452,7 +4452,7 @@
           },
           "response": [
             {
-              "id": "b3d56adb-79b8-4c7a-bb04-9bd45a0e6737",
+              "id": "13222dbf-1051-430d-9e8f-e363e0c1ac60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4501,7 +4501,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4529,7 +4529,7 @@
           }
         },
         {
-          "id": "ba495ae3-8b12-40b9-9488-7c2d68913a3c",
+          "id": "9b76528c-a4be-4697-bfc6-d6d3eb27cfd6",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4565,7 +4565,7 @@
           },
           "response": [
             {
-              "id": "5436715f-27fd-40b6-85de-3d112fce801b",
+              "id": "25f1763f-29ff-4037-8a4c-438c33049097",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4619,7 +4619,7 @@
           }
         },
         {
-          "id": "ffbfd14f-f88a-4b10-8eb3-4b1f41cbb786",
+          "id": "677b98ee-179e-4970-af25-5e43b892b9fe",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4668,7 +4668,7 @@
           },
           "response": [
             {
-              "id": "9b420e8f-758e-4c4b-897b-9c6a785ed682",
+              "id": "570e7f3e-0d98-4c27-8636-8285f72c7aef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "09eec8ec-6a84-4a72-8c91-d21d7c0f88b6",
+          "id": "1eba255b-7cbd-4d68-af67-f14e0ec0807a",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4770,7 +4770,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4782,7 +4782,7 @@
           },
           "response": [
             {
-              "id": "d3a76cba-4fc6-402a-b04b-44c962efe6c5",
+              "id": "a2b80676-682c-49d6-9606-a45d572790c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4819,7 +4819,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4847,7 +4847,7 @@
           }
         },
         {
-          "id": "10977676-1602-4488-a318-85f356439895",
+          "id": "bcbde338-1f1b-4776-8a29-a3abc2a5e629",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4890,7 +4890,7 @@
           },
           "response": [
             {
-              "id": "a8930dde-4942-4a35-be1f-a4fc78eab77b",
+              "id": "dbf01e3b-cce6-4450-86c1-a419f6b91aac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4955,7 +4955,7 @@
           }
         },
         {
-          "id": "c8eae701-7e04-4a47-bd00-90c618c5f692",
+          "id": "fa0da023-1d66-4db0-b718-0c4c8fbe8b86",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4998,7 +4998,7 @@
           },
           "response": [
             {
-              "id": "7ecd7fd7-5d81-439e-94b8-1a764a99b0e8",
+              "id": "3103812d-17e2-41a7-b1ff-dcd4cd0ea2ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5063,7 +5063,7 @@
           }
         },
         {
-          "id": "3db8498c-1673-497b-a785-a77bf1005bf8",
+          "id": "20ac26cc-3475-4b0d-8b00-4e4f7f18358d",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -5094,7 +5094,7 @@
           },
           "response": [
             {
-              "id": "292bde1b-1734-459b-8b8d-676767cc9a33",
+              "id": "ce10431b-5b98-4026-98e9-f61c79d72274",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5147,7 +5147,7 @@
           }
         },
         {
-          "id": "95472d25-6169-41e4-9912-88528277073e",
+          "id": "2cf7d334-0d31-42b6-a6b0-2441cf65bd3b",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -5178,7 +5178,7 @@
           },
           "response": [
             {
-              "id": "108c5ef9-01e0-4120-a379-fdbaa55c7e95",
+              "id": "b638a6b5-35f0-4de1-8492-29156ffcaa7c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5237,7 +5237,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "7f5a6e14-34ae-48f5-bcde-1bc62744aed0",
+          "id": "9c77c4d9-5b72-4084-a11c-876d14f941d9",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5279,7 +5279,7 @@
           },
           "response": [
             {
-              "id": "86c70f82-0c0a-4d57-9e09-6df6cc6c28fc",
+              "id": "b6253a44-1ba0-4114-b232-3397ff9224a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5343,7 +5343,7 @@
           }
         },
         {
-          "id": "671163ed-86b1-4e1d-971f-22361f1921d5",
+          "id": "9701de44-14d5-4245-9ccd-a642c5421bf5",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5398,7 +5398,7 @@
           },
           "response": [
             {
-              "id": "c62315d6-bfd8-4825-9926-41e41fe4af65",
+              "id": "2da596b6-9958-425d-87d0-10f3640c0895",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5475,7 +5475,7 @@
           }
         },
         {
-          "id": "1688a9df-21af-452f-95f2-a55554e50db4",
+          "id": "69c66f52-6fd4-4750-a410-d50130506aa8",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5511,7 +5511,7 @@
           },
           "response": [
             {
-              "id": "f505a07d-3930-4a3c-ae53-12d47c854972",
+              "id": "fbc9799d-4740-46bd-9ff7-5c66ec432669",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5565,7 +5565,7 @@
           }
         },
         {
-          "id": "741d98b8-8e63-4f07-b4bc-4ecccdde16f0",
+          "id": "5afa6677-b693-40d9-870d-dbbdbfe46cbc",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5595,7 +5595,7 @@
           },
           "response": [
             {
-              "id": "d9936240-8f4d-474f-9980-f67e3e73b3c8",
+              "id": "c17b0e5b-db21-4e6b-91bb-ba1a50003348",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5647,7 +5647,7 @@
           }
         },
         {
-          "id": "477b54bb-35b9-4db3-9829-3617192f8c4e",
+          "id": "5708696a-c237-4ac5-9ab2-902461b96c84",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5690,7 +5690,7 @@
           },
           "response": [
             {
-              "id": "c915b0ca-89fd-4d2e-8cb5-36ba264cea80",
+              "id": "283ad6ac-e923-400d-8f90-66fa4ea75d5d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5761,7 +5761,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "2f5dfcd7-cdeb-4344-8bbf-9443d799f8b6",
+          "id": "996db613-3da2-45a0-9df1-7c3e35ff24c0",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5814,7 +5814,7 @@
           },
           "response": [
             {
-              "id": "868edc26-dbeb-468f-a34d-1a29d446058d",
+              "id": "f0ac97b5-a354-478b-8f12-4529d1b86e67",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5889,7 +5889,7 @@
           }
         },
         {
-          "id": "dae989b5-3541-4fa2-8ffc-500f5bfc2be5",
+          "id": "5022afd2-6539-48c1-9bac-6b366e05105d",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5955,7 +5955,7 @@
           },
           "response": [
             {
-              "id": "4f131ca0-7a14-42b7-bef5-b9ccd3142f21",
+              "id": "d375d907-ad1b-4150-bbb5-7f2af58d3474",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6043,7 +6043,7 @@
           }
         },
         {
-          "id": "f3795ee0-7335-49f7-81aa-a09fa9f90b09",
+          "id": "18bb6c8e-0e4e-4e8c-8ee1-bdab22fefc46",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -6090,7 +6090,7 @@
           },
           "response": [
             {
-              "id": "1521414d-274e-42b0-92fd-49faf3356518",
+              "id": "552e08cd-97c3-4ab1-a43c-a9e3c32f6cd2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6155,7 +6155,7 @@
           }
         },
         {
-          "id": "68e27dba-71a2-4c34-aeec-196bfc7223d4",
+          "id": "82a0c008-fa86-49f7-87b4-ce8d0b1cd9bc",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -6197,7 +6197,7 @@
           },
           "response": [
             {
-              "id": "a9f7faa6-a887-4155-b26a-0fe22254eb18",
+              "id": "3b3f3389-4b3d-4682-8811-64591838aef9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6261,7 +6261,7 @@
           }
         },
         {
-          "id": "8938cb48-4763-485a-9d0a-72318b1386f1",
+          "id": "80de6cce-2279-4663-af93-a35c3626dde7",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6316,7 +6316,7 @@
           },
           "response": [
             {
-              "id": "b8b68229-86c3-4f45-8350-228e3ec7af81",
+              "id": "f3098ea3-52e1-411a-b43d-372bf9f53db5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6393,7 +6393,7 @@
           }
         },
         {
-          "id": "7ef0f539-693f-4000-a05a-e271ace8a000",
+          "id": "582c577b-70d7-4623-ac04-105aeaed2745",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6460,7 +6460,7 @@
           },
           "response": [
             {
-              "id": "6c7e62a9-d37a-4886-99e8-a1297ca1f817",
+              "id": "77683434-b1bf-493e-8967-a3476178429e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6549,7 +6549,7 @@
           }
         },
         {
-          "id": "841b1ccd-e961-497b-961b-e91ab8fca68c",
+          "id": "1adec691-c864-41b0-acc7-a633f6f6e5b9",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6603,7 +6603,7 @@
           },
           "response": [
             {
-              "id": "da904e44-a321-4589-b7fb-7d2719d4e29c",
+              "id": "c9033f0f-5117-4483-85fd-43e97459fb9e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6685,7 +6685,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "ff9a0a9b-4780-4c31-947e-01ee971be4e6",
+          "id": "95b13c61-faf1-4675-85bd-8c13a2f40d0c",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6738,7 +6738,7 @@
           },
           "response": [
             {
-              "id": "fdb9b8a4-b8a9-4fa4-b63e-7f70868a10ed",
+              "id": "88cea40c-fd5a-4006-99a1-e9b0894acecb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6813,7 +6813,7 @@
           }
         },
         {
-          "id": "8eb157d2-0241-4529-be58-6b62967968ac",
+          "id": "30614271-49c4-4959-9304-9c4bc20e8640",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6879,7 +6879,7 @@
           },
           "response": [
             {
-              "id": "6cf47670-4aa1-4294-a535-bd03625aa77c",
+              "id": "33df292b-c908-453e-b22d-243f291dfcf2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6967,7 +6967,7 @@
           }
         },
         {
-          "id": "8dcc8a4f-5042-475f-a12d-d21d7e7eb0e0",
+          "id": "f46d08ba-9955-4f87-9587-b1853b38a876",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -7014,7 +7014,7 @@
           },
           "response": [
             {
-              "id": "2b1f9960-a58f-419c-8483-9e26657c7b61",
+              "id": "3887a54b-adc0-4e0f-8bf3-efe8a0e0b7b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7079,7 +7079,7 @@
           }
         },
         {
-          "id": "07e18f3c-c361-44a3-a29a-b96c4624f327",
+          "id": "cad32376-3afd-4799-9e2c-e26355898285",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -7121,7 +7121,7 @@
           },
           "response": [
             {
-              "id": "3b910646-5204-4d70-bd92-cf227d8cd523",
+              "id": "839d2556-d66e-4d88-af15-aef6b06087d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7185,7 +7185,7 @@
           }
         },
         {
-          "id": "32a3af9b-218b-4a1a-9668-9d4986c2677d",
+          "id": "10c64d84-af18-45e2-b285-5248f1934ed5",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7240,7 +7240,7 @@
           },
           "response": [
             {
-              "id": "42ae7ebc-198d-485e-a26b-312758b182c4",
+              "id": "c437de61-dac9-4121-8b3a-86510e14bd36",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7323,7 +7323,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "1cd71648-8d2d-4149-9522-a239ed3902ec",
+          "id": "9dabc6bf-8c15-402b-93b4-87616e82d9fd",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7364,7 +7364,7 @@
           },
           "response": [
             {
-              "id": "c7961604-0121-4cbf-99db-118f070d5076",
+              "id": "adae662a-ca77-479a-b448-d65a2a9aad33",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7427,7 +7427,7 @@
           }
         },
         {
-          "id": "2a92b997-72ba-49dd-82a3-5a62f5b8d830",
+          "id": "d0ba7b56-19e1-46b5-94c2-ba44ca0bb936",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7481,7 +7481,7 @@
           },
           "response": [
             {
-              "id": "ea98e4e7-35b8-4094-87ca-afde30345c3c",
+              "id": "a1a8dbbe-58bc-46b2-9664-6b5ebb0a2ab8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7557,7 +7557,7 @@
           }
         },
         {
-          "id": "47da71e9-6f68-4621-9cdb-af374d8e3963",
+          "id": "d4f2bc16-c64a-4cf1-a105-56913a0dc6f0",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7592,7 +7592,7 @@
           },
           "response": [
             {
-              "id": "403a7d21-dff7-4389-b3b7-427bbaebcb2c",
+              "id": "25295144-59ba-4a9f-9310-865e31cef60b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7645,7 +7645,7 @@
           }
         },
         {
-          "id": "15724610-0016-416c-a932-170afb7b856a",
+          "id": "ef06498b-2b56-47eb-81f7-aaec5b6f73e8",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7702,7 +7702,7 @@
           },
           "response": [
             {
-              "id": "f7c4464b-235d-4901-907d-8e4d67812a46",
+              "id": "b582635c-e86c-4acd-8aca-5b24c2da3222",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7781,7 +7781,7 @@
           }
         },
         {
-          "id": "64cbf444-24de-4f09-9022-8234d0e70042",
+          "id": "33f6f300-792b-487c-803b-a3ffab2c8eda",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7823,7 +7823,7 @@
           },
           "response": [
             {
-              "id": "54211c88-23cd-4325-b8fa-7d8d141f0437",
+              "id": "1bcbaf4b-b56a-439a-8fb7-dabeb23a3211",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "c5717802-933e-4722-a375-fcde8761c842",
+          "id": "5da9b71a-097c-43aa-9ffb-2c8fd06320bb",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7946,7 +7946,7 @@
           },
           "response": [
             {
-              "id": "09bc4b14-fd93-46b7-a866-438eae7603ea",
+              "id": "70bbc2ab-1799-4401-b994-50c1bf4e028d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8021,7 +8021,7 @@
           }
         },
         {
-          "id": "1e18be1d-8dcc-43f5-a470-25e5184e5975",
+          "id": "d08e4633-f3f0-48db-a791-292db2cdd723",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -8087,7 +8087,7 @@
           },
           "response": [
             {
-              "id": "245c4bda-ad72-4add-9016-9504d669ef49",
+              "id": "0a646ebd-e741-432a-aa55-9b5897f40913",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8175,7 +8175,7 @@
           }
         },
         {
-          "id": "cb3830cd-07b6-4158-a5e6-cb2bd86b2689",
+          "id": "041fbfc9-ede0-499a-bd05-4e843cccd990",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8222,7 +8222,7 @@
           },
           "response": [
             {
-              "id": "c6b0934f-287b-4aac-8ada-d7d12062f56b",
+              "id": "daa00a1a-baf9-40ee-a12a-9f96e25a2315",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8287,7 +8287,7 @@
           }
         },
         {
-          "id": "90aefd7a-6f1c-40aa-ac7f-e9f7fa614d7d",
+          "id": "4929dfec-2cdb-4c99-bf13-9e55e7aa4bc1",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8329,7 +8329,7 @@
           },
           "response": [
             {
-              "id": "649106df-9185-4790-8a8f-f9f1e05782ed",
+              "id": "9f0f84df-8468-4c31-961e-30cae2e7d51c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8393,7 +8393,7 @@
           }
         },
         {
-          "id": "073a4fec-b275-46dd-bf19-5313043b6d7b",
+          "id": "989d6ff2-6ae7-405a-a799-123afcec6ab6",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8448,7 +8448,7 @@
           },
           "response": [
             {
-              "id": "1c849a62-823e-44df-9022-dc51bf6a80da",
+              "id": "0414d6c2-77e4-409d-9db0-e27777fad1ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8531,7 +8531,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "17f67647-178c-42fa-8aa1-f5c6b01bb48c",
+          "id": "bc0a22e6-cd9f-4254-a2a4-e46035eae5ff",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8573,7 +8573,7 @@
           },
           "response": [
             {
-              "id": "9dc15ea9-15d0-4154-9fb0-e9346c03cf79",
+              "id": "c2891226-63ed-4c12-a106-ee93fa6f0add",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "1c846749-af4d-40d1-87d7-c2842eda9fe6",
+          "id": "699e01f3-dcf4-4fe8-9068-f629de4ee750",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8692,7 +8692,7 @@
           },
           "response": [
             {
-              "id": "de92c2ad-d6d3-439d-9f05-3abaa689cda7",
+              "id": "c9b0ca41-7c7c-4f73-9e6c-e6c5df9edca2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8769,7 +8769,7 @@
           }
         },
         {
-          "id": "f5b0a998-dd80-46aa-bb77-75740537629a",
+          "id": "cc414236-639c-4e95-8d41-fd23e8141149",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8805,7 +8805,7 @@
           },
           "response": [
             {
-              "id": "3c6d393e-8156-4f5d-ab74-792667c57d6e",
+              "id": "50f44ecc-e877-4d4f-a28d-bc15fd04c1e9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8859,7 +8859,7 @@
           }
         },
         {
-          "id": "5d9c6a13-15c6-4227-9984-7c0fb08ec680",
+          "id": "7ef3f789-a8c2-42d2-b8e7-57ce3bed6076",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8889,7 +8889,7 @@
           },
           "response": [
             {
-              "id": "5f5919df-d194-4114-a516-49c93ad451fa",
+              "id": "99c8894f-ba8a-4618-9485-1ff21d74c5cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8941,7 +8941,7 @@
           }
         },
         {
-          "id": "5b7c178e-3a86-4cbf-9aec-3bf52c72712f",
+          "id": "c34f2de9-1ad1-41f1-82ff-961360ef5722",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8984,7 +8984,7 @@
           },
           "response": [
             {
-              "id": "12010277-8d4b-41ed-9183-eb52ce63fbd4",
+              "id": "81b34c23-4270-493e-872e-0ca14476bc8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9055,7 +9055,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "3582d9e7-bde0-4ad5-92a9-8a8237cbfebe",
+          "id": "306795fa-a760-420b-94ad-048441013bc2",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -9097,7 +9097,7 @@
           },
           "response": [
             {
-              "id": "70ee2047-d33a-46e3-b701-3e723849336b",
+              "id": "1a849ad2-d806-4d33-a3cb-9aa408fc1652",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9155,7 +9155,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3f6f78a3-e1b9-4478-88ce-be0fb8ab7683",
+              "id": "6d60326e-fcd6-4f3c-8c45-72871235f693",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9219,7 +9219,7 @@
           }
         },
         {
-          "id": "667398df-2e04-4ade-9be6-38dc1e4fba78",
+          "id": "36257f06-84f5-430f-9e13-3ff7f064ba54",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9274,7 +9274,7 @@
           },
           "response": [
             {
-              "id": "7d5b4164-b1f5-40fd-8b9d-58cc0b5a94a4",
+              "id": "9692fb17-4445-45bb-a712-6ead2b309f8e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9345,7 +9345,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "73eb27d8-c36d-49b0-b80f-e49b3982fa96",
+              "id": "cef148b1-2e43-4f06-bc8c-b306d00199b3",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9416,7 +9416,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b9827437-36d8-43d6-a6bc-e06a07cec3a3",
+              "id": "d5ca96e2-6a4a-404c-855f-b28a054202f5",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9493,7 +9493,7 @@
           }
         },
         {
-          "id": "a854b93b-bc9d-4d60-901c-4743f8f2263b",
+          "id": "eea534f0-2833-48a2-96ed-9df0b43912b8",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9529,7 +9529,7 @@
           },
           "response": [
             {
-              "id": "fceddc2e-9134-45da-ab30-8a6fe3cc4a63",
+              "id": "37a374db-3d6d-4f55-9951-2098dc3ce6eb",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9577,7 +9577,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "bf0c1c8f-021f-4be1-9f9c-0ca170852b77",
+              "id": "b519bc00-7a4f-4d67-87e0-f96338bb6f30",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9625,7 +9625,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b0a8e4c9-e6c5-44e1-b35b-7d8ba4db3e95",
+              "id": "68ad312f-3304-4d26-8e7e-1019bce4f6d7",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9679,7 +9679,7 @@
           }
         },
         {
-          "id": "de237e55-e011-4bd3-955c-80a7b0f67e68",
+          "id": "eeda7b5c-6492-4bf8-b1d4-649c19595707",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9709,7 +9709,7 @@
           },
           "response": [
             {
-              "id": "4a710b04-2b76-4695-885c-49647bd7bd76",
+              "id": "5731c187-6046-43dc-b7f4-5839609eb67b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9761,7 +9761,7 @@
           }
         },
         {
-          "id": "24abcb20-e945-4226-a401-cfc4613da3d6",
+          "id": "72c153d8-3248-4040-a9c3-2bdc466abd6c",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9804,7 +9804,7 @@
           },
           "response": [
             {
-              "id": "3e875d93-99dd-438e-9e48-6c874bd2e296",
+              "id": "50cb1cfc-5b20-4882-bb09-8db9ed0a7c8f",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9863,7 +9863,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "35d0a2a1-6121-4bef-b321-ff3c27d20d41",
+              "id": "28427e35-5804-4443-b331-f2223248fbb0",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9934,7 +9934,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "fd0b2595-38ab-4d46-ba9c-3bcd50efaf38",
+          "id": "9281ea07-b5b9-48f5-b62e-7c3f83010872",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -10000,7 +10000,7 @@
           },
           "response": [
             {
-              "id": "246772b4-9ff5-4807-abb3-0a7c14eae2a5",
+              "id": "71b396ca-38ce-4471-943b-86460ff1074d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10074,7 +10074,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -10091,7 +10091,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "12e1aa7e-1832-4246-b63f-0ee0fafa71b8",
+          "id": "df3daed3-fec9-40a0-90c5-2e31c78c2468",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -10133,7 +10133,7 @@
           },
           "response": [
             {
-              "id": "437773a9-f5d6-439e-ab8d-f5baffa89271",
+              "id": "74f1e3ff-57d0-47b9-ad12-423cab987b1e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10203,7 +10203,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "f0a5bdf1-7f88-416f-8565-c50b8547610b",
+          "id": "aaabf95d-6f87-4696-954b-6c25fa087d2d",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10245,7 +10245,7 @@
           },
           "response": [
             {
-              "id": "9206d265-b9b0-414d-8daf-c562842d06eb",
+              "id": "2ffbe76d-5f5d-459a-aef9-c53615934f80",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10309,7 +10309,7 @@
           }
         },
         {
-          "id": "dff0d216-c419-4889-af39-8ba1efe03cca",
+          "id": "f6fac47f-7910-4a8f-b412-9826a83bdf91",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10352,7 +10352,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#b8470D\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#9D0e50\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10364,7 +10364,7 @@
           },
           "response": [
             {
-              "id": "137e7ac7-8c11-4143-ae67-f3375821ec87",
+              "id": "68f7351c-2005-47db-9fa4-4ede3aeea5dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10413,7 +10413,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#b8470D\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#9D0e50\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10441,7 +10441,7 @@
           }
         },
         {
-          "id": "2c0e5380-5782-407a-a51c-3ffd378db6ae",
+          "id": "3bb96b84-975a-4743-8139-3c1a6fba5660",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10477,7 +10477,7 @@
           },
           "response": [
             {
-              "id": "307f6960-d5c4-4631-b524-dd24c8539ee9",
+              "id": "c4f2d2e7-5e36-4cbf-89e5-e8a176031b85",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10531,7 +10531,7 @@
           }
         },
         {
-          "id": "254bf28d-12c4-4ae6-8a12-15958b76fbd3",
+          "id": "d2b8ca05-8df1-4b58-b2ad-0aa4d1ace16d",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10561,7 +10561,7 @@
           },
           "response": [
             {
-              "id": "dc862db9-4ccb-4d32-9a95-75b1b12950f7",
+              "id": "fd40e166-7744-49d3-8943-069377a2cf61",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10613,7 +10613,7 @@
           }
         },
         {
-          "id": "b94676fd-bed5-4137-8448-0bcbd8d8645c",
+          "id": "841963bb-6d10-45a4-b43f-ba5cd87dcccf",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10644,7 +10644,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#5Ebf31\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#fbCFe2\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10656,7 +10656,7 @@
           },
           "response": [
             {
-              "id": "196cf5cc-a82a-4c1e-a464-b57e02fe2208",
+              "id": "dca83ef2-5a0b-4764-a4a0-c29cd7545298",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10693,7 +10693,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#5Ebf31\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#fbCFe2\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10721,7 +10721,7 @@
           }
         },
         {
-          "id": "7172bae8-de0f-44ad-a71d-289463b1f2ae",
+          "id": "c6f0c6c6-9f37-42b1-8c29-f10d87be2b79",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10752,7 +10752,7 @@
           },
           "response": [
             {
-              "id": "d2b40703-a5c8-4543-b423-8a5ee62c5720",
+              "id": "4991e476-a70f-4a3e-ac1c-47fcf2a81aa4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "31b7ddfb-e337-4c80-854f-c9fe8e349612",
+          "id": "ae2f5b29-c4fd-42d8-9fec-57919d1bf2cc",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10864,7 +10864,7 @@
           },
           "response": [
             {
-              "id": "50de29a0-5da4-4757-893f-90d9bf99639c",
+              "id": "9f025b50-5038-46ae-a09e-df81eb5683b9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10939,7 +10939,7 @@
           }
         },
         {
-          "id": "0e554ceb-0c41-4f78-84bd-da034e9e9259",
+          "id": "5271f429-2327-4aa1-9bcb-7f71fd29a2d4",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -11005,7 +11005,7 @@
           },
           "response": [
             {
-              "id": "a9bc6e4a-65cb-4699-94b5-a4c16ffabfe1",
+              "id": "9b08b6f5-566e-4cfc-a5b6-3f4b62cdda8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11093,7 +11093,7 @@
           }
         },
         {
-          "id": "aff31886-a706-4e5b-9c34-6ce7d6ee2ae6",
+          "id": "9cdcb8ce-eb68-4ad9-ad6c-dc2e23a35d22",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -11140,7 +11140,7 @@
           },
           "response": [
             {
-              "id": "370b30b7-3845-4586-9bf5-2378c92e5553",
+              "id": "ec3c8208-6268-4108-93c3-c3c6e5c14c68",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11205,7 +11205,7 @@
           }
         },
         {
-          "id": "9a354812-7e7b-406d-9923-24dbeb6ebf38",
+          "id": "e3ab85f3-8246-4118-b0ce-7296205cb2e2",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11247,7 +11247,7 @@
           },
           "response": [
             {
-              "id": "cb926062-e8db-48cc-9f40-9410a4e8648f",
+              "id": "fb29e41c-04f8-4232-afcb-5b539265df39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11311,7 +11311,7 @@
           }
         },
         {
-          "id": "9f52a836-9e5e-4e99-b244-8d09b0b78210",
+          "id": "8dd8caf9-5000-4a0f-9e4e-2d80035e9053",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11366,7 +11366,7 @@
           },
           "response": [
             {
-              "id": "8cd530e0-d361-4c58-a92e-3a18feae2d1f",
+              "id": "790d9c53-a483-4c2a-8dc7-ac23f22657d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11443,7 +11443,7 @@
           }
         },
         {
-          "id": "80c8c9e7-798d-4fae-b7eb-4cc1bffbea1b",
+          "id": "281bbd0d-2f7d-436d-97a1-d36eeb632486",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11497,7 +11497,7 @@
           },
           "response": [
             {
-              "id": "e29946e8-18a8-4025-92b8-dea58fa78f48",
+              "id": "7033b096-9f22-4f3d-882f-4e0f68d84c97",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11573,7 +11573,7 @@
           }
         },
         {
-          "id": "bc8ee725-1e33-493d-b081-50cf96d7c5f8",
+          "id": "9955c5b7-1592-476b-82b4-32ae8ae62afe",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11639,7 +11639,7 @@
           },
           "response": [
             {
-              "id": "f67c7d11-8662-4616-ab2c-5364fbd9cec4",
+              "id": "f4b24a4b-5781-4e1e-81fe-5323b1e57ea3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11727,7 +11727,7 @@
           }
         },
         {
-          "id": "d412f284-22ea-476b-8f25-1ab5254b916d",
+          "id": "008253c6-3649-4c0c-8ff2-e83c5cccfd76",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11805,7 +11805,7 @@
           },
           "response": [
             {
-              "id": "3e3f7632-915f-4fe6-80b3-066ec7f68a32",
+              "id": "fc5edbd1-5888-41e8-93a8-05e780007e66",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11905,7 +11905,7 @@
           }
         },
         {
-          "id": "a2da595c-f148-414e-b51a-71e4ceded0a6",
+          "id": "fd8a7b8e-5195-4746-b883-7afc4f9fd2a5",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11971,7 +11971,7 @@
           },
           "response": [
             {
-              "id": "438abf3f-5db9-4cfc-abe7-42798fcbcb2b",
+              "id": "b412d02d-4bde-46eb-b093-a2ea25c9073f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12059,7 +12059,7 @@
           }
         },
         {
-          "id": "1553f585-e91e-4678-aed1-83c5ad107d09",
+          "id": "cef9e744-8073-4c06-834e-7bd6e4fe069d",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -12114,7 +12114,7 @@
           },
           "response": [
             {
-              "id": "d4f5af49-9fa6-4659-9b28-030e3ba91df1",
+              "id": "38f706fa-0f9e-4a53-a9f0-3d23a41646ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12197,7 +12197,7 @@
       "description": "",
       "item": [
         {
-          "id": "2dd4cba2-a6e9-43ff-9f51-25f29cd9d3df",
+          "id": "fce750e7-93d0-4e0d-89d5-1fcd9abbaa2e",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12238,7 +12238,7 @@
           },
           "response": [
             {
-              "id": "659c2d8b-da44-4260-8a41-e0dae163eae1",
+              "id": "81962813-e93b-4ef9-841a-db725fed8240",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12301,7 +12301,7 @@
           }
         },
         {
-          "id": "181ebd93-679d-4a2f-8d6e-433f598e15c0",
+          "id": "2d95d98f-96b6-47de-9223-017e77c21146",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12355,7 +12355,7 @@
           },
           "response": [
             {
-              "id": "53112984-cb7f-4825-b7cb-3d9fb46c6e35",
+              "id": "b10f2c2f-6c6c-474e-8af1-94c585690ef3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12431,7 +12431,7 @@
           }
         },
         {
-          "id": "fccfdcd5-d063-471f-bdd9-9f9dbce97987",
+          "id": "51e7700e-daec-4fca-b2b0-59d40733167b",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12466,7 +12466,7 @@
           },
           "response": [
             {
-              "id": "11c51d6c-366f-4301-9295-f57b3843e009",
+              "id": "2d8494d7-2164-4bd3-a6a8-ed2f90682591",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12519,7 +12519,7 @@
           }
         },
         {
-          "id": "992daaf9-1cab-4981-ade0-58f2927c3bdf",
+          "id": "f51e14ab-d821-47d9-a77e-a970aceee803",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12580,7 +12580,7 @@
           },
           "response": [
             {
-              "id": "b1ea36d6-4911-4133-a23f-0fcf01f2056a",
+              "id": "ec4f6622-fe66-4a34-b3af-59a6700154a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12663,7 +12663,7 @@
           }
         },
         {
-          "id": "7eb383ea-1755-4746-8697-f1b4fdc6325d",
+          "id": "bd1b4841-e09c-4d44-9047-1995a08c9831",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12705,7 +12705,7 @@
           },
           "response": [
             {
-              "id": "ddc879b4-4346-4d80-903e-42dfc95f6f2b",
+              "id": "4b876cc1-dbac-4957-8bcb-3178342d402d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12769,7 +12769,7 @@
           }
         },
         {
-          "id": "68483a6f-3d7a-41b6-884f-9cab900e4524",
+          "id": "e5008ea5-b228-4ef5-841b-3334c06a62cd",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12844,7 +12844,7 @@
           },
           "response": [
             {
-              "id": "0a3f07a4-a4ff-4b3c-93c8-6971a6f1ebc7",
+              "id": "e6e28a3a-1561-4c28-a475-3bf4c5b19e40",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12941,7 +12941,7 @@
           }
         },
         {
-          "id": "53a56b61-1e4c-4514-94e1-f847e03e7f0b",
+          "id": "b004e589-0550-4d4c-8051-58d3c2fb2608",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12983,7 +12983,7 @@
           },
           "response": [
             {
-              "id": "526e868f-a7dc-44df-a397-7b76822ddb8c",
+              "id": "56576fe2-54d7-4953-bcbb-a019ed87a875",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13047,7 +13047,7 @@
           }
         },
         {
-          "id": "5265595a-6930-48cf-a442-6c928f0b2ac7",
+          "id": "73c171df-d65b-4185-ad9b-7f79ab91dbae",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -13090,7 +13090,7 @@
           },
           "response": [
             {
-              "id": "73b23260-7c3c-4804-aa04-7844336e2520",
+              "id": "f5a261ea-f346-46b3-be79-5046113efa0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13155,7 +13155,7 @@
           }
         },
         {
-          "id": "165863ae-900e-4606-9324-f4dbaa14b6e0",
+          "id": "b18cce34-ea3b-4365-adb6-a72becf16b97",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "b47b2543-ed4e-49cc-938e-87b2649482fc",
+              "id": "87154d87-bac0-4649-b940-bbfa3e709d25",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13263,7 +13263,7 @@
           }
         },
         {
-          "id": "d2fda366-c82b-4cd3-9786-b9c8c8b45f45",
+          "id": "a45795ab-88c5-49ee-8ffd-7cf6846e1089",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13315,7 +13315,7 @@
           },
           "response": [
             {
-              "id": "acaa5bbe-b583-41e6-918b-5f76aaadef2c",
+              "id": "1c83f094-d5de-45c6-931d-af513aa5c2c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13389,7 +13389,7 @@
           }
         },
         {
-          "id": "09482311-2cf9-4866-902d-df3a8616bdb6",
+          "id": "bb016e2f-fb1f-43e7-a19b-5ffff37b28dd",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13431,7 +13431,7 @@
           },
           "response": [
             {
-              "id": "e50789b0-be95-464c-8a3f-2f9a3e733879",
+              "id": "f63cb7ad-b57d-48ff-beb0-7aa80f7395f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13495,7 +13495,7 @@
           }
         },
         {
-          "id": "0d0420a3-4081-40a9-9982-c57b39db0cf4",
+          "id": "6db650d5-c2c0-4bd2-bff4-0301c6fc3d08",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13548,7 +13548,7 @@
           },
           "response": [
             {
-              "id": "4d0db79c-d714-400a-a113-7d599ac3e1c3",
+              "id": "64bf7e2b-82e0-44a6-a714-c60bf60a3a63",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13623,7 +13623,7 @@
           }
         },
         {
-          "id": "bf14b7a9-0979-49a3-8656-f1e466cceb27",
+          "id": "eabe31b5-b506-48cc-ba3f-6d9bbea57030",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -13676,7 +13676,7 @@
           },
           "response": [
             {
-              "id": "b196f1ad-b29e-45b8-b027-ba717bbdb807",
+              "id": "0044e8e1-bfb0-4438-9575-d5ef8c9c6456",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13751,7 +13751,7 @@
           }
         },
         {
-          "id": "aae5b327-2f6c-41a1-b36f-6deb211a834f",
+          "id": "7dcd507a-1e6e-41c8-81a3-f6ede15474da",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13795,7 +13795,7 @@
           },
           "response": [
             {
-              "id": "91f31677-6f80-4ee5-b327-5f29ae88d76c",
+              "id": "abd66e2e-90ce-4ee0-8fda-8867713a812a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13850,7 +13850,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13861,7 +13861,7 @@
           }
         },
         {
-          "id": "5c823125-3da4-4e9e-8041-6dd300cca4aa",
+          "id": "fb8f2fb4-2a65-49f4-a977-11cb2bb56ad3",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13905,7 +13905,7 @@
           },
           "response": [
             {
-              "id": "16c9f269-3b30-4303-a2bc-5c898b6d20b2",
+              "id": "55543789-49e9-48a2-9181-137236546ec8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13960,7 +13960,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13977,7 +13977,7 @@
       "description": "",
       "item": [
         {
-          "id": "83e45be4-d7cd-4855-a577-315a04428cda",
+          "id": "38209b56-8c3b-424d-bd0a-1c223b9220ce",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -14019,7 +14019,7 @@
           },
           "response": [
             {
-              "id": "433023f6-d685-4008-abe5-98ada53c0baa",
+              "id": "a978d0da-c80c-4495-b0e2-cf19961bc3ce",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1e78c089-f869-4856-8373-e702e5b7c7e0",
+              "id": "ece8c2da-6737-4976-92a5-8be98db5ad26",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -14123,7 +14123,7 @@
           }
         },
         {
-          "id": "d9a57a1e-d4f9-4308-83b2-ca503c52f651",
+          "id": "1a99a176-a085-4d38-80ec-dbd1d1fb65ca",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -14169,7 +14169,7 @@
           },
           "response": [
             {
-              "id": "a4adb18f-1bec-46ed-b9bb-9fa6d344a773",
+              "id": "01c67d9d-dc80-4460-afeb-2d965af01e8d",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -14228,7 +14228,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "897a23a4-7d43-46b5-a420-164db2206035",
+              "id": "d19e07da-9dc7-4d9e-bd0e-a18ef9e09cd6",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -14293,7 +14293,7 @@
           }
         },
         {
-          "id": "cb2e72ab-9fbe-439e-b4d4-e886690551bc",
+          "id": "4744bf25-7b06-4b9d-b225-32f854f1e122",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14339,7 +14339,7 @@
           },
           "response": [
             {
-              "id": "794c8dcf-13c2-467b-a86f-264e65053da6",
+              "id": "8d33dac9-c49c-49bc-bfec-33b928c149ea",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14398,7 +14398,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "68e9099a-e695-448c-a212-f39f4e8e270f",
+              "id": "f4e19dc9-8aa5-4bdd-b441-d248e9ff345a",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14463,7 +14463,7 @@
           }
         },
         {
-          "id": "9e85033d-d4de-4c6c-a509-ee8396bbab6a",
+          "id": "783c6d57-2b5f-4fb2-a016-d17122016a6f",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14505,7 +14505,7 @@
           },
           "response": [
             {
-              "id": "fccc9263-7816-4322-8fc9-a185fbb1a557",
+              "id": "7a9e264c-0efc-461e-b653-47c33c96e154",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14566,7 +14566,7 @@
       "description": "",
       "item": [
         {
-          "id": "b78d9593-0199-4881-bfd6-6672c7b57d17",
+          "id": "904083b3-f2dd-4680-840c-4c2f7598282b",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14615,7 +14615,7 @@
           },
           "response": [
             {
-              "id": "7decd331-b9bb-4a23-bc12-340caec128e9",
+              "id": "9d7072de-1f17-4d39-a3ed-7bef94d47d6f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14675,7 +14675,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14686,7 +14686,7 @@
           }
         },
         {
-          "id": "0b91e8ba-0710-44a8-895a-e03efd745ce2",
+          "id": "61d63344-63fb-4803-b90a-0357f38cf228",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14735,7 +14735,7 @@
           },
           "response": [
             {
-              "id": "1fcea666-aafa-4c3f-918c-366d41b33674",
+              "id": "ce54db17-5fa5-40f1-84ef-39b22e497fc9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14806,7 +14806,7 @@
           }
         },
         {
-          "id": "8688b525-5487-4447-9ef9-dc174524e6df",
+          "id": "5028a665-e62f-4ffb-8638-02468f9e3716",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14855,7 +14855,7 @@
           },
           "response": [
             {
-              "id": "676b7ed0-60c3-418e-87a3-38a3b2052551",
+              "id": "765ccdcf-fc86-4c1c-81f8-1848c9b70b87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14926,7 +14926,7 @@
           }
         },
         {
-          "id": "8f913713-9e7d-4333-bf85-5adcef356942",
+          "id": "21ef90fb-3d37-49c0-975e-2df6ef208ee4",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14975,7 +14975,7 @@
           },
           "response": [
             {
-              "id": "88756837-16d6-44d9-8643-2f22e1d200c2",
+              "id": "e5b73269-bffd-44d2-a589-bb08389535a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15052,7 +15052,7 @@
       "description": "",
       "item": [
         {
-          "id": "8b3f6095-ceaa-4ef2-b83e-a4d96bc98de0",
+          "id": "8752643e-bed9-4a57-abe4-14aef8871d13",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -15092,7 +15092,7 @@
           },
           "response": [
             {
-              "id": "609b291f-4a25-40ac-9ca4-ee9786e50ca5",
+              "id": "34c87d30-0184-4eda-bcf7-7fb814c88c9f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15154,7 +15154,7 @@
           }
         },
         {
-          "id": "2af28e97-803f-49b2-8298-3cb53c41e567",
+          "id": "3dc11085-774d-415a-9907-52cb4a1fffd2",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -15184,7 +15184,7 @@
           },
           "response": [
             {
-              "id": "e2bfb99d-cfa1-4f25-ba87-4d44f4354826",
+              "id": "5f6f7067-1090-40f3-b833-0dfe1942863b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15225,7 +15225,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15236,7 +15236,7 @@
           }
         },
         {
-          "id": "a3149f19-c3ca-427f-8612-cd96eae8443e",
+          "id": "93ad2aee-3790-4959-a84b-e95b88bb0fc2",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -15288,7 +15288,7 @@
           },
           "response": [
             {
-              "id": "44523e2f-e693-4bcd-930f-26b8df96fcd8",
+              "id": "5e893d69-f47e-48ea-8cd8-913d3685472a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15368,7 +15368,7 @@
       "description": "",
       "item": [
         {
-          "id": "5a8a574d-726d-469d-bb05-f9e2e93b00da",
+          "id": "04338bb6-6231-4dd5-88ad-9eabbb94705e",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15397,7 +15397,7 @@
           },
           "response": [
             {
-              "id": "17790c37-2874-4b9d-86bb-766111bab491",
+              "id": "f5643238-90b1-4fac-bdf8-2e44c2e02bad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15448,7 +15448,7 @@
           }
         },
         {
-          "id": "415660be-4232-4d2d-bb45-a18956b3b2e2",
+          "id": "9588f854-a3fd-4311-b57a-ce510ce2f506",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15489,7 +15489,7 @@
           },
           "response": [
             {
-              "id": "24c574d4-5bf0-4cc1-add3-967005270d96",
+              "id": "b8554654-0454-43ba-9241-2b2b4694e46e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15558,7 +15558,7 @@
       "description": "",
       "item": [
         {
-          "id": "fe142421-6961-45fa-853d-32c84a4c694f",
+          "id": "6c31b1a2-bdcd-415c-a999-d9fe3c648902",
           "name": "health",
           "request": {
             "name": "health",
@@ -15587,7 +15587,7 @@
           },
           "response": [
             {
-              "id": "b858af94-10d4-4181-b72f-4c2960829536",
+              "id": "a8e64892-5541-4e09-a153-bde7e72d808e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15627,7 +15627,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": 1738\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15644,7 +15644,7 @@
       "description": "",
       "item": [
         {
-          "id": "8baac1cb-894c-4a1b-bdfd-bd12af5fd5f8",
+          "id": "cdfed765-833f-4093-b928-af932c3ed23d",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15696,7 +15696,7 @@
           },
           "response": [
             {
-              "id": "bc1e1cef-4775-4a64-b442-4af0b64ef0fe",
+              "id": "7e873ac2-db0f-4f08-b17d-1182443a5f1d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15770,7 +15770,7 @@
           }
         },
         {
-          "id": "94994651-105d-408c-9f99-1ac588cb06c1",
+          "id": "09d51d49-420c-44c2-aa7b-347142f7220f",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15811,7 +15811,7 @@
           },
           "response": [
             {
-              "id": "5783d755-56f7-4cea-8abc-86d973ceb535",
+              "id": "14ee8714-a577-495a-bb74-8471a1b65a7d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15863,7 +15863,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_3\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15874,7 +15874,7 @@
           }
         },
         {
-          "id": "6e89d42c-e328-4510-b231-9f448f404c40",
+          "id": "9ad4231e-59f8-4366-b850-9b820e43d14d",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15904,7 +15904,7 @@
           },
           "response": [
             {
-              "id": "48d527e1-bc12-4cc9-ae88-7c4d66e1692d",
+              "id": "2d795122-6b10-408a-ba76-be4bc9dfbf14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15976,9 +15976,9 @@
     }
   ],
   "info": {
-    "_postman_id": "99fc4e91-56ce-44df-a756-ded963951a38",
+    "_postman_id": "a02e9594-ad8e-42c7-840b-e61c083efe8e",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 01:59 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 02:03 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/TenantStatusBroadcastListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/TenantStatusBroadcastListener.kt
@@ -45,10 +45,11 @@ class TenantStatusBroadcastListener(
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     fun onDeviceCurrentValuesFlushed(event: DeviceCurrentValuesFlushedEvent) {
         if (event.tenantIds.isEmpty()) return
-        logger.debug("DeviceCurrentValuesFlushedEvent received for {} tenants", event.tenantIds.size)
+        logger.info("TenantStatusBroadcast received source={} tenants={}",
+            SOURCE_SENSOR_FLUSH, event.tenantIds.size)
         event.tenantIds.forEach { tenantId ->
             try {
-                wsBroadcaster.broadcastTenantStatus(tenantId)
+                wsBroadcaster.broadcastTenantStatus(tenantId, SOURCE_SENSOR_FLUSH)
             } catch (e: Exception) {
                 // Async submit can fail under extreme pressure
                 // (DiscardOldestPolicy never throws here, but defensive in
@@ -62,10 +63,15 @@ class TenantStatusBroadcastListener(
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     fun onAlertStateChanged(event: AlertStateChangedEvent) {
         val tenantId = event.alert.tenantId.value
-        logger.debug("AlertStateChangedEvent → broadcast tenantId={} alertCode={} toResolved={}",
-            tenantId, event.alert.code, event.change.toResolved)
+        // toResolved=true means the alert was just RESOLVED (so the source
+        // semantically is "ALERT_RESOLVED"); toResolved=false means the
+        // alert was ACTIVATED. Mirrors the convention used by
+        // AlertActivationPushListener for the FCM path.
+        val source = if (event.change.toResolved) SOURCE_ALERT_RESOLVED else SOURCE_ALERT_ACTIVATED
+        logger.info("TenantStatusBroadcast received source={} tenants=1 alertCode={}",
+            source, event.alert.code)
         try {
-            wsBroadcaster.broadcastTenantStatus(tenantId)
+            wsBroadcaster.broadcastTenantStatus(tenantId, source)
         } catch (e: Exception) {
             logger.warn("Failed to enqueue WS broadcast for tenantId={}: {}", tenantId, e.message)
         }
@@ -73,13 +79,23 @@ class TenantStatusBroadcastListener(
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     fun onTenantStatusChanged(event: TenantStatusChangedEvent) {
-        logger.debug("TenantStatusChangedEvent received: tenantId={} source={}",
-            event.tenantId, event.source)
+        val source = event.source.name
+        logger.info("TenantStatusBroadcast received source={} tenants=1", source)
         try {
-            wsBroadcaster.broadcastTenantStatus(event.tenantId)
+            wsBroadcaster.broadcastTenantStatus(event.tenantId, source)
         } catch (e: Exception) {
             logger.warn("Failed to enqueue WS broadcast for tenantId={}: {}",
                 event.tenantId, e.message)
         }
+    }
+
+    companion object {
+        // Source tags emitted alongside every broadcast for log
+        // correlation. Kept as plain strings (not an enum) so future
+        // callers — e.g. a command-confirm flow — can inject a custom tag
+        // without forcing a code change here.
+        const val SOURCE_SENSOR_FLUSH = "SENSOR_FLUSH"
+        const val SOURCE_ALERT_ACTIVATED = "ALERT_ACTIVATED"
+        const val SOURCE_ALERT_RESOLVED = "ALERT_RESOLVED"
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsBroadcaster.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsBroadcaster.kt
@@ -2,6 +2,8 @@ package com.apptolast.invernaderos.features.websocket.broadcast
 
 import com.apptolast.invernaderos.features.user.UserRepository
 import com.apptolast.invernaderos.features.websocket.GreenhouseStatusAssembler
+import com.apptolast.invernaderos.features.websocket.dto.GreenhouseStatusResponse
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.data.redis.core.RedisTemplate
@@ -9,6 +11,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.messaging.simp.user.SimpUserRegistry
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Routes a fresh per-tenant snapshot to every active user of the tenant
@@ -41,25 +44,44 @@ class WsBroadcaster(
     private val userRepository: UserRepository,
     private val simpUserRegistry: SimpUserRegistry,
     private val messagingTemplate: SimpMessagingTemplate,
+    private val objectMapper: ObjectMapper,
     @Qualifier("redisTemplate") private val redisTemplate: RedisTemplate<String, Any>,
     @Qualifier("wsBroadcastChannel") private val redisChannel: String
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    /**
+     * Last broadcast timestamp (System.nanoTime) per tenant, used to compute
+     * how often we are pushing to clients of a given tenant. Useful to verify
+     * that the natural rate matches the configured `flushPendingChanges`
+     * cadence (≤1 broadcast/s/tenant) and to detect runaway producers.
+     *
+     * Map grows at most by the number of active tenants. No invalidation
+     * needed — entries are just stale timestamps that get overwritten on
+     * the next broadcast.
+     */
+    private val lastBroadcastNanos = ConcurrentHashMap<Long, Long>()
+
     companion object {
         const val USER_QUEUE_DESTINATION = "/queue/status/response"
+        const val SOURCE_REDIS_PEER = "REDIS_PEER"
     }
 
     /**
      * Broadcast originated locally (event listener). Publishes to Redis so
      * peer pods can deliver to their users, **and** delivers locally for
      * users connected to this pod.
+     *
+     * @param source human-readable origin tag for logs/observability —
+     *   `SENSOR_FLUSH`, `ALERT_ACTIVATED`, `ALERT_RESOLVED`, `GREENHOUSE_CRUD`,
+     *   `SECTOR_CRUD`, `DEVICE_CRUD`, `SETTING_CRUD`, `USER_CRUD`. Not
+     *   transmitted over Redis — peers see [SOURCE_REDIS_PEER] instead.
      */
     @Async("wsBroadcastExecutor")
-    open fun broadcastTenantStatus(tenantId: Long) {
+    open fun broadcastTenantStatus(tenantId: Long, source: String) {
         publishToRedis(tenantId)
-        deliverLocally(tenantId)
+        deliverLocally(tenantId, source)
     }
 
     /**
@@ -68,7 +90,7 @@ class WsBroadcaster(
      */
     @Async("wsBroadcastExecutor")
     open fun deliverLocallyOnly(tenantId: Long) {
-        deliverLocally(tenantId)
+        deliverLocally(tenantId, SOURCE_REDIS_PEER)
     }
 
     private fun publishToRedis(tenantId: Long) {
@@ -80,7 +102,8 @@ class WsBroadcaster(
         }
     }
 
-    private fun deliverLocally(tenantId: Long) {
+    private fun deliverLocally(tenantId: Long, source: String) {
+        val startNanos = System.nanoTime()
         val targetUsers = try {
             resolveLocalRecipients(tenantId)
         } catch (e: Exception) {
@@ -88,7 +111,10 @@ class WsBroadcaster(
             return
         }
         if (targetUsers.isEmpty()) {
-            logger.trace("No local recipients for tenantId={}", tenantId)
+            // Don't log at INFO — broadcasts to tenants whose users live on
+            // another pod are normal and expected. The peer pod logs the
+            // delivery for them.
+            logger.debug("No local recipients for tenantId={} source={}", tenantId, source)
             return
         }
 
@@ -109,8 +135,67 @@ class WsBroadcaster(
                     username, tenantId, e.message)
             }
         }
-        logger.info("WS broadcast tenantId={} usersTargeted={} delivered={} tenants-in-payload={}",
-            tenantId, targetUsers.size, delivered, snapshot.tenants.size)
+
+        val deltaMs = updateLastBroadcastAndComputeDelta(tenantId, startNanos)
+        val payloadBytes = safePayloadSize(snapshot)
+        val counts = countSnapshotItems(snapshot)
+        val elapsedMs = (System.nanoTime() - startNanos) / 1_000_000
+
+        // Single-line INFO log per broadcast. Format optimised so each field
+        // is greppable (`grep "WS broadcast" | grep "source=SENSOR_FLUSH"`).
+        logger.info(
+            "WS broadcast tenantId={} source={} usersTargeted={} delivered={} " +
+                "payloadBytes={} deltaMsSinceLastForTenant={} " +
+                "greenhouses={} sectors={} devices={} settings={} alerts={} elapsedMs={}",
+            tenantId, source, targetUsers.size, delivered,
+            payloadBytes, deltaMs,
+            counts.greenhouses, counts.sectors, counts.devices, counts.settings, counts.alerts,
+            elapsedMs
+        )
+    }
+
+    private fun updateLastBroadcastAndComputeDelta(tenantId: Long, nowNanos: Long): Long {
+        val previous = lastBroadcastNanos.put(tenantId, nowNanos)
+        return if (previous == null) -1L else (nowNanos - previous) / 1_000_000
+    }
+
+    /**
+     * Bytes the JSON-serialised snapshot would occupy on the wire. Computed
+     * with the same Jackson [ObjectMapper] used by Spring for the actual
+     * STOMP delivery, so the number is representative.
+     *
+     * Falls back to `-1` if serialisation fails — the broadcast itself isn't
+     * affected because Spring re-serialises with its MessageConverter.
+     */
+    private fun safePayloadSize(snapshot: GreenhouseStatusResponse): Int = try {
+        objectMapper.writeValueAsBytes(snapshot).size
+    } catch (e: Exception) {
+        logger.warn("Failed to size snapshot payload: {}", e.message)
+        -1
+    }
+
+    private data class SnapshotCounts(
+        val greenhouses: Int,
+        val sectors: Int,
+        val devices: Int,
+        val settings: Int,
+        val alerts: Int
+    )
+
+    private fun countSnapshotItems(snapshot: GreenhouseStatusResponse): SnapshotCounts {
+        var gh = 0; var sec = 0; var dev = 0; var set = 0; var alt = 0
+        snapshot.tenants.forEach { tenant ->
+            tenant.greenhouses.forEach { greenhouse ->
+                gh++
+                greenhouse.sectors.forEach { sector ->
+                    sec++
+                    dev += sector.devices.size
+                    set += sector.settings.size
+                    alt += sector.alerts.size
+                }
+            }
+        }
+        return SnapshotCounts(greenhouses = gh, sectors = sec, devices = dev, settings = set, alerts = alt)
     }
 
     /**

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsRedisListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsRedisListener.kt
@@ -36,6 +36,12 @@ class WsRedisListener(
             logger.warn("Ignoring Redis pub/sub message with non-numeric body: '{}'", raw)
             return
         }
+        // INFO so the cross-pod handover is visible in logs without enabling
+        // DEBUG. Will appear at most once per broadcast on each peer pod and
+        // pairs with the originating pod's "WS broadcast" line for easy
+        // grepping by tenantId.
+        logger.info("WS broadcast peer received tenantId={} channel={}",
+            tenantId, String(message.channel))
         try {
             wsBroadcaster.deliverLocallyOnly(tenantId)
         } catch (e: Exception) {

--- a/src/main/kotlin/com/apptolast/invernaderos/mqtt/service/DeviceStatusProcessor.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/mqtt/service/DeviceStatusProcessor.kt
@@ -122,8 +122,6 @@ class DeviceStatusProcessor(
             deviceCurrentValueRepository.upsert(code, value, timestamp)
         }
 
-        logger.debug("Upserted {} current values", updates.size)
-
         // Resolve which tenants are affected and publish an event so the
         // WebSocket broadcaster can fan out a fresh snapshot to their users.
         // Codes that fail to resolve (unknown / DB hiccup) are silently
@@ -139,6 +137,11 @@ class DeviceStatusProcessor(
                 DeviceCurrentValuesFlushedEvent(tenantIds = affectedTenants)
             )
         }
+        // INFO instead of DEBUG so the cadence and volume of the flush is
+        // visible in production without enabling DEBUG globally. One log
+        // per flush that has work to do (i.e. ≤1/s in steady state).
+        logger.info("Flush upserted={} currentValues tenantsAffected={}",
+            updates.size, affectedTenants.size)
     }
 
     private fun flushRawReadings() {
@@ -146,6 +149,8 @@ class DeviceStatusProcessor(
         if (rawToPersist.isEmpty()) return
 
         sensorReadingRawRepository.saveAll(rawToPersist)
+        // DEBUG kept: raw flush count is verbose (~78/s in steady state)
+        // and the aggregate is already visible in flushCurrentValues' INFO.
         logger.debug("Persisted {} raw readings", rawToPersist.size)
     }
 
@@ -154,7 +159,8 @@ class DeviceStatusProcessor(
         if (dedupedToPersist.isEmpty()) return
 
         sensorReadingRepository.saveAll(dedupedToPersist)
-        logger.info("Persisted {} deduped readings (raw total in this batch included above)", dedupedToPersist.size)
+        logger.info("Flush dedupedReadings={} (only those that passed Redis dedup)",
+            dedupedToPersist.size)
     }
 
     private fun <T> drainQueue(queue: ConcurrentLinkedQueue<T>): List<T> {


### PR DESCRIPTION
## Summary

Cleans up the cluster's old DEBUG levels (Spring Redis / Lettuce / Hibernate / MQTT) that were drowning the new WebSocket broadcast logs from PR #108. Adds cadence + payload metadata to every broadcast line so debugging is possible from Dozzle without flipping anything to DEBUG.

### New per-broadcast INFO line

```
WS broadcast tenantId=... source=SENSOR_FLUSH usersTargeted=2 delivered=2
  payloadBytes=18432 deltaMsSinceLastForTenant=1003
  greenhouses=3 sectors=12 devices=48 settings=24 alerts=1 elapsedMs=14
```

- `source` — SENSOR_FLUSH | ALERT_ACTIVATED | ALERT_RESOLVED | GREENHOUSE_CRUD | SECTOR_CRUD | DEVICE_CRUD | SETTING_CRUD | USER_CRUD | REDIS_PEER (cross-pod handover).
- `deltaMsSinceLastForTenant` from a `ConcurrentHashMap<Long, Long>` keyed by tenantId. Lets you eyeball cadence and detect runaway producers.
- `payloadBytes` Jackson-serialised once per broadcast (not per recipient).
- counts iterate the in-memory snapshot — O(n) over the response that's already in RAM.
- `elapsedMs` covers assemble + serialise + send.

### Surrounding chain

`TenantStatusBroadcastListener.onDeviceCurrentValuesFlushed` / `onAlertStateChanged` / `onTenantStatusChanged` — moved from DEBUG → INFO, with the source tag visible.

`WsRedisListener.onMessage` — INFO line per peer-pod handover.

`DeviceStatusProcessor.flushCurrentValues` — INFO line each second when there's work, with `upserted` and `tenantsAffected`.

`DeviceStatusProcessor.flushDedupedReadings` — already INFO, kept; `flushRawReadings` stays DEBUG (~78/s would spam).

### ConfigMap cleanup (already applied to dev/prod cluster)

| Logger | Antes | Después | Por qué |
|---|---|---|---|
| `org.springframework.data.redis` | DEBUG (dev) / INFO (prod) | **WARN** | "Closing Redis Connection" cada operación |
| `io.lettuce.core` | DEBUG (dev) / INFO (prod) | **WARN** | "dispatching command [type=PUBLISH …]" cada comando |
| `org.hibernate.SQL` | DEBUG (dev) / WARN (prod) | **WARN** | ~78 SQL/s con sensores activos |
| `org.springframework.integration.mqtt` | DEBUG (dev) / INFO (prod) | **INFO** | Conexión sí, mensaje a mensaje no |
| `com.apptolast.invernaderos` | DEBUG (dev) / INFO (prod) | **INFO** | Lo importante ya está en INFO |

### Bonus

`monitoring/dozzle-image-updater` CronJob: rolling restart de Dozzle cada 12 h para coger la última `amir20/dozzle:latest`, mismo patrón que el `image-updater` del API. Aplicado al cluster.

### Verified live in dev

```
Flush upserted=2 currentValues tenantsAffected=1
TenantStatusBroadcast received source=SENSOR_FLUSH tenants=1
WS broadcast peer received tenantId=814... channel=inverapi:dev:ws:tenant-status
```

Spam check: 0 lines en últimos 500 logs (antes: cientos/min).

### Out of scope

- The final `WS broadcast … usersTargeted=…` line only appears once a STOMP-authenticated client connects (Alberto adds Bearer header to GreenhouseFronts' Krossbow CONNECT frame). Until then the line stays silent on purpose — the listener and Redis-peer logs prove the upstream half of the pipeline is alive.

### Test plan

- [x] `./gradlew compileKotlin` clean
- [x] `./gradlew test` full suite green
- [x] Dev rollout — health 200, broadcast chain visible, 0 spam
- [ ] Prod rollout after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)