### PR TITLE
feat(auth): add refresh-tokens with rotation + reuse-detection

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -460,6 +460,115 @@ Las métricas están disponibles en formato Prometheus en `/actuator/prometheus`
 
 ---
 
+## Autenticación — Refresh tokens
+
+A partir de la migración V39 el servicio emite **refresh tokens opacos con
+rotación + detección de reuse** además del JWT de acceso.
+
+### Flujo
+
+1. `POST /api/v1/auth/login` (o `/register`) → devuelve `JwtResponse` con:
+   - `token` (JWT access, HS256, TTL 1h por defecto)
+   - `refreshToken` (string opaco, 32B aleatorios base64url, TTL 30d por defecto)
+   - `expiresIn` (segundos hasta expirar el access)
+   - `refreshExpiresIn` (segundos hasta expirar el refresh)
+2. Cuando el access caduca, el cliente llama `POST /api/v1/auth/refresh`
+   con el body `{ "refreshToken": "..." }` (sin `Authorization` header).
+3. El backend valida el refresh, lo revoca y emite un par nuevo
+   (rotación) heredando el `family_id` original.
+4. **Detección de reuse**: si llega un `refreshToken` ya revocado, se
+   revoca toda la familia (cadena de rotaciones de ese login) y se
+   devuelve `401`. Se emite un log `WARN SECURITY: refresh-token reuse
+   detected …` en `RotateRefreshTokenUseCaseImpl`.
+5. `POST /api/v1/auth/logout` (con Bearer válido) revoca todos los
+   refresh tokens activos del usuario.
+
+### TTLs configurables
+
+| Variable | Default | Descripción |
+|----------|---------|-------------|
+| `JWT_ACCESS_EXPIRATION`  | `3600000`    | TTL del access JWT en ms (1h) |
+| `JWT_REFRESH_EXPIRATION` | `2592000000` | TTL del refresh en ms (30d)   |
+| `REFRESH_TOKEN_ENABLED`  | `true`       | Kill-switch del feature       |
+
+### Kill-switch (sin redeploy)
+
+Si tras un deploy aparece un bug en el flow de refresh:
+
+```bash
+kubectl set env deployment/invernaderos-api \
+  -n apptolast-invernadero-api-prod \
+  REFRESH_TOKEN_ENABLED=false
+```
+
+El pod se reinicia automáticamente. Tras 30s:
+- `/login` y `/register` devuelven `JwtResponse` solo con `token` (campos
+  nuevos como `null`, omitidos por Jackson `default-property-inclusion: non_null`).
+- `/refresh` devuelve `503`.
+- `logout` deja de revocar refresh (no-op).
+- Los rows de `metadata.refresh_tokens` permanecen y son válidos cuando
+  el flag se reactive.
+
+### Rotación de `JWT_SECRET`
+
+`JWT_SECRET` es el HMAC-SHA-256 con el que se firma el access JWT. Se
+inyecta en el pod desde el Secret `invernaderos-api-secret` (key
+`JWT_SECRET`). **No se commitea** al repo: el manifest contiene un
+placeholder y el valor real se aplica vía `kubectl`:
+
+```bash
+# DEV — usar valor distinto al de prod
+kubectl -n apptolast-invernadero-api-dev create secret generic invernaderos-api-secret \
+  --from-literal=TIMESCALE_PASSWORD="..." \
+  --from-literal=METADATA_PASSWORD="..." \
+  --from-literal=REDIS_PASSWORD="..." \
+  --from-literal=MQTT_USERNAME="..." \
+  --from-literal=MQTT_PASSWORD="..." \
+  --from-literal=SPRING_MAIL_PASSWORD="..." \
+  --from-literal=JWT_SECRET="$(openssl rand -base64 64 | tr -d '\n')" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# PROD — repetir con el namespace -prod y un secret DIFERENTE
+```
+
+Rotar `JWT_SECRET` invalida **todos** los access JWTs activos: los
+usuarios verán un `401` en su próxima request y la app caerá a re-login
+una vez. Los refresh tokens opacos sobreviven a la rotación porque no se
+firman con `JWT_SECRET`. Esto suele ser lo deseable: se renueva el
+secret sin perder sesiones (el cliente refresca silenciosamente y
+recibe un access firmado con el nuevo secret).
+
+### Tabla `metadata.refresh_tokens`
+
+Definida en `V39__create_refresh_tokens.sql`:
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| `id` | BIGSERIAL PK | Identificador interno |
+| `user_id` | BIGINT FK users(id) | Usuario propietario |
+| `token_hash` | CHAR(64) UNIQUE | SHA-256 hex del token plano (el plano no se persiste) |
+| `family_id` | UUID | Agrupa la cadena de rotaciones de un login |
+| `rotated_from_id` | BIGINT NULLABLE FK self | Padre del token (NULL para el primero de la familia) |
+| `expires_at` | TIMESTAMPTZ | Caducidad absoluta |
+| `revoked_at` | TIMESTAMPTZ NULLABLE | NULL = activo. Se setea en rotación / logout / reuse |
+| `created_at` | TIMESTAMPTZ | Timestamp de emisión |
+
+Índices:
+- `idx_refresh_tokens_user` — búsquedas por usuario
+- `idx_refresh_tokens_family` — revocación de familia en reuse
+- `idx_refresh_tokens_expires` — barridos de limpieza
+- `idx_refresh_tokens_user_active` (PARTIAL `WHERE revoked_at IS NULL`) — logout
+
+### Concurrencia
+
+El adapter usa `@Lock(LockModeType.PESSIMISTIC_WRITE)` con
+`jakarta.persistence.lock.timeout=3000` ms en `lockByTokenHash`.  Dos
+`/refresh` simultáneos con el mismo token: el primero gana el lock,
+revoca y emite el child; el segundo lee el row con `revoked_at` ya
+seteado → se interpreta como reuse → revocación de familia + 401.
+
+---
+
 ## Recursos Adicionales
 
 - [Documentación de Spring Boot](https://docs.spring.io/spring-boot/docs/current/reference/html/)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,14 @@ dependencies {
 	testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
 	// MockK - Kotlin-idiomatic mocking framework (preferred over Mockito for Kotlin)
 	testImplementation("io.mockk:mockk:1.13.16")
+	// Testcontainers — ephemeral PostgreSQL for @SpringBootTest integration tests.
+	// Provides the org.testcontainers.jdbc.ContainerDatabaseDriver consumed via
+	// the magic JDBC URL `jdbc:tc:postgresql:16-alpine:///<dbname>` from
+	// src/test/resources/application.yaml. Avoids any test ever touching the
+	// shared dev/prod databases.
+	testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.4"))
+	testImplementation("org.testcontainers:postgresql")
+	testImplementation("org.testcontainers:junit-jupiter")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/com/apptolast/invernaderos/config/FlywayConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/FlywayConfig.kt
@@ -34,6 +34,15 @@ class FlywayConfig {
     private var autoMigrate: Boolean = true
 
     /**
+     * Master switch to skip Flyway entirely. Used by tests so that Testcontainers
+     * databases (which start empty) rely on Hibernate `ddl-auto: create-drop`
+     * rather than running real migrations against an ephemeral container.
+     * Defaults to true in dev/prod where Flyway is the source of truth.
+     */
+    @Value("\${flyway.enabled:true}")
+    private var flywayEnabled: Boolean = true
+
+    /**
      * Flyway principal para PostgreSQL Metadata (schema 'metadata').
      * Migraciones en: classpath:db/migration/
      */
@@ -63,6 +72,11 @@ class FlywayConfig {
         @Qualifier("timescaleDataSource") timescaleDataSource: DataSource
     ): FlywayMigrationStrategy {
         return FlywayMigrationStrategy { metadataFlyway ->
+            if (!flywayEnabled) {
+                logger.info("Flyway DESACTIVADO via flyway.enabled=false (test profile) - skipping migrations.")
+                return@FlywayMigrationStrategy
+            }
+
             val timescaleFlyway = Flyway.configure()
                 .dataSource(timescaleDataSource)
                 .locations("classpath:db/migration-timescaledb")

--- a/src/main/kotlin/com/apptolast/invernaderos/config/PostGreSQLDataSourceConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/PostGreSQLDataSourceConfig.kt
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariDataSource
 import jakarta.persistence.EntityManagerFactory
 import javax.sql.DataSource
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -32,7 +33,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
                         "com.apptolast.invernaderos.features.device",
                         "com.apptolast.invernaderos.features.catalog",
                         "com.apptolast.invernaderos.features.user",
-
+                        "com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.repository",
                         "com.apptolast.invernaderos.features.statistics",
                         "com.apptolast.invernaderos.features.setting",
                         "com.apptolast.invernaderos.features.command",
@@ -40,7 +41,10 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
         entityManagerFactoryRef = "metadataEntityManagerFactory",
         transactionManagerRef = "metadataTransactionManager"
 )
-class PostGreSQLDataSourceConfig {
+class PostGreSQLDataSourceConfig(
+    @Value("\${spring.jpa.hibernate.ddl-auto:validate}")
+    private val ddlAuto: String
+) {
 
     @Bean(name = ["metadataDataSourceProperties"], defaultCandidate = false)
     @ConfigurationProperties("spring.datasource-metadata")
@@ -74,6 +78,7 @@ class PostGreSQLDataSourceConfig {
                 "com.apptolast.invernaderos.features.device",
                 "com.apptolast.invernaderos.features.catalog",
                 "com.apptolast.invernaderos.features.user",
+                "com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.entity",
                 "com.apptolast.invernaderos.features.statistics",
                 "com.apptolast.invernaderos.features.setting",
                 "com.apptolast.invernaderos.features.command",
@@ -88,7 +93,7 @@ class PostGreSQLDataSourceConfig {
         val properties =
                 hashMapOf<String, Any>(
                         "hibernate.dialect" to "org.hibernate.dialect.PostgreSQLDialect",
-                        "hibernate.hbm2ddl.auto" to "validate",
+                        "hibernate.hbm2ddl.auto" to ddlAuto,
                         "hibernate.show_sql" to "false",
                         "hibernate.format_sql" to "true"
                 )

--- a/src/main/kotlin/com/apptolast/invernaderos/core/security/JwtLogoutHandler.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/core/security/JwtLogoutHandler.kt
@@ -1,0 +1,33 @@
+package com.apptolast.invernaderos.core.security
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RevokeUserRefreshTokensUseCase
+import com.apptolast.invernaderos.features.user.UserService
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.logout.LogoutHandler
+import org.springframework.stereotype.Component
+
+@Component
+class JwtLogoutHandler(
+    private val revokeUserRefreshTokensUseCase: RevokeUserRefreshTokensUseCase,
+    private val userService: UserService,
+    @Value("\${auth.refresh-token.enabled:true}") private val refreshEnabled: Boolean
+) : LogoutHandler {
+
+    private val log = LoggerFactory.getLogger(JwtLogoutHandler::class.java)
+
+    override fun logout(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        auth: Authentication?
+    ) {
+        if (!refreshEnabled || auth == null) return
+        val username = auth.name ?: return
+        val user = userService.findByEmail(username) ?: return
+        val n = revokeUserRefreshTokensUseCase.execute(user.id!!)
+        log.info("Logout: revoked {} active refresh tokens for userId={}", n, user.id)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/core/security/JwtService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/core/security/JwtService.kt
@@ -16,7 +16,7 @@ class JwtService {
 
     @Value("\${spring.security.jwt.secret}") private lateinit var secretKey: String
 
-    @Value("\${spring.security.jwt.expiration}") private var jwtExpiration: Long = 0
+    @Value("\${spring.security.jwt.access-expiration}") private var accessExpirationMs: Long = 0
 
     fun extractUsername(token: String): String {
         return extractClaim(token, Claims::getSubject)
@@ -32,8 +32,10 @@ class JwtService {
     }
 
     fun generateToken(extraClaims: Map<String, Any>, userDetails: UserDetails): String {
-        return buildToken(extraClaims, userDetails, jwtExpiration)
+        return buildToken(extraClaims, userDetails, accessExpirationMs)
     }
+
+    fun getAccessTtlSeconds(): Long = accessExpirationMs / 1000
 
     private fun buildToken(
             extraClaims: Map<String, Any>,
@@ -49,7 +51,6 @@ class JwtService {
                 .compact()
     }
 
-    
     fun isTokenValid(token: String, userDetails: UserDetails): Boolean {
         val username = extractUsername(token)
         return (username == userDetails.username) && !isTokenExpired(token)

--- a/src/main/kotlin/com/apptolast/invernaderos/core/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/core/security/SecurityConfig.kt
@@ -2,6 +2,7 @@ package com.apptolast.invernaderos.core.security
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Lazy
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
@@ -22,7 +23,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 @EnableWebSecurity
 class SecurityConfig(
         private val jwtAuthenticationFilter: JwtAuthenticationFilter,
-        private val userDetailsService: UserDetailsService
+        private val userDetailsService: UserDetailsService,
+        @Lazy private val jwtLogoutHandler: JwtLogoutHandler
 ) {
 
     @Bean
@@ -63,9 +65,9 @@ class SecurityConfig(
                         UsernamePasswordAuthenticationFilter::class.java
                 )
                 .logout { logout ->
-                    logout.logoutUrl("/api/v1/auth/logout").logoutSuccessHandler { _, response, _ ->
-                        response.status = 200
-                    }
+                    logout.logoutUrl("/api/v1/auth/logout")
+                        .addLogoutHandler(jwtLogoutHandler)
+                        .logoutSuccessHandler { _, response, _ -> response.status = 200 }
                 }
 
         return http.build()

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthController.kt
@@ -2,11 +2,15 @@ package com.apptolast.invernaderos.features.auth
 
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.LoginRequest
+import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
 import com.apptolast.invernaderos.features.auth.dto.request.RegisterRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -59,4 +63,27 @@ class AuthController(private val authService: AuthService) {
         authService.resetPassword(request)
         return ResponseEntity.ok().build()
     }
+
+    @PostMapping("/refresh")
+    @Operation(
+        summary = "Rotate refresh token",
+        description = "Validates the refresh token, revokes it, and issues a new access + refresh pair. Detects reuse of revoked tokens (revokes the whole family).",
+        security = []
+    )
+    @ApiResponse(responseCode = "200", description = "New token pair issued")
+    @ApiResponse(responseCode = "400", description = "Malformed body")
+    @ApiResponse(responseCode = "401", description = "Refresh token invalid, expired, revoked or reused")
+    @ApiResponse(responseCode = "503", description = "Refresh token feature is disabled")
+    fun refresh(@Valid @RequestBody request: RefreshRequest): ResponseEntity<JwtResponse> =
+        authService.refresh(request).fold(
+            onSuccess = { ResponseEntity.ok(it) },
+            onFailure = { ex ->
+                val err = (ex as? AuthErrorException)?.error
+                when (err) {
+                    AuthError.FeatureDisabled -> ResponseEntity.status(503).build()
+                    AuthError.MalformedToken  -> ResponseEntity.badRequest().build()
+                    else                      -> ResponseEntity.status(401).build()
+                }
+            }
+        )
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthRefreshService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthRefreshService.kt
@@ -1,0 +1,104 @@
+package com.apptolast.invernaderos.features.auth
+
+import com.apptolast.invernaderos.core.security.JwtService
+import com.apptolast.invernaderos.features.auth.dto.mapper.toJwtResponse
+import com.apptolast.invernaderos.features.auth.dto.request.LoginRequest
+import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
+import com.apptolast.invernaderos.features.auth.dto.request.RegisterRequest
+import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RotateRefreshTokenUseCase
+import com.apptolast.invernaderos.features.user.UserService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Service
+
+/**
+ * Extends authentication with opaque refresh-token rotation.
+ * Wraps [AuthService] for login/register with refresh-token issuance,
+ * and provides the /refresh endpoint operation.
+ *
+ * This service is intentionally separate from [AuthService] so that
+ * existing unit tests for [AuthService] do not require mocking of the
+ * refresh-token use cases.
+ */
+@Service
+class AuthRefreshService(
+        private val authenticationManager: AuthenticationManager,
+        private val jwtService: JwtService,
+        private val userService: UserService,
+        private val userDetailsService: UserDetailsService,
+        private val emailService: EmailService,
+        private val issueRefreshTokenUseCase: IssueRefreshTokenUseCase,
+        private val rotateRefreshTokenUseCase: RotateRefreshTokenUseCase,
+        @Value("\${auth.refresh-token.enabled:true}") private val refreshTokenEnabled: Boolean
+) {
+
+        fun loginWithRefresh(request: LoginRequest): JwtResponse {
+                authenticationManager.authenticate(
+                        UsernamePasswordAuthenticationToken(request.username, request.password)
+                )
+
+                val userDetails = userDetailsService.loadUserByUsername(request.username)
+                val user = userService.findByEmail(request.username)
+                        ?: throw RuntimeException("User not found after authentication")
+
+                return if (refreshTokenEnabled) {
+                        val tokens = issueRefreshTokenUseCase.execute(
+                                IssueRefreshTokenCommand(userId = user.id!!)
+                        )
+                        tokens.toJwtResponse()
+                } else {
+                        val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
+                        val token = jwtService.generateToken(extraClaims, userDetails)
+                        JwtResponse(
+                                token = token,
+                                username = userDetails.username,
+                                roles = userDetails.authorities.map { it.authority }
+                        )
+                }
+        }
+
+        fun registerWithRefresh(request: RegisterRequest): JwtResponse {
+                val user = userService.createTenantAndAdminUser(
+                        tenantName = request.companyName,
+                        email = request.email,
+                        passwordRaw = request.password,
+                        firstName = request.firstName,
+                        lastName = request.lastName,
+                        phone = request.phone,
+                        province = request.address
+                )
+
+                return if (refreshTokenEnabled) {
+                        val savedUser = userService.findByEmail(user.email)
+                                ?: throw RuntimeException("User not found after registration")
+                        val tokens = issueRefreshTokenUseCase.execute(
+                                IssueRefreshTokenCommand(userId = savedUser.id!!)
+                        )
+                        tokens.toJwtResponse()
+                } else {
+                        val userDetails = userDetailsService.loadUserByUsername(user.email)
+                        val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
+                        val token = jwtService.generateToken(extraClaims, userDetails)
+                        JwtResponse(
+                                token = token,
+                                username = user.email,
+                                roles = listOf("ROLE_" + user.role)
+                        )
+                }
+        }
+
+        fun refresh(req: RefreshRequest): Result<JwtResponse> {
+                if (!refreshTokenEnabled) {
+                        return Result.failure(AuthErrorException(AuthError.FeatureDisabled))
+                }
+                return rotateRefreshTokenUseCase.execute(req.refreshToken)
+                        .map { it.toJwtResponse() }
+        }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthRefreshService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthRefreshService.kt
@@ -33,7 +33,6 @@ class AuthRefreshService(
         private val jwtService: JwtService,
         private val userService: UserService,
         private val userDetailsService: UserDetailsService,
-        private val emailService: EmailService,
         private val issueRefreshTokenUseCase: IssueRefreshTokenUseCase,
         private val rotateRefreshTokenUseCase: RotateRefreshTokenUseCase,
         @Value("\${auth.refresh-token.enabled:true}") private val refreshTokenEnabled: Boolean
@@ -46,11 +45,13 @@ class AuthRefreshService(
 
                 val userDetails = userDetailsService.loadUserByUsername(request.username)
                 val user = userService.findByEmail(request.username)
-                        ?: throw RuntimeException("User not found after authentication")
+                        ?: throw IllegalStateException("User not found after authentication")
+                val userId = user.id
+                        ?: throw IllegalStateException("Persisted user ${user.email} has null id")
 
                 return if (refreshTokenEnabled) {
                         val tokens = issueRefreshTokenUseCase.execute(
-                                IssueRefreshTokenCommand(userId = user.id!!)
+                                IssueRefreshTokenCommand(userId = userId)
                         )
                         tokens.toJwtResponse()
                 } else {
@@ -77,9 +78,11 @@ class AuthRefreshService(
 
                 return if (refreshTokenEnabled) {
                         val savedUser = userService.findByEmail(user.email)
-                                ?: throw RuntimeException("User not found after registration")
+                                ?: throw IllegalStateException("User not found after registration")
+                        val savedUserId = savedUser.id
+                                ?: throw IllegalStateException("Persisted user ${savedUser.email} has null id")
                         val tokens = issueRefreshTokenUseCase.execute(
-                                IssueRefreshTokenCommand(userId = savedUser.id!!)
+                                IssueRefreshTokenCommand(userId = savedUserId)
                         )
                         tokens.toJwtResponse()
                 } else {

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthService.kt
@@ -3,10 +3,14 @@ package com.apptolast.invernaderos.features.auth
 import com.apptolast.invernaderos.core.security.JwtService
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.LoginRequest
+import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
 import com.apptolast.invernaderos.features.auth.dto.request.RegisterRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
 import com.apptolast.invernaderos.features.user.UserService
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.userdetails.UserDetailsService
@@ -21,7 +25,16 @@ class AuthService(
         private val emailService: EmailService
 ) {
 
+        /** Injected after construction to avoid circular dependency and preserve 5-arg constructor for tests. */
+        @Autowired(required = false)
+        private var authRefreshService: AuthRefreshService? = null
+
         fun login(request: LoginRequest): JwtResponse {
+                val delegate = authRefreshService
+                if (delegate != null) {
+                        return delegate.loginWithRefresh(request)
+                }
+
                 authenticationManager.authenticate(
                         UsernamePasswordAuthenticationToken(request.username, request.password)
                 )
@@ -31,10 +44,9 @@ class AuthService(
                         userService.findByEmail(request.username)
                                 ?: throw RuntimeException(
                                         "User not found after authentication"
-                                ) // Should not happen
+                                )
 
                 val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
-
                 val token = jwtService.generateToken(extraClaims, userDetails)
 
                 return JwtResponse(
@@ -49,6 +61,11 @@ class AuthService(
                         throw RuntimeException("Email already in use")
                 }
 
+                val delegate = authRefreshService
+                if (delegate != null) {
+                        return delegate.registerWithRefresh(request)
+                }
+
                 val user =
                         userService.createTenantAndAdminUser(
                                 tenantName = request.companyName,
@@ -60,7 +77,6 @@ class AuthService(
                                 province = request.address
                         )
 
-                // Auto-login after registration
                 val userDetails = userDetailsService.loadUserByUsername(user.email)
                 val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
                 val token = jwtService.generateToken(extraClaims, userDetails)
@@ -68,13 +84,18 @@ class AuthService(
                 return JwtResponse(
                         token = token,
                         username = user.email,
-                        roles = listOf("ROLE_" + user.role) // Simple mapping
+                        roles = listOf("ROLE_" + user.role)
                 )
+        }
+
+        fun refresh(req: RefreshRequest): Result<JwtResponse> {
+                val delegate = authRefreshService
+                        ?: return Result.failure(AuthErrorException(AuthError.FeatureDisabled))
+                return delegate.refresh(req)
         }
 
         fun forgotPassword(request: ForgotPasswordRequest) {
                 val token = userService.generatePasswordResetToken(request.email)
-                // In a real scenario, we might want to do this asynchronously
                 emailService.sendPasswordResetEmail(request.email, token)
         }
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthService.kt
@@ -1,98 +1,33 @@
 package com.apptolast.invernaderos.features.auth
 
-import com.apptolast.invernaderos.core.security.JwtService
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.LoginRequest
 import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
 import com.apptolast.invernaderos.features.auth.dto.request.RegisterRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
-import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
-import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
 import com.apptolast.invernaderos.features.user.UserService
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.security.authentication.AuthenticationManager
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.stereotype.Service
 
 @Service
 class AuthService(
-        private val authenticationManager: AuthenticationManager,
-        private val jwtService: JwtService,
         private val userService: UserService,
-        private val userDetailsService: UserDetailsService,
-        private val emailService: EmailService
+        private val emailService: EmailService,
+        private val authRefreshService: AuthRefreshService
 ) {
 
-        /** Injected after construction to avoid circular dependency and preserve 5-arg constructor for tests. */
-        @Autowired(required = false)
-        private var authRefreshService: AuthRefreshService? = null
-
-        fun login(request: LoginRequest): JwtResponse {
-                val delegate = authRefreshService
-                if (delegate != null) {
-                        return delegate.loginWithRefresh(request)
-                }
-
-                authenticationManager.authenticate(
-                        UsernamePasswordAuthenticationToken(request.username, request.password)
-                )
-
-                val userDetails = userDetailsService.loadUserByUsername(request.username)
-                val user =
-                        userService.findByEmail(request.username)
-                                ?: throw RuntimeException(
-                                        "User not found after authentication"
-                                )
-
-                val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
-                val token = jwtService.generateToken(extraClaims, userDetails)
-
-                return JwtResponse(
-                        token = token,
-                        username = userDetails.username,
-                        roles = userDetails.authorities.map { it.authority }
-                )
-        }
+        fun login(request: LoginRequest): JwtResponse =
+                authRefreshService.loginWithRefresh(request)
 
         fun register(request: RegisterRequest): JwtResponse {
                 if (userService.existsByEmail(request.email)) {
                         throw RuntimeException("Email already in use")
                 }
-
-                val delegate = authRefreshService
-                if (delegate != null) {
-                        return delegate.registerWithRefresh(request)
-                }
-
-                val user =
-                        userService.createTenantAndAdminUser(
-                                tenantName = request.companyName,
-                                email = request.email,
-                                passwordRaw = request.password,
-                                firstName = request.firstName,
-                                lastName = request.lastName,
-                                phone = request.phone,
-                                province = request.address
-                        )
-
-                val userDetails = userDetailsService.loadUserByUsername(user.email)
-                val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
-                val token = jwtService.generateToken(extraClaims, userDetails)
-
-                return JwtResponse(
-                        token = token,
-                        username = user.email,
-                        roles = listOf("ROLE_" + user.role)
-                )
+                return authRefreshService.registerWithRefresh(request)
         }
 
-        fun refresh(req: RefreshRequest): Result<JwtResponse> {
-                val delegate = authRefreshService
-                        ?: return Result.failure(AuthErrorException(AuthError.FeatureDisabled))
-                return delegate.refresh(req)
-        }
+        fun refresh(req: RefreshRequest): Result<JwtResponse> =
+                authRefreshService.refresh(req)
 
         fun forgotPassword(request: ForgotPasswordRequest) {
                 val token = userService.generatePasswordResetToken(request.email)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/mapper/AuthMappers.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/mapper/AuthMappers.kt
@@ -1,0 +1,13 @@
+package com.apptolast.invernaderos.features.auth.dto.mapper
+
+import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+
+fun AuthTokensResult.toJwtResponse(): JwtResponse = JwtResponse(
+    token = accessToken,
+    username = username,
+    roles = roles,
+    refreshToken = refreshToken,
+    expiresIn = accessTtlSeconds,
+    refreshExpiresIn = refreshTtlSeconds
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/request/RefreshRequest.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/request/RefreshRequest.kt
@@ -1,0 +1,11 @@
+package com.apptolast.invernaderos.features.auth.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "Request body for /api/v1/auth/refresh")
+data class RefreshRequest(
+    @field:NotBlank(message = "refreshToken is required")
+    @Schema(description = "The refresh token previously issued by /login or /refresh", required = true)
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/response/JwtResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/response/JwtResponse.kt
@@ -2,10 +2,13 @@ package com.apptolast.invernaderos.features.auth.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Response object containing JWT token")
+@Schema(description = "Response object containing JWT and refresh tokens")
 data class JwtResponse(
-        @Schema(description = "JWT Access Token") val token: String,
-        @Schema(description = "Token type", example = "Bearer") val type: String = "Bearer",
-        @Schema(description = "Username/Email of the authenticated user") val username: String,
-        @Schema(description = "List of roles assigned to the user") val roles: List<String>
+    @Schema(description = "JWT Access Token") val token: String,
+    @Schema(description = "Token type", example = "Bearer") val type: String = "Bearer",
+    @Schema(description = "Username/Email of the authenticated user") val username: String,
+    @Schema(description = "List of roles assigned to the user") val roles: List<String>,
+    @Schema(description = "Opaque refresh token (rotates on /refresh)") val refreshToken: String? = null,
+    @Schema(description = "Access token TTL in seconds") val expiresIn: Long? = null,
+    @Schema(description = "Refresh token TTL in seconds") val refreshExpiresIn: Long? = null
 )

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/AuthErrorException.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/AuthErrorException.kt
@@ -1,0 +1,5 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+
+class AuthErrorException(val error: AuthError) : RuntimeException(error.message)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseImpl.kt
@@ -35,7 +35,7 @@ class IssueRefreshTokenUseCaseImpl(
             userId = cmd.userId,
             tokenHash = tokenHash,
             familyId = familyId,
-            rotatedFromId = null,
+            rotatedFromId = cmd.rotatedFromId,
             expiresAt = now.plus(refreshTtl),
             revokedAt = null,
             createdAt = now

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseImpl.kt
@@ -1,0 +1,56 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.AccessTokenIssuer
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.UserClaimsLookup
+import java.time.Clock
+import java.time.Duration
+
+class IssueRefreshTokenUseCaseImpl(
+    private val repo: RefreshTokenRepositoryPort,
+    private val gen: OpaqueTokenGenerator,
+    private val accessIssuer: AccessTokenIssuer,
+    private val userClaims: UserClaimsLookup,
+    private val refreshTtl: Duration,
+    private val clock: Clock
+) : IssueRefreshTokenUseCase {
+
+    override fun execute(cmd: IssueRefreshTokenCommand): AuthTokensResult {
+        val now = clock.instant()
+        val plainToken = gen.generate()
+        val tokenHash = gen.hash(plainToken)
+
+        val familyId = cmd.familyId ?: RefreshTokenFamilyId.new()
+
+        val snapshot = userClaims.loadForToken(cmd.userId)
+
+        val refreshToken = RefreshToken(
+            id = null,
+            userId = cmd.userId,
+            tokenHash = tokenHash,
+            familyId = familyId,
+            rotatedFromId = null,
+            expiresAt = now.plus(refreshTtl),
+            revokedAt = null,
+            createdAt = now
+        )
+        repo.save(refreshToken)
+
+        val accessToken = accessIssuer.issue(snapshot.username, snapshot.claims)
+
+        return AuthTokensResult(
+            accessToken = accessToken,
+            refreshToken = plainToken,
+            accessTtlSeconds = accessIssuer.accessTtlSeconds(),
+            refreshTtlSeconds = refreshTtl.seconds,
+            username = snapshot.username,
+            roles = snapshot.roles
+        )
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RevokeUserRefreshTokensUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RevokeUserRefreshTokensUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RevokeUserRefreshTokensUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import java.time.Clock
+
+class RevokeUserRefreshTokensUseCaseImpl(
+    private val repo: RefreshTokenRepositoryPort,
+    private val clock: Clock
+) : RevokeUserRefreshTokensUseCase {
+
+    override fun execute(userId: Long): Int {
+        return repo.revokeAllActiveByUser(userId, clock.instant())
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseImpl.kt
@@ -1,0 +1,56 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RotateRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import org.slf4j.LoggerFactory
+import java.time.Clock
+
+class RotateRefreshTokenUseCaseImpl(
+    private val repo: RefreshTokenRepositoryPort,
+    private val gen: OpaqueTokenGenerator,
+    private val issueUseCase: IssueRefreshTokenUseCase,
+    private val clock: Clock
+) : RotateRefreshTokenUseCase {
+
+    private val log = LoggerFactory.getLogger(RotateRefreshTokenUseCaseImpl::class.java)
+
+    override fun execute(rawRefreshToken: String): Result<AuthTokensResult> {
+        if (rawRefreshToken.isBlank()) {
+            return Result.failure(AuthErrorException(AuthError.MalformedToken))
+        }
+
+        val now = clock.instant()
+        val hash = gen.hash(rawRefreshToken)
+        val stored = repo.findByTokenHashLocking(hash)
+            ?: return Result.failure(AuthErrorException(AuthError.TokenNotFound))
+
+        if (stored.isRevoked()) {
+            val revokedRows = repo.revokeFamily(stored.familyId, now)
+            log.warn(
+                "SECURITY: refresh-token reuse detected — userId={} familyId={} revokedRows={}",
+                stored.userId,
+                stored.familyId.value,
+                revokedRows
+            )
+            return Result.failure(
+                AuthErrorException(AuthError.TokenReuseDetected(stored.familyId.value, stored.userId))
+            )
+        }
+
+        if (stored.isExpired(now)) {
+            return Result.failure(AuthErrorException(AuthError.TokenExpired))
+        }
+
+        stored.id?.let { repo.revoke(it, now) }
+
+        val tokens = issueUseCase.execute(
+            IssueRefreshTokenCommand(userId = stored.userId, familyId = stored.familyId)
+        )
+        return Result.success(tokens)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseImpl.kt
@@ -46,10 +46,18 @@ class RotateRefreshTokenUseCaseImpl(
             return Result.failure(AuthErrorException(AuthError.TokenExpired))
         }
 
-        stored.id?.let { repo.revoke(it, now) }
+        val parentId = stored.id
+            ?: return Result.failure(
+                AuthErrorException(AuthError.TokenNotFound)
+            ) // defensive: a stored token without id is malformed persistence state
+        repo.revoke(parentId, now)
 
         val tokens = issueUseCase.execute(
-            IssueRefreshTokenCommand(userId = stored.userId, familyId = stored.familyId)
+            IssueRefreshTokenCommand(
+                userId = stored.userId,
+                familyId = stored.familyId,
+                rotatedFromId = parentId
+            )
         )
         return Result.success(tokens)
     }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/error/AuthError.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/error/AuthError.kt
@@ -1,0 +1,31 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.error
+
+import java.util.UUID
+
+sealed interface AuthError {
+    val message: String
+
+    data object MalformedToken : AuthError {
+        override val message = "Malformed refresh token"
+    }
+
+    data object TokenNotFound : AuthError {
+        override val message = "Refresh token not found"
+    }
+
+    data object TokenExpired : AuthError {
+        override val message = "Refresh token expired"
+    }
+
+    data object TokenRevoked : AuthError {
+        override val message = "Refresh token revoked"
+    }
+
+    data class TokenReuseDetected(val familyId: UUID, val userId: Long) : AuthError {
+        override val message = "Refresh token reuse detected for user $userId family $familyId"
+    }
+
+    data object FeatureDisabled : AuthError {
+        override val message = "Refresh token feature is disabled"
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/AuthTokensResult.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/AuthTokensResult.kt
@@ -1,0 +1,10 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.model
+
+data class AuthTokensResult(
+    val accessToken: String,
+    val refreshToken: String,           // plaintext, ONLY here, never persisted
+    val accessTtlSeconds: Long,
+    val refreshTtlSeconds: Long,
+    val username: String,
+    val roles: List<String>
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshToken.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshToken.kt
@@ -1,0 +1,18 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.model
+
+import java.time.Instant
+
+data class RefreshToken(
+    val id: Long?,
+    val userId: Long,
+    val tokenHash: String,
+    val familyId: RefreshTokenFamilyId,
+    val rotatedFromId: Long?,
+    val expiresAt: Instant,
+    val revokedAt: Instant?,
+    val createdAt: Instant
+) {
+    fun isExpired(now: Instant): Boolean = !now.isBefore(expiresAt)
+    fun isRevoked(): Boolean = revokedAt != null
+    fun isUsable(now: Instant): Boolean = !isRevoked() && !isExpired(now)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshTokenFamilyId.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshTokenFamilyId.kt
@@ -1,0 +1,9 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.model
+
+import java.util.UUID
+
+@JvmInline value class RefreshTokenFamilyId(val value: UUID) {
+    companion object {
+        fun new(): RefreshTokenFamilyId = RefreshTokenFamilyId(UUID.randomUUID())
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshTokenId.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshTokenId.kt
@@ -1,0 +1,3 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.model
+
+@JvmInline value class RefreshTokenId(val value: Long)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/IssueRefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/IssueRefreshTokenUseCase.kt
@@ -5,7 +5,8 @@ import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToke
 
 data class IssueRefreshTokenCommand(
     val userId: Long,
-    val familyId: RefreshTokenFamilyId? = null  // null → new family (login/register); set → rotation
+    val familyId: RefreshTokenFamilyId? = null,  // null → new family (login/register); set → rotation
+    val rotatedFromId: Long? = null              // parent token id when rotating; null on login/register
 )
 
 interface IssueRefreshTokenUseCase {

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/IssueRefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/IssueRefreshTokenUseCase.kt
@@ -1,0 +1,13 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.input
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+
+data class IssueRefreshTokenCommand(
+    val userId: Long,
+    val familyId: RefreshTokenFamilyId? = null  // null → new family (login/register); set → rotation
+)
+
+interface IssueRefreshTokenUseCase {
+    fun execute(cmd: IssueRefreshTokenCommand): AuthTokensResult
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/RevokeUserRefreshTokensUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/RevokeUserRefreshTokensUseCase.kt
@@ -1,0 +1,6 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.input
+
+interface RevokeUserRefreshTokensUseCase {
+    /** Revokes all active refresh tokens of a user. Returns the number of rows revoked. */
+    fun execute(userId: Long): Int
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/RotateRefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/RotateRefreshTokenUseCase.kt
@@ -1,0 +1,13 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.input
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+
+interface RotateRefreshTokenUseCase {
+    /**
+     * Validates and rotates an opaque refresh token.
+     * Returns Result.success with the new token pair, or Result.failure(AuthErrorException(error))
+     * containing the AuthError as cause.
+     * Reuse of a revoked token triggers full-family revocation (the failure carries TokenReuseDetected).
+     */
+    fun execute(rawRefreshToken: String): Result<AuthTokensResult>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/AccessTokenIssuer.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/AccessTokenIssuer.kt
@@ -1,0 +1,6 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.output
+
+interface AccessTokenIssuer {
+    fun issue(username: String, extraClaims: Map<String, Any>): String
+    fun accessTtlSeconds(): Long
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/OpaqueTokenGenerator.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/OpaqueTokenGenerator.kt
@@ -1,0 +1,6 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.output
+
+interface OpaqueTokenGenerator {
+    fun generate(): String          // 32-byte SecureRandom, base64url no-padding
+    fun hash(token: String): String // SHA-256 hex (lowercase, 64 chars)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/RefreshTokenRepositoryPort.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/RefreshTokenRepositoryPort.kt
@@ -1,0 +1,20 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.output
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import java.time.Instant
+
+interface RefreshTokenRepositoryPort {
+    fun save(token: RefreshToken): RefreshToken
+
+    /**
+     * MUST acquire a row-level write lock (SELECT ... FOR UPDATE) so concurrent
+     * /refresh calls with the same token serialize and reuse-detection works
+     * deterministically.
+     */
+    fun findByTokenHashLocking(tokenHash: String): RefreshToken?
+
+    fun revoke(id: Long, at: Instant)
+    fun revokeFamily(familyId: RefreshTokenFamilyId, at: Instant): Int
+    fun revokeAllActiveByUser(userId: Long, at: Instant): Int
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/UserClaimsLookup.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/UserClaimsLookup.kt
@@ -1,0 +1,11 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.output
+
+interface UserClaimsLookup {
+    fun loadForToken(userId: Long): UserClaimsSnapshot
+
+    data class UserClaimsSnapshot(
+        val username: String,
+        val roles: List<String>,
+        val claims: Map<String, Any>     // tenantId, role
+    )
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/JwtAccessTokenIssuerAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/JwtAccessTokenIssuerAdapter.kt
@@ -1,0 +1,20 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.core.security.JwtService
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.AccessTokenIssuer
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Component
+
+@Component
+class JwtAccessTokenIssuerAdapter(
+    private val jwtService: JwtService,
+    private val userDetailsService: UserDetailsService
+) : AccessTokenIssuer {
+
+    override fun issue(username: String, extraClaims: Map<String, Any>): String {
+        val ud = userDetailsService.loadUserByUsername(username)
+        return jwtService.generateToken(extraClaims, ud)
+    }
+
+    override fun accessTtlSeconds(): Long = jwtService.getAccessTtlSeconds()
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/RefreshTokenRepositoryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/RefreshTokenRepositoryAdapter.kt
@@ -1,0 +1,34 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.mapper.toDomain
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.mapper.toEntity
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.repository.RefreshTokenJpaRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Component
+@Transactional("metadataTransactionManager")
+class RefreshTokenRepositoryAdapter(
+    private val jpa: RefreshTokenJpaRepository
+) : RefreshTokenRepositoryPort {
+
+    override fun save(token: RefreshToken): RefreshToken =
+        jpa.save(token.toEntity()).toDomain()
+
+    override fun findByTokenHashLocking(tokenHash: String): RefreshToken? =
+        jpa.lockByTokenHash(tokenHash)?.toDomain()
+
+    override fun revoke(id: Long, at: Instant) {
+        jpa.revokeById(id, at)
+    }
+
+    override fun revokeFamily(familyId: RefreshTokenFamilyId, at: Instant): Int =
+        jpa.revokeFamily(familyId.value, at)
+
+    override fun revokeAllActiveByUser(userId: Long, at: Instant): Int =
+        jpa.revokeAllActiveByUser(userId, at)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/Sha256OpaqueTokenGenerator.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/Sha256OpaqueTokenGenerator.kt
@@ -1,0 +1,24 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import org.springframework.stereotype.Component
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+@Component
+class Sha256OpaqueTokenGenerator : OpaqueTokenGenerator {
+
+    private val rnd = SecureRandom()
+
+    override fun generate(): String {
+        val buf = ByteArray(32)
+        rnd.nextBytes(buf)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(buf)
+    }
+
+    override fun hash(token: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(token.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/UserClaimsLookupAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/UserClaimsLookupAdapter.kt
@@ -1,0 +1,24 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.UserClaimsLookup
+import com.apptolast.invernaderos.features.user.UserService
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Component
+
+@Component
+class UserClaimsLookupAdapter(
+    private val userService: UserService,
+    private val userDetailsService: UserDetailsService
+) : UserClaimsLookup {
+
+    override fun loadForToken(userId: Long): UserClaimsLookup.UserClaimsSnapshot {
+        val user = userService.findById(userId)
+            ?: throw IllegalStateException("User $userId not found while issuing refresh token")
+        val ud = userDetailsService.loadUserByUsername(user.email)
+        return UserClaimsLookup.UserClaimsSnapshot(
+            username = user.email,
+            roles = ud.authorities.map { it.authority },
+            claims = mapOf("tenantId" to user.tenantId, "role" to user.role)
+        )
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/config/RefreshTokenModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/config/RefreshTokenModuleConfig.kt
@@ -1,0 +1,50 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.config
+
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.IssueRefreshTokenUseCaseImpl
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.RevokeUserRefreshTokensUseCaseImpl
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.RotateRefreshTokenUseCaseImpl
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RevokeUserRefreshTokensUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RotateRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.AccessTokenIssuer
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.UserClaimsLookup
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+import java.time.Duration
+
+@Configuration
+class RefreshTokenModuleConfig {
+
+    @Bean
+    fun clock(): Clock = Clock.systemUTC()
+
+    @Bean
+    fun issueRefreshTokenUseCase(
+        repo: RefreshTokenRepositoryPort,
+        gen: OpaqueTokenGenerator,
+        accessIssuer: AccessTokenIssuer,
+        userClaims: UserClaimsLookup,
+        @Value("\${spring.security.jwt.refresh-expiration}") refreshMs: Long,
+        clock: Clock
+    ): IssueRefreshTokenUseCase = IssueRefreshTokenUseCaseImpl(
+        repo, gen, accessIssuer, userClaims, Duration.ofMillis(refreshMs), clock
+    )
+
+    @Bean
+    fun rotateRefreshTokenUseCase(
+        repo: RefreshTokenRepositoryPort,
+        gen: OpaqueTokenGenerator,
+        issue: IssueRefreshTokenUseCase,
+        clock: Clock
+    ): RotateRefreshTokenUseCase = RotateRefreshTokenUseCaseImpl(repo, gen, issue, clock)
+
+    @Bean
+    fun revokeUserRefreshTokensUseCase(
+        repo: RefreshTokenRepositoryPort,
+        clock: Clock
+    ): RevokeUserRefreshTokensUseCase = RevokeUserRefreshTokensUseCaseImpl(repo, clock)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/entity/RefreshTokenEntity.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/entity/RefreshTokenEntity.kt
@@ -1,0 +1,39 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "refresh_tokens", schema = "metadata")
+class RefreshTokenEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+
+    @Column(name = "token_hash", nullable = false, length = 64, unique = true)
+    var tokenHash: String,
+
+    @Column(name = "family_id", nullable = false, columnDefinition = "uuid")
+    var familyId: UUID,
+
+    @Column(name = "rotated_from_id")
+    var rotatedFromId: Long? = null,
+
+    @Column(name = "expires_at", nullable = false)
+    var expiresAt: Instant,
+
+    @Column(name = "revoked_at")
+    var revokedAt: Instant? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/mapper/RefreshTokenMappers.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/mapper/RefreshTokenMappers.kt
@@ -1,0 +1,27 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.mapper
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.entity.RefreshTokenEntity
+
+fun RefreshTokenEntity.toDomain() = RefreshToken(
+    id = id,
+    userId = userId,
+    tokenHash = tokenHash,
+    familyId = RefreshTokenFamilyId(familyId),
+    rotatedFromId = rotatedFromId,
+    expiresAt = expiresAt,
+    revokedAt = revokedAt,
+    createdAt = createdAt
+)
+
+fun RefreshToken.toEntity() = RefreshTokenEntity(
+    id = id,
+    userId = userId,
+    tokenHash = tokenHash,
+    familyId = familyId.value,
+    rotatedFromId = rotatedFromId,
+    expiresAt = expiresAt,
+    revokedAt = revokedAt,
+    createdAt = createdAt
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/repository/RefreshTokenJpaRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/repository/RefreshTokenJpaRepository.kt
@@ -1,0 +1,33 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.repository
+
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.entity.RefreshTokenEntity
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
+import org.springframework.data.repository.query.Param
+import java.time.Instant
+import java.util.UUID
+
+interface RefreshTokenJpaRepository : JpaRepository<RefreshTokenEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    @Query("SELECT r FROM RefreshTokenEntity r WHERE r.tokenHash = :h")
+    fun lockByTokenHash(@Param("h") h: String): RefreshTokenEntity?
+
+    @Modifying
+    @Query("UPDATE RefreshTokenEntity r SET r.revokedAt = :at WHERE r.id = :id AND r.revokedAt IS NULL")
+    fun revokeById(@Param("id") id: Long, @Param("at") at: Instant): Int
+
+    @Modifying
+    @Query("UPDATE RefreshTokenEntity r SET r.revokedAt = :at WHERE r.familyId = :fid AND r.revokedAt IS NULL")
+    fun revokeFamily(@Param("fid") fid: UUID, @Param("at") at: Instant): Int
+
+    @Modifying
+    @Query("UPDATE RefreshTokenEntity r SET r.revokedAt = :at WHERE r.userId = :uid AND r.revokedAt IS NULL")
+    fun revokeAllActiveByUser(@Param("uid") uid: Long, @Param("at") at: Instant): Int
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/user/UserService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/user/UserService.kt
@@ -24,6 +24,10 @@ class UserService(
                 return userRepository.findByEmail(email)
         }
 
+        fun findById(id: Long): User? {
+                return userRepository.findById(id).orElse(null)
+        }
+
         fun existsByEmail(email: String): Boolean {
                 return userRepository.existsByEmail(email)
         }

--- a/src/main/resources/db/migration/V39__create_refresh_tokens.sql
+++ b/src/main/resources/db/migration/V39__create_refresh_tokens.sql
@@ -1,0 +1,54 @@
+-- =============================================================================
+-- V39 — Refresh tokens with rotation + reuse-detection family tracking
+-- =============================================================================
+-- Stores opaque refresh tokens issued by /api/v1/auth/login, /register and
+-- rotated by /api/v1/auth/refresh. Implements the OAuth-style rotation +
+-- reuse-detection pattern:
+--
+--   * token_hash       = SHA-256 hex (lowercase, 64 chars) of the opaque token.
+--                        The plaintext token is NEVER persisted; only the hash.
+--   * family_id        = UUID grouping the rotation chain of a single login.
+--                        On rotation the new row inherits the parent's family_id.
+--                        If a row whose revoked_at is already set is presented
+--                        again, the whole family is revoked (reuse → robbery
+--                        signal) and a SECURITY WARN log is emitted.
+--   * rotated_from_id  = self-reference to the parent token in the rotation
+--                        chain. NULL for the first token in a family (issued
+--                        by login/register).
+--   * expires_at       = absolute expiration timestamp (default refresh TTL
+--                        is 30d, configurable via JWT_REFRESH_EXPIRATION env).
+--   * revoked_at       = NULL while the token is active. Set by /refresh
+--                        rotation, /logout, or family-wide reuse detection.
+--
+-- The unique index on token_hash enforces single-use semantics. Hot lookup
+-- path is "find by hash WHERE revoked_at IS NULL"; the partial index
+-- idx_refresh_tokens_user_active accelerates per-user revocation on logout.
+--
+-- Idempotent (uses IF NOT EXISTS) so repeated runs against dev/prod databases
+-- are safe. Foreign key on user_id cascades on user deletion (matches the
+-- existing pattern of metadata.push_tokens, V38).
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS metadata.refresh_tokens (
+    id              BIGSERIAL    PRIMARY KEY,
+    user_id         BIGINT       NOT NULL REFERENCES metadata.users(id)          ON DELETE CASCADE,
+    token_hash      VARCHAR(64)  NOT NULL UNIQUE,
+    family_id       UUID         NOT NULL,
+    rotated_from_id BIGINT       NULL     REFERENCES metadata.refresh_tokens(id) ON DELETE SET NULL,
+    expires_at      TIMESTAMPTZ  NOT NULL,
+    revoked_at      TIMESTAMPTZ  NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user        ON metadata.refresh_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_family      ON metadata.refresh_tokens(family_id);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires     ON metadata.refresh_tokens(expires_at);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_active
+    ON metadata.refresh_tokens(user_id) WHERE revoked_at IS NULL;
+
+COMMENT ON TABLE metadata.refresh_tokens IS
+    'Opaque refresh tokens with rotation. Stores SHA-256 hash only. family_id groups the rotation chain; reuse of a revoked token triggers full-family revocation.';
+COMMENT ON COLUMN metadata.refresh_tokens.token_hash      IS 'SHA-256 hex (lowercase) of the plaintext opaque token. Plaintext is never stored.';
+COMMENT ON COLUMN metadata.refresh_tokens.family_id       IS 'Groups all rotations that descend from the same login.';
+COMMENT ON COLUMN metadata.refresh_tokens.rotated_from_id IS 'Parent token in the rotation chain. NULL for the first token of a family.';
+COMMENT ON COLUMN metadata.refresh_tokens.revoked_at      IS 'NULL while active. Set on rotation, logout, or family-wide reuse detection.';

--- a/src/test/kotlin/com/apptolast/invernaderos/ArchitectureTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/ArchitectureTest.kt
@@ -94,4 +94,21 @@ class ArchitectureTest {
                     .dependOnClassesThat()
                     .resideInAPackage("..dto..")
                     .because("Domain must not depend on DTOs")
+
+    // --- refresh-token specific rule (explicit documentation, redundant with domainMustNotDependOnSpring) ---
+
+    @ArchTest
+    val refreshTokenDomainPure: ArchRule =
+            noClasses()
+                    .that()
+                    .resideInAPackage("..features.auth.refresh.domain..")
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAnyPackage(
+                            "org.springframework..",
+                            "jakarta..",
+                            "org.hibernate..",
+                            "io.jsonwebtoken.."
+                    )
+                    .because("refresh-token domain must remain pure Kotlin")
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/AuthServiceTest.kt
@@ -1,6 +1,5 @@
 package com.apptolast.invernaderos.features.auth
 
-import com.apptolast.invernaderos.core.security.JwtService
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.user.UserService
@@ -11,21 +10,15 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
-import org.springframework.security.authentication.AuthenticationManager
-import org.springframework.security.core.userdetails.UserDetailsService
 
 @ExtendWith(MockitoExtension::class)
 class AuthServiceTest {
 
-    @Mock lateinit var authenticationManager: AuthenticationManager
-
-    @Mock lateinit var jwtService: JwtService
-
     @Mock lateinit var userService: UserService
 
-    @Mock lateinit var userDetailsService: UserDetailsService
-
     @Mock lateinit var emailService: EmailService
+
+    @Mock lateinit var authRefreshService: AuthRefreshService
 
     @InjectMocks lateinit var authService: AuthService
 

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/AuthServiceTest.kt
@@ -3,24 +3,18 @@ package com.apptolast.invernaderos.features.auth
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.user.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
-import org.mockito.Mock
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
-import org.mockito.junit.jupiter.MockitoExtension
 
-@ExtendWith(MockitoExtension::class)
 class AuthServiceTest {
 
-    @Mock lateinit var userService: UserService
+    private val userService: UserService = mockk(relaxed = true)
+    private val emailService: EmailService = mockk(relaxed = true)
+    private val authRefreshService: AuthRefreshService = mockk(relaxed = true)
 
-    @Mock lateinit var emailService: EmailService
-
-    @Mock lateinit var authRefreshService: AuthRefreshService
-
-    @InjectMocks lateinit var authService: AuthService
+    private val authService = AuthService(userService, emailService, authRefreshService)
 
     @Test
     fun `forgotPassword should generate token and send email`() {
@@ -28,12 +22,12 @@ class AuthServiceTest {
         val token = "reset-token"
         val request = ForgotPasswordRequest(email)
 
-        `when`(userService.generatePasswordResetToken(email)).thenReturn(token)
+        every { userService.generatePasswordResetToken(email) } returns token
 
         authService.forgotPassword(request)
 
-        verify(userService).generatePasswordResetToken(email)
-        verify(emailService).sendPasswordResetEmail(email, token)
+        verify { userService.generatePasswordResetToken(email) }
+        verify { emailService.sendPasswordResetEmail(email, token) }
     }
 
     @Test
@@ -44,6 +38,6 @@ class AuthServiceTest {
 
         authService.resetPassword(request)
 
-        verify(userService).resetPassword(token, newPassword)
+        verify { userService.resetPassword(token, newPassword) }
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/RefreshTokenIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/RefreshTokenIntegrationTest.kt
@@ -1,0 +1,213 @@
+package com.apptolast.invernaderos.features.auth
+
+import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
+import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+/**
+ * HTTP contract tests for POST /api/v1/auth/refresh.
+ *
+ * Strategy: mock AuthRefreshService at the Spring bean level (@MockBean) so
+ * the full Spring Security / MockMvc / Jackson / validation stack is exercised
+ * without touching the DEV database or any real use case wiring.
+ *
+ * All assertions verify the *HTTP contract*: status code + JSON shape.
+ * Business-logic correctness is covered by RotateRefreshTokenUseCaseTest.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class RefreshTokenIntegrationTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    /**
+     * Mocking AuthRefreshService instead of the individual use cases because
+     * AuthController -> AuthService -> AuthRefreshService.refresh() is the
+     * single call site that produces the Result<JwtResponse> the controller
+     * unwraps into HTTP status codes.
+     */
+    @MockBean private lateinit var authRefreshService: AuthRefreshService
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    private val validJwtResponse = JwtResponse(
+        token = "header.payload.sig",
+        type = "Bearer",
+        username = "farmer@greenhouse.io",
+        roles = listOf("ROLE_USER"),
+        refreshToken = "new-opaque-refresh-token",
+        expiresIn = 900L,
+        refreshExpiresIn = 86400L
+    )
+
+    private fun refreshBody(token: String) =
+        objectMapper.writeValueAsString(mapOf("refreshToken" to token))
+
+    private fun stubRefreshSuccess() {
+        `when`(authRefreshService.refresh(RefreshRequest("valid-token")))
+            .thenReturn(Result.success(validJwtResponse))
+    }
+
+    private fun stubRefreshFailure(token: String, error: AuthError) {
+        `when`(authRefreshService.refresh(RefreshRequest(token)))
+            .thenReturn(Result.failure(AuthErrorException(error)))
+    }
+
+    // -------------------------------------------------------------------------
+    // 200 — successful rotation
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 200 with full JwtResponse when token rotates successfully`() {
+        stubRefreshSuccess()
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("valid-token"))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.token").value("header.payload.sig"))
+            .andExpect(jsonPath("$.type").value("Bearer"))
+            .andExpect(jsonPath("$.username").value("farmer@greenhouse.io"))
+            .andExpect(jsonPath("$.roles[0]").value("ROLE_USER"))
+            .andExpect(jsonPath("$.refreshToken").value("new-opaque-refresh-token"))
+            .andExpect(jsonPath("$.expiresIn").value(900))
+            .andExpect(jsonPath("$.refreshExpiresIn").value(86400))
+    }
+
+    // -------------------------------------------------------------------------
+    // 401 — invalid / expired / revoked / reused
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 401 when token is not found in the store`() {
+        stubRefreshFailure("unknown-token", AuthError.TokenNotFound)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("unknown-token"))
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 401 when token is expired`() {
+        stubRefreshFailure("expired-token", AuthError.TokenExpired)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("expired-token"))
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 401 when token was already explicitly revoked`() {
+        stubRefreshFailure("revoked-token", AuthError.TokenRevoked)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("revoked-token"))
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 401 when reuse of a revoked token is detected and whole family is revoked`() {
+        val familyId = UUID.fromString("cafebabe-cafe-babe-cafe-babecafebabe")
+        stubRefreshFailure("reused-token", AuthError.TokenReuseDetected(familyId = familyId, userId = 42L))
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("reused-token"))
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    // -------------------------------------------------------------------------
+    // 400 — malformed token value (business-level, not Jakarta validation)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 400 when the refresh token string is malformed according to business rules`() {
+        stubRefreshFailure("bad-token", AuthError.MalformedToken)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("bad-token"))
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    // -------------------------------------------------------------------------
+    // 503 — feature disabled
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 503 when the refresh token feature is administratively disabled`() {
+        stubRefreshFailure("any-token", AuthError.FeatureDisabled)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("any-token"))
+        )
+            .andExpect(status().isServiceUnavailable)
+    }
+
+    // -------------------------------------------------------------------------
+    // 400 — Jakarta @NotBlank validation (before any use case is invoked)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 400 when refreshToken field is present but blank`() {
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"refreshToken":""}""")
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when refreshToken field is missing from request body`() {
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when request body is entirely absent`() {
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/RefreshTokenIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/RefreshTokenIntegrationTest.kt
@@ -10,8 +10,8 @@ import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -41,7 +41,7 @@ class RefreshTokenIntegrationTest {
      * single call site that produces the Result<JwtResponse> the controller
      * unwraps into HTTP status codes.
      */
-    @MockBean private lateinit var authRefreshService: AuthRefreshService
+    @MockitoBean private lateinit var authRefreshService: AuthRefreshService
 
     // -------------------------------------------------------------------------
     // Fixtures

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseTest.kt
@@ -1,0 +1,176 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.AccessTokenIssuer
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.UserClaimsLookup
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class IssueRefreshTokenUseCaseTest {
+
+    private val repo: RefreshTokenRepositoryPort = mockk(relaxed = true)
+    private val gen: OpaqueTokenGenerator = mockk()
+    private val accessIssuer: AccessTokenIssuer = mockk()
+    private val userClaims: UserClaimsLookup = mockk()
+
+    private val now: Instant = Instant.parse("2026-05-01T12:00:00Z")
+    private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
+    private val refreshTtl: Duration = Duration.ofSeconds(86400)
+
+    private val sut = IssueRefreshTokenUseCaseImpl(repo, gen, accessIssuer, userClaims, refreshTtl, clock)
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    private val userId = 7L
+    private val plainToken = "plain-opaque-token"
+    private val tokenHash = "sha256hexhash0000000000000000000000000000000000000000000000000000"
+    private val accessJwt = "header.payload.signature"
+    private val accessTtl = 900L
+    private val username = "farmer@greenhouse.io"
+    private val roles = listOf("ROLE_USER")
+    private val claims = mapOf<String, Any>("tenantId" to 3L, "role" to "USER")
+
+    private fun stubGenerator() {
+        every { gen.generate() } returns plainToken
+        every { gen.hash(plainToken) } returns tokenHash
+    }
+
+    private fun stubUserClaims() {
+        every { userClaims.loadForToken(userId) } returns
+            UserClaimsLookup.UserClaimsSnapshot(username = username, roles = roles, claims = claims)
+    }
+
+    private fun stubAccessIssuer() {
+        every { accessIssuer.issue(username, claims) } returns accessJwt
+        every { accessIssuer.accessTtlSeconds() } returns accessTtl
+    }
+
+    // -------------------------------------------------------------------------
+    // New family (login / register flow)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should generate new familyId when command carries no familyId`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+
+        val savedSlot = slot<RefreshToken>()
+        every { repo.save(capture(savedSlot)) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        val result = sut.execute(cmd)
+
+        val saved = savedSlot.captured
+        // A new UUID-based familyId must have been generated (not null, not the command's null)
+        assertThat(saved.familyId).isNotNull()
+        assertThat(saved.familyId.value).isInstanceOf(UUID::class.java)
+    }
+
+    @Test
+    fun `should persist token with correct fields when issuing for a new family`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+
+        val savedSlot = slot<RefreshToken>()
+        every { repo.save(capture(savedSlot)) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        sut.execute(cmd)
+
+        val saved = savedSlot.captured
+        assertThat(saved.userId).isEqualTo(userId)
+        assertThat(saved.tokenHash).isEqualTo(tokenHash)
+        assertThat(saved.revokedAt).isNull()
+        assertThat(saved.expiresAt).isEqualTo(now.plus(refreshTtl))
+        assertThat(saved.createdAt).isEqualTo(now)
+        assertThat(saved.id).isNull() // id is assigned by DB, must be null on save
+    }
+
+    @Test
+    fun `should return AuthTokensResult with correct TTLs and credentials when issuing new family`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+        every { repo.save(any()) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        val result = sut.execute(cmd)
+
+        assertThat(result.accessToken).isEqualTo(accessJwt)
+        assertThat(result.refreshToken).isEqualTo(plainToken)
+        assertThat(result.accessTtlSeconds).isEqualTo(accessTtl)
+        assertThat(result.refreshTtlSeconds).isEqualTo(refreshTtl.seconds)
+        assertThat(result.username).isEqualTo(username)
+        assertThat(result.roles).isEqualTo(roles)
+    }
+
+    // -------------------------------------------------------------------------
+    // Inherited family (rotation flow)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should persist token with exact inherited familyId when command carries an existing familyId`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+
+        val inheritedFamilyId = RefreshTokenFamilyId(UUID.fromString("cafebabe-cafe-babe-cafe-babecafebabe"))
+
+        val savedSlot = slot<RefreshToken>()
+        every { repo.save(capture(savedSlot)) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = inheritedFamilyId)
+        sut.execute(cmd)
+
+        val saved = savedSlot.captured
+        assertThat(saved.familyId).isEqualTo(inheritedFamilyId)
+    }
+
+    @Test
+    fun `should return plaintext token in result so caller can send it to the client`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+        every { repo.save(any()) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        val result = sut.execute(cmd)
+
+        // plainToken must appear in the result (for the client), not the hash
+        assertThat(result.refreshToken).isEqualTo(plainToken)
+        assertThat(result.refreshToken).isNotEqualTo(tokenHash)
+    }
+
+    @Test
+    fun `should invoke generate then hash in order and call repo save exactly once`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+        every { repo.save(any()) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        sut.execute(cmd)
+
+        verify(exactly = 1) { gen.generate() }
+        verify(exactly = 1) { gen.hash(plainToken) }
+        verify(exactly = 1) { repo.save(any()) }
+        verify(exactly = 1) { accessIssuer.issue(username, claims) }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseTest.kt
@@ -72,7 +72,7 @@ class RotateRefreshTokenUseCaseTest {
 
         every { gen.hash(rawToken) } returns tokenHash
         every { repo.findByTokenHashLocking(tokenHash) } returns stored
-        every { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId)) } returns expectedTokens
+        every { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId, rotatedFromId = 99L)) } returns expectedTokens
 
         val result = sut.execute(rawToken)
 
@@ -82,7 +82,7 @@ class RotateRefreshTokenUseCaseTest {
         // Must revoke the consumed token using its Long id
         verify(exactly = 1) { repo.revoke(99L, now) }
         // Must issue new tokens preserving the same familyId
-        verify(exactly = 1) { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId)) }
+        verify(exactly = 1) { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId, rotatedFromId = 99L)) }
         // Must NOT revoke the whole family on a clean rotation
         verify(exactly = 0) { repo.revokeFamily(any(), any()) }
     }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseTest.kt
@@ -1,0 +1,221 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class RotateRefreshTokenUseCaseTest {
+
+    private val repo: RefreshTokenRepositoryPort = mockk(relaxed = true)
+    private val gen: OpaqueTokenGenerator = mockk()
+    private val issueUseCase: IssueRefreshTokenUseCase = mockk()
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-01T12:00:00Z"), ZoneOffset.UTC)
+
+    private val sut = RotateRefreshTokenUseCaseImpl(repo, gen, issueUseCase, clock)
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    private val now: Instant = Instant.parse("2026-05-01T12:00:00Z")
+    private val familyId = RefreshTokenFamilyId(UUID.fromString("11111111-1111-1111-1111-111111111111"))
+    private val userId = 42L
+    private val tokenHash = "abc123hash"
+    private val rawToken = "plain-raw-token"
+
+    private fun buildStoredToken(
+        revokedAt: Instant? = null,
+        expiresAt: Instant = now.plusSeconds(3600)
+    ) = RefreshToken(
+        id = 99L,
+        userId = userId,
+        tokenHash = tokenHash,
+        familyId = familyId,
+        rotatedFromId = null,
+        expiresAt = expiresAt,
+        revokedAt = revokedAt,
+        createdAt = now.minusSeconds(60)
+    )
+
+    private fun buildTokensResult() = AuthTokensResult(
+        accessToken = "new-access-jwt",
+        refreshToken = "new-plain-refresh",
+        accessTtlSeconds = 900L,
+        refreshTtlSeconds = 86400L,
+        username = "user@example.com",
+        roles = listOf("ROLE_USER")
+    )
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should rotate token and inherit family when token is valid and not expired`() {
+        val stored = buildStoredToken()
+        val expectedTokens = buildTokensResult()
+
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns stored
+        every { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId)) } returns expectedTokens
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(expectedTokens)
+
+        // Must revoke the consumed token using its Long id
+        verify(exactly = 1) { repo.revoke(99L, now) }
+        // Must issue new tokens preserving the same familyId
+        verify(exactly = 1) { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId)) }
+        // Must NOT revoke the whole family on a clean rotation
+        verify(exactly = 0) { repo.revokeFamily(any(), any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Expired token
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return TokenExpired failure when stored token has passed its expiry`() {
+        val expired = buildStoredToken(expiresAt = now.minusSeconds(1))
+
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns expired
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex).isNotNull()
+        assertThat(ex!!.error).isEqualTo(AuthError.TokenExpired)
+
+        // Expired path must never revoke or issue
+        verify(exactly = 0) { repo.revoke(any(), any()) }
+        verify(exactly = 0) { issueUseCase.execute(any()) }
+    }
+
+    @Test
+    fun `should return TokenExpired when token expires exactly at now (boundary)`() {
+        // isExpired uses !now.isBefore(expiresAt), so expiresAt == now is expired
+        val expired = buildStoredToken(expiresAt = now)
+
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns expired
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex!!.error).isEqualTo(AuthError.TokenExpired)
+    }
+
+    // -------------------------------------------------------------------------
+    // Reuse detection
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should revoke entire family and return TokenReuseDetected when token is already revoked`() {
+        val revokedAt = now.minusSeconds(30)
+        val revoked = buildStoredToken(revokedAt = revokedAt)
+
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns revoked
+        every { repo.revokeFamily(familyId, now) } returns 3
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex).isNotNull()
+        val error = ex!!.error
+        assertThat(error).isInstanceOf(AuthError.TokenReuseDetected::class.java)
+        val reuseError = error as AuthError.TokenReuseDetected
+        assertThat(reuseError.familyId).isEqualTo(familyId.value)
+        assertThat(reuseError.userId).isEqualTo(userId)
+
+        // Full family revocation must happen
+        verify(exactly = 1) { repo.revokeFamily(familyId, now) }
+        // Must NOT revoke a single token nor issue new tokens
+        verify(exactly = 0) { repo.revoke(any(), any()) }
+        verify(exactly = 0) { issueUseCase.execute(any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Token not found
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return TokenNotFound failure when hash does not match any stored token`() {
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns null
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex).isNotNull()
+        assertThat(ex!!.error).isEqualTo(AuthError.TokenNotFound)
+
+        verify(exactly = 0) { repo.revoke(any(), any()) }
+        verify(exactly = 0) { issueUseCase.execute(any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Malformed / blank token
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return MalformedToken failure for empty string without touching repo or generator`() {
+        val result = sut.execute("")
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex).isNotNull()
+        assertThat(ex!!.error).isEqualTo(AuthError.MalformedToken)
+
+        verify(exactly = 0) { gen.hash(any()) }
+        verify(exactly = 0) { repo.findByTokenHashLocking(any()) }
+        confirmVerified(gen, repo, issueUseCase)
+    }
+
+    @Test
+    fun `should return MalformedToken failure for blank whitespace-only token`() {
+        val result = sut.execute("   ")
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex!!.error).isEqualTo(AuthError.MalformedToken)
+
+        verify(exactly = 0) { gen.hash(any()) }
+        verify(exactly = 0) { repo.findByTokenHashLocking(any()) }
+        confirmVerified(gen, repo, issueUseCase)
+    }
+
+    @Test
+    fun `should return MalformedToken failure for tab-only token`() {
+        val result = sut.execute("\t")
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex!!.error).isEqualTo(AuthError.MalformedToken)
+
+        verify(exactly = 0) { gen.hash(any()) }
+        verify(exactly = 0) { repo.findByTokenHashLocking(any()) }
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,171 @@
+# =============================================================================
+# Test configuration — overrides src/main/resources/application.yaml
+# =============================================================================
+# Goal: NO @SpringBootTest in this codebase ever touches the shared PROD
+# database (greenhouse_metadata / greenhouse_timeseries).
+#
+# Strategy: route integration tests at the DEV databases (the same ones the
+# develop branch deploys against). DEV is throwaway and is rebuilt by
+# flyway-migrate on each push to develop, so tests can pollute it freely.
+#
+# Why not Testcontainers?
+#   - The org.testcontainers:postgresql dependency is on the classpath, but
+#     the local docker daemon API version (1.32) does not match what
+#     testcontainers 1.21.x expects (1.40+). Migrating to Testcontainers
+#     requires a docker upgrade plus dual-datasource @ServiceConnection
+#     wiring. Out of scope for the refresh-token PR; revisit when CI runners
+#     and dev workstations are aligned.
+#   - GitHub Actions runners use a current docker, so we keep the Testcontainers
+#     deps for that follow-up work.
+#
+# Hibernate `ddl-auto: update` lets new JPA entities (e.g. RefreshTokenEntity
+# during local feature development) materialize their tables without waiting
+# for Flyway. Pre-existing schema is left untouched. Flyway is fully disabled
+# from tests (see flyway.enabled below; FlywayConfig.kt honours the flag).
+#
+# JWT_SECRET / TTLs are test-only constants; nothing in src/test depends on
+# real production values.
+# =============================================================================
+
+spring:
+  application:
+    name: invernaderos-test
+
+  # TimescaleDB (primary) — DEV instance.
+  datasource:
+    url: jdbc:postgresql://138.199.157.58:30432/greenhouse_timeseries_dev
+    username: admin
+    password: AppToLast2023%
+    driver-class-name: org.postgresql.Driver
+    configuration:
+      maximum-pool-size: 5
+      minimum-idle: 1
+      connection-timeout: 5000
+
+  # Metadata — DEV instance.
+  datasource-metadata:
+    url: jdbc:postgresql://138.199.157.58:30433/greenhouse_metadata_dev
+    username: admin
+    password: AppToLast2023%
+    driver-class-name: org.postgresql.Driver
+    configuration:
+      maximum-pool-size: 5
+      minimum-idle: 1
+      connection-timeout: 5000
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: false
+        show_sql: false
+
+  flyway:
+    enabled: false
+
+  security:
+    jwt:
+      secret: dGVzdC1zZWNyZXQtMjU2LWJpdC1mb3ItdGVzdHMtb25seS1ub3QtZm9yLXByb2QxMjM=
+      access-expiration: 60000
+      refresh-expiration: 600000
+
+  mail:
+    host: localhost
+    port: 25
+    username: test@local
+    password: test
+    properties:
+      mail:
+        smtp:
+          auth: false
+
+  data:
+    redis:
+      host: 138.199.157.58
+      port: 30379
+      password: AppToLast2023%
+      database: 1
+      timeout: 5000ms
+      connect-timeout: 3000ms
+      client-name: invernaderos-test
+      client-type: lettuce
+      lettuce:
+        pool:
+          enabled: true
+          max-active: 4
+          max-idle: 2
+          min-idle: 1
+      repositories:
+        enabled: false
+
+  cache:
+    type: none
+
+  # MQTT — point at an unreachable broker; tests must not depend on MQTT.
+  # Note the `spring.` prefix: matches MqttConfig.kt @Value("\${spring.mqtt.*}").
+  mqtt:
+    broker:
+      url: tcp://localhost:11883
+    username: test
+    password: test
+    client:
+      id-prefix: test-client
+      clean-session: true
+      connection-timeout: 1
+      keep-alive-interval: 5
+      automatic-reconnect: false
+    topics:
+      greenhouse-multi-tenant: "GREENHOUSE/+"
+      greenhouse-status: "GREENHOUSE/STATUS"
+      sensors-pattern: "GREENHOUSE"
+      actuators-pattern: "greenhouse/+/actuators/#"
+      actuators-status: "greenhouse/+/actuators/status"
+      system-events: "system/events/#"
+      alerts: "greenhouse/+/alerts/#"
+      response: "GREENHOUSE/RESPONSE"
+    qos:
+      sensors: 0
+      actuators: 1
+      alerts: 2
+      default: 0
+    message:
+      retained: false
+      max-payload-size: 1048576
+
+# FlywayConfig.kt skips both migrate and validate when this flag is false.
+flyway:
+  enabled: false
+  auto-migrate: false
+
+auth:
+  refresh-token:
+    enabled: true
+
+greenhouse:
+  simulation:
+    enabled: false
+
+# Sensor / dedup / alert sections referenced by feature configs.
+sensor:
+  rate-limiter:
+    enabled: false
+    min-interval-seconds: 30
+    use-redis: false
+  deduplication:
+    enabled: false
+    window-seconds: 600
+    use-redis: false
+
+alert:
+  mqtt:
+    value-true-means: ACTIVE
+    echo:
+      enabled: false
+
+logging:
+  level:
+    root: WARN
+    com.apptolast.invernaderos: INFO
+    org.springframework.test: WARN

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -25,6 +25,14 @@
 #
 # JWT_SECRET / TTLs are test-only constants; nothing in src/test depends on
 # real production values.
+#
+# DB credentials are NOT committed: the password resolves from
+# INVERNADEROS_TEST_DB_PASSWORD (env var). To run @SpringBootTest locally,
+# export it in your shell before invoking gradle:
+#     export INVERNADEROS_TEST_DB_PASSWORD='<dev-db-password>'
+# In CI it is provided as a GitHub Actions secret. Tests that do not need
+# DB connectivity (unit tests with MockK / mocked use cases) run fine
+# without setting this variable.
 # =============================================================================
 
 spring:
@@ -35,7 +43,7 @@ spring:
   datasource:
     url: jdbc:postgresql://138.199.157.58:30432/greenhouse_timeseries_dev
     username: admin
-    password: AppToLast2023%
+    password: ${INVERNADEROS_TEST_DB_PASSWORD:no-password-set}
     driver-class-name: org.postgresql.Driver
     configuration:
       maximum-pool-size: 5
@@ -46,7 +54,7 @@ spring:
   datasource-metadata:
     url: jdbc:postgresql://138.199.157.58:30433/greenhouse_metadata_dev
     username: admin
-    password: AppToLast2023%
+    password: ${INVERNADEROS_TEST_DB_PASSWORD:no-password-set}
     driver-class-name: org.postgresql.Driver
     configuration:
       maximum-pool-size: 5
@@ -85,7 +93,7 @@ spring:
     redis:
       host: 138.199.157.58
       port: 30379
-      password: AppToLast2023%
+      password: ${INVERNADEROS_TEST_DB_PASSWORD:no-password-set}
       database: 1
       timeout: 5000ms
       connect-timeout: 3000ms


### PR DESCRIPTION
## Summary

- Implement OAuth-style refresh-token flow with rotation + reuse-detection (full-family revocation on robbery signal)
- New `POST /api/v1/auth/refresh` endpoint (no Bearer required); login/register now return `refreshToken`, `expiresIn`, `refreshExpiresIn` (nullable, retrocompatible)
- Logout revokes all active refresh tokens of the user
- Hexagonal layout under `features/auth/refresh/{domain,application,infrastructure}/`; pure-Kotlin domain, ArchUnit-enforced
- TTLs: access `1h`, refresh `30d` (configurable via `JWT_ACCESS_EXPIRATION` / `JWT_REFRESH_EXPIRATION`); kill-switch via `REFRESH_TOKEN_ENABLED=false`
- New Flyway migration **V39** creates `metadata.refresh_tokens` (SHA-256 hashed tokens, family_id rotation chain, partial index for active tokens)
- WebSocket / `StompJwtAuthInterceptor` untouched; client refreshes proactively when JWT expires

## Why

The mobile KMP/Android client (`apptolast/GreenhouseFronts`) is already wired with `AuthRepository.refreshAccessToken()` + Ktor `bearer { refreshTokens { ... } }` stub. Without this PR the user is forced to re-login every time the JWT expires (currently 24h, becomes 1h after deploy). With it, the client refreshes silently — sessions stay alive up to 30d.

## Architecture

```
features/auth/refresh/
├── domain/                 # pure Kotlin: model, sealed AuthError, ports
├── application/usecase/    # IssueRefreshTokenUseCaseImpl, RotateRefreshTokenUseCaseImpl, RevokeUserRefreshTokensUseCaseImpl
└── infrastructure/         # JPA entity + repo + adapter, Sha256OpaqueTokenGenerator, JwtAccessTokenIssuerAdapter, UserClaimsLookupAdapter, RefreshTokenModuleConfig
```

Glue:
- `AuthService` → constructor injection of `AuthRefreshService` (CLAUDE.md compliant)
- `JwtService.expiration` → `access-expiration` (renamed); adds `getAccessTtlSeconds()`
- `JwtLogoutHandler` → revokes refresh tokens on logout (registered in `SecurityConfig`)
- `JwtResponse` extended with 3 nullable fields (Jackson omits nulls — old clients unaffected)

## Security

- Refresh tokens are **opaque random bytes** (32B from SecureRandom, base64url no-padding); only **SHA-256 hex** is persisted
- `@Lock(PESSIMISTIC_WRITE)` with 3 s timeout on the lookup query — concurrent `/refresh` calls serialize, the loser hits the reuse path
- Reuse of a revoked token → revoke entire family + WARN security log
- Multi-tenant safe: rotation re-derives claims from `userId`; no tenant-hopping

## Test plan

- [x] `./gradlew compileKotlin && compileTestKotlin` — green, 0 warnings
- [x] `./gradlew test` — **229 tests, 0 failures, 0 errors**
- [x] ArchUnit: `domainMustNotDependOnSpring/Infrastructure/Dto` + new `refreshTokenDomainPure` rule
- [x] Unit (MockK): `IssueRefreshTokenUseCaseTest` (6 cases), `RotateRefreshTokenUseCaseTest` (8 cases) covering happy/expired/reuse/not-found/malformed/boundary
- [x] Integration: `RefreshTokenIntegrationTest` (10 cases) verifying full HTTP contract — 200/400/401/503 mapping
- [x] Regression: `LogoutIntegrationTest` still green; `AuthServiceTest` migrated to MockK and green
- [x] Tests no longer touch PROD DB (route at DEV via env-var driven password; Testcontainers deps added for follow-up once docker daemon is upgraded)

## Deploy plan (manual, post-merge)

After this PR merges to `develop`:

1. `kubectl create secret invernaderos-api-secret` in `apptolast-invernadero-api-dev` with all existing keys + new `JWT_SECRET` (256-bit random)
2. `kubectl apply` the K8s manifests under `~/k8s/11-api-dev/` (configmap with renamed `access-expiration`, secret with `JWT_SECRET`, deployment with new env var)
3. `kubectl rollout restart deployment/invernaderos-api -n apptolast-invernadero-api-dev`
4. Smoke: curl /login → captures refreshToken, curl /refresh → 200 new pair, curl /refresh with old token → 401 family revoked
5. Repeat in `apptolast-invernadero-api-prod` after dev verification (with a DIFFERENT JWT_SECRET value)

## Notes

- PROD DB was inadvertently touched during early test runs (an `@SpringBootTest` connected to PROD because no `application-test.yaml` existed). Cleaned up before this PR: V39 entry + empty `refresh_tokens` table dropped. Test config now points to DEV with env-var driven credentials so this cannot recur.
- `JWT_SECRET` rotation invalidates current 24h JWTs once. Active users will see one forced re-login on the rollover; refresh tokens are not affected (signed differently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)