### PR TITLE
release(auth): refresh-tokens promotion dev → prod

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -460,6 +460,115 @@ Las métricas están disponibles en formato Prometheus en `/actuator/prometheus`
 
 ---
 
+## Autenticación — Refresh tokens
+
+A partir de la migración V39 el servicio emite **refresh tokens opacos con
+rotación + detección de reuse** además del JWT de acceso.
+
+### Flujo
+
+1. `POST /api/v1/auth/login` (o `/register`) → devuelve `JwtResponse` con:
+   - `token` (JWT access, HS256, TTL 1h por defecto)
+   - `refreshToken` (string opaco, 32B aleatorios base64url, TTL 30d por defecto)
+   - `expiresIn` (segundos hasta expirar el access)
+   - `refreshExpiresIn` (segundos hasta expirar el refresh)
+2. Cuando el access caduca, el cliente llama `POST /api/v1/auth/refresh`
+   con el body `{ "refreshToken": "..." }` (sin `Authorization` header).
+3. El backend valida el refresh, lo revoca y emite un par nuevo
+   (rotación) heredando el `family_id` original.
+4. **Detección de reuse**: si llega un `refreshToken` ya revocado, se
+   revoca toda la familia (cadena de rotaciones de ese login) y se
+   devuelve `401`. Se emite un log `WARN SECURITY: refresh-token reuse
+   detected …` en `RotateRefreshTokenUseCaseImpl`.
+5. `POST /api/v1/auth/logout` (con Bearer válido) revoca todos los
+   refresh tokens activos del usuario.
+
+### TTLs configurables
+
+| Variable | Default | Descripción |
+|----------|---------|-------------|
+| `JWT_ACCESS_EXPIRATION`  | `3600000`    | TTL del access JWT en ms (1h) |
+| `JWT_REFRESH_EXPIRATION` | `2592000000` | TTL del refresh en ms (30d)   |
+| `REFRESH_TOKEN_ENABLED`  | `true`       | Kill-switch del feature       |
+
+### Kill-switch (sin redeploy)
+
+Si tras un deploy aparece un bug en el flow de refresh:
+
+```bash
+kubectl set env deployment/invernaderos-api \
+  -n apptolast-invernadero-api-prod \
+  REFRESH_TOKEN_ENABLED=false
+```
+
+El pod se reinicia automáticamente. Tras 30s:
+- `/login` y `/register` devuelven `JwtResponse` solo con `token` (campos
+  nuevos como `null`, omitidos por Jackson `default-property-inclusion: non_null`).
+- `/refresh` devuelve `503`.
+- `logout` deja de revocar refresh (no-op).
+- Los rows de `metadata.refresh_tokens` permanecen y son válidos cuando
+  el flag se reactive.
+
+### Rotación de `JWT_SECRET`
+
+`JWT_SECRET` es el HMAC-SHA-256 con el que se firma el access JWT. Se
+inyecta en el pod desde el Secret `invernaderos-api-secret` (key
+`JWT_SECRET`). **No se commitea** al repo: el manifest contiene un
+placeholder y el valor real se aplica vía `kubectl`:
+
+```bash
+# DEV — usar valor distinto al de prod
+kubectl -n apptolast-invernadero-api-dev create secret generic invernaderos-api-secret \
+  --from-literal=TIMESCALE_PASSWORD="..." \
+  --from-literal=METADATA_PASSWORD="..." \
+  --from-literal=REDIS_PASSWORD="..." \
+  --from-literal=MQTT_USERNAME="..." \
+  --from-literal=MQTT_PASSWORD="..." \
+  --from-literal=SPRING_MAIL_PASSWORD="..." \
+  --from-literal=JWT_SECRET="$(openssl rand -base64 64 | tr -d '\n')" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# PROD — repetir con el namespace -prod y un secret DIFERENTE
+```
+
+Rotar `JWT_SECRET` invalida **todos** los access JWTs activos: los
+usuarios verán un `401` en su próxima request y la app caerá a re-login
+una vez. Los refresh tokens opacos sobreviven a la rotación porque no se
+firman con `JWT_SECRET`. Esto suele ser lo deseable: se renueva el
+secret sin perder sesiones (el cliente refresca silenciosamente y
+recibe un access firmado con el nuevo secret).
+
+### Tabla `metadata.refresh_tokens`
+
+Definida en `V39__create_refresh_tokens.sql`:
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| `id` | BIGSERIAL PK | Identificador interno |
+| `user_id` | BIGINT FK users(id) | Usuario propietario |
+| `token_hash` | CHAR(64) UNIQUE | SHA-256 hex del token plano (el plano no se persiste) |
+| `family_id` | UUID | Agrupa la cadena de rotaciones de un login |
+| `rotated_from_id` | BIGINT NULLABLE FK self | Padre del token (NULL para el primero de la familia) |
+| `expires_at` | TIMESTAMPTZ | Caducidad absoluta |
+| `revoked_at` | TIMESTAMPTZ NULLABLE | NULL = activo. Se setea en rotación / logout / reuse |
+| `created_at` | TIMESTAMPTZ | Timestamp de emisión |
+
+Índices:
+- `idx_refresh_tokens_user` — búsquedas por usuario
+- `idx_refresh_tokens_family` — revocación de familia en reuse
+- `idx_refresh_tokens_expires` — barridos de limpieza
+- `idx_refresh_tokens_user_active` (PARTIAL `WHERE revoked_at IS NULL`) — logout
+
+### Concurrencia
+
+El adapter usa `@Lock(LockModeType.PESSIMISTIC_WRITE)` con
+`jakarta.persistence.lock.timeout=3000` ms en `lockByTokenHash`.  Dos
+`/refresh` simultáneos con el mismo token: el primero gana el lock,
+revoca y emite el child; el segundo lee el row con `revoked_at` ya
+seteado → se interpreta como reuse → revocación de familia + 401.
+
+---
+
 ## Recursos Adicionales
 
 - [Documentación de Spring Boot](https://docs.spring.io/spring-boot/docs/current/reference/html/)

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "f6b10e47-2eb9-4322-b845-48d63e62874b",
+          "id": "a2de9bce-de43-4967-b85c-7106ca43a9f8",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "b7b9f4b9-ee99-4a81-8784-764e73bc697f",
+              "id": "cf1ee91e-2d97-4d5d-bd49-d6db8296c4f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "9750f467-5f7e-4892-9c6f-b6bd065ea713",
+          "id": "7d9c0ff7-0566-4ef8-83f1-77b25e4ab3b5",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "d97aac7b-4c68-46f7-9bb8-40674ba898e8",
+              "id": "34c248c0-d6cc-477e-93d9-f2ea796ca7aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "eec0de76-a525-443f-817e-0f9a40296385",
+          "id": "7fd8e00a-3745-4e1a-a8a8-fae4f1a9428e",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "96dc170f-2cb8-4686-964d-bd3e92fbe3e3",
+              "id": "706b1bd9-8a2e-4842-9f96-63ce33efe90d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "3365fa95-1293-43cb-b10e-d4287b6bfad3",
+          "id": "93729e89-1c63-465b-9b7c-340bed3d8846",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "aa20f197-0797-49ea-ac88-ce1210b8b8f1",
+              "id": "4d7d9012-145d-40bb-bc13-243eb2b0c07c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "965d89b2-c593-4ef9-80d3-fadd06303574",
+          "id": "4a9cdd91-748e-4921-ba03-f485b7ec8cb2",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "5fd91289-fff4-41a1-9df6-1da62b0885e3",
+              "id": "156c4d00-57d5-44c1-89cd-8fc4f394c967",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "5758469d-cbb3-4ff8-871e-1dd08e4bb10b",
+          "id": "e1127021-c0d6-49aa-918f-bbc3a90a62cd",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "666109f5-9f39-4e06-9711-34e91523734a",
+              "id": "67434aa2-c29b-4776-abe6-8eaa50e80b7d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "598eb1c5-f865-4629-a92d-3600c7cac0ec",
+          "id": "a3e5ffb9-2a9e-46a7-b821-226887c8cfee",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "6545f3fe-3c8b-4b3e-b6d3-e67f6b1c4100",
+              "id": "39a03cc9-ef50-4d41-9e06-505d5079c5e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "5f23face-9b4b-4057-bf37-1d2d31b775ea",
+          "id": "14269745-d7c2-426d-a779-c5ac88471745",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "e845e225-0ebd-4db0-84fb-7ccb83f15d5c",
+              "id": "5fe218fd-d90b-482a-9d3c-4f34ca2efe87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "9af78e09-c9ff-4853-85b9-352f2567bb41",
+          "id": "24da7515-ce2f-425b-8bdb-022fdf6c3774",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "87487f93-fee0-44b9-990d-30e71fc6c412",
+              "id": "3ebf9050-7f9f-4ba9-b007-27c391841cc7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "168c440f-0b50-49cd-a6ac-ff178d3ca11f",
+          "id": "bcef3939-549b-41c5-8231-8ea839b73abd",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "f7e6dcc0-419f-44fa-84d5-cfcf1090a479",
+              "id": "1dd468c5-ff2b-468a-86d8-9e523d3318a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "09555044-6692-4b4e-855f-3ff1bb9a5b96",
+          "id": "04c47283-c45a-453c-a934-5362d0ad2279",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "23a2c958-ad45-4425-9cdf-848bac934d3d",
+              "id": "0841fc93-a7fd-44a1-a170-cd14b7357744",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "c50ccb29-5e0f-47a3-868a-30418834428f",
+          "id": "4476cf7b-e34d-4b14-9f22-e8d0b9f0f81d",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "b1967fea-8974-4647-b7e6-7045c45bb234",
+              "id": "adb161dc-312d-4b79-a1fd-aa8011f3a567",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "f119c721-a57d-4798-9998-fc8feba8effe",
+          "id": "52a4082d-1ce4-433c-b61d-c84c97c2265d",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "d28903b5-948e-49cc-ada2-c2c795dbc560",
+              "id": "4ef1e602-69da-49d9-8830-ae8649f2dc87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "a32249ae-3718-4da5-a7f3-0399b09f03b8",
+          "id": "dbecd62f-d304-4c50-ac5b-9e1b418235a2",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "d9caa891-bb14-4faf-a484-4d2fe927d59a",
+              "id": "93ef0bbe-fc68-45b2-9300-16cd8a674488",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "be7dc431-8248-4bf7-b8da-e7b35fe69c2b",
+          "id": "009e27e6-7146-4982-bef5-c8c3d2bf5861",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "2ba1dda1-93ae-49fc-9043-f5ba2c5a1b3f",
+              "id": "fcd0ce3e-d594-4191-bfd2-72c115119b3e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "f2f56bc6-44e2-45bc-a4c1-a193fa3e9691",
+          "id": "a6f32101-7f17-4630-b5ac-000c1e90fcb9",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "8be5836d-c676-4e73-b8b0-4bffe49b4af3",
+              "id": "fe53f7d7-1a28-4822-bfac-9cefd115fcd4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "e900e152-8e13-48b4-9f2a-134a3430c2c1",
+          "id": "3062d437-9573-480c-a967-bf8cf1ec391e",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -1859,7 +1859,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -1879,7 +1879,7 @@
           },
           "response": [
             {
-              "id": "4f749eeb-5319-4702-9efd-9d2bf0195465",
+              "id": "22bfa902-9cf7-4ecb-a444-423bdc51897a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1911,7 +1911,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1933,7 +1933,7 @@
           }
         },
         {
-          "id": "b41b0fa4-b933-4519-abbf-44dfd6a30a61",
+          "id": "3f40f0ae-9284-454a-842a-e7f90b96b64a",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -1976,7 +1976,7 @@
           },
           "response": [
             {
-              "id": "d848f679-86ba-4200-bb95-4f05b4f2fd0e",
+              "id": "cd7cb89d-9e0e-40a2-bd53-e0afc63e17f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "276a9fd6-4224-44b3-8447-5b64b763c4ba",
+          "id": "0664b5b5-8b7e-4834-8fdc-711406d19d78",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -2088,7 +2088,7 @@
           },
           "response": [
             {
-              "id": "69e8c137-7f80-47ab-861b-24568a5aab4c",
+              "id": "06c21917-ef65-4dc5-b195-5e55e69b6465",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2163,7 +2163,7 @@
           }
         },
         {
-          "id": "f2a146ba-605c-40d1-83b2-6444fe342dbf",
+          "id": "92c43e02-0a11-4922-817c-8efd3eb5dac3",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "e9dc1380-1257-4bda-8621-34f3cfdce39f",
+              "id": "fc789286-2792-437f-9c67-e4da61dc1971",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2317,7 +2317,7 @@
           }
         },
         {
-          "id": "761d6725-db3a-432e-823a-2687d6c32cb4",
+          "id": "67fb2bd4-922b-40c8-bf4e-eed08efebf19",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2364,7 +2364,7 @@
           },
           "response": [
             {
-              "id": "b35c74fd-04c3-4cb5-93ad-e1795eeb8547",
+              "id": "13a4c396-9a5f-443c-8632-333b22f11f3a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2429,7 +2429,7 @@
           }
         },
         {
-          "id": "ef09ff41-954f-49b7-9af6-aa3f9bfaf42d",
+          "id": "525c1bcc-1202-476a-b04d-59b176fd4ab8",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2471,7 +2471,7 @@
           },
           "response": [
             {
-              "id": "a1e8b81f-1a9d-42e7-83ff-216520be82fb",
+              "id": "d69de80b-5733-450c-8202-e140e0c20028",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2535,7 +2535,7 @@
           }
         },
         {
-          "id": "8359b5cf-754c-4ec8-9d0e-89eaab018e7f",
+          "id": "95d17704-200b-4d0a-ae8e-648026009ff1",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2590,7 +2590,7 @@
           },
           "response": [
             {
-              "id": "8610e470-2114-42e7-ac6b-96e01ca3647a",
+              "id": "d1d3e409-e189-4418-b567-d124a3819efe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2667,7 +2667,7 @@
           }
         },
         {
-          "id": "6af4ead5-d4f3-4c33-922d-f927e58a316c",
+          "id": "2b59a4e7-4172-460e-9a21-ff76797f0355",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2731,7 +2731,7 @@
           },
           "response": [
             {
-              "id": "106c8858-06f8-4092-82a9-60c9e9989107",
+              "id": "c7ab901a-5553-48d2-9772-8c1656adf6cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2823,7 +2823,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "b07133cd-bf60-4ed7-861b-e57aa3bf09e7",
+          "id": "f5a8c523-0c26-4c79-ae30-f774c028d400",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2865,7 +2865,7 @@
           },
           "response": [
             {
-              "id": "9d233c10-6fc9-4cf0-975e-d4560b95538e",
+              "id": "eafa7024-2e19-4dd2-9686-4a7c22ea4424",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2929,7 +2929,7 @@
           }
         },
         {
-          "id": "a087a3c3-2cbb-4daa-8045-ef99345e9584",
+          "id": "386d4c9b-20c1-4c0c-9186-5ab49f5e1cf9",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2972,7 +2972,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2f7f1B\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a35cCB\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2984,7 +2984,7 @@
           },
           "response": [
             {
-              "id": "3906378a-dbfd-476e-a74f-1826d103626c",
+              "id": "e6f16f27-9447-47c8-9d93-3ca10e404892",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3033,7 +3033,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2f7f1B\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a35cCB\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3061,7 +3061,7 @@
           }
         },
         {
-          "id": "19615b96-8561-47ac-acc9-e9020ecdb90e",
+          "id": "653d0e8a-7538-44f1-9d9d-b3b5a6aa340a",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -3097,7 +3097,7 @@
           },
           "response": [
             {
-              "id": "063edfc4-d2b7-4a8b-82ba-7c32f80f81e0",
+              "id": "40523156-cf34-4698-a207-6ad2b7c8d3a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
           }
         },
         {
-          "id": "f31f13a0-3c7a-491d-b62b-c45886d68e1c",
+          "id": "22e88e1c-ccfe-483d-a620-c1051360f8c4",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -3181,7 +3181,7 @@
           },
           "response": [
             {
-              "id": "2e8a310a-7e5e-4c1b-929d-bdb3230d9621",
+              "id": "a988c2d7-6c3d-4838-acd9-316a2dcd7c73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3233,7 +3233,7 @@
           }
         },
         {
-          "id": "4751b530-e7dd-46e2-b013-9eee41858f9b",
+          "id": "11b0fcfe-fd4b-45f0-a452-a55111de80a2",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3264,7 +3264,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6b0e3C\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#0376A1\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3276,7 +3276,7 @@
           },
           "response": [
             {
-              "id": "a299ba8d-2624-4ce0-8b47-caeeb8c67448",
+              "id": "cc8010cd-51f6-48c8-8dc2-3358b5eaadb6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3313,7 +3313,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6b0e3C\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#0376A1\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3341,7 +3341,7 @@
           }
         },
         {
-          "id": "96f80080-fde3-45ea-b30d-54a6fd440777",
+          "id": "d921e3b4-c64c-4060-8caa-99945f809fdf",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3372,7 +3372,7 @@
           },
           "response": [
             {
-              "id": "45e33475-ec71-46f7-84cf-3339ff054e84",
+              "id": "819ebefd-6592-47a2-ad59-5394c79e9eda",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3431,7 +3431,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "c70ea71f-6b5a-4382-91e7-458d24cc21a3",
+          "id": "640e5439-a761-40e1-804f-712c24f34ab0",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3473,7 +3473,7 @@
           },
           "response": [
             {
-              "id": "2db50326-c922-4895-b354-c95e38e8e21c",
+              "id": "edfba4bd-3f68-4f72-9d41-c4050054edbe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
           }
         },
         {
-          "id": "f57fa51a-8f61-47a5-8269-4e197d318250",
+          "id": "bd9dda21-be5c-463c-b526-c49f3b0095e7",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3592,7 +3592,7 @@
           },
           "response": [
             {
-              "id": "33d1325e-1cb2-41c3-81ed-dffe88256aaf",
+              "id": "1904bf9c-648c-445d-9ab0-7373739dfc5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3669,7 +3669,7 @@
           }
         },
         {
-          "id": "803aaf5f-8d86-446c-ad94-4ce2156e4680",
+          "id": "cc05f7c6-a3b7-45f4-aa36-8f4c4de80e53",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3711,7 +3711,7 @@
           },
           "response": [
             {
-              "id": "2a6361fd-588f-429f-920d-7c90232f5907",
+              "id": "7c62549a-e067-4911-b0f2-5fe90341b39d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3775,7 +3775,7 @@
           }
         },
         {
-          "id": "a74ee6a3-b115-47aa-84f4-ba73a228b931",
+          "id": "f3eb5c41-6e0a-448a-8a21-5efde89f8862",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3805,7 +3805,7 @@
           },
           "response": [
             {
-              "id": "a444003f-e862-41b2-a9ee-ec8e28ad1f4e",
+              "id": "a39bd8df-cdd5-4fc3-b54d-4c953d3be4a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3857,7 +3857,7 @@
           }
         },
         {
-          "id": "86611bfe-fcfd-44a5-92fd-7c3c89cafb4c",
+          "id": "01573d50-d009-4637-ad42-44bccbfdccf9",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3900,7 +3900,7 @@
           },
           "response": [
             {
-              "id": "011eeeb8-27ae-4c57-8f9f-1647d4702436",
+              "id": "7bc7f19b-f6c6-40c3-9258-b829284f4e11",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3965,7 +3965,7 @@
           }
         },
         {
-          "id": "5142f0cf-c371-4743-8eae-1b7232f54a9e",
+          "id": "0cd2a860-9e90-40f0-80dd-ec7cedc9c262",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -4018,7 +4018,7 @@
           },
           "response": [
             {
-              "id": "81dd42dd-348d-455b-98b0-68fd8fdeee65",
+              "id": "13f41d26-f529-438b-8171-911cd829dc4a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4082,7 +4082,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 6018,\n  \"key_1\": 8080,\n  \"key_2\": 5715.168284869076\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -4093,7 +4093,7 @@
           }
         },
         {
-          "id": "cf66508a-83eb-4511-bc17-c09d23006582",
+          "id": "eb13436a-271e-4c16-af1c-80c827261e91",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -4136,7 +4136,7 @@
           },
           "response": [
             {
-              "id": "7187a01a-a3ed-40a4-9bcf-888b90682166",
+              "id": "041df00b-5dcd-4048-a232-3db3e658789e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4201,7 +4201,7 @@
           }
         },
         {
-          "id": "d214d7f6-0c22-4076-b32b-0c24a49a0af6",
+          "id": "db23bc25-9d19-4ccc-aff4-858dd51eda36",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4232,7 +4232,7 @@
           },
           "response": [
             {
-              "id": "04a9e230-a96a-4409-9d67-3764a301fb0d",
+              "id": "0c7f3f1c-fcfa-4382-be9a-c8f4d0915174",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4291,7 +4291,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "5783f1ae-db51-4dcb-b9bb-f4962edf21c1",
+          "id": "48286ff9-5441-433b-8f20-1b276017c1f5",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4333,7 +4333,7 @@
           },
           "response": [
             {
-              "id": "20230fd0-1b3a-46e1-a532-bdce0c4c4608",
+              "id": "d1d5fc6d-4848-40c8-ba0f-6fce0300ed1b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4397,7 +4397,7 @@
           }
         },
         {
-          "id": "c50cb9dc-2213-4037-90ac-6628e6890eb6",
+          "id": "e28e8fd6-a435-49b0-9299-afdbaef1a21a",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4440,7 +4440,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4452,7 +4452,7 @@
           },
           "response": [
             {
-              "id": "8a56997a-61aa-41b4-93a3-30e0c635e26a",
+              "id": "805970b8-1927-41ab-a5ed-cbdc03ab030c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4501,7 +4501,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4529,7 +4529,7 @@
           }
         },
         {
-          "id": "917b64d6-e273-410c-86e5-7014e70ea62b",
+          "id": "205da7b2-e62c-47fb-b39c-866f1981da8c",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4565,7 +4565,7 @@
           },
           "response": [
             {
-              "id": "f8a3cd3a-17c5-46ff-8c2c-41ff3b836987",
+              "id": "6d71c7c7-6ca4-4e9e-be0f-ea8de3044c15",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4619,7 +4619,7 @@
           }
         },
         {
-          "id": "24d2a908-2b42-4caf-8d65-a0acfd38365b",
+          "id": "a6575ea8-9bf1-4e5b-95de-b22cc723884c",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4668,7 +4668,7 @@
           },
           "response": [
             {
-              "id": "fc9b161b-e5f9-40c6-90b7-03f887f371b3",
+              "id": "cbf542c0-9c12-4e76-afe2-9195a1cc95d7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "b18ba2d7-0326-483f-84df-1f505091ab78",
+          "id": "8a1ff6ce-857e-4857-ad56-60e7897b77c4",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4770,7 +4770,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4782,7 +4782,7 @@
           },
           "response": [
             {
-              "id": "8f88a744-a5ea-4c1e-a5ea-39763b266b84",
+              "id": "01e2a309-5987-4bde-8496-acd4961be238",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4819,7 +4819,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4847,7 +4847,7 @@
           }
         },
         {
-          "id": "5cf3d45b-da14-4ab4-a80b-f8958f476ec4",
+          "id": "11b540f6-fd64-412c-818a-cf2ae82fdbda",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4890,7 +4890,7 @@
           },
           "response": [
             {
-              "id": "698efd84-45ba-4390-853f-8ca5324de999",
+              "id": "0d525410-a3d6-4982-a674-3e10abb64e1f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4955,7 +4955,7 @@
           }
         },
         {
-          "id": "ba4da0e1-8615-4354-9bd1-6729a30f0b32",
+          "id": "a84dd3be-1058-46c6-8909-246dd113c7ae",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4998,7 +4998,7 @@
           },
           "response": [
             {
-              "id": "376e2f2e-032d-4cc9-b14b-316c310e7ef0",
+              "id": "d0a2aecb-1318-4cad-93c1-87f11d94fff2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5063,7 +5063,7 @@
           }
         },
         {
-          "id": "8924c765-1b74-4f3f-8a62-dc66d3e7f027",
+          "id": "1dbc8b07-0a7c-4725-ab9f-83bc013a2ca6",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -5094,7 +5094,7 @@
           },
           "response": [
             {
-              "id": "07fcdf02-d2c1-41e4-a83f-8e8fc515bc28",
+              "id": "ab79165f-9353-4aac-b486-6cb5b995937f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5147,7 +5147,7 @@
           }
         },
         {
-          "id": "1b9c74ec-f4ed-4be8-b27e-60d04995f9e1",
+          "id": "7fcfc21e-b12b-4c2b-9c98-4c021051dfe4",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -5178,7 +5178,7 @@
           },
           "response": [
             {
-              "id": "dc650276-70ca-4bb2-9a67-e1577901a610",
+              "id": "19ec4941-ed46-461c-859d-361efa22a681",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5237,7 +5237,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "afe8976e-023b-4b24-a716-ee56b665a5bc",
+          "id": "a3ae146a-413e-4fa7-aa6a-0e0818739f18",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5279,7 +5279,7 @@
           },
           "response": [
             {
-              "id": "ee7c1ee7-9a86-4e60-8849-8d91e43c38b4",
+              "id": "9c8ef085-1a66-41d8-be2d-cf8c02f69111",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5343,7 +5343,7 @@
           }
         },
         {
-          "id": "3920795a-ab85-4943-b1f5-747ade550d47",
+          "id": "267f07a9-489f-4af8-aad9-72447e05b4fd",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5398,7 +5398,7 @@
           },
           "response": [
             {
-              "id": "b4153ee6-852b-4726-979f-12220f25d1a8",
+              "id": "662753df-7b5f-429e-94d0-66a8b83b2a18",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5475,7 +5475,7 @@
           }
         },
         {
-          "id": "f0a0b8cf-6982-4b75-81a7-50b33c43a610",
+          "id": "6466b1bb-7d12-42e1-b3ca-0994a6a9a95e",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5511,7 +5511,7 @@
           },
           "response": [
             {
-              "id": "c140bbbb-4f4d-4d4d-b1b3-e9c701117bae",
+              "id": "a1127a2a-dd4f-4229-98ad-97fe4b64fba4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5565,7 +5565,7 @@
           }
         },
         {
-          "id": "3a9c7111-42cb-458d-b4a0-01c611739d52",
+          "id": "003507c3-0e83-4222-a33c-c5d9b24b1f1e",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5595,7 +5595,7 @@
           },
           "response": [
             {
-              "id": "59418cf8-d7dc-45ae-9eed-9c919a2455e3",
+              "id": "766d3c56-617a-4287-bee3-c884bf0d131f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5647,7 +5647,7 @@
           }
         },
         {
-          "id": "5c8560fc-8b20-40e1-a7ee-4234db3e388a",
+          "id": "8a068636-dae7-41b0-b9d0-76e354de0a91",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5690,7 +5690,7 @@
           },
           "response": [
             {
-              "id": "7549c09d-aa67-45cb-9e0b-3e83b8fd5134",
+              "id": "14e076e6-013f-424d-a476-d386cbe2cc85",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5761,7 +5761,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "ddbf4315-65a2-4c53-8a80-932a9b408717",
+          "id": "3823fdb8-f4dc-4f78-8dcd-3fd6c7a9330d",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5814,7 +5814,7 @@
           },
           "response": [
             {
-              "id": "977748e6-b695-447a-9f70-501065dcb59a",
+              "id": "b8447aa4-add4-4e9a-a2a8-a210fc68c627",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5889,7 +5889,7 @@
           }
         },
         {
-          "id": "8dedf149-fade-479f-afb5-ad78b16441e3",
+          "id": "944a3bb3-95e2-46fb-a33e-321519e4c262",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5955,7 +5955,7 @@
           },
           "response": [
             {
-              "id": "5cf3ceaa-f408-47c2-b089-6335b0ee29d0",
+              "id": "0e4cddb8-f752-4125-8eff-21dbc28da07c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6043,7 +6043,7 @@
           }
         },
         {
-          "id": "f3cd4882-f8ae-4a5b-947c-ddccd44012fc",
+          "id": "00b20b25-faea-4b1c-9ba1-d58e82adc91b",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -6090,7 +6090,7 @@
           },
           "response": [
             {
-              "id": "3d966ab9-a53f-44ec-a28b-372e72f8ab13",
+              "id": "e3a74af5-81a1-4bce-ad29-85c7f07afe07",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6155,7 +6155,7 @@
           }
         },
         {
-          "id": "67eb221d-ec0b-4860-aecb-0d465dc55f9c",
+          "id": "b258ee8c-0bb4-4980-a12c-5bae6ba027a1",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -6197,7 +6197,7 @@
           },
           "response": [
             {
-              "id": "b0ca383f-c32c-4879-be77-8b93822ebebd",
+              "id": "7f4cd842-5232-4d78-9c01-ac993cc9f7f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6261,7 +6261,7 @@
           }
         },
         {
-          "id": "794bbcf4-45ea-4cf6-9383-bc5b3ec3b5d1",
+          "id": "30c62ef5-8213-4ad8-9e50-03c5d58c1d9e",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6316,7 +6316,7 @@
           },
           "response": [
             {
-              "id": "1851f40d-5374-47db-b421-19d8bb438dbe",
+              "id": "d5831014-feef-408f-83d2-6c078836b5d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6393,7 +6393,7 @@
           }
         },
         {
-          "id": "4c8034d3-f256-4c19-9252-ba567d4a4232",
+          "id": "228597c3-f1b2-442b-b45e-482970ad81eb",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6460,7 +6460,7 @@
           },
           "response": [
             {
-              "id": "1323be5f-3ed2-43b8-aa43-161d1d821ef2",
+              "id": "5320d4af-3002-4cd3-a8ec-32e91d5d6c2d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6549,7 +6549,7 @@
           }
         },
         {
-          "id": "d6aa6716-05d9-48f1-83bd-6249d34fc4c3",
+          "id": "06f50d01-4e40-4038-b8ef-20aeb6a0817f",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6603,7 +6603,7 @@
           },
           "response": [
             {
-              "id": "17e0d753-73df-4b6b-812d-d8758270c471",
+              "id": "5c1be1f6-b8a6-49f2-8409-63acb6ff9cbc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6685,7 +6685,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "dfb68e95-892f-4a84-8965-8ad7687f3bf5",
+          "id": "b89b7dfc-4be4-48a0-b405-d6cbce72f524",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6738,7 +6738,7 @@
           },
           "response": [
             {
-              "id": "2c1dcbac-8006-4aa9-a5bc-7dc70cec8b12",
+              "id": "6a1927b3-1085-4859-bd91-40e2f5b169f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6813,7 +6813,7 @@
           }
         },
         {
-          "id": "56674043-95b3-4992-bcb7-439d8af20e9f",
+          "id": "c1049f81-d145-4e0f-816e-913b847baf43",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6879,7 +6879,7 @@
           },
           "response": [
             {
-              "id": "844498af-2ec2-4ae4-b0b4-970908b7d778",
+              "id": "8b76ddfc-0bf5-42ae-a754-bd682dc7e4f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6967,7 +6967,7 @@
           }
         },
         {
-          "id": "f0d33533-68b7-492d-b51e-707f78427fe2",
+          "id": "121de705-9322-461a-98b0-913208c068f7",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -7014,7 +7014,7 @@
           },
           "response": [
             {
-              "id": "012704fb-9def-4685-9ec1-b1a2c7b04272",
+              "id": "a9334a90-0576-4526-bc32-6cfa2003e9fb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7079,7 +7079,7 @@
           }
         },
         {
-          "id": "d323a29b-24b7-4e5e-b9fc-9c42e06953c8",
+          "id": "b7e3fb0c-c0a6-4b57-9fdb-9bb84c5d6ab1",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -7121,7 +7121,7 @@
           },
           "response": [
             {
-              "id": "f2d3482a-0d3b-4173-9406-cbc433b355ae",
+              "id": "74e08e52-e9ac-4b7d-9e28-d1bac191ba41",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7185,7 +7185,7 @@
           }
         },
         {
-          "id": "becc10c7-9092-4cd4-bca2-47b418998c10",
+          "id": "039c60e9-cea4-4a0f-b630-f6952b6d2ab5",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7240,7 +7240,7 @@
           },
           "response": [
             {
-              "id": "8ec01b10-830a-4b17-bb86-c648aece7141",
+              "id": "909991d8-223e-4df7-8042-38d0e90edc94",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7323,7 +7323,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "5368b7d3-8480-424d-a870-7ff5e6fafbd3",
+          "id": "9409626f-01c3-40e1-80b8-e0829181b10a",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7364,7 +7364,7 @@
           },
           "response": [
             {
-              "id": "45a0dedb-736a-4e4b-a9f9-e4c21f846d41",
+              "id": "0fd0a8f7-31dd-48c5-8870-fa30cd8f6b78",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7427,7 +7427,7 @@
           }
         },
         {
-          "id": "85e64630-1191-44b9-be14-548047f714ee",
+          "id": "6f1940c8-eec5-4249-9faf-3f178760916d",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7481,7 +7481,7 @@
           },
           "response": [
             {
-              "id": "4a5d9336-7138-4304-80e7-a98c6472ae63",
+              "id": "612624a8-1994-4118-906f-732b690b5363",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7557,7 +7557,7 @@
           }
         },
         {
-          "id": "f2ab3bc9-f939-4c2a-ad62-f49e5bcf6802",
+          "id": "b918c853-e1f2-4cef-aae0-70e059b8f7ee",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7592,7 +7592,7 @@
           },
           "response": [
             {
-              "id": "ed209579-c344-4ab9-86d9-6bb8fa11ca8f",
+              "id": "113929dd-702b-4fe6-ab1c-d3261dd45a60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7645,7 +7645,7 @@
           }
         },
         {
-          "id": "85c1e0e7-d5aa-41be-84b6-b3925fcdf876",
+          "id": "0ca163f4-3e2b-4afa-80c3-7e03975604ec",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7702,7 +7702,7 @@
           },
           "response": [
             {
-              "id": "705f65b7-4c9e-451a-bec2-eb4f1ef02b10",
+              "id": "ee7c8d73-3d06-4de3-8a44-d8e0cd8aa158",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7781,7 +7781,7 @@
           }
         },
         {
-          "id": "4c7fd0d6-8649-4946-823a-0d9bcb918dd2",
+          "id": "94533bf0-9490-4a8c-ab45-ad1be0ddadf9",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7823,7 +7823,7 @@
           },
           "response": [
             {
-              "id": "6b213e47-997d-47dc-b9ba-ea70aa989ff2",
+              "id": "db426051-9fd8-4c85-b670-bdae00b0baf0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "acd95c70-46dc-467a-a3f2-9ede3ccc39d2",
+          "id": "ef620a4c-d9cf-4686-aca5-c5286be54170",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7946,7 +7946,7 @@
           },
           "response": [
             {
-              "id": "ecddd6fa-ce10-4cf7-a0e8-9e8915dca2a8",
+              "id": "19ce0d46-166d-4a73-b676-d2625aed93b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8021,7 +8021,7 @@
           }
         },
         {
-          "id": "c2229ed7-2914-4ed4-8323-be066ccad6e9",
+          "id": "00d1b896-1e89-4ae1-a473-36ea6778d3cd",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -8087,7 +8087,7 @@
           },
           "response": [
             {
-              "id": "a78ffc7e-c2df-4f01-b742-b41207b3e0d3",
+              "id": "712f6e0b-1edb-4312-9758-93e89cf81530",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8175,7 +8175,7 @@
           }
         },
         {
-          "id": "2bcdad13-a047-496b-9e7f-80c7aabba9f3",
+          "id": "b46240ee-0349-43db-b6ce-dd19dfa8a633",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8222,7 +8222,7 @@
           },
           "response": [
             {
-              "id": "9ce1ac9c-9db4-4d81-a38c-ad2e65a03126",
+              "id": "48252753-fbde-4f68-84dc-ec13238d91c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8287,7 +8287,7 @@
           }
         },
         {
-          "id": "ab71f849-0e8a-41c6-b285-2c3fa2208aa0",
+          "id": "fc85d07c-8c1b-42da-a865-d1ccfa468ccf",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8329,7 +8329,7 @@
           },
           "response": [
             {
-              "id": "31af5362-db2d-4da1-85be-aaabba66bea6",
+              "id": "a3591307-854c-49a0-99b0-051200e3728f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8393,7 +8393,7 @@
           }
         },
         {
-          "id": "59b6d996-1212-4fba-b1b8-bfa62916798b",
+          "id": "72740c4f-03e3-4d20-88b4-36ce4c3dac39",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8448,7 +8448,7 @@
           },
           "response": [
             {
-              "id": "15213348-c4ec-46f6-becc-a2e06acaa757",
+              "id": "25a7cba8-6c83-4646-8eb1-8ac3fd68bee6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8531,7 +8531,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "338a9f5b-27c7-4dd8-9765-407c6ec3c13d",
+          "id": "8dd0c274-fbce-4779-b65c-95cac6b3b9c4",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8573,7 +8573,7 @@
           },
           "response": [
             {
-              "id": "15bbd22c-59c7-489e-9f17-b6590c7ff942",
+              "id": "369b6c91-061b-43c4-a977-c9beb8445973",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "308c8d19-1a5e-4d39-9e05-c79e04ed081a",
+          "id": "5b5145a8-3cfa-43b5-8e7e-70bc2813670c",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8692,7 +8692,7 @@
           },
           "response": [
             {
-              "id": "5d3e6804-fd3a-476c-b97c-2783c44f2768",
+              "id": "32e90190-6a36-41cb-adc7-4890448cb6ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8769,7 +8769,7 @@
           }
         },
         {
-          "id": "3485423e-5f8e-401e-ac0f-92459463110f",
+          "id": "7f6b37b3-d5b2-4255-84d7-176f013c8c5d",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8805,7 +8805,7 @@
           },
           "response": [
             {
-              "id": "affcba32-e603-45f0-b508-b638a88ae303",
+              "id": "0de02041-4694-412a-a098-031397f37435",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8859,7 +8859,7 @@
           }
         },
         {
-          "id": "4f70d1c7-5510-4e10-b4e5-e224ffe1eabe",
+          "id": "66032c7a-fc0d-4984-bca5-9ee77c83d0c8",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8889,7 +8889,7 @@
           },
           "response": [
             {
-              "id": "a3fa87f0-5002-4455-904c-541db596d65d",
+              "id": "72c888bd-1a96-4beb-82fe-085db1684435",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8941,7 +8941,7 @@
           }
         },
         {
-          "id": "b46e2996-379d-4ee9-9f11-ade2f01b366a",
+          "id": "da7a8d59-bc21-4a7f-b1b1-8d5eff3b7f57",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8984,7 +8984,7 @@
           },
           "response": [
             {
-              "id": "d84f3372-1c97-4d2c-8322-1172d29fe8fb",
+              "id": "93cf34ab-0a83-4106-8b05-5f04388e52c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9055,7 +9055,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "90d58c93-99c5-4fdd-82a3-244e31766002",
+          "id": "c595758f-801b-4302-bb59-41f474bfd46d",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -9097,7 +9097,7 @@
           },
           "response": [
             {
-              "id": "a6b6573a-2fac-47c1-be95-1b5f42f3b893",
+              "id": "f57664c6-99de-433b-bc27-70bffb881102",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9155,7 +9155,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "9e335f2e-fe2d-4b03-965e-43ab9d65a029",
+              "id": "e1d50fd7-8a2a-42e4-ba75-7f1b0016e4e7",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9219,7 +9219,7 @@
           }
         },
         {
-          "id": "d487105d-c2df-40e6-9475-763f2dfa4023",
+          "id": "851cbfa7-b2ea-4a4f-b233-c97e1f6439d5",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9274,7 +9274,7 @@
           },
           "response": [
             {
-              "id": "68cf90a7-574e-4835-8057-079b768c10a2",
+              "id": "2570ff04-b618-49b9-a19f-c28182ef16ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9345,7 +9345,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4c988fbc-f49e-45b2-a0bf-4bb425cdc129",
+              "id": "85b66590-2b98-4a1d-8bd1-fbad5fec81bd",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9416,7 +9416,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "dd5a5085-4906-46fb-81b4-304796f6352e",
+              "id": "d2622650-c5ad-4c6b-b1fe-93f77f8e3eba",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9493,7 +9493,7 @@
           }
         },
         {
-          "id": "249b864a-b3e3-4e8a-97be-fde8b66c0a21",
+          "id": "9000c43f-9be1-4b0e-a883-9bacb2e94495",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9529,7 +9529,7 @@
           },
           "response": [
             {
-              "id": "dba260f7-e13e-4971-9a7d-87f9929128be",
+              "id": "b63039a9-36ba-4cd1-8ca7-5abc6334b05b",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9577,7 +9577,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "875e96a8-755a-4457-bfc7-32c77ad14c1f",
+              "id": "56b70246-e151-4dfd-bebc-8abe11f6a324",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9625,7 +9625,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "30dac93c-9a13-46f5-9fb2-081e0ea34595",
+              "id": "7f4a7ffa-ba14-4c4f-89e0-9353768caf69",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9679,7 +9679,7 @@
           }
         },
         {
-          "id": "646b72d6-031e-489f-b1a8-988922f931bf",
+          "id": "ce972fc1-3936-44d4-90f6-12577f0da4f0",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9709,7 +9709,7 @@
           },
           "response": [
             {
-              "id": "a6f3121a-1244-4455-86f5-30fc8838dfe7",
+              "id": "3fa3d915-5339-43f1-81ab-cdb2ac84d00e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9761,7 +9761,7 @@
           }
         },
         {
-          "id": "7af2ff37-c6a1-4f3b-9e53-0dbb98567291",
+          "id": "4f62ef9a-e5ba-4323-8d4e-cb1ea59e04e8",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9804,7 +9804,7 @@
           },
           "response": [
             {
-              "id": "3d28e571-36c2-481a-a810-0f1266887162",
+              "id": "133bf0cd-4e7d-4423-b351-bdb364c3a7a1",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9863,7 +9863,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "91cd908b-bf74-4ac0-9e11-6cffb496b5d4",
+              "id": "adf89918-4e66-4479-a109-2c25bd08a1e8",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9934,7 +9934,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "41612ac1-b436-45bc-ace9-97a33c37459e",
+          "id": "f61b29c7-7365-4462-b013-eb0e2820c69d",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -10000,7 +10000,7 @@
           },
           "response": [
             {
-              "id": "4e19e5f5-2dd4-4ab7-a216-c048a107e3cc",
+              "id": "64a738a5-163f-4a90-a687-637d7cd6186b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10074,7 +10074,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 6018,\n  \"key_1\": 8080,\n  \"key_2\": 5715.168284869076\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -10091,7 +10091,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "fa28ccb0-78a7-4dab-9c35-6cc16b3ae9cb",
+          "id": "4b7fa989-66a3-46f9-8902-da97931e5259",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -10133,7 +10133,7 @@
           },
           "response": [
             {
-              "id": "051cede2-9290-4f9f-8b25-c9cd070dbd93",
+              "id": "adaa3153-b4c4-4b66-9872-5a007e59e320",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10203,7 +10203,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "6d981a91-8ab8-4975-8330-66fbf283ef68",
+          "id": "390de8db-09c1-46a4-9118-09a61f72af27",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10245,7 +10245,7 @@
           },
           "response": [
             {
-              "id": "87329225-b6fc-44f7-aac1-f2c185155b6e",
+              "id": "14992849-6a84-4ee1-99df-1a832cb9267f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10309,7 +10309,7 @@
           }
         },
         {
-          "id": "2e2c8647-70ec-44b0-ae61-dba563b8c0e5",
+          "id": "e94a1006-aa1e-48c4-bed9-db1189dd50ec",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10352,7 +10352,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#601A84\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#d831ba\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10364,7 +10364,7 @@
           },
           "response": [
             {
-              "id": "9ff84110-b12d-4f9a-8175-82d7bd249476",
+              "id": "5454a419-ff67-4c85-a319-47590e5df986",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10413,7 +10413,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#601A84\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#d831ba\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10441,7 +10441,7 @@
           }
         },
         {
-          "id": "46cbbc0c-dff5-4da2-ae4b-ac187f12df4d",
+          "id": "43b8ac7e-0296-4184-b758-5e25675e9886",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10477,7 +10477,7 @@
           },
           "response": [
             {
-              "id": "e4688fb6-1f4a-440f-ad29-3daf559623ee",
+              "id": "8ddb24dc-ba91-4a27-b5c1-0d06e998cb01",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10531,7 +10531,7 @@
           }
         },
         {
-          "id": "b1e7965d-a274-4690-92c5-5801ab45d61a",
+          "id": "bab62051-24f4-42ec-a2b8-24094401db08",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10561,7 +10561,7 @@
           },
           "response": [
             {
-              "id": "122cb9ef-c941-4366-be63-e3fbea763aca",
+              "id": "127f9644-c829-437a-bd37-cbb4fe1f20ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10613,7 +10613,7 @@
           }
         },
         {
-          "id": "917cc3b9-7793-44c5-b3d7-4fb5453df244",
+          "id": "2d506473-d0a6-43bc-a427-720087f3a58a",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10644,7 +10644,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6BE0c0\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#910A32\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10656,7 +10656,7 @@
           },
           "response": [
             {
-              "id": "52e0e0db-8c49-4418-977e-5b7e9fc558bc",
+              "id": "3880b86d-d587-4bec-9640-52a5fcbc880e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10693,7 +10693,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6BE0c0\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#910A32\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10721,7 +10721,7 @@
           }
         },
         {
-          "id": "f15a5193-258a-452d-8268-80d273653525",
+          "id": "e5b69631-28a8-495e-abd7-9a2a97c71cc9",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10752,7 +10752,7 @@
           },
           "response": [
             {
-              "id": "f4fcc4da-1896-4031-b52c-7be677f74b68",
+              "id": "df73563e-7f80-4e31-b8f6-11cfe119d28b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "7ee1704c-0d2a-4e2e-a257-dad8df07069c",
+          "id": "ed8d40a9-056b-4431-adfa-518514f19f63",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10864,7 +10864,7 @@
           },
           "response": [
             {
-              "id": "f3dbc6c9-8cdb-410d-93c1-6c77d2059cef",
+              "id": "947dfff3-379a-431e-ac1f-c1f9d14e6811",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10939,7 +10939,7 @@
           }
         },
         {
-          "id": "6ed26165-9bcb-4cc5-b255-887d011c5a36",
+          "id": "f447827c-ae32-42b5-9eac-02dedd8324dc",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -11005,7 +11005,7 @@
           },
           "response": [
             {
-              "id": "00cffaac-86d1-4dba-99fc-c32acd56cd2e",
+              "id": "6b973565-9e98-4014-ba27-144da3fea459",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11093,7 +11093,7 @@
           }
         },
         {
-          "id": "8194917e-0e08-45f9-bdca-4619b5ae26ec",
+          "id": "fbef6c77-e484-452d-a7bb-242bd9348d92",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -11140,7 +11140,7 @@
           },
           "response": [
             {
-              "id": "f84018cd-32d9-4b51-8f4e-c0eef0c7e3b6",
+              "id": "bd7e3428-2dfc-4013-889d-3064c7d3d3fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11205,7 +11205,7 @@
           }
         },
         {
-          "id": "2c0a9565-02df-41b1-b81e-b0ee68ae7899",
+          "id": "39f3be8e-21c9-4964-8bcb-47c843752283",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11247,7 +11247,7 @@
           },
           "response": [
             {
-              "id": "dd628002-2d56-4bfc-a4f0-8b7b00ec7f8b",
+              "id": "22e83975-f85f-4819-90d0-9855b2b300f7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11311,7 +11311,7 @@
           }
         },
         {
-          "id": "2eef419a-38e7-4db3-96a5-f7ebef7ed7b9",
+          "id": "e24e9bc4-b1fc-4b65-bd8f-8933781b431c",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11366,7 +11366,7 @@
           },
           "response": [
             {
-              "id": "1f8212c3-264d-4076-b822-6e98352d8d9a",
+              "id": "b3a67578-dc06-4169-98e5-8055a4588530",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11443,7 +11443,7 @@
           }
         },
         {
-          "id": "d8fec355-f253-4f8e-8631-547ad0b5f0ca",
+          "id": "183bdc1b-94a6-4b7b-9c35-90b73d29bbeb",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11497,7 +11497,7 @@
           },
           "response": [
             {
-              "id": "90c9604e-45c4-40f2-9a24-a63bb68f9883",
+              "id": "60104284-6b29-4ba2-9396-97f0102aa1c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11573,7 +11573,7 @@
           }
         },
         {
-          "id": "47ab661a-b2ca-4f85-8ae5-2a64cea8663e",
+          "id": "aac6cb2d-fab7-411c-a867-c77d747d3463",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11639,7 +11639,7 @@
           },
           "response": [
             {
-              "id": "57b1b538-0c1c-41b7-8bf9-96de478f99db",
+              "id": "f3392996-497a-4770-bc41-5a343837d6d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11727,7 +11727,7 @@
           }
         },
         {
-          "id": "915d545d-f8ec-4398-b4f9-93958b72900e",
+          "id": "10f2090a-1a2b-43a0-9de5-deecf1764c05",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11805,7 +11805,7 @@
           },
           "response": [
             {
-              "id": "88d4e1c2-bdb6-4c19-ae18-2f58cda36386",
+              "id": "8a5f6c64-5588-4b74-add6-2ab266e22a49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11905,7 +11905,7 @@
           }
         },
         {
-          "id": "2d978dd4-c54d-4e31-b141-01cd15d6bcf2",
+          "id": "6b08ee24-8068-43a6-9fc1-2df21d0ff722",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11971,7 +11971,7 @@
           },
           "response": [
             {
-              "id": "d1af04cf-6eea-4409-9ae2-ed34ec19efc9",
+              "id": "4d5a6cf8-ceec-46ab-9c9f-1eb430b7ebcb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12059,7 +12059,7 @@
           }
         },
         {
-          "id": "bc317534-49fb-4b66-b7ca-9996b6c7ca7e",
+          "id": "5b007ded-c0e7-4dbf-bdfe-2b700af61b99",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -12114,7 +12114,7 @@
           },
           "response": [
             {
-              "id": "a4b48145-70b7-4d59-a65c-0f93f3b46565",
+              "id": "58e8e0fb-d76d-4e07-a609-1c96587fb126",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12197,7 +12197,7 @@
       "description": "",
       "item": [
         {
-          "id": "e8e2266e-7857-4d95-a1aa-90687ae6509a",
+          "id": "170d90bc-383b-40fc-b1ee-ada59662858c",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12238,7 +12238,7 @@
           },
           "response": [
             {
-              "id": "da1535c5-cc1d-455c-b496-7bdf488925a0",
+              "id": "210d193a-00b2-49fc-b6ae-f8220a97764d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12301,7 +12301,7 @@
           }
         },
         {
-          "id": "bd04623a-169b-4e56-b332-fe8dab38ffa3",
+          "id": "fe11773e-bee7-46a4-bf1b-6ef2e282d072",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12355,7 +12355,7 @@
           },
           "response": [
             {
-              "id": "e38072a7-3fbc-4614-ae97-10a26719d78e",
+              "id": "536fab29-da67-48b7-9918-4fbd95428f8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12431,7 +12431,7 @@
           }
         },
         {
-          "id": "882818c3-6b09-4c7a-b2db-0d6443f5e774",
+          "id": "e42ac8cc-8ca6-48de-ae0e-129514c0f4e5",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12466,7 +12466,7 @@
           },
           "response": [
             {
-              "id": "01b5367f-1d3d-4ea1-9d58-c4fe9b727c65",
+              "id": "ed61a649-16cf-46a5-a1b3-78b6c9770781",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12519,7 +12519,7 @@
           }
         },
         {
-          "id": "72765948-18d8-4fc6-85ca-b0e8af84d601",
+          "id": "92f19b77-947c-43d4-8f90-a0b1b198bdba",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12580,7 +12580,7 @@
           },
           "response": [
             {
-              "id": "7c43ae6f-56ee-4497-833e-166d47a21f3f",
+              "id": "df31b927-8f8e-4677-809f-5253bfa245b4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12663,7 +12663,7 @@
           }
         },
         {
-          "id": "d8e0b95e-3360-467a-bb6d-eca40bc34144",
+          "id": "80ca294d-e807-496a-adbd-1dfc0c7162d9",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12705,7 +12705,7 @@
           },
           "response": [
             {
-              "id": "cedee16e-cde4-4aa1-b491-52889ea2d6c6",
+              "id": "68618a70-669e-4110-a51b-9b192f81846a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12769,7 +12769,7 @@
           }
         },
         {
-          "id": "ab9d67cb-b78c-48b6-9071-ae101ec4c146",
+          "id": "6a1f4fb3-eaa6-4415-be78-8bc45c3d9d00",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12844,7 +12844,7 @@
           },
           "response": [
             {
-              "id": "b3c84437-b378-4780-a1c8-0afdba367a0e",
+              "id": "ae3a5d61-29c3-4924-82d3-e06c91e9ff89",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12941,7 +12941,7 @@
           }
         },
         {
-          "id": "5b3821c7-7147-48f9-aaed-552a5d80fca6",
+          "id": "b41acbef-896f-4f5f-8d69-74d64ba592e7",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12983,7 +12983,7 @@
           },
           "response": [
             {
-              "id": "0c3c1eba-4584-4b14-9124-b225834a68e8",
+              "id": "67e187a0-715c-43ff-a50d-9306c8222976",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13047,7 +13047,7 @@
           }
         },
         {
-          "id": "fd3f2217-d800-4fbe-a3b5-12fc6298bf9f",
+          "id": "4f03ff10-1c19-4d2e-80d2-98a9d7340c29",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -13090,7 +13090,7 @@
           },
           "response": [
             {
-              "id": "3bad1537-fcae-4611-ae61-db5b0a1b2277",
+              "id": "add3ea5b-caa6-42f6-8675-150c0f5a7fa0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13155,7 +13155,7 @@
           }
         },
         {
-          "id": "882eddd3-e8b7-4601-b4d0-ee5d16702bbd",
+          "id": "cf3934c5-45cd-4077-a894-1164acf76a16",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "6416c058-b493-40a8-a3c0-489ee08c7610",
+              "id": "4125bcef-760c-44f2-9492-1ca5f74202b5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13263,7 +13263,7 @@
           }
         },
         {
-          "id": "e02681de-7b3e-44be-8c49-e81357b17e13",
+          "id": "67bda1d5-f3bd-4ca3-a407-0085710e935d",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13315,7 +13315,7 @@
           },
           "response": [
             {
-              "id": "ffdd2f54-cbfc-4a8c-beaa-71835fa8eeca",
+              "id": "271c7368-39a3-4e48-a100-fc38df8733dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13389,7 +13389,7 @@
           }
         },
         {
-          "id": "ae68d33b-9a6c-4bc4-aa7a-0b27eb038ec8",
+          "id": "241ca06d-0d67-4479-93f4-09f142601fa7",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13431,7 +13431,7 @@
           },
           "response": [
             {
-              "id": "ab3d58d4-afe8-4ca3-b8c2-c4b8f88ee533",
+              "id": "2bc56b75-55fb-4292-9511-b9457686371a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13495,7 +13495,7 @@
           }
         },
         {
-          "id": "f7f2b172-efea-4a56-b6e6-a40f819811ea",
+          "id": "f6b4572e-92ae-428d-875f-0fcae80fa9b7",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13548,7 +13548,7 @@
           },
           "response": [
             {
-              "id": "34bc955c-30a1-434c-9881-4e4d3ee6ee7b",
+              "id": "41da950b-42dd-4ff1-9e23-8935f91f48a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13623,7 +13623,7 @@
           }
         },
         {
-          "id": "5a3e9cd2-39da-44bc-82ec-98e682718359",
+          "id": "f652c9e2-58ac-4a64-9051-2c05a545d33b",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -13676,7 +13676,7 @@
           },
           "response": [
             {
-              "id": "420f4c09-2ef1-4166-a1b0-59240f3218c6",
+              "id": "702dfd7d-d410-45e7-a8d0-10f181544405",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13751,7 +13751,7 @@
           }
         },
         {
-          "id": "74786dc2-2b35-4617-b01d-f2409e06e669",
+          "id": "4a17af54-afd0-415f-a421-3f59f22a74dc",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13795,7 +13795,7 @@
           },
           "response": [
             {
-              "id": "eabeedbd-5b34-4386-822d-77a291091af4",
+              "id": "a490a932-dcce-4790-9fa9-7371c7c4e0c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13850,7 +13850,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13861,7 +13861,7 @@
           }
         },
         {
-          "id": "365962cf-901a-47c6-90bc-77c6e2fbf746",
+          "id": "52526e79-5722-4a1c-843c-b14c6701c60e",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13905,7 +13905,7 @@
           },
           "response": [
             {
-              "id": "290ea6e2-812d-4aa4-a729-61cee8043ce6",
+              "id": "7c0656dc-859b-48fe-8194-c50ee8081ad8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13960,7 +13960,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13977,7 +13977,7 @@
       "description": "",
       "item": [
         {
-          "id": "e223b9d4-9be7-499c-a301-5c102a3639ed",
+          "id": "4a46a412-b6ac-4dbd-a734-01695a3b3966",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -14019,7 +14019,7 @@
           },
           "response": [
             {
-              "id": "b2a55499-03e0-40ac-9688-a3cb139f3bc3",
+              "id": "8359930d-da24-4507-a8b4-c42dd310a278",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b0f95acc-3744-4745-a36a-08af2c3bf90b",
+              "id": "40f866b7-4847-4fc2-9b91-47e780112cd3",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -14123,7 +14123,7 @@
           }
         },
         {
-          "id": "9e700566-57f2-4452-b3bc-788fe0b06a8d",
+          "id": "2d41d86b-da2f-46a2-98f2-1f6c2a718bd3",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -14169,7 +14169,7 @@
           },
           "response": [
             {
-              "id": "fbe8cc30-7f72-4e75-904c-d44ad622a7af",
+              "id": "d1de7740-aed3-4ce4-af2d-a3a408622b5e",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -14228,7 +14228,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e14126f8-21d0-4035-a6f2-6d9e29ad6fc8",
+              "id": "e37990d8-bf16-4601-88d2-b648c0892459",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -14293,7 +14293,7 @@
           }
         },
         {
-          "id": "3901021d-3b3e-466c-9cc7-e8d3da2c36ba",
+          "id": "882e241d-411e-4823-a960-4cad0597a9e8",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14339,7 +14339,7 @@
           },
           "response": [
             {
-              "id": "4190a4d0-7490-43e8-bd13-badf3d61ef72",
+              "id": "cadf12c0-5f0d-48fe-a545-6efbb2d733da",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14398,7 +14398,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c5bc93ff-da65-4a4d-8706-562d5b16cb6a",
+              "id": "6689fd5f-e37a-4247-87dc-6b9d2666d748",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14463,7 +14463,7 @@
           }
         },
         {
-          "id": "da74bb9c-e232-4c16-8c32-d486b9e69599",
+          "id": "f97aaca1-9146-4597-b4e6-26322ee954b7",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14505,7 +14505,7 @@
           },
           "response": [
             {
-              "id": "9773f1df-c5f8-48a9-a858-d7c48f9469e9",
+              "id": "9423c136-d4f0-435a-b214-5d31e9b3944f",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14566,7 +14566,7 @@
       "description": "",
       "item": [
         {
-          "id": "0e7807b8-5a09-4998-b931-9c903f6f578e",
+          "id": "986878ee-ff57-41a9-b1b1-20bcb501c7e7",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14615,7 +14615,7 @@
           },
           "response": [
             {
-              "id": "79d9e7c1-09c9-42a2-8258-417f8d011705",
+              "id": "c0115c92-99f2-408e-976e-2248a5b2a79b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14675,7 +14675,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 6018,\n  \"key_1\": 8080,\n  \"key_2\": 5715.168284869076\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14686,7 +14686,7 @@
           }
         },
         {
-          "id": "6e1b641d-29f7-431c-9a93-16f42d3d5924",
+          "id": "13d0cb9a-cbb6-4114-9d58-9f0c9f973611",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14735,7 +14735,7 @@
           },
           "response": [
             {
-              "id": "b895ad8a-6736-401c-a351-803bcaca63ea",
+              "id": "0901c34a-851b-4f5e-a1a7-ecd87279897f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14806,7 +14806,7 @@
           }
         },
         {
-          "id": "7409ba1f-8afa-43b6-9c4d-3c56c9ab3768",
+          "id": "b472d18c-7b2f-4bf4-90b0-c37459a7e15a",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14855,7 +14855,7 @@
           },
           "response": [
             {
-              "id": "aacf65f2-e99c-4098-b08c-4f82292ee143",
+              "id": "bcb337e5-2fce-481d-81eb-fa90acbd3008",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14926,7 +14926,7 @@
           }
         },
         {
-          "id": "35f185e1-15d1-4916-ba01-98acd58c9def",
+          "id": "b0265e30-e966-40bf-adef-fa13d7812e11",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14975,7 +14975,7 @@
           },
           "response": [
             {
-              "id": "fb6314e6-f4fb-4266-8d9b-538ab05681b7",
+              "id": "9c1b6be6-b000-4934-87d5-b867e74da656",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15052,7 +15052,7 @@
       "description": "",
       "item": [
         {
-          "id": "83a6fdb0-b23a-4b88-95d0-67452b1f4862",
+          "id": "19058994-d7f4-4c9a-b05c-ae4ca29b2a51",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -15092,7 +15092,7 @@
           },
           "response": [
             {
-              "id": "78d9fe8a-78b8-4f90-bd89-1729c29d59cb",
+              "id": "20c292a3-ef37-457c-b7bf-5fd8f202242a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15154,7 +15154,7 @@
           }
         },
         {
-          "id": "99e1efb6-4a09-45c9-9740-142a78637488",
+          "id": "9883c1b7-18f4-46f6-a68e-92fa72be613d",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -15184,7 +15184,7 @@
           },
           "response": [
             {
-              "id": "cf2e64a5-613f-4f73-9626-1aad5d0eb454",
+              "id": "90c5e20d-69ca-459d-afc8-9b46a10b4f98",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15225,7 +15225,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 6018,\n  \"key_1\": 8080,\n  \"key_2\": 5715.168284869076\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15236,7 +15236,7 @@
           }
         },
         {
-          "id": "23edf037-1b3c-432d-a2d3-fddc2dc248ee",
+          "id": "26789a88-7f59-4c93-adf8-5b95abd5ff28",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -15288,7 +15288,7 @@
           },
           "response": [
             {
-              "id": "7091d02f-9582-403e-952f-47e4ed30015c",
+              "id": "32d2b85c-ef42-40f2-bedc-f3e1284265f8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15368,7 +15368,7 @@
       "description": "",
       "item": [
         {
-          "id": "b2a696b6-1c77-4379-874c-24fed3f3a936",
+          "id": "3e971b6d-c1d7-4fc1-ba06-30914c6b69d9",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15397,7 +15397,7 @@
           },
           "response": [
             {
-              "id": "a34aa998-8f96-4066-836e-f35459d4406b",
+              "id": "887759cc-b4b1-4134-9056-b7e117b37759",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15448,7 +15448,7 @@
           }
         },
         {
-          "id": "fe1486bf-bce8-44be-b1eb-15a07c6a0ae2",
+          "id": "3b107305-74f2-4239-8726-1669f7de7c84",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15489,7 +15489,7 @@
           },
           "response": [
             {
-              "id": "08c52a7b-3dd1-48f6-a083-d23a4ce6adba",
+              "id": "9049bcb3-ba36-41e6-928c-c9a23d2783c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15558,7 +15558,7 @@
       "description": "",
       "item": [
         {
-          "id": "9246274d-ec46-44bc-a01c-44f7ee744840",
+          "id": "ede469c4-2bc4-47ea-9fd1-633ffc1b67c5",
           "name": "health",
           "request": {
             "name": "health",
@@ -15587,7 +15587,7 @@
           },
           "response": [
             {
-              "id": "b75a8748-69c9-4595-a447-aa1b9c747fd8",
+              "id": "6e8254e1-047e-47cd-986d-7e53a654d9e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15627,7 +15627,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
+              "body": "{\n  \"key_0\": 6018,\n  \"key_1\": 8080,\n  \"key_2\": 5715.168284869076\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15644,7 +15644,7 @@
       "description": "",
       "item": [
         {
-          "id": "ffea36f0-357a-4a48-99f2-e199bbbf0f5d",
+          "id": "8df34c65-f1fc-4066-bd54-14f11a05fda9",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15696,7 +15696,7 @@
           },
           "response": [
             {
-              "id": "ed76a199-1207-4cbb-ab72-03013be91f0e",
+              "id": "8e411992-6912-476d-83d2-4b4043684feb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15770,7 +15770,7 @@
           }
         },
         {
-          "id": "e63d2e59-346a-4f93-957b-df4b7896ed06",
+          "id": "d9d92953-aa53-4d2c-ad8f-0307190af589",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15811,7 +15811,7 @@
           },
           "response": [
             {
-              "id": "8d7328f3-1475-4e9f-a7ca-e6287eb87f1b",
+              "id": "2164934e-f9eb-44e9-9416-08bf9699d37b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15863,7 +15863,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15874,7 +15874,7 @@
           }
         },
         {
-          "id": "d7d5ac06-a666-48c9-bc9f-a38a405a15c7",
+          "id": "b6a99f33-e0fe-4b79-a4e8-a0e701cc7dbc",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15904,7 +15904,7 @@
           },
           "response": [
             {
-              "id": "59f659d9-8448-4a97-8e81-048b9c9f1e67",
+              "id": "55c90a2e-7ff6-4789-9ee2-04e66a025cbc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15945,7 +15945,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15976,9 +15976,9 @@
     }
   ],
   "info": {
-    "_postman_id": "3cc3c413-2d98-4136-bade-c6932aff7b92",
+    "_postman_id": "a85cff69-3203-4f55-9533-4b41680c890a",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-02 00:58 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-02 00:59 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "978db363-711d-474e-ba28-ffeb15e3f0d9",
+          "id": "f6b10e47-2eb9-4322-b845-48d63e62874b",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "6f4f224b-d909-44c6-8260-56732eea6507",
+              "id": "b7b9f4b9-ee99-4a81-8784-764e73bc697f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "82440c9a-61ee-4fbf-bc1a-4d7da7f39593",
+          "id": "9750f467-5f7e-4892-9c6f-b6bd065ea713",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "2220fe0b-094c-4986-af5d-ef73b5c44af2",
+              "id": "d97aac7b-4c68-46f7-9bb8-40674ba898e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "5c80fae0-53e5-4904-8d46-9cbb225eb451",
+          "id": "eec0de76-a525-443f-817e-0f9a40296385",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "b872dde5-3e29-4a63-8f40-4decc7abb07c",
+              "id": "96dc170f-2cb8-4686-964d-bd3e92fbe3e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "d5fe182b-9ff1-4c31-a914-2b633e75bd1c",
+          "id": "3365fa95-1293-43cb-b10e-d4287b6bfad3",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "3f42b2e0-0f29-4577-a427-611273530716",
+              "id": "aa20f197-0797-49ea-ac88-ce1210b8b8f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "280cc5dc-8539-4935-92d9-40437bedabc2",
+          "id": "965d89b2-c593-4ef9-80d3-fadd06303574",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "6ebedc3b-0f31-47e2-be48-c14ff8b8e28a",
+              "id": "5fd91289-fff4-41a1-9df6-1da62b0885e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "8687c332-1b1b-407f-ac30-b11f47192999",
+          "id": "5758469d-cbb3-4ff8-871e-1dd08e4bb10b",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "ee46005d-2d1c-4793-8198-c462ab93c6c4",
+              "id": "666109f5-9f39-4e06-9711-34e91523734a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "4055e8c0-bf4a-40f6-b57d-5be3dbb7203f",
+          "id": "598eb1c5-f865-4629-a92d-3600c7cac0ec",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "8c5b7699-52ba-4d6e-b0a9-cef17e5760fb",
+              "id": "6545f3fe-3c8b-4b3e-b6d3-e67f6b1c4100",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "1457904f-4106-42d0-bf12-ee1bcfd2c05b",
+          "id": "5f23face-9b4b-4057-bf37-1d2d31b775ea",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "a29d7cd7-9f69-4e3a-8005-038c67d16351",
+              "id": "e845e225-0ebd-4db0-84fb-7ccb83f15d5c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "62ffe469-d800-4b08-abe1-8f5c44e5b6d4",
+          "id": "9af78e09-c9ff-4853-85b9-352f2567bb41",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "4d2674b7-b1ee-4297-bfb7-bac4b4a8794e",
+              "id": "87487f93-fee0-44b9-990d-30e71fc6c412",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "e8ab8b05-42a2-4490-9e0e-0a91fc29cbec",
+          "id": "168c440f-0b50-49cd-a6ac-ff178d3ca11f",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "f1b79631-f071-4922-b989-76453387f364",
+              "id": "f7e6dcc0-419f-44fa-84d5-cfcf1090a479",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "8addef99-7cc8-4d51-ae10-2f57cfb793ac",
+          "id": "09555044-6692-4b4e-855f-3ff1bb9a5b96",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "48ee7bb5-def9-4946-8a66-b0649d8abd50",
+              "id": "23a2c958-ad45-4425-9cdf-848bac934d3d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "351eca1d-014c-4707-887b-b01e1bd5c751",
+          "id": "c50ccb29-5e0f-47a3-868a-30418834428f",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "df0c0987-f4b4-42b7-b39e-59e3ca3c8a5f",
+              "id": "b1967fea-8974-4647-b7e6-7045c45bb234",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "32fb3855-68dc-4bd8-90f3-d8968cbae41f",
+          "id": "f119c721-a57d-4798-9998-fc8feba8effe",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -1445,7 +1445,7 @@
           },
           "response": [
             {
-              "id": "caa5cfe2-de8f-49de-a46d-6dacb51060f6",
+              "id": "d28903b5-948e-49cc-ada2-c2c795dbc560",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1509,7 +1509,7 @@
           }
         },
         {
-          "id": "1dae8552-f2c6-4b32-8c94-9bbd0ed01d99",
+          "id": "a32249ae-3718-4da5-a7f3-0399b09f03b8",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -1569,7 +1569,7 @@
           },
           "response": [
             {
-              "id": "8f71e446-e8af-4c7f-9547-712a854b02e1",
+              "id": "d9caa891-bb14-4faf-a484-4d2fe927d59a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1657,7 +1657,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "9cf22608-80ca-4afc-ad2a-d9390393b2dc",
+          "id": "be7dc431-8248-4bf7-b8da-e7b35fe69c2b",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -1690,7 +1690,7 @@
           },
           "response": [
             {
-              "id": "7b48e91f-d954-48ca-a4cd-1f6dd7c0a8b6",
+              "id": "2ba1dda1-93ae-49fc-9043-f5ba2c5a1b3f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1731,7 +1731,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1742,7 +1742,7 @@
           }
         },
         {
-          "id": "a287f06f-89cb-4751-bdf7-429c4215832f",
+          "id": "f2f56bc6-44e2-45bc-a4c1-a193fa3e9691",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -1775,7 +1775,7 @@
           },
           "response": [
             {
-              "id": "c2b41d39-2a71-4fb3-839c-a4fe34a1d41a",
+              "id": "8be5836d-c676-4e73-b8b0-4bffe49b4af3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1833,7 +1833,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "0d2b1eca-2fa3-4e07-a0d8-0e22d9d2e0c9",
+          "id": "e900e152-8e13-48b4-9f2a-134a3430c2c1",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -1859,7 +1859,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -1879,7 +1879,7 @@
           },
           "response": [
             {
-              "id": "8b826400-72d6-46d9-a71b-b9c47112ecc2",
+              "id": "4f749eeb-5319-4702-9efd-9d2bf0195465",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1911,7 +1911,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1933,7 +1933,7 @@
           }
         },
         {
-          "id": "e6ba5fd3-beed-4133-96e1-af0b56c91451",
+          "id": "b41b0fa4-b933-4519-abbf-44dfd6a30a61",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -1976,7 +1976,7 @@
           },
           "response": [
             {
-              "id": "84c017cb-ba24-4161-a899-65c78fdc3d65",
+              "id": "d848f679-86ba-4200-bb95-4f05b4f2fd0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "6ff2ed90-1c35-455c-b538-bb6b6c84b63a",
+          "id": "276a9fd6-4224-44b3-8447-5b64b763c4ba",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -2088,7 +2088,7 @@
           },
           "response": [
             {
-              "id": "baf545c3-b4c8-4b25-bb51-5c29954c7fcd",
+              "id": "69e8c137-7f80-47ab-861b-24568a5aab4c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2163,7 +2163,7 @@
           }
         },
         {
-          "id": "0e93e35f-e21c-4a55-b94d-aaed5eed2409",
+          "id": "f2a146ba-605c-40d1-83b2-6444fe342dbf",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "cc83cee4-4a81-473d-9187-90672e219f13",
+              "id": "e9dc1380-1257-4bda-8621-34f3cfdce39f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2317,7 +2317,7 @@
           }
         },
         {
-          "id": "821256e9-e130-4279-a1cb-5e04bdc28149",
+          "id": "761d6725-db3a-432e-823a-2687d6c32cb4",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -2364,7 +2364,7 @@
           },
           "response": [
             {
-              "id": "6f006b34-f8fb-42e1-83ee-133ab62ec670",
+              "id": "b35c74fd-04c3-4cb5-93ad-e1795eeb8547",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2429,7 +2429,7 @@
           }
         },
         {
-          "id": "2e0626a7-4175-428a-b937-5b96104940a9",
+          "id": "ef09ff41-954f-49b7-9af6-aa3f9bfaf42d",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -2471,7 +2471,7 @@
           },
           "response": [
             {
-              "id": "3c41dfe9-6b13-494d-a96d-1266d4b8c896",
+              "id": "a1e8b81f-1a9d-42e7-83ff-216520be82fb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2535,7 +2535,7 @@
           }
         },
         {
-          "id": "7ff1a8c0-c6d3-4a22-b110-03e9e01a7b7c",
+          "id": "8359b5cf-754c-4ec8-9d0e-89eaab018e7f",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -2590,7 +2590,7 @@
           },
           "response": [
             {
-              "id": "0183dff4-9818-488e-a615-46d645e4c795",
+              "id": "8610e470-2114-42e7-ac6b-96e01ca3647a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2667,7 +2667,7 @@
           }
         },
         {
-          "id": "2488ab6a-433c-4b69-9c70-a89ba21c6732",
+          "id": "6af4ead5-d4f3-4c33-922d-f927e58a316c",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -2731,7 +2731,7 @@
           },
           "response": [
             {
-              "id": "542599df-faab-4c4f-bd95-0a98c2a6e16f",
+              "id": "106c8858-06f8-4092-82a9-60c9e9989107",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2823,7 +2823,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "5058f2ce-0bc5-4ebb-86b0-8ffa687d801c",
+          "id": "b07133cd-bf60-4ed7-861b-e57aa3bf09e7",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -2865,7 +2865,7 @@
           },
           "response": [
             {
-              "id": "8ce705c0-1ea1-49d9-8994-e6879ca8e637",
+              "id": "9d233c10-6fc9-4cf0-975e-d4560b95538e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2929,7 +2929,7 @@
           }
         },
         {
-          "id": "5c087c5c-583d-43dd-b593-e25ab60c53fc",
+          "id": "a087a3c3-2cbb-4daa-8045-ef99345e9584",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -2972,7 +2972,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#AeABB6\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2f7f1B\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2984,7 +2984,7 @@
           },
           "response": [
             {
-              "id": "fed2e9b3-a5fc-4537-95b2-e58410de4cad",
+              "id": "3906378a-dbfd-476e-a74f-1826d103626c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3033,7 +3033,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#AeABB6\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2f7f1B\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3061,7 +3061,7 @@
           }
         },
         {
-          "id": "1a85b453-216d-4024-9d8f-bf0ea0749285",
+          "id": "19615b96-8561-47ac-acc9-e9020ecdb90e",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -3097,7 +3097,7 @@
           },
           "response": [
             {
-              "id": "c3f04c2f-e88f-40e8-a005-853172b56f18",
+              "id": "063edfc4-d2b7-4a8b-82ba-7c32f80f81e0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
           }
         },
         {
-          "id": "a8e50354-46ae-4f03-be5e-73d86d5f949c",
+          "id": "f31f13a0-3c7a-491d-b62b-c45886d68e1c",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -3181,7 +3181,7 @@
           },
           "response": [
             {
-              "id": "47f15494-4f8a-4404-8ed5-4a0e9e8db2e9",
+              "id": "2e8a310a-7e5e-4c1b-929d-bdb3230d9621",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3233,7 +3233,7 @@
           }
         },
         {
-          "id": "4b187d20-2871-474a-8a10-92072d9797dd",
+          "id": "4751b530-e7dd-46e2-b013-9eee41858f9b",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -3264,7 +3264,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#42c6Fc\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6b0e3C\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3276,7 +3276,7 @@
           },
           "response": [
             {
-              "id": "6637e0d5-df1f-4120-8980-2ed09037cd7c",
+              "id": "a299ba8d-2624-4ce0-8b47-caeeb8c67448",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3313,7 +3313,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#42c6Fc\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6b0e3C\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3341,7 +3341,7 @@
           }
         },
         {
-          "id": "1332cad8-1a70-4cda-9ff8-421d9384022f",
+          "id": "96f80080-fde3-45ea-b30d-54a6fd440777",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -3372,7 +3372,7 @@
           },
           "response": [
             {
-              "id": "fb29909e-3d48-4229-9a1f-6ddb6952dafa",
+              "id": "45e33475-ec71-46f7-84cf-3339ff054e84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3431,7 +3431,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "89e372ad-ce1c-4442-9a7d-562e4de3b8b1",
+          "id": "c70ea71f-6b5a-4382-91e7-458d24cc21a3",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -3473,7 +3473,7 @@
           },
           "response": [
             {
-              "id": "ba057b42-db71-4452-9c81-880ccdab45d4",
+              "id": "2db50326-c922-4895-b354-c95e38e8e21c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
           }
         },
         {
-          "id": "bbf400a0-1e79-4f1d-be0e-c39b3a0d3c6e",
+          "id": "f57fa51a-8f61-47a5-8269-4e197d318250",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -3592,7 +3592,7 @@
           },
           "response": [
             {
-              "id": "eeb28ae1-b2d5-4d3a-9949-2e4a97b8557c",
+              "id": "33d1325e-1cb2-41c3-81ed-dffe88256aaf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3669,7 +3669,7 @@
           }
         },
         {
-          "id": "495ef6eb-4156-4f39-9c35-392eb95e5ea8",
+          "id": "803aaf5f-8d86-446c-ad94-4ce2156e4680",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -3711,7 +3711,7 @@
           },
           "response": [
             {
-              "id": "98d96ee4-052a-4795-afef-ea59bfc0d656",
+              "id": "2a6361fd-588f-429f-920d-7c90232f5907",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3775,7 +3775,7 @@
           }
         },
         {
-          "id": "014ef996-7059-47d6-afdc-9422305c94f8",
+          "id": "a74ee6a3-b115-47aa-84f4-ba73a228b931",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -3805,7 +3805,7 @@
           },
           "response": [
             {
-              "id": "ff32b915-beee-4f49-bfef-b85b6bde58b0",
+              "id": "a444003f-e862-41b2-a9ee-ec8e28ad1f4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3857,7 +3857,7 @@
           }
         },
         {
-          "id": "d4ffa9a9-98db-4d59-9b7f-c6cac7218988",
+          "id": "86611bfe-fcfd-44a5-92fd-7c3c89cafb4c",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -3900,7 +3900,7 @@
           },
           "response": [
             {
-              "id": "519808a1-5b32-41be-abd0-c8b80f33ff66",
+              "id": "011eeeb8-27ae-4c57-8f9f-1647d4702436",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3965,7 +3965,7 @@
           }
         },
         {
-          "id": "0add23c1-a1ba-49a4-80a6-403117745281",
+          "id": "5142f0cf-c371-4743-8eae-1b7232f54a9e",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -4018,7 +4018,7 @@
           },
           "response": [
             {
-              "id": "e2b7fafd-9220-427e-b8a9-a173cc7aae54",
+              "id": "81dd42dd-348d-455b-98b0-68fd8fdeee65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4082,7 +4082,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": 2141.6599912647107,\n  \"key_2\": \"string\",\n  \"key_3\": 1335.4963759546722\n}",
+              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -4093,7 +4093,7 @@
           }
         },
         {
-          "id": "dd5ff74c-20cb-4ff9-baeb-c52353141b95",
+          "id": "cf66508a-83eb-4511-bc17-c09d23006582",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -4136,7 +4136,7 @@
           },
           "response": [
             {
-              "id": "04088d53-e024-4f1c-88bc-a0f8a067ade2",
+              "id": "7187a01a-a3ed-40a4-9bcf-888b90682166",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4201,7 +4201,7 @@
           }
         },
         {
-          "id": "b46102b0-8c34-49bf-a40d-85bc32341233",
+          "id": "d214d7f6-0c22-4076-b32b-0c24a49a0af6",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -4232,7 +4232,7 @@
           },
           "response": [
             {
-              "id": "c8160782-5a31-44f7-8940-10cd39a176ad",
+              "id": "04a9e230-a96a-4409-9d67-3764a301fb0d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4291,7 +4291,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "0ca3fabb-5b4a-460b-8705-0d90460a04b1",
+          "id": "5783f1ae-db51-4dcb-b9bb-f4962edf21c1",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -4333,7 +4333,7 @@
           },
           "response": [
             {
-              "id": "5d881109-12ad-497e-a30f-8b38003ff81f",
+              "id": "20230fd0-1b3a-46e1-a532-bdce0c4c4608",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4397,7 +4397,7 @@
           }
         },
         {
-          "id": "c4e4d06e-05d4-4ad7-9c84-6bf1374898ec",
+          "id": "c50cb9dc-2213-4037-90ac-6628e6890eb6",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -4440,7 +4440,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4452,7 +4452,7 @@
           },
           "response": [
             {
-              "id": "d82457b3-88e6-4400-8cc1-2bfa4d450ce6",
+              "id": "8a56997a-61aa-41b4-93a3-30e0c635e26a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4501,7 +4501,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4529,7 +4529,7 @@
           }
         },
         {
-          "id": "39cc5c95-9be2-4dce-b88d-53ce2b00c96a",
+          "id": "917b64d6-e273-410c-86e5-7014e70ea62b",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -4565,7 +4565,7 @@
           },
           "response": [
             {
-              "id": "0bf6cd9c-d3ce-4c3d-9b38-04332475ec1c",
+              "id": "f8a3cd3a-17c5-46ff-8c2c-41ff3b836987",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4619,7 +4619,7 @@
           }
         },
         {
-          "id": "0b131034-fc9b-4c36-85df-183bf162895c",
+          "id": "24d2a908-2b42-4caf-8d65-a0acfd38365b",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -4668,7 +4668,7 @@
           },
           "response": [
             {
-              "id": "b1cbe459-531a-45c1-875d-18a7a149ed78",
+              "id": "fc9b161b-e5f9-40c6-90b7-03f887f371b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "c01107d6-690a-41a0-8a6a-c37f0be48a4b",
+          "id": "b18ba2d7-0326-483f-84df-1f505091ab78",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -4770,7 +4770,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4782,7 +4782,7 @@
           },
           "response": [
             {
-              "id": "c039b54a-b2fe-44a0-bc4f-493bc8d0109f",
+              "id": "8f88a744-a5ea-4c1e-a5ea-39763b266b84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4819,7 +4819,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4847,7 +4847,7 @@
           }
         },
         {
-          "id": "768e2042-dbe8-4a8e-b807-1b7c814d59a2",
+          "id": "5cf3d45b-da14-4ab4-a80b-f8958f476ec4",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -4890,7 +4890,7 @@
           },
           "response": [
             {
-              "id": "221337cd-8dd5-4fdc-a7b7-0155ed2bf84f",
+              "id": "698efd84-45ba-4390-853f-8ca5324de999",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4955,7 +4955,7 @@
           }
         },
         {
-          "id": "d2b084db-ed83-4f6e-bc60-baecd99049cf",
+          "id": "ba4da0e1-8615-4354-9bd1-6729a30f0b32",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -4998,7 +4998,7 @@
           },
           "response": [
             {
-              "id": "b6b8ecfb-8af2-45e0-8c9e-8cb40ed90d4c",
+              "id": "376e2f2e-032d-4cc9-b14b-316c310e7ef0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5063,7 +5063,7 @@
           }
         },
         {
-          "id": "3da6ffe1-fa33-4e97-8f0d-ba432afdd76d",
+          "id": "8924c765-1b74-4f3f-8a62-dc66d3e7f027",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -5094,7 +5094,7 @@
           },
           "response": [
             {
-              "id": "45eeb67c-fc0d-40a4-a90b-e81a8d903114",
+              "id": "07fcdf02-d2c1-41e4-a83f-8e8fc515bc28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5147,7 +5147,7 @@
           }
         },
         {
-          "id": "2ae076ee-ef00-4399-aea5-87b0974162dc",
+          "id": "1b9c74ec-f4ed-4be8-b27e-60d04995f9e1",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -5178,7 +5178,7 @@
           },
           "response": [
             {
-              "id": "1d3fb73a-7529-4c42-98d4-eacf0c8f60a0",
+              "id": "dc650276-70ca-4bb2-9a67-e1577901a610",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5237,7 +5237,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "95c5ac6e-e378-411c-b0dc-38bbbaccd6ca",
+          "id": "afe8976e-023b-4b24-a716-ee56b665a5bc",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -5279,7 +5279,7 @@
           },
           "response": [
             {
-              "id": "e11f4e3e-e098-45e7-abab-5b6558391b31",
+              "id": "ee7c1ee7-9a86-4e60-8849-8d91e43c38b4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5343,7 +5343,7 @@
           }
         },
         {
-          "id": "bba1e8ed-18a2-45af-86bc-e9592d7ebb40",
+          "id": "3920795a-ab85-4943-b1f5-747ade550d47",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -5398,7 +5398,7 @@
           },
           "response": [
             {
-              "id": "9dc00865-6118-46be-9d0c-f545d118948e",
+              "id": "b4153ee6-852b-4726-979f-12220f25d1a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5475,7 +5475,7 @@
           }
         },
         {
-          "id": "ab0d4d2b-4c03-4a7f-8f53-3f92f267cc5b",
+          "id": "f0a0b8cf-6982-4b75-81a7-50b33c43a610",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -5511,7 +5511,7 @@
           },
           "response": [
             {
-              "id": "b4e52d0e-31da-4d8f-bbc6-7b47774a1339",
+              "id": "c140bbbb-4f4d-4d4d-b1b3-e9c701117bae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5565,7 +5565,7 @@
           }
         },
         {
-          "id": "adc2310e-faf4-41ad-a5fd-351f921d9d08",
+          "id": "3a9c7111-42cb-458d-b4a0-01c611739d52",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -5595,7 +5595,7 @@
           },
           "response": [
             {
-              "id": "f5c9fc43-aa65-48c3-9e37-a127d6caa421",
+              "id": "59418cf8-d7dc-45ae-9eed-9c919a2455e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5647,7 +5647,7 @@
           }
         },
         {
-          "id": "971b0cff-0240-4cc4-bfaf-b63efa9588ac",
+          "id": "5c8560fc-8b20-40e1-a7ee-4234db3e388a",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -5690,7 +5690,7 @@
           },
           "response": [
             {
-              "id": "480324c7-ac28-4408-bb15-af1a3428c2e3",
+              "id": "7549c09d-aa67-45cb-9e0b-3e83b8fd5134",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5761,7 +5761,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "c7c7555a-fba7-4895-9b48-f0d8037aede1",
+          "id": "ddbf4315-65a2-4c53-8a80-932a9b408717",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -5814,7 +5814,7 @@
           },
           "response": [
             {
-              "id": "22b3a949-1913-4399-bada-b9f149de12d9",
+              "id": "977748e6-b695-447a-9f70-501065dcb59a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5889,7 +5889,7 @@
           }
         },
         {
-          "id": "d1ab7e15-cd10-4548-8b88-1481536a0fdb",
+          "id": "8dedf149-fade-479f-afb5-ad78b16441e3",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -5955,7 +5955,7 @@
           },
           "response": [
             {
-              "id": "cae48148-ebbb-44d7-9a02-8d3aa0cbe420",
+              "id": "5cf3ceaa-f408-47c2-b089-6335b0ee29d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6043,7 +6043,7 @@
           }
         },
         {
-          "id": "d05ca5a4-e57a-4314-932e-cd1c53d5fbbf",
+          "id": "f3cd4882-f8ae-4a5b-947c-ddccd44012fc",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -6090,7 +6090,7 @@
           },
           "response": [
             {
-              "id": "40d5c75b-94ec-42f5-833f-bd1a067dcc16",
+              "id": "3d966ab9-a53f-44ec-a28b-372e72f8ab13",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6155,7 +6155,7 @@
           }
         },
         {
-          "id": "46bc37cd-aa3a-4166-b30a-c6fc48d325a5",
+          "id": "67eb221d-ec0b-4860-aecb-0d465dc55f9c",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -6197,7 +6197,7 @@
           },
           "response": [
             {
-              "id": "450496ac-b3d9-4d10-845c-168e5af735b0",
+              "id": "b0ca383f-c32c-4879-be77-8b93822ebebd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6261,7 +6261,7 @@
           }
         },
         {
-          "id": "9f6e0750-653c-42e1-ab01-382a6779fc11",
+          "id": "794bbcf4-45ea-4cf6-9383-bc5b3ec3b5d1",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -6316,7 +6316,7 @@
           },
           "response": [
             {
-              "id": "267ce9df-fb36-4eb3-990e-05f040bae0bb",
+              "id": "1851f40d-5374-47db-b421-19d8bb438dbe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6393,7 +6393,7 @@
           }
         },
         {
-          "id": "911cd007-98af-49c7-85ad-2f2ef1c5e35f",
+          "id": "4c8034d3-f256-4c19-9252-ba567d4a4232",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -6460,7 +6460,7 @@
           },
           "response": [
             {
-              "id": "272ba785-f61e-405f-91b0-3e1b98dfa140",
+              "id": "1323be5f-3ed2-43b8-aa43-161d1d821ef2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6549,7 +6549,7 @@
           }
         },
         {
-          "id": "57e1a492-7018-414a-9b0a-17834ebb691e",
+          "id": "d6aa6716-05d9-48f1-83bd-6249d34fc4c3",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -6603,7 +6603,7 @@
           },
           "response": [
             {
-              "id": "279d71c0-36a9-43aa-af71-8adeaacd7cec",
+              "id": "17e0d753-73df-4b6b-812d-d8758270c471",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6685,7 +6685,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "ff04ea14-c393-4ab0-ba37-d7f15c9290e5",
+          "id": "dfb68e95-892f-4a84-8965-8ad7687f3bf5",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -6738,7 +6738,7 @@
           },
           "response": [
             {
-              "id": "63bcb739-65f1-4e8b-8b50-5156abf0607a",
+              "id": "2c1dcbac-8006-4aa9-a5bc-7dc70cec8b12",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6813,7 +6813,7 @@
           }
         },
         {
-          "id": "dafbd94c-cbf1-4b4d-95d9-880b8abb93ef",
+          "id": "56674043-95b3-4992-bcb7-439d8af20e9f",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -6879,7 +6879,7 @@
           },
           "response": [
             {
-              "id": "6dfd51b3-f80d-48e4-a3ba-82b7ba1ee0dc",
+              "id": "844498af-2ec2-4ae4-b0b4-970908b7d778",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6967,7 +6967,7 @@
           }
         },
         {
-          "id": "ef882be6-2edf-4ff1-874c-7e376f916ded",
+          "id": "f0d33533-68b7-492d-b51e-707f78427fe2",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -7014,7 +7014,7 @@
           },
           "response": [
             {
-              "id": "4b88d263-2865-4abc-bec1-a40cae4915ee",
+              "id": "012704fb-9def-4685-9ec1-b1a2c7b04272",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7079,7 +7079,7 @@
           }
         },
         {
-          "id": "e1718a7a-a1bf-44db-888a-0ac8f419b933",
+          "id": "d323a29b-24b7-4e5e-b9fc-9c42e06953c8",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -7121,7 +7121,7 @@
           },
           "response": [
             {
-              "id": "d8954b62-14f4-4403-8072-49ca390deb96",
+              "id": "f2d3482a-0d3b-4173-9406-cbc433b355ae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7185,7 +7185,7 @@
           }
         },
         {
-          "id": "1f8544ca-6658-4339-b708-35fa81ed95d6",
+          "id": "becc10c7-9092-4cd4-bca2-47b418998c10",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -7240,7 +7240,7 @@
           },
           "response": [
             {
-              "id": "229a758b-a03f-461d-80b0-40a925f8e26b",
+              "id": "8ec01b10-830a-4b17-bb86-c648aece7141",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7323,7 +7323,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "faa56a1c-27ae-4b5c-b781-e79f058ba44e",
+          "id": "5368b7d3-8480-424d-a870-7ff5e6fafbd3",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -7364,7 +7364,7 @@
           },
           "response": [
             {
-              "id": "ea9db277-62f1-4cfa-b1fa-8ed7e6f89771",
+              "id": "45a0dedb-736a-4e4b-a9f9-e4c21f846d41",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7427,7 +7427,7 @@
           }
         },
         {
-          "id": "102b69d8-b758-45fd-b2f4-54fc068b1545",
+          "id": "85e64630-1191-44b9-be14-548047f714ee",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -7481,7 +7481,7 @@
           },
           "response": [
             {
-              "id": "d3305029-a8c7-4553-b65f-f305d6bd241d",
+              "id": "4a5d9336-7138-4304-80e7-a98c6472ae63",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7557,7 +7557,7 @@
           }
         },
         {
-          "id": "0f308a23-047c-4100-b7e2-4975a9fad915",
+          "id": "f2ab3bc9-f939-4c2a-ad62-f49e5bcf6802",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -7592,7 +7592,7 @@
           },
           "response": [
             {
-              "id": "6d1099d8-abec-42b8-8829-64242c0a7f39",
+              "id": "ed209579-c344-4ab9-86d9-6bb8fa11ca8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7645,7 +7645,7 @@
           }
         },
         {
-          "id": "2343b165-b1de-4ef8-bd6c-7718c37e287e",
+          "id": "85c1e0e7-d5aa-41be-84b6-b3925fcdf876",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -7702,7 +7702,7 @@
           },
           "response": [
             {
-              "id": "35382945-b3d2-49af-8994-f5d812cb374c",
+              "id": "705f65b7-4c9e-451a-bec2-eb4f1ef02b10",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7781,7 +7781,7 @@
           }
         },
         {
-          "id": "0ee06ef8-afb1-48b0-a64e-38c5e6670907",
+          "id": "4c7fd0d6-8649-4946-823a-0d9bcb918dd2",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -7823,7 +7823,7 @@
           },
           "response": [
             {
-              "id": "d90a892e-44d1-45b4-abd7-257340dc8d60",
+              "id": "6b213e47-997d-47dc-b9ba-ea70aa989ff2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "2b4b5f3e-0d72-4f29-976b-294eb2f06fe4",
+          "id": "acd95c70-46dc-467a-a3f2-9ede3ccc39d2",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -7946,7 +7946,7 @@
           },
           "response": [
             {
-              "id": "d026eb31-d970-4143-8066-82d326937f16",
+              "id": "ecddd6fa-ce10-4cf7-a0e8-9e8915dca2a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8021,7 +8021,7 @@
           }
         },
         {
-          "id": "3a54850b-ba03-414f-96b6-66e3825abaa6",
+          "id": "c2229ed7-2914-4ed4-8323-be066ccad6e9",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -8087,7 +8087,7 @@
           },
           "response": [
             {
-              "id": "0fcd8278-eb4d-497e-bf0e-08fd76dd341d",
+              "id": "a78ffc7e-c2df-4f01-b742-b41207b3e0d3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8175,7 +8175,7 @@
           }
         },
         {
-          "id": "1d07acd1-6117-43d8-bd0a-a7e2159f3e43",
+          "id": "2bcdad13-a047-496b-9e7f-80c7aabba9f3",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -8222,7 +8222,7 @@
           },
           "response": [
             {
-              "id": "b5e7d069-34a4-4758-87a7-d250268c2998",
+              "id": "9ce1ac9c-9db4-4d81-a38c-ad2e65a03126",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8287,7 +8287,7 @@
           }
         },
         {
-          "id": "be9bd4c9-4e89-4725-95fc-dac3ae703c96",
+          "id": "ab71f849-0e8a-41c6-b285-2c3fa2208aa0",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -8329,7 +8329,7 @@
           },
           "response": [
             {
-              "id": "0eb5c802-2408-48c2-99ab-988edfaf22a5",
+              "id": "31af5362-db2d-4da1-85be-aaabba66bea6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8393,7 +8393,7 @@
           }
         },
         {
-          "id": "8cf60fa5-1214-4880-9139-0221076b16da",
+          "id": "59b6d996-1212-4fba-b1b8-bfa62916798b",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -8448,7 +8448,7 @@
           },
           "response": [
             {
-              "id": "fecb1747-89fc-4d2e-ae6c-1e36b6fa9f26",
+              "id": "15213348-c4ec-46f6-becc-a2e06acaa757",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8531,7 +8531,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "24f2d84e-933b-41e8-9d0a-1be696f5d47f",
+          "id": "338a9f5b-27c7-4dd8-9765-407c6ec3c13d",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -8573,7 +8573,7 @@
           },
           "response": [
             {
-              "id": "a10cd24d-4b5e-4fb6-b286-cc0789541e4d",
+              "id": "15bbd22c-59c7-489e-9f17-b6590c7ff942",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "4fb4bba9-01c2-47b6-a774-9098dbc1edb1",
+          "id": "308c8d19-1a5e-4d39-9e05-c79e04ed081a",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -8692,7 +8692,7 @@
           },
           "response": [
             {
-              "id": "6fef99a8-9653-43bd-a658-7e25dad36d2c",
+              "id": "5d3e6804-fd3a-476c-b97c-2783c44f2768",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8769,7 +8769,7 @@
           }
         },
         {
-          "id": "6e5d0add-3206-47b8-944e-53f7fcd8905b",
+          "id": "3485423e-5f8e-401e-ac0f-92459463110f",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -8805,7 +8805,7 @@
           },
           "response": [
             {
-              "id": "f64942fe-435d-463c-a9a0-89b947663573",
+              "id": "affcba32-e603-45f0-b508-b638a88ae303",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8859,7 +8859,7 @@
           }
         },
         {
-          "id": "ccf48428-8213-4a75-8299-75470fcdb5c8",
+          "id": "4f70d1c7-5510-4e10-b4e5-e224ffe1eabe",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -8889,7 +8889,7 @@
           },
           "response": [
             {
-              "id": "8aa5f459-79a8-449d-a1dd-ae2247dc83ff",
+              "id": "a3fa87f0-5002-4455-904c-541db596d65d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8941,7 +8941,7 @@
           }
         },
         {
-          "id": "e57234f9-1663-4224-831e-b1b93247145c",
+          "id": "b46e2996-379d-4ee9-9f11-ade2f01b366a",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -8984,7 +8984,7 @@
           },
           "response": [
             {
-              "id": "4d4107f1-ae70-4d59-8238-4627c19e9412",
+              "id": "d84f3372-1c97-4d2c-8322-1172d29fe8fb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9055,7 +9055,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "ede45354-5ac7-433b-843d-fce928087153",
+          "id": "90d58c93-99c5-4fdd-82a3-244e31766002",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -9097,7 +9097,7 @@
           },
           "response": [
             {
-              "id": "1fdd452d-c89b-4fa7-bed5-73d0096a3520",
+              "id": "a6b6573a-2fac-47c1-be95-1b5f42f3b893",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9155,7 +9155,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a17a44c7-e943-4e07-bddb-89192930f2bb",
+              "id": "9e335f2e-fe2d-4b03-965e-43ab9d65a029",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9219,7 +9219,7 @@
           }
         },
         {
-          "id": "f24dbe99-c0e3-4602-b182-8ef88f0c8407",
+          "id": "d487105d-c2df-40e6-9475-763f2dfa4023",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -9274,7 +9274,7 @@
           },
           "response": [
             {
-              "id": "031b6b74-97d1-4b37-9f93-dbdeb4534d3d",
+              "id": "68cf90a7-574e-4835-8057-079b768c10a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9345,7 +9345,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "7d2c7f29-573e-4a97-bc8e-473b2848e872",
+              "id": "4c988fbc-f49e-45b2-a0bf-4bb425cdc129",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9416,7 +9416,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a181fa36-fb00-4304-a317-bc1099ad3915",
+              "id": "dd5a5085-4906-46fb-81b4-304796f6352e",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9493,7 +9493,7 @@
           }
         },
         {
-          "id": "26b34c9c-ec45-4362-9a80-ef851c01756e",
+          "id": "249b864a-b3e3-4e8a-97be-fde8b66c0a21",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -9529,7 +9529,7 @@
           },
           "response": [
             {
-              "id": "9a95d5d4-332e-4e1e-871b-36a6dd6e56e1",
+              "id": "dba260f7-e13e-4971-9a7d-87f9929128be",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -9577,7 +9577,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "37f43fca-1472-41f5-bec2-90f4b9116754",
+              "id": "875e96a8-755a-4457-bfc7-32c77ad14c1f",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -9625,7 +9625,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "91827b28-521e-42d0-bfe3-c8f0fce411b5",
+              "id": "30dac93c-9a13-46f5-9fb2-081e0ea34595",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -9679,7 +9679,7 @@
           }
         },
         {
-          "id": "d8507129-9103-4a64-b15f-c5ed7cbe98c8",
+          "id": "646b72d6-031e-489f-b1a8-988922f931bf",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -9709,7 +9709,7 @@
           },
           "response": [
             {
-              "id": "bf1806e0-b353-4dea-adef-8182ec8756c5",
+              "id": "a6f3121a-1244-4455-86f5-30fc8838dfe7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9761,7 +9761,7 @@
           }
         },
         {
-          "id": "7c59508b-e329-4a6d-8e47-6b8514e38872",
+          "id": "7af2ff37-c6a1-4f3b-9e53-0dbb98567291",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -9804,7 +9804,7 @@
           },
           "response": [
             {
-              "id": "ce07cf88-960c-4237-940e-5cd9f3a092e4",
+              "id": "3d28e571-36c2-481a-a810-0f1266887162",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -9863,7 +9863,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "19f76f82-53cd-45fc-92b1-9e9540f9f3ee",
+              "id": "91cd908b-bf74-4ac0-9e11-6cffb496b5d4",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -9934,7 +9934,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "64748f15-1799-4178-a592-ecf55022cbb7",
+          "id": "41612ac1-b436-45bc-ace9-97a33c37459e",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -10000,7 +10000,7 @@
           },
           "response": [
             {
-              "id": "d62164a8-39aa-4954-b46c-cb6569a19197",
+              "id": "4e19e5f5-2dd4-4ab7-a216-c048a107e3cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10074,7 +10074,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": 2141.6599912647107,\n  \"key_2\": \"string\",\n  \"key_3\": 1335.4963759546722\n}",
+              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -10091,7 +10091,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "8380ce68-00f1-4d7b-ab31-c5b8ddabde63",
+          "id": "fa28ccb0-78a7-4dab-9c35-6cc16b3ae9cb",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -10133,7 +10133,7 @@
           },
           "response": [
             {
-              "id": "172c47be-4c41-4dfa-9ccb-5d10e8684cd2",
+              "id": "051cede2-9290-4f9f-8b25-c9cd070dbd93",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10203,7 +10203,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "42cab359-cca9-435e-a131-27cb969dfdf3",
+          "id": "6d981a91-8ab8-4975-8330-66fbf283ef68",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -10245,7 +10245,7 @@
           },
           "response": [
             {
-              "id": "86a5fa14-62a4-4b1e-afd6-33e2d8b15863",
+              "id": "87329225-b6fc-44f7-aac1-f2c185155b6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10309,7 +10309,7 @@
           }
         },
         {
-          "id": "ceec4f68-7176-4925-99fd-41c07f99d217",
+          "id": "2e2c8647-70ec-44b0-ae61-dba563b8c0e5",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -10352,7 +10352,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#b4ddC2\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#601A84\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10364,7 +10364,7 @@
           },
           "response": [
             {
-              "id": "52f269fd-d8d1-482b-8972-d65a4efa6b3a",
+              "id": "9ff84110-b12d-4f9a-8175-82d7bd249476",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10413,7 +10413,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#b4ddC2\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#601A84\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10441,7 +10441,7 @@
           }
         },
         {
-          "id": "49f45ebc-201e-4b7f-9bad-45771e89577d",
+          "id": "46cbbc0c-dff5-4da2-ae4b-ac187f12df4d",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -10477,7 +10477,7 @@
           },
           "response": [
             {
-              "id": "78cc165d-056c-4a95-88ca-91e42e621265",
+              "id": "e4688fb6-1f4a-440f-ad29-3daf559623ee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10531,7 +10531,7 @@
           }
         },
         {
-          "id": "ee62224e-b9e9-4b0b-bbfd-9e2c7a7796ce",
+          "id": "b1e7965d-a274-4690-92c5-5801ab45d61a",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -10561,7 +10561,7 @@
           },
           "response": [
             {
-              "id": "f432bd1a-8ec5-410a-875d-edadb771a305",
+              "id": "122cb9ef-c941-4366-be63-e3fbea763aca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10613,7 +10613,7 @@
           }
         },
         {
-          "id": "fd917d7e-55c1-4d2a-8263-1f9173ecdcfc",
+          "id": "917cc3b9-7793-44c5-b3d7-4fb5453df244",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -10644,7 +10644,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F3Aa53\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6BE0c0\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -10656,7 +10656,7 @@
           },
           "response": [
             {
-              "id": "294674bf-b28e-4068-b33d-68f29408d4a6",
+              "id": "52e0e0db-8c49-4418-977e-5b7e9fc558bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10693,7 +10693,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F3Aa53\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6BE0c0\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -10721,7 +10721,7 @@
           }
         },
         {
-          "id": "97a57a6a-6d4c-4c0b-8fc6-f28a6802ea8f",
+          "id": "f15a5193-258a-452d-8268-80d273653525",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -10752,7 +10752,7 @@
           },
           "response": [
             {
-              "id": "61903b2f-edd5-4a99-b7d5-6933f37819a4",
+              "id": "f4fcc4da-1896-4031-b52c-7be677f74b68",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "b22ad429-c1e4-4cdc-a858-58ae59f96763",
+          "id": "7ee1704c-0d2a-4e2e-a257-dad8df07069c",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -10864,7 +10864,7 @@
           },
           "response": [
             {
-              "id": "16217b59-901c-4a34-be2d-b372d269f331",
+              "id": "f3dbc6c9-8cdb-410d-93c1-6c77d2059cef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10939,7 +10939,7 @@
           }
         },
         {
-          "id": "003ac97b-d5ab-458a-a52c-26c872fda1a8",
+          "id": "6ed26165-9bcb-4cc5-b255-887d011c5a36",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -11005,7 +11005,7 @@
           },
           "response": [
             {
-              "id": "264cb8fb-db9c-4883-abc8-b273948d9501",
+              "id": "00cffaac-86d1-4dba-99fc-c32acd56cd2e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11093,7 +11093,7 @@
           }
         },
         {
-          "id": "18ff8bf9-20e7-4f17-92a8-f143e247ecba",
+          "id": "8194917e-0e08-45f9-bdca-4619b5ae26ec",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -11140,7 +11140,7 @@
           },
           "response": [
             {
-              "id": "516f28b9-282e-421d-8ad4-4b40331f2117",
+              "id": "f84018cd-32d9-4b51-8f4e-c0eef0c7e3b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11205,7 +11205,7 @@
           }
         },
         {
-          "id": "45fa30cd-d097-4ea3-b9e1-e1c501091248",
+          "id": "2c0a9565-02df-41b1-b81e-b0ee68ae7899",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -11247,7 +11247,7 @@
           },
           "response": [
             {
-              "id": "035bcad1-f4bc-469c-b24b-ffd7416050f5",
+              "id": "dd628002-2d56-4bfc-a4f0-8b7b00ec7f8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11311,7 +11311,7 @@
           }
         },
         {
-          "id": "e5b50cbb-10de-4645-bee3-a4fc171cbd6d",
+          "id": "2eef419a-38e7-4db3-96a5-f7ebef7ed7b9",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -11366,7 +11366,7 @@
           },
           "response": [
             {
-              "id": "58532f94-4d6a-4911-83d6-b478992ab1d7",
+              "id": "1f8212c3-264d-4076-b822-6e98352d8d9a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11443,7 +11443,7 @@
           }
         },
         {
-          "id": "d980b22c-7b88-4fe4-831c-597c5fc3a1aa",
+          "id": "d8fec355-f253-4f8e-8631-547ad0b5f0ca",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -11497,7 +11497,7 @@
           },
           "response": [
             {
-              "id": "e94458d8-6f75-4f32-beea-3718a8ba82a4",
+              "id": "90c9604e-45c4-40f2-9a24-a63bb68f9883",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11573,7 +11573,7 @@
           }
         },
         {
-          "id": "1276f013-9b48-4885-9ab4-b053cb9c44b7",
+          "id": "47ab661a-b2ca-4f85-8ae5-2a64cea8663e",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -11639,7 +11639,7 @@
           },
           "response": [
             {
-              "id": "16dc1fa6-237c-45f0-b4ba-10bb0ebaa29f",
+              "id": "57b1b538-0c1c-41b7-8bf9-96de478f99db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11727,7 +11727,7 @@
           }
         },
         {
-          "id": "31d33f1c-d586-4ead-b080-59e62271a758",
+          "id": "915d545d-f8ec-4398-b4f9-93958b72900e",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -11805,7 +11805,7 @@
           },
           "response": [
             {
-              "id": "24d26303-0fe6-4b93-adaf-ae1977b2a449",
+              "id": "88d4e1c2-bdb6-4c19-ae18-2f58cda36386",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11905,7 +11905,7 @@
           }
         },
         {
-          "id": "9c877465-3c97-4edf-ab80-cd4d94bddbf4",
+          "id": "2d978dd4-c54d-4e31-b141-01cd15d6bcf2",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -11971,7 +11971,7 @@
           },
           "response": [
             {
-              "id": "8ec759b4-3d44-434f-9517-f51f2707daf3",
+              "id": "d1af04cf-6eea-4409-9ae2-ed34ec19efc9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12059,7 +12059,7 @@
           }
         },
         {
-          "id": "3517f53f-deee-4da1-8437-2b99d2c53780",
+          "id": "bc317534-49fb-4b66-b7ca-9996b6c7ca7e",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -12114,7 +12114,7 @@
           },
           "response": [
             {
-              "id": "612c6460-77e7-4dd5-aba2-99291db139fb",
+              "id": "a4b48145-70b7-4d59-a65c-0f93f3b46565",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12197,7 +12197,7 @@
       "description": "",
       "item": [
         {
-          "id": "044d5bdb-6768-4d98-9bf9-40d1e4b71f37",
+          "id": "e8e2266e-7857-4d95-a1aa-90687ae6509a",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -12238,7 +12238,7 @@
           },
           "response": [
             {
-              "id": "7bc6f0ea-7879-4f4e-9bdd-c368c61bb445",
+              "id": "da1535c5-cc1d-455c-b496-7bdf488925a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12301,7 +12301,7 @@
           }
         },
         {
-          "id": "4f9548ea-368d-4393-8c56-5fa6d9934a6a",
+          "id": "bd04623a-169b-4e56-b332-fe8dab38ffa3",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -12355,7 +12355,7 @@
           },
           "response": [
             {
-              "id": "455dee8e-482d-45f7-b7bc-f0e2541c49bc",
+              "id": "e38072a7-3fbc-4614-ae97-10a26719d78e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12431,7 +12431,7 @@
           }
         },
         {
-          "id": "3d7f2597-8886-44ac-995e-401502549d8a",
+          "id": "882818c3-6b09-4c7a-b2db-0d6443f5e774",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -12466,7 +12466,7 @@
           },
           "response": [
             {
-              "id": "80bb4a36-275a-4ac7-acce-1d1f1ae7a736",
+              "id": "01b5367f-1d3d-4ea1-9d58-c4fe9b727c65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12519,7 +12519,7 @@
           }
         },
         {
-          "id": "5db29da3-4b9b-4e23-86bc-e7f09c8fd458",
+          "id": "72765948-18d8-4fc6-85ca-b0e8af84d601",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -12580,7 +12580,7 @@
           },
           "response": [
             {
-              "id": "8bd75ff9-c552-4ce3-800b-47bf14da363c",
+              "id": "7c43ae6f-56ee-4497-833e-166d47a21f3f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12663,7 +12663,7 @@
           }
         },
         {
-          "id": "83db74c6-35c0-46f1-9a82-48db03efd270",
+          "id": "d8e0b95e-3360-467a-bb6d-eca40bc34144",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -12705,7 +12705,7 @@
           },
           "response": [
             {
-              "id": "5f71ab9f-1a8b-4157-a51f-4425c0967a5a",
+              "id": "cedee16e-cde4-4aa1-b491-52889ea2d6c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12769,7 +12769,7 @@
           }
         },
         {
-          "id": "495c1bd2-850b-4135-8a8c-a16350414f3a",
+          "id": "ab9d67cb-b78c-48b6-9071-ae101ec4c146",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -12844,7 +12844,7 @@
           },
           "response": [
             {
-              "id": "4eb7e572-07c3-489a-9875-2de89e29c79d",
+              "id": "b3c84437-b378-4780-a1c8-0afdba367a0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12941,7 +12941,7 @@
           }
         },
         {
-          "id": "053927ec-a0e5-46a3-8e20-4823d7cb8d90",
+          "id": "5b3821c7-7147-48f9-aaed-552a5d80fca6",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -12983,7 +12983,7 @@
           },
           "response": [
             {
-              "id": "d30ea47e-8598-401f-9605-3a15fe7e7e2b",
+              "id": "0c3c1eba-4584-4b14-9124-b225834a68e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13047,7 +13047,7 @@
           }
         },
         {
-          "id": "c8be9916-aa4c-4bf5-b27b-e957c77cf412",
+          "id": "fd3f2217-d800-4fbe-a3b5-12fc6298bf9f",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -13090,7 +13090,7 @@
           },
           "response": [
             {
-              "id": "a24f982b-e8e5-4843-9553-10aa09a1b296",
+              "id": "3bad1537-fcae-4611-ae61-db5b0a1b2277",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13155,7 +13155,7 @@
           }
         },
         {
-          "id": "3bcddc15-0bb6-411d-ab63-3d5099d83d4c",
+          "id": "882eddd3-e8b7-4601-b4d0-ee5d16702bbd",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "1cc02881-009e-47b6-81e2-96c611120c0a",
+              "id": "6416c058-b493-40a8-a3c0-489ee08c7610",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13263,7 +13263,7 @@
           }
         },
         {
-          "id": "8d4eee13-c2fe-4be7-b0e8-d236699bd64f",
+          "id": "e02681de-7b3e-44be-8c49-e81357b17e13",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -13315,7 +13315,7 @@
           },
           "response": [
             {
-              "id": "09ca6c7c-a2c2-4304-b1d1-492ba339551c",
+              "id": "ffdd2f54-cbfc-4a8c-beaa-71835fa8eeca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13389,7 +13389,7 @@
           }
         },
         {
-          "id": "17bf546d-7ff3-4a09-b359-8b677c4705df",
+          "id": "ae68d33b-9a6c-4bc4-aa7a-0b27eb038ec8",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -13431,7 +13431,7 @@
           },
           "response": [
             {
-              "id": "025b5b8a-e037-44e8-b220-a855030daebd",
+              "id": "ab3d58d4-afe8-4ca3-b8c2-c4b8f88ee533",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13495,7 +13495,7 @@
           }
         },
         {
-          "id": "c71b155d-7f6c-4823-9ad7-55ff956370d0",
+          "id": "f7f2b172-efea-4a56-b6e6-a40f819811ea",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -13548,7 +13548,7 @@
           },
           "response": [
             {
-              "id": "64261fb1-b1a7-4e2d-9be5-38d11f2a0cac",
+              "id": "34bc955c-30a1-434c-9881-4e4d3ee6ee7b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13623,7 +13623,7 @@
           }
         },
         {
-          "id": "19f7e096-f4ed-4655-b6d1-748638284b55",
+          "id": "5a3e9cd2-39da-44bc-82ec-98e682718359",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -13676,7 +13676,7 @@
           },
           "response": [
             {
-              "id": "f5a2906e-376e-49d4-870b-29ebc9a384bf",
+              "id": "420f4c09-2ef1-4166-a1b0-59240f3218c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13751,7 +13751,7 @@
           }
         },
         {
-          "id": "72704cbb-315c-4253-8486-614f297814ae",
+          "id": "74786dc2-2b35-4617-b01d-f2409e06e669",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -13795,7 +13795,7 @@
           },
           "response": [
             {
-              "id": "56aed29b-f5f7-4aba-98af-0bda30218945",
+              "id": "eabeedbd-5b34-4386-822d-77a291091af4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13850,7 +13850,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13861,7 +13861,7 @@
           }
         },
         {
-          "id": "c2ab3371-2667-47ba-becd-3667b931ae22",
+          "id": "365962cf-901a-47c6-90bc-77c6e2fbf746",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -13905,7 +13905,7 @@
           },
           "response": [
             {
-              "id": "9cc81ad8-c886-47b6-99c8-68bba86a6100",
+              "id": "290ea6e2-812d-4aa4-a729-61cee8043ce6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13960,7 +13960,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -13977,7 +13977,7 @@
       "description": "",
       "item": [
         {
-          "id": "8e8cfc9c-2af1-4eb0-bf29-8e5dee4f25db",
+          "id": "e223b9d4-9be7-499c-a301-5c102a3639ed",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -14019,7 +14019,7 @@
           },
           "response": [
             {
-              "id": "e5486457-bf7c-4220-89e8-ccc9c6f69ae3",
+              "id": "b2a55499-03e0-40ac-9688-a3cb139f3bc3",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -14068,7 +14068,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "de4b07c6-abfb-444e-9f8f-d245cef9b4aa",
+              "id": "b0f95acc-3744-4745-a36a-08af2c3bf90b",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -14123,7 +14123,7 @@
           }
         },
         {
-          "id": "751da3aa-aa32-4596-b7e0-de81ca10b9fd",
+          "id": "9e700566-57f2-4452-b3bc-788fe0b06a8d",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -14169,7 +14169,7 @@
           },
           "response": [
             {
-              "id": "c1c50239-94e2-4717-87d8-d68169783df1",
+              "id": "fbe8cc30-7f72-4e75-904c-d44ad622a7af",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -14228,7 +14228,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "2c55efe1-1db3-4bbb-9365-4225f05c057e",
+              "id": "e14126f8-21d0-4035-a6f2-6d9e29ad6fc8",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -14293,7 +14293,7 @@
           }
         },
         {
-          "id": "6e5f7166-7c81-490f-832e-5213277d52c9",
+          "id": "3901021d-3b3e-466c-9cc7-e8d3da2c36ba",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -14339,7 +14339,7 @@
           },
           "response": [
             {
-              "id": "6ea75ce7-ccc3-4592-b91e-184e97ff3cb3",
+              "id": "4190a4d0-7490-43e8-bd13-badf3d61ef72",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -14398,7 +14398,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c0c02429-8c32-42da-8c0b-9aaa79efe6ae",
+              "id": "c5bc93ff-da65-4a4d-8706-562d5b16cb6a",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -14463,7 +14463,7 @@
           }
         },
         {
-          "id": "a06de970-6b68-4ba4-9788-5eb1fe07e388",
+          "id": "da74bb9c-e232-4c16-8c32-d486b9e69599",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -14505,7 +14505,7 @@
           },
           "response": [
             {
-              "id": "f63bfb4a-06d1-4370-8ab1-1d67c3f2e786",
+              "id": "9773f1df-c5f8-48a9-a858-d7c48f9469e9",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -14566,7 +14566,7 @@
       "description": "",
       "item": [
         {
-          "id": "e4d7f1b3-736f-4700-bdd3-7e5b6f0592ac",
+          "id": "0e7807b8-5a09-4998-b931-9c903f6f578e",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -14615,7 +14615,7 @@
           },
           "response": [
             {
-              "id": "8e116407-fac1-416a-8128-b151195ed8ca",
+              "id": "79d9e7c1-09c9-42a2-8258-417f8d011705",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14675,7 +14675,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": 2141.6599912647107,\n  \"key_2\": \"string\",\n  \"key_3\": 1335.4963759546722\n}",
+              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -14686,7 +14686,7 @@
           }
         },
         {
-          "id": "c528c7fc-5da1-43ee-9973-c9386ba199bb",
+          "id": "6e1b641d-29f7-431c-9a93-16f42d3d5924",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -14735,7 +14735,7 @@
           },
           "response": [
             {
-              "id": "2102f0a8-e9eb-4a5c-a83c-10cdf2a3c1d7",
+              "id": "b895ad8a-6736-401c-a351-803bcaca63ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14806,7 +14806,7 @@
           }
         },
         {
-          "id": "de99638f-ee25-4aba-92af-1ef165522782",
+          "id": "7409ba1f-8afa-43b6-9c4d-3c56c9ab3768",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -14855,7 +14855,7 @@
           },
           "response": [
             {
-              "id": "3b7c4893-ed55-4065-83d3-3d0ebbea70fe",
+              "id": "aacf65f2-e99c-4098-b08c-4f82292ee143",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14926,7 +14926,7 @@
           }
         },
         {
-          "id": "fafbbba8-08a7-49c5-95db-9192a9268643",
+          "id": "35f185e1-15d1-4916-ba01-98acd58c9def",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -14975,7 +14975,7 @@
           },
           "response": [
             {
-              "id": "a6643591-68b7-4520-b73f-74790be43130",
+              "id": "fb6314e6-f4fb-4266-8d9b-538ab05681b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15052,7 +15052,7 @@
       "description": "",
       "item": [
         {
-          "id": "d4258e48-03a0-4b2b-bf49-e44609eb3023",
+          "id": "83a6fdb0-b23a-4b88-95d0-67452b1f4862",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -15092,7 +15092,7 @@
           },
           "response": [
             {
-              "id": "ca770cfb-ab89-43e5-b095-4e24032387c8",
+              "id": "78d9fe8a-78b8-4f90-bd89-1729c29d59cb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15154,7 +15154,7 @@
           }
         },
         {
-          "id": "40498a52-c72a-4a8e-a29c-d3d5bda9dcf4",
+          "id": "99e1efb6-4a09-45c9-9740-142a78637488",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -15184,7 +15184,7 @@
           },
           "response": [
             {
-              "id": "944f6533-015b-4b68-98f3-7c51890a373a",
+              "id": "cf2e64a5-613f-4f73-9626-1aad5d0eb454",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15225,7 +15225,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": 2141.6599912647107,\n  \"key_2\": \"string\",\n  \"key_3\": 1335.4963759546722\n}",
+              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15236,7 +15236,7 @@
           }
         },
         {
-          "id": "00645e06-9dce-432c-ba55-afc4f19790d6",
+          "id": "23edf037-1b3c-432d-a2d3-fddc2dc248ee",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -15288,7 +15288,7 @@
           },
           "response": [
             {
-              "id": "0e2d56bc-381d-46f5-9683-23edb8a30776",
+              "id": "7091d02f-9582-403e-952f-47e4ed30015c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15368,7 +15368,7 @@
       "description": "",
       "item": [
         {
-          "id": "7be4a0c9-a0da-4035-b844-6d6b8b1588e8",
+          "id": "b2a696b6-1c77-4379-874c-24fed3f3a936",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -15397,7 +15397,7 @@
           },
           "response": [
             {
-              "id": "4272718d-24d6-4061-89f8-377c05c9a924",
+              "id": "a34aa998-8f96-4066-836e-f35459d4406b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15448,7 +15448,7 @@
           }
         },
         {
-          "id": "e8e4fc59-2ff3-44c2-8eca-4ff07020c5bb",
+          "id": "fe1486bf-bce8-44be-b1eb-15a07c6a0ae2",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -15489,7 +15489,7 @@
           },
           "response": [
             {
-              "id": "fcb76da7-873c-446f-9223-3449c90a6608",
+              "id": "08c52a7b-3dd1-48f6-a083-d23a4ce6adba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15558,7 +15558,7 @@
       "description": "",
       "item": [
         {
-          "id": "0626dba7-9f71-452b-b449-5989529d753e",
+          "id": "9246274d-ec46-44bc-a01c-44f7ee744840",
           "name": "health",
           "request": {
             "name": "health",
@@ -15587,7 +15587,7 @@
           },
           "response": [
             {
-              "id": "73797dc6-d6de-4782-adb3-3cfdf7eb9017",
+              "id": "b75a8748-69c9-4595-a447-aa1b9c747fd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15627,7 +15627,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": 2141.6599912647107,\n  \"key_2\": \"string\",\n  \"key_3\": 1335.4963759546722\n}",
+              "body": "{\n  \"key_0\": 6227.120308025594,\n  \"key_1\": \"string\",\n  \"key_2\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15644,7 +15644,7 @@
       "description": "",
       "item": [
         {
-          "id": "140f4906-76be-4eca-b320-233761565bdc",
+          "id": "ffea36f0-357a-4a48-99f2-e199bbbf0f5d",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -15696,7 +15696,7 @@
           },
           "response": [
             {
-              "id": "c50ec579-de19-4905-9944-498dafb72605",
+              "id": "ed76a199-1207-4cbb-ab72-03013be91f0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15770,7 +15770,7 @@
           }
         },
         {
-          "id": "72de9e20-3afa-4694-8731-8b82ce9dc8a1",
+          "id": "e63d2e59-346a-4f93-957b-df4b7896ed06",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -15811,7 +15811,7 @@
           },
           "response": [
             {
-              "id": "04e3896c-9637-43f9-848b-75b8fe978052",
+              "id": "8d7328f3-1475-4e9f-a7ca-e6287eb87f1b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15863,7 +15863,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15874,7 +15874,7 @@
           }
         },
         {
-          "id": "017fdeda-667f-424e-b87e-6e91d410d423",
+          "id": "d7d5ac06-a666-48c9-bc9f-a38a405a15c7",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -15904,7 +15904,7 @@
           },
           "response": [
             {
-              "id": "67427280-327a-4933-9212-a76c47a8e2e5",
+              "id": "59f659d9-8448-4a97-8e81-048b9c9f1e67",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15945,7 +15945,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -15976,9 +15976,9 @@
     }
   ],
   "info": {
-    "_postman_id": "8c485d2d-a090-445c-a231-04fba915cf7f",
+    "_postman_id": "3cc3c413-2d98-4136-bade-c6932aff7b92",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-01 09:24 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-02 00:58 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,14 @@ dependencies {
 	testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
 	// MockK - Kotlin-idiomatic mocking framework (preferred over Mockito for Kotlin)
 	testImplementation("io.mockk:mockk:1.13.16")
+	// Testcontainers — ephemeral PostgreSQL for @SpringBootTest integration tests.
+	// Provides the org.testcontainers.jdbc.ContainerDatabaseDriver consumed via
+	// the magic JDBC URL `jdbc:tc:postgresql:16-alpine:///<dbname>` from
+	// src/test/resources/application.yaml. Avoids any test ever touching the
+	// shared dev/prod databases.
+	testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.4"))
+	testImplementation("org.testcontainers:postgresql")
+	testImplementation("org.testcontainers:junit-jupiter")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/com/apptolast/invernaderos/config/FlywayConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/FlywayConfig.kt
@@ -34,6 +34,15 @@ class FlywayConfig {
     private var autoMigrate: Boolean = true
 
     /**
+     * Master switch to skip Flyway entirely. Used by tests so that Testcontainers
+     * databases (which start empty) rely on Hibernate `ddl-auto: create-drop`
+     * rather than running real migrations against an ephemeral container.
+     * Defaults to true in dev/prod where Flyway is the source of truth.
+     */
+    @Value("\${flyway.enabled:true}")
+    private var flywayEnabled: Boolean = true
+
+    /**
      * Flyway principal para PostgreSQL Metadata (schema 'metadata').
      * Migraciones en: classpath:db/migration/
      */
@@ -63,6 +72,11 @@ class FlywayConfig {
         @Qualifier("timescaleDataSource") timescaleDataSource: DataSource
     ): FlywayMigrationStrategy {
         return FlywayMigrationStrategy { metadataFlyway ->
+            if (!flywayEnabled) {
+                logger.info("Flyway DESACTIVADO via flyway.enabled=false (test profile) - skipping migrations.")
+                return@FlywayMigrationStrategy
+            }
+
             val timescaleFlyway = Flyway.configure()
                 .dataSource(timescaleDataSource)
                 .locations("classpath:db/migration-timescaledb")

--- a/src/main/kotlin/com/apptolast/invernaderos/config/PostGreSQLDataSourceConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/PostGreSQLDataSourceConfig.kt
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariDataSource
 import jakarta.persistence.EntityManagerFactory
 import javax.sql.DataSource
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -32,7 +33,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
                         "com.apptolast.invernaderos.features.device",
                         "com.apptolast.invernaderos.features.catalog",
                         "com.apptolast.invernaderos.features.user",
-
+                        "com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.repository",
                         "com.apptolast.invernaderos.features.statistics",
                         "com.apptolast.invernaderos.features.setting",
                         "com.apptolast.invernaderos.features.command",
@@ -40,7 +41,10 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
         entityManagerFactoryRef = "metadataEntityManagerFactory",
         transactionManagerRef = "metadataTransactionManager"
 )
-class PostGreSQLDataSourceConfig {
+class PostGreSQLDataSourceConfig(
+    @Value("\${spring.jpa.hibernate.ddl-auto:validate}")
+    private val ddlAuto: String
+) {
 
     @Bean(name = ["metadataDataSourceProperties"], defaultCandidate = false)
     @ConfigurationProperties("spring.datasource-metadata")
@@ -74,6 +78,7 @@ class PostGreSQLDataSourceConfig {
                 "com.apptolast.invernaderos.features.device",
                 "com.apptolast.invernaderos.features.catalog",
                 "com.apptolast.invernaderos.features.user",
+                "com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.entity",
                 "com.apptolast.invernaderos.features.statistics",
                 "com.apptolast.invernaderos.features.setting",
                 "com.apptolast.invernaderos.features.command",
@@ -88,7 +93,7 @@ class PostGreSQLDataSourceConfig {
         val properties =
                 hashMapOf<String, Any>(
                         "hibernate.dialect" to "org.hibernate.dialect.PostgreSQLDialect",
-                        "hibernate.hbm2ddl.auto" to "validate",
+                        "hibernate.hbm2ddl.auto" to ddlAuto,
                         "hibernate.show_sql" to "false",
                         "hibernate.format_sql" to "true"
                 )

--- a/src/main/kotlin/com/apptolast/invernaderos/core/security/JwtLogoutHandler.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/core/security/JwtLogoutHandler.kt
@@ -1,0 +1,33 @@
+package com.apptolast.invernaderos.core.security
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RevokeUserRefreshTokensUseCase
+import com.apptolast.invernaderos.features.user.UserService
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.logout.LogoutHandler
+import org.springframework.stereotype.Component
+
+@Component
+class JwtLogoutHandler(
+    private val revokeUserRefreshTokensUseCase: RevokeUserRefreshTokensUseCase,
+    private val userService: UserService,
+    @Value("\${auth.refresh-token.enabled:true}") private val refreshEnabled: Boolean
+) : LogoutHandler {
+
+    private val log = LoggerFactory.getLogger(JwtLogoutHandler::class.java)
+
+    override fun logout(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        auth: Authentication?
+    ) {
+        if (!refreshEnabled || auth == null) return
+        val username = auth.name ?: return
+        val user = userService.findByEmail(username) ?: return
+        val n = revokeUserRefreshTokensUseCase.execute(user.id!!)
+        log.info("Logout: revoked {} active refresh tokens for userId={}", n, user.id)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/core/security/JwtService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/core/security/JwtService.kt
@@ -16,7 +16,7 @@ class JwtService {
 
     @Value("\${spring.security.jwt.secret}") private lateinit var secretKey: String
 
-    @Value("\${spring.security.jwt.expiration}") private var jwtExpiration: Long = 0
+    @Value("\${spring.security.jwt.access-expiration}") private var accessExpirationMs: Long = 0
 
     fun extractUsername(token: String): String {
         return extractClaim(token, Claims::getSubject)
@@ -32,8 +32,10 @@ class JwtService {
     }
 
     fun generateToken(extraClaims: Map<String, Any>, userDetails: UserDetails): String {
-        return buildToken(extraClaims, userDetails, jwtExpiration)
+        return buildToken(extraClaims, userDetails, accessExpirationMs)
     }
+
+    fun getAccessTtlSeconds(): Long = accessExpirationMs / 1000
 
     private fun buildToken(
             extraClaims: Map<String, Any>,
@@ -49,7 +51,6 @@ class JwtService {
                 .compact()
     }
 
-    
     fun isTokenValid(token: String, userDetails: UserDetails): Boolean {
         val username = extractUsername(token)
         return (username == userDetails.username) && !isTokenExpired(token)

--- a/src/main/kotlin/com/apptolast/invernaderos/core/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/core/security/SecurityConfig.kt
@@ -2,6 +2,7 @@ package com.apptolast.invernaderos.core.security
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Lazy
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
@@ -22,7 +23,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 @EnableWebSecurity
 class SecurityConfig(
         private val jwtAuthenticationFilter: JwtAuthenticationFilter,
-        private val userDetailsService: UserDetailsService
+        private val userDetailsService: UserDetailsService,
+        @Lazy private val jwtLogoutHandler: JwtLogoutHandler
 ) {
 
     @Bean
@@ -63,9 +65,9 @@ class SecurityConfig(
                         UsernamePasswordAuthenticationFilter::class.java
                 )
                 .logout { logout ->
-                    logout.logoutUrl("/api/v1/auth/logout").logoutSuccessHandler { _, response, _ ->
-                        response.status = 200
-                    }
+                    logout.logoutUrl("/api/v1/auth/logout")
+                        .addLogoutHandler(jwtLogoutHandler)
+                        .logoutSuccessHandler { _, response, _ -> response.status = 200 }
                 }
 
         return http.build()

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthController.kt
@@ -2,11 +2,15 @@ package com.apptolast.invernaderos.features.auth
 
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.LoginRequest
+import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
 import com.apptolast.invernaderos.features.auth.dto.request.RegisterRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -59,4 +63,27 @@ class AuthController(private val authService: AuthService) {
         authService.resetPassword(request)
         return ResponseEntity.ok().build()
     }
+
+    @PostMapping("/refresh")
+    @Operation(
+        summary = "Rotate refresh token",
+        description = "Validates the refresh token, revokes it, and issues a new access + refresh pair. Detects reuse of revoked tokens (revokes the whole family).",
+        security = []
+    )
+    @ApiResponse(responseCode = "200", description = "New token pair issued")
+    @ApiResponse(responseCode = "400", description = "Malformed body")
+    @ApiResponse(responseCode = "401", description = "Refresh token invalid, expired, revoked or reused")
+    @ApiResponse(responseCode = "503", description = "Refresh token feature is disabled")
+    fun refresh(@Valid @RequestBody request: RefreshRequest): ResponseEntity<JwtResponse> =
+        authService.refresh(request).fold(
+            onSuccess = { ResponseEntity.ok(it) },
+            onFailure = { ex ->
+                val err = (ex as? AuthErrorException)?.error
+                when (err) {
+                    AuthError.FeatureDisabled -> ResponseEntity.status(503).build()
+                    AuthError.MalformedToken  -> ResponseEntity.badRequest().build()
+                    else                      -> ResponseEntity.status(401).build()
+                }
+            }
+        )
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthRefreshService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthRefreshService.kt
@@ -1,0 +1,104 @@
+package com.apptolast.invernaderos.features.auth
+
+import com.apptolast.invernaderos.core.security.JwtService
+import com.apptolast.invernaderos.features.auth.dto.mapper.toJwtResponse
+import com.apptolast.invernaderos.features.auth.dto.request.LoginRequest
+import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
+import com.apptolast.invernaderos.features.auth.dto.request.RegisterRequest
+import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RotateRefreshTokenUseCase
+import com.apptolast.invernaderos.features.user.UserService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Service
+
+/**
+ * Extends authentication with opaque refresh-token rotation.
+ * Wraps [AuthService] for login/register with refresh-token issuance,
+ * and provides the /refresh endpoint operation.
+ *
+ * This service is intentionally separate from [AuthService] so that
+ * existing unit tests for [AuthService] do not require mocking of the
+ * refresh-token use cases.
+ */
+@Service
+class AuthRefreshService(
+        private val authenticationManager: AuthenticationManager,
+        private val jwtService: JwtService,
+        private val userService: UserService,
+        private val userDetailsService: UserDetailsService,
+        private val emailService: EmailService,
+        private val issueRefreshTokenUseCase: IssueRefreshTokenUseCase,
+        private val rotateRefreshTokenUseCase: RotateRefreshTokenUseCase,
+        @Value("\${auth.refresh-token.enabled:true}") private val refreshTokenEnabled: Boolean
+) {
+
+        fun loginWithRefresh(request: LoginRequest): JwtResponse {
+                authenticationManager.authenticate(
+                        UsernamePasswordAuthenticationToken(request.username, request.password)
+                )
+
+                val userDetails = userDetailsService.loadUserByUsername(request.username)
+                val user = userService.findByEmail(request.username)
+                        ?: throw RuntimeException("User not found after authentication")
+
+                return if (refreshTokenEnabled) {
+                        val tokens = issueRefreshTokenUseCase.execute(
+                                IssueRefreshTokenCommand(userId = user.id!!)
+                        )
+                        tokens.toJwtResponse()
+                } else {
+                        val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
+                        val token = jwtService.generateToken(extraClaims, userDetails)
+                        JwtResponse(
+                                token = token,
+                                username = userDetails.username,
+                                roles = userDetails.authorities.map { it.authority }
+                        )
+                }
+        }
+
+        fun registerWithRefresh(request: RegisterRequest): JwtResponse {
+                val user = userService.createTenantAndAdminUser(
+                        tenantName = request.companyName,
+                        email = request.email,
+                        passwordRaw = request.password,
+                        firstName = request.firstName,
+                        lastName = request.lastName,
+                        phone = request.phone,
+                        province = request.address
+                )
+
+                return if (refreshTokenEnabled) {
+                        val savedUser = userService.findByEmail(user.email)
+                                ?: throw RuntimeException("User not found after registration")
+                        val tokens = issueRefreshTokenUseCase.execute(
+                                IssueRefreshTokenCommand(userId = savedUser.id!!)
+                        )
+                        tokens.toJwtResponse()
+                } else {
+                        val userDetails = userDetailsService.loadUserByUsername(user.email)
+                        val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
+                        val token = jwtService.generateToken(extraClaims, userDetails)
+                        JwtResponse(
+                                token = token,
+                                username = user.email,
+                                roles = listOf("ROLE_" + user.role)
+                        )
+                }
+        }
+
+        fun refresh(req: RefreshRequest): Result<JwtResponse> {
+                if (!refreshTokenEnabled) {
+                        return Result.failure(AuthErrorException(AuthError.FeatureDisabled))
+                }
+                return rotateRefreshTokenUseCase.execute(req.refreshToken)
+                        .map { it.toJwtResponse() }
+        }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthRefreshService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthRefreshService.kt
@@ -33,7 +33,6 @@ class AuthRefreshService(
         private val jwtService: JwtService,
         private val userService: UserService,
         private val userDetailsService: UserDetailsService,
-        private val emailService: EmailService,
         private val issueRefreshTokenUseCase: IssueRefreshTokenUseCase,
         private val rotateRefreshTokenUseCase: RotateRefreshTokenUseCase,
         @Value("\${auth.refresh-token.enabled:true}") private val refreshTokenEnabled: Boolean
@@ -46,11 +45,13 @@ class AuthRefreshService(
 
                 val userDetails = userDetailsService.loadUserByUsername(request.username)
                 val user = userService.findByEmail(request.username)
-                        ?: throw RuntimeException("User not found after authentication")
+                        ?: throw IllegalStateException("User not found after authentication")
+                val userId = user.id
+                        ?: throw IllegalStateException("Persisted user ${user.email} has null id")
 
                 return if (refreshTokenEnabled) {
                         val tokens = issueRefreshTokenUseCase.execute(
-                                IssueRefreshTokenCommand(userId = user.id!!)
+                                IssueRefreshTokenCommand(userId = userId)
                         )
                         tokens.toJwtResponse()
                 } else {
@@ -77,9 +78,11 @@ class AuthRefreshService(
 
                 return if (refreshTokenEnabled) {
                         val savedUser = userService.findByEmail(user.email)
-                                ?: throw RuntimeException("User not found after registration")
+                                ?: throw IllegalStateException("User not found after registration")
+                        val savedUserId = savedUser.id
+                                ?: throw IllegalStateException("Persisted user ${savedUser.email} has null id")
                         val tokens = issueRefreshTokenUseCase.execute(
-                                IssueRefreshTokenCommand(userId = savedUser.id!!)
+                                IssueRefreshTokenCommand(userId = savedUserId)
                         )
                         tokens.toJwtResponse()
                 } else {

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthService.kt
@@ -3,10 +3,14 @@ package com.apptolast.invernaderos.features.auth
 import com.apptolast.invernaderos.core.security.JwtService
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.LoginRequest
+import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
 import com.apptolast.invernaderos.features.auth.dto.request.RegisterRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
 import com.apptolast.invernaderos.features.user.UserService
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.userdetails.UserDetailsService
@@ -21,7 +25,16 @@ class AuthService(
         private val emailService: EmailService
 ) {
 
+        /** Injected after construction to avoid circular dependency and preserve 5-arg constructor for tests. */
+        @Autowired(required = false)
+        private var authRefreshService: AuthRefreshService? = null
+
         fun login(request: LoginRequest): JwtResponse {
+                val delegate = authRefreshService
+                if (delegate != null) {
+                        return delegate.loginWithRefresh(request)
+                }
+
                 authenticationManager.authenticate(
                         UsernamePasswordAuthenticationToken(request.username, request.password)
                 )
@@ -31,10 +44,9 @@ class AuthService(
                         userService.findByEmail(request.username)
                                 ?: throw RuntimeException(
                                         "User not found after authentication"
-                                ) // Should not happen
+                                )
 
                 val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
-
                 val token = jwtService.generateToken(extraClaims, userDetails)
 
                 return JwtResponse(
@@ -49,6 +61,11 @@ class AuthService(
                         throw RuntimeException("Email already in use")
                 }
 
+                val delegate = authRefreshService
+                if (delegate != null) {
+                        return delegate.registerWithRefresh(request)
+                }
+
                 val user =
                         userService.createTenantAndAdminUser(
                                 tenantName = request.companyName,
@@ -60,7 +77,6 @@ class AuthService(
                                 province = request.address
                         )
 
-                // Auto-login after registration
                 val userDetails = userDetailsService.loadUserByUsername(user.email)
                 val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
                 val token = jwtService.generateToken(extraClaims, userDetails)
@@ -68,13 +84,18 @@ class AuthService(
                 return JwtResponse(
                         token = token,
                         username = user.email,
-                        roles = listOf("ROLE_" + user.role) // Simple mapping
+                        roles = listOf("ROLE_" + user.role)
                 )
+        }
+
+        fun refresh(req: RefreshRequest): Result<JwtResponse> {
+                val delegate = authRefreshService
+                        ?: return Result.failure(AuthErrorException(AuthError.FeatureDisabled))
+                return delegate.refresh(req)
         }
 
         fun forgotPassword(request: ForgotPasswordRequest) {
                 val token = userService.generatePasswordResetToken(request.email)
-                // In a real scenario, we might want to do this asynchronously
                 emailService.sendPasswordResetEmail(request.email, token)
         }
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/AuthService.kt
@@ -1,98 +1,33 @@
 package com.apptolast.invernaderos.features.auth
 
-import com.apptolast.invernaderos.core.security.JwtService
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.LoginRequest
 import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
 import com.apptolast.invernaderos.features.auth.dto.request.RegisterRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
-import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
-import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
 import com.apptolast.invernaderos.features.user.UserService
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.security.authentication.AuthenticationManager
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.stereotype.Service
 
 @Service
 class AuthService(
-        private val authenticationManager: AuthenticationManager,
-        private val jwtService: JwtService,
         private val userService: UserService,
-        private val userDetailsService: UserDetailsService,
-        private val emailService: EmailService
+        private val emailService: EmailService,
+        private val authRefreshService: AuthRefreshService
 ) {
 
-        /** Injected after construction to avoid circular dependency and preserve 5-arg constructor for tests. */
-        @Autowired(required = false)
-        private var authRefreshService: AuthRefreshService? = null
-
-        fun login(request: LoginRequest): JwtResponse {
-                val delegate = authRefreshService
-                if (delegate != null) {
-                        return delegate.loginWithRefresh(request)
-                }
-
-                authenticationManager.authenticate(
-                        UsernamePasswordAuthenticationToken(request.username, request.password)
-                )
-
-                val userDetails = userDetailsService.loadUserByUsername(request.username)
-                val user =
-                        userService.findByEmail(request.username)
-                                ?: throw RuntimeException(
-                                        "User not found after authentication"
-                                )
-
-                val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
-                val token = jwtService.generateToken(extraClaims, userDetails)
-
-                return JwtResponse(
-                        token = token,
-                        username = userDetails.username,
-                        roles = userDetails.authorities.map { it.authority }
-                )
-        }
+        fun login(request: LoginRequest): JwtResponse =
+                authRefreshService.loginWithRefresh(request)
 
         fun register(request: RegisterRequest): JwtResponse {
                 if (userService.existsByEmail(request.email)) {
                         throw RuntimeException("Email already in use")
                 }
-
-                val delegate = authRefreshService
-                if (delegate != null) {
-                        return delegate.registerWithRefresh(request)
-                }
-
-                val user =
-                        userService.createTenantAndAdminUser(
-                                tenantName = request.companyName,
-                                email = request.email,
-                                passwordRaw = request.password,
-                                firstName = request.firstName,
-                                lastName = request.lastName,
-                                phone = request.phone,
-                                province = request.address
-                        )
-
-                val userDetails = userDetailsService.loadUserByUsername(user.email)
-                val extraClaims = mapOf("tenantId" to user.tenantId, "role" to user.role)
-                val token = jwtService.generateToken(extraClaims, userDetails)
-
-                return JwtResponse(
-                        token = token,
-                        username = user.email,
-                        roles = listOf("ROLE_" + user.role)
-                )
+                return authRefreshService.registerWithRefresh(request)
         }
 
-        fun refresh(req: RefreshRequest): Result<JwtResponse> {
-                val delegate = authRefreshService
-                        ?: return Result.failure(AuthErrorException(AuthError.FeatureDisabled))
-                return delegate.refresh(req)
-        }
+        fun refresh(req: RefreshRequest): Result<JwtResponse> =
+                authRefreshService.refresh(req)
 
         fun forgotPassword(request: ForgotPasswordRequest) {
                 val token = userService.generatePasswordResetToken(request.email)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/mapper/AuthMappers.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/mapper/AuthMappers.kt
@@ -1,0 +1,13 @@
+package com.apptolast.invernaderos.features.auth.dto.mapper
+
+import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+
+fun AuthTokensResult.toJwtResponse(): JwtResponse = JwtResponse(
+    token = accessToken,
+    username = username,
+    roles = roles,
+    refreshToken = refreshToken,
+    expiresIn = accessTtlSeconds,
+    refreshExpiresIn = refreshTtlSeconds
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/request/RefreshRequest.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/request/RefreshRequest.kt
@@ -1,0 +1,11 @@
+package com.apptolast.invernaderos.features.auth.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "Request body for /api/v1/auth/refresh")
+data class RefreshRequest(
+    @field:NotBlank(message = "refreshToken is required")
+    @Schema(description = "The refresh token previously issued by /login or /refresh", required = true)
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/response/JwtResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/dto/response/JwtResponse.kt
@@ -2,10 +2,13 @@ package com.apptolast.invernaderos.features.auth.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Response object containing JWT token")
+@Schema(description = "Response object containing JWT and refresh tokens")
 data class JwtResponse(
-        @Schema(description = "JWT Access Token") val token: String,
-        @Schema(description = "Token type", example = "Bearer") val type: String = "Bearer",
-        @Schema(description = "Username/Email of the authenticated user") val username: String,
-        @Schema(description = "List of roles assigned to the user") val roles: List<String>
+    @Schema(description = "JWT Access Token") val token: String,
+    @Schema(description = "Token type", example = "Bearer") val type: String = "Bearer",
+    @Schema(description = "Username/Email of the authenticated user") val username: String,
+    @Schema(description = "List of roles assigned to the user") val roles: List<String>,
+    @Schema(description = "Opaque refresh token (rotates on /refresh)") val refreshToken: String? = null,
+    @Schema(description = "Access token TTL in seconds") val expiresIn: Long? = null,
+    @Schema(description = "Refresh token TTL in seconds") val refreshExpiresIn: Long? = null
 )

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/AuthErrorException.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/AuthErrorException.kt
@@ -1,0 +1,5 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+
+class AuthErrorException(val error: AuthError) : RuntimeException(error.message)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseImpl.kt
@@ -35,7 +35,7 @@ class IssueRefreshTokenUseCaseImpl(
             userId = cmd.userId,
             tokenHash = tokenHash,
             familyId = familyId,
-            rotatedFromId = null,
+            rotatedFromId = cmd.rotatedFromId,
             expiresAt = now.plus(refreshTtl),
             revokedAt = null,
             createdAt = now

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseImpl.kt
@@ -1,0 +1,56 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.AccessTokenIssuer
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.UserClaimsLookup
+import java.time.Clock
+import java.time.Duration
+
+class IssueRefreshTokenUseCaseImpl(
+    private val repo: RefreshTokenRepositoryPort,
+    private val gen: OpaqueTokenGenerator,
+    private val accessIssuer: AccessTokenIssuer,
+    private val userClaims: UserClaimsLookup,
+    private val refreshTtl: Duration,
+    private val clock: Clock
+) : IssueRefreshTokenUseCase {
+
+    override fun execute(cmd: IssueRefreshTokenCommand): AuthTokensResult {
+        val now = clock.instant()
+        val plainToken = gen.generate()
+        val tokenHash = gen.hash(plainToken)
+
+        val familyId = cmd.familyId ?: RefreshTokenFamilyId.new()
+
+        val snapshot = userClaims.loadForToken(cmd.userId)
+
+        val refreshToken = RefreshToken(
+            id = null,
+            userId = cmd.userId,
+            tokenHash = tokenHash,
+            familyId = familyId,
+            rotatedFromId = null,
+            expiresAt = now.plus(refreshTtl),
+            revokedAt = null,
+            createdAt = now
+        )
+        repo.save(refreshToken)
+
+        val accessToken = accessIssuer.issue(snapshot.username, snapshot.claims)
+
+        return AuthTokensResult(
+            accessToken = accessToken,
+            refreshToken = plainToken,
+            accessTtlSeconds = accessIssuer.accessTtlSeconds(),
+            refreshTtlSeconds = refreshTtl.seconds,
+            username = snapshot.username,
+            roles = snapshot.roles
+        )
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RevokeUserRefreshTokensUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RevokeUserRefreshTokensUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RevokeUserRefreshTokensUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import java.time.Clock
+
+class RevokeUserRefreshTokensUseCaseImpl(
+    private val repo: RefreshTokenRepositoryPort,
+    private val clock: Clock
+) : RevokeUserRefreshTokensUseCase {
+
+    override fun execute(userId: Long): Int {
+        return repo.revokeAllActiveByUser(userId, clock.instant())
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseImpl.kt
@@ -1,0 +1,56 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RotateRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import org.slf4j.LoggerFactory
+import java.time.Clock
+
+class RotateRefreshTokenUseCaseImpl(
+    private val repo: RefreshTokenRepositoryPort,
+    private val gen: OpaqueTokenGenerator,
+    private val issueUseCase: IssueRefreshTokenUseCase,
+    private val clock: Clock
+) : RotateRefreshTokenUseCase {
+
+    private val log = LoggerFactory.getLogger(RotateRefreshTokenUseCaseImpl::class.java)
+
+    override fun execute(rawRefreshToken: String): Result<AuthTokensResult> {
+        if (rawRefreshToken.isBlank()) {
+            return Result.failure(AuthErrorException(AuthError.MalformedToken))
+        }
+
+        val now = clock.instant()
+        val hash = gen.hash(rawRefreshToken)
+        val stored = repo.findByTokenHashLocking(hash)
+            ?: return Result.failure(AuthErrorException(AuthError.TokenNotFound))
+
+        if (stored.isRevoked()) {
+            val revokedRows = repo.revokeFamily(stored.familyId, now)
+            log.warn(
+                "SECURITY: refresh-token reuse detected — userId={} familyId={} revokedRows={}",
+                stored.userId,
+                stored.familyId.value,
+                revokedRows
+            )
+            return Result.failure(
+                AuthErrorException(AuthError.TokenReuseDetected(stored.familyId.value, stored.userId))
+            )
+        }
+
+        if (stored.isExpired(now)) {
+            return Result.failure(AuthErrorException(AuthError.TokenExpired))
+        }
+
+        stored.id?.let { repo.revoke(it, now) }
+
+        val tokens = issueUseCase.execute(
+            IssueRefreshTokenCommand(userId = stored.userId, familyId = stored.familyId)
+        )
+        return Result.success(tokens)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseImpl.kt
@@ -46,10 +46,18 @@ class RotateRefreshTokenUseCaseImpl(
             return Result.failure(AuthErrorException(AuthError.TokenExpired))
         }
 
-        stored.id?.let { repo.revoke(it, now) }
+        val parentId = stored.id
+            ?: return Result.failure(
+                AuthErrorException(AuthError.TokenNotFound)
+            ) // defensive: a stored token without id is malformed persistence state
+        repo.revoke(parentId, now)
 
         val tokens = issueUseCase.execute(
-            IssueRefreshTokenCommand(userId = stored.userId, familyId = stored.familyId)
+            IssueRefreshTokenCommand(
+                userId = stored.userId,
+                familyId = stored.familyId,
+                rotatedFromId = parentId
+            )
         )
         return Result.success(tokens)
     }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/error/AuthError.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/error/AuthError.kt
@@ -1,0 +1,31 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.error
+
+import java.util.UUID
+
+sealed interface AuthError {
+    val message: String
+
+    data object MalformedToken : AuthError {
+        override val message = "Malformed refresh token"
+    }
+
+    data object TokenNotFound : AuthError {
+        override val message = "Refresh token not found"
+    }
+
+    data object TokenExpired : AuthError {
+        override val message = "Refresh token expired"
+    }
+
+    data object TokenRevoked : AuthError {
+        override val message = "Refresh token revoked"
+    }
+
+    data class TokenReuseDetected(val familyId: UUID, val userId: Long) : AuthError {
+        override val message = "Refresh token reuse detected for user $userId family $familyId"
+    }
+
+    data object FeatureDisabled : AuthError {
+        override val message = "Refresh token feature is disabled"
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/AuthTokensResult.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/AuthTokensResult.kt
@@ -1,0 +1,10 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.model
+
+data class AuthTokensResult(
+    val accessToken: String,
+    val refreshToken: String,           // plaintext, ONLY here, never persisted
+    val accessTtlSeconds: Long,
+    val refreshTtlSeconds: Long,
+    val username: String,
+    val roles: List<String>
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshToken.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshToken.kt
@@ -1,0 +1,18 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.model
+
+import java.time.Instant
+
+data class RefreshToken(
+    val id: Long?,
+    val userId: Long,
+    val tokenHash: String,
+    val familyId: RefreshTokenFamilyId,
+    val rotatedFromId: Long?,
+    val expiresAt: Instant,
+    val revokedAt: Instant?,
+    val createdAt: Instant
+) {
+    fun isExpired(now: Instant): Boolean = !now.isBefore(expiresAt)
+    fun isRevoked(): Boolean = revokedAt != null
+    fun isUsable(now: Instant): Boolean = !isRevoked() && !isExpired(now)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshTokenFamilyId.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshTokenFamilyId.kt
@@ -1,0 +1,9 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.model
+
+import java.util.UUID
+
+@JvmInline value class RefreshTokenFamilyId(val value: UUID) {
+    companion object {
+        fun new(): RefreshTokenFamilyId = RefreshTokenFamilyId(UUID.randomUUID())
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshTokenId.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/model/RefreshTokenId.kt
@@ -1,0 +1,3 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.model
+
+@JvmInline value class RefreshTokenId(val value: Long)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/IssueRefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/IssueRefreshTokenUseCase.kt
@@ -5,7 +5,8 @@ import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToke
 
 data class IssueRefreshTokenCommand(
     val userId: Long,
-    val familyId: RefreshTokenFamilyId? = null  // null → new family (login/register); set → rotation
+    val familyId: RefreshTokenFamilyId? = null,  // null → new family (login/register); set → rotation
+    val rotatedFromId: Long? = null              // parent token id when rotating; null on login/register
 )
 
 interface IssueRefreshTokenUseCase {

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/IssueRefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/IssueRefreshTokenUseCase.kt
@@ -1,0 +1,13 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.input
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+
+data class IssueRefreshTokenCommand(
+    val userId: Long,
+    val familyId: RefreshTokenFamilyId? = null  // null → new family (login/register); set → rotation
+)
+
+interface IssueRefreshTokenUseCase {
+    fun execute(cmd: IssueRefreshTokenCommand): AuthTokensResult
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/RevokeUserRefreshTokensUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/RevokeUserRefreshTokensUseCase.kt
@@ -1,0 +1,6 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.input
+
+interface RevokeUserRefreshTokensUseCase {
+    /** Revokes all active refresh tokens of a user. Returns the number of rows revoked. */
+    fun execute(userId: Long): Int
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/RotateRefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/input/RotateRefreshTokenUseCase.kt
@@ -1,0 +1,13 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.input
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+
+interface RotateRefreshTokenUseCase {
+    /**
+     * Validates and rotates an opaque refresh token.
+     * Returns Result.success with the new token pair, or Result.failure(AuthErrorException(error))
+     * containing the AuthError as cause.
+     * Reuse of a revoked token triggers full-family revocation (the failure carries TokenReuseDetected).
+     */
+    fun execute(rawRefreshToken: String): Result<AuthTokensResult>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/AccessTokenIssuer.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/AccessTokenIssuer.kt
@@ -1,0 +1,6 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.output
+
+interface AccessTokenIssuer {
+    fun issue(username: String, extraClaims: Map<String, Any>): String
+    fun accessTtlSeconds(): Long
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/OpaqueTokenGenerator.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/OpaqueTokenGenerator.kt
@@ -1,0 +1,6 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.output
+
+interface OpaqueTokenGenerator {
+    fun generate(): String          // 32-byte SecureRandom, base64url no-padding
+    fun hash(token: String): String // SHA-256 hex (lowercase, 64 chars)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/RefreshTokenRepositoryPort.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/RefreshTokenRepositoryPort.kt
@@ -1,0 +1,20 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.output
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import java.time.Instant
+
+interface RefreshTokenRepositoryPort {
+    fun save(token: RefreshToken): RefreshToken
+
+    /**
+     * MUST acquire a row-level write lock (SELECT ... FOR UPDATE) so concurrent
+     * /refresh calls with the same token serialize and reuse-detection works
+     * deterministically.
+     */
+    fun findByTokenHashLocking(tokenHash: String): RefreshToken?
+
+    fun revoke(id: Long, at: Instant)
+    fun revokeFamily(familyId: RefreshTokenFamilyId, at: Instant): Int
+    fun revokeAllActiveByUser(userId: Long, at: Instant): Int
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/UserClaimsLookup.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/domain/port/output/UserClaimsLookup.kt
@@ -1,0 +1,11 @@
+package com.apptolast.invernaderos.features.auth.refresh.domain.port.output
+
+interface UserClaimsLookup {
+    fun loadForToken(userId: Long): UserClaimsSnapshot
+
+    data class UserClaimsSnapshot(
+        val username: String,
+        val roles: List<String>,
+        val claims: Map<String, Any>     // tenantId, role
+    )
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/JwtAccessTokenIssuerAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/JwtAccessTokenIssuerAdapter.kt
@@ -1,0 +1,20 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.core.security.JwtService
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.AccessTokenIssuer
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Component
+
+@Component
+class JwtAccessTokenIssuerAdapter(
+    private val jwtService: JwtService,
+    private val userDetailsService: UserDetailsService
+) : AccessTokenIssuer {
+
+    override fun issue(username: String, extraClaims: Map<String, Any>): String {
+        val ud = userDetailsService.loadUserByUsername(username)
+        return jwtService.generateToken(extraClaims, ud)
+    }
+
+    override fun accessTtlSeconds(): Long = jwtService.getAccessTtlSeconds()
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/RefreshTokenRepositoryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/RefreshTokenRepositoryAdapter.kt
@@ -1,0 +1,34 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.mapper.toDomain
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.mapper.toEntity
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.repository.RefreshTokenJpaRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Component
+@Transactional("metadataTransactionManager")
+class RefreshTokenRepositoryAdapter(
+    private val jpa: RefreshTokenJpaRepository
+) : RefreshTokenRepositoryPort {
+
+    override fun save(token: RefreshToken): RefreshToken =
+        jpa.save(token.toEntity()).toDomain()
+
+    override fun findByTokenHashLocking(tokenHash: String): RefreshToken? =
+        jpa.lockByTokenHash(tokenHash)?.toDomain()
+
+    override fun revoke(id: Long, at: Instant) {
+        jpa.revokeById(id, at)
+    }
+
+    override fun revokeFamily(familyId: RefreshTokenFamilyId, at: Instant): Int =
+        jpa.revokeFamily(familyId.value, at)
+
+    override fun revokeAllActiveByUser(userId: Long, at: Instant): Int =
+        jpa.revokeAllActiveByUser(userId, at)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/Sha256OpaqueTokenGenerator.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/Sha256OpaqueTokenGenerator.kt
@@ -1,0 +1,24 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import org.springframework.stereotype.Component
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+@Component
+class Sha256OpaqueTokenGenerator : OpaqueTokenGenerator {
+
+    private val rnd = SecureRandom()
+
+    override fun generate(): String {
+        val buf = ByteArray(32)
+        rnd.nextBytes(buf)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(buf)
+    }
+
+    override fun hash(token: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(token.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/UserClaimsLookupAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/adapter/output/UserClaimsLookupAdapter.kt
@@ -1,0 +1,24 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.UserClaimsLookup
+import com.apptolast.invernaderos.features.user.UserService
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Component
+
+@Component
+class UserClaimsLookupAdapter(
+    private val userService: UserService,
+    private val userDetailsService: UserDetailsService
+) : UserClaimsLookup {
+
+    override fun loadForToken(userId: Long): UserClaimsLookup.UserClaimsSnapshot {
+        val user = userService.findById(userId)
+            ?: throw IllegalStateException("User $userId not found while issuing refresh token")
+        val ud = userDetailsService.loadUserByUsername(user.email)
+        return UserClaimsLookup.UserClaimsSnapshot(
+            username = user.email,
+            roles = ud.authorities.map { it.authority },
+            claims = mapOf("tenantId" to user.tenantId, "role" to user.role)
+        )
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/config/RefreshTokenModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/config/RefreshTokenModuleConfig.kt
@@ -1,0 +1,50 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.config
+
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.IssueRefreshTokenUseCaseImpl
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.RevokeUserRefreshTokensUseCaseImpl
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.RotateRefreshTokenUseCaseImpl
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RevokeUserRefreshTokensUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.RotateRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.AccessTokenIssuer
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.UserClaimsLookup
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+import java.time.Duration
+
+@Configuration
+class RefreshTokenModuleConfig {
+
+    @Bean
+    fun clock(): Clock = Clock.systemUTC()
+
+    @Bean
+    fun issueRefreshTokenUseCase(
+        repo: RefreshTokenRepositoryPort,
+        gen: OpaqueTokenGenerator,
+        accessIssuer: AccessTokenIssuer,
+        userClaims: UserClaimsLookup,
+        @Value("\${spring.security.jwt.refresh-expiration}") refreshMs: Long,
+        clock: Clock
+    ): IssueRefreshTokenUseCase = IssueRefreshTokenUseCaseImpl(
+        repo, gen, accessIssuer, userClaims, Duration.ofMillis(refreshMs), clock
+    )
+
+    @Bean
+    fun rotateRefreshTokenUseCase(
+        repo: RefreshTokenRepositoryPort,
+        gen: OpaqueTokenGenerator,
+        issue: IssueRefreshTokenUseCase,
+        clock: Clock
+    ): RotateRefreshTokenUseCase = RotateRefreshTokenUseCaseImpl(repo, gen, issue, clock)
+
+    @Bean
+    fun revokeUserRefreshTokensUseCase(
+        repo: RefreshTokenRepositoryPort,
+        clock: Clock
+    ): RevokeUserRefreshTokensUseCase = RevokeUserRefreshTokensUseCaseImpl(repo, clock)
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/entity/RefreshTokenEntity.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/entity/RefreshTokenEntity.kt
@@ -1,0 +1,39 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "refresh_tokens", schema = "metadata")
+class RefreshTokenEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+
+    @Column(name = "token_hash", nullable = false, length = 64, unique = true)
+    var tokenHash: String,
+
+    @Column(name = "family_id", nullable = false, columnDefinition = "uuid")
+    var familyId: UUID,
+
+    @Column(name = "rotated_from_id")
+    var rotatedFromId: Long? = null,
+
+    @Column(name = "expires_at", nullable = false)
+    var expiresAt: Instant,
+
+    @Column(name = "revoked_at")
+    var revokedAt: Instant? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/mapper/RefreshTokenMappers.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/mapper/RefreshTokenMappers.kt
@@ -1,0 +1,27 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.mapper
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.entity.RefreshTokenEntity
+
+fun RefreshTokenEntity.toDomain() = RefreshToken(
+    id = id,
+    userId = userId,
+    tokenHash = tokenHash,
+    familyId = RefreshTokenFamilyId(familyId),
+    rotatedFromId = rotatedFromId,
+    expiresAt = expiresAt,
+    revokedAt = revokedAt,
+    createdAt = createdAt
+)
+
+fun RefreshToken.toEntity() = RefreshTokenEntity(
+    id = id,
+    userId = userId,
+    tokenHash = tokenHash,
+    familyId = familyId.value,
+    rotatedFromId = rotatedFromId,
+    expiresAt = expiresAt,
+    revokedAt = revokedAt,
+    createdAt = createdAt
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/repository/RefreshTokenJpaRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/auth/refresh/infrastructure/persistence/repository/RefreshTokenJpaRepository.kt
@@ -1,0 +1,33 @@
+package com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.repository
+
+import com.apptolast.invernaderos.features.auth.refresh.infrastructure.persistence.entity.RefreshTokenEntity
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
+import org.springframework.data.repository.query.Param
+import java.time.Instant
+import java.util.UUID
+
+interface RefreshTokenJpaRepository : JpaRepository<RefreshTokenEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    @Query("SELECT r FROM RefreshTokenEntity r WHERE r.tokenHash = :h")
+    fun lockByTokenHash(@Param("h") h: String): RefreshTokenEntity?
+
+    @Modifying
+    @Query("UPDATE RefreshTokenEntity r SET r.revokedAt = :at WHERE r.id = :id AND r.revokedAt IS NULL")
+    fun revokeById(@Param("id") id: Long, @Param("at") at: Instant): Int
+
+    @Modifying
+    @Query("UPDATE RefreshTokenEntity r SET r.revokedAt = :at WHERE r.familyId = :fid AND r.revokedAt IS NULL")
+    fun revokeFamily(@Param("fid") fid: UUID, @Param("at") at: Instant): Int
+
+    @Modifying
+    @Query("UPDATE RefreshTokenEntity r SET r.revokedAt = :at WHERE r.userId = :uid AND r.revokedAt IS NULL")
+    fun revokeAllActiveByUser(@Param("uid") uid: Long, @Param("at") at: Instant): Int
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/user/UserService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/user/UserService.kt
@@ -24,6 +24,10 @@ class UserService(
                 return userRepository.findByEmail(email)
         }
 
+        fun findById(id: Long): User? {
+                return userRepository.findById(id).orElse(null)
+        }
+
         fun existsByEmail(email: String): Boolean {
                 return userRepository.existsByEmail(email)
         }

--- a/src/main/resources/db/migration/V39__create_refresh_tokens.sql
+++ b/src/main/resources/db/migration/V39__create_refresh_tokens.sql
@@ -1,0 +1,54 @@
+-- =============================================================================
+-- V39 — Refresh tokens with rotation + reuse-detection family tracking
+-- =============================================================================
+-- Stores opaque refresh tokens issued by /api/v1/auth/login, /register and
+-- rotated by /api/v1/auth/refresh. Implements the OAuth-style rotation +
+-- reuse-detection pattern:
+--
+--   * token_hash       = SHA-256 hex (lowercase, 64 chars) of the opaque token.
+--                        The plaintext token is NEVER persisted; only the hash.
+--   * family_id        = UUID grouping the rotation chain of a single login.
+--                        On rotation the new row inherits the parent's family_id.
+--                        If a row whose revoked_at is already set is presented
+--                        again, the whole family is revoked (reuse → robbery
+--                        signal) and a SECURITY WARN log is emitted.
+--   * rotated_from_id  = self-reference to the parent token in the rotation
+--                        chain. NULL for the first token in a family (issued
+--                        by login/register).
+--   * expires_at       = absolute expiration timestamp (default refresh TTL
+--                        is 30d, configurable via JWT_REFRESH_EXPIRATION env).
+--   * revoked_at       = NULL while the token is active. Set by /refresh
+--                        rotation, /logout, or family-wide reuse detection.
+--
+-- The unique index on token_hash enforces single-use semantics. Hot lookup
+-- path is "find by hash WHERE revoked_at IS NULL"; the partial index
+-- idx_refresh_tokens_user_active accelerates per-user revocation on logout.
+--
+-- Idempotent (uses IF NOT EXISTS) so repeated runs against dev/prod databases
+-- are safe. Foreign key on user_id cascades on user deletion (matches the
+-- existing pattern of metadata.push_tokens, V38).
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS metadata.refresh_tokens (
+    id              BIGSERIAL    PRIMARY KEY,
+    user_id         BIGINT       NOT NULL REFERENCES metadata.users(id)          ON DELETE CASCADE,
+    token_hash      VARCHAR(64)  NOT NULL UNIQUE,
+    family_id       UUID         NOT NULL,
+    rotated_from_id BIGINT       NULL     REFERENCES metadata.refresh_tokens(id) ON DELETE SET NULL,
+    expires_at      TIMESTAMPTZ  NOT NULL,
+    revoked_at      TIMESTAMPTZ  NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user        ON metadata.refresh_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_family      ON metadata.refresh_tokens(family_id);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires     ON metadata.refresh_tokens(expires_at);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_active
+    ON metadata.refresh_tokens(user_id) WHERE revoked_at IS NULL;
+
+COMMENT ON TABLE metadata.refresh_tokens IS
+    'Opaque refresh tokens with rotation. Stores SHA-256 hash only. family_id groups the rotation chain; reuse of a revoked token triggers full-family revocation.';
+COMMENT ON COLUMN metadata.refresh_tokens.token_hash      IS 'SHA-256 hex (lowercase) of the plaintext opaque token. Plaintext is never stored.';
+COMMENT ON COLUMN metadata.refresh_tokens.family_id       IS 'Groups all rotations that descend from the same login.';
+COMMENT ON COLUMN metadata.refresh_tokens.rotated_from_id IS 'Parent token in the rotation chain. NULL for the first token of a family.';
+COMMENT ON COLUMN metadata.refresh_tokens.revoked_at      IS 'NULL while active. Set on rotation, logout, or family-wide reuse detection.';

--- a/src/test/kotlin/com/apptolast/invernaderos/ArchitectureTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/ArchitectureTest.kt
@@ -94,4 +94,21 @@ class ArchitectureTest {
                     .dependOnClassesThat()
                     .resideInAPackage("..dto..")
                     .because("Domain must not depend on DTOs")
+
+    // --- refresh-token specific rule (explicit documentation, redundant with domainMustNotDependOnSpring) ---
+
+    @ArchTest
+    val refreshTokenDomainPure: ArchRule =
+            noClasses()
+                    .that()
+                    .resideInAPackage("..features.auth.refresh.domain..")
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAnyPackage(
+                            "org.springframework..",
+                            "jakarta..",
+                            "org.hibernate..",
+                            "io.jsonwebtoken.."
+                    )
+                    .because("refresh-token domain must remain pure Kotlin")
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/AuthServiceTest.kt
@@ -1,6 +1,5 @@
 package com.apptolast.invernaderos.features.auth
 
-import com.apptolast.invernaderos.core.security.JwtService
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.user.UserService
@@ -11,21 +10,15 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
-import org.springframework.security.authentication.AuthenticationManager
-import org.springframework.security.core.userdetails.UserDetailsService
 
 @ExtendWith(MockitoExtension::class)
 class AuthServiceTest {
 
-    @Mock lateinit var authenticationManager: AuthenticationManager
-
-    @Mock lateinit var jwtService: JwtService
-
     @Mock lateinit var userService: UserService
 
-    @Mock lateinit var userDetailsService: UserDetailsService
-
     @Mock lateinit var emailService: EmailService
+
+    @Mock lateinit var authRefreshService: AuthRefreshService
 
     @InjectMocks lateinit var authService: AuthService
 

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/AuthServiceTest.kt
@@ -3,24 +3,18 @@ package com.apptolast.invernaderos.features.auth
 import com.apptolast.invernaderos.features.auth.dto.request.ForgotPasswordRequest
 import com.apptolast.invernaderos.features.auth.dto.request.ResetPasswordRequest
 import com.apptolast.invernaderos.features.user.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
-import org.mockito.Mock
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
-import org.mockito.junit.jupiter.MockitoExtension
 
-@ExtendWith(MockitoExtension::class)
 class AuthServiceTest {
 
-    @Mock lateinit var userService: UserService
+    private val userService: UserService = mockk(relaxed = true)
+    private val emailService: EmailService = mockk(relaxed = true)
+    private val authRefreshService: AuthRefreshService = mockk(relaxed = true)
 
-    @Mock lateinit var emailService: EmailService
-
-    @Mock lateinit var authRefreshService: AuthRefreshService
-
-    @InjectMocks lateinit var authService: AuthService
+    private val authService = AuthService(userService, emailService, authRefreshService)
 
     @Test
     fun `forgotPassword should generate token and send email`() {
@@ -28,12 +22,12 @@ class AuthServiceTest {
         val token = "reset-token"
         val request = ForgotPasswordRequest(email)
 
-        `when`(userService.generatePasswordResetToken(email)).thenReturn(token)
+        every { userService.generatePasswordResetToken(email) } returns token
 
         authService.forgotPassword(request)
 
-        verify(userService).generatePasswordResetToken(email)
-        verify(emailService).sendPasswordResetEmail(email, token)
+        verify { userService.generatePasswordResetToken(email) }
+        verify { emailService.sendPasswordResetEmail(email, token) }
     }
 
     @Test
@@ -44,6 +38,6 @@ class AuthServiceTest {
 
         authService.resetPassword(request)
 
-        verify(userService).resetPassword(token, newPassword)
+        verify { userService.resetPassword(token, newPassword) }
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/RefreshTokenIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/RefreshTokenIntegrationTest.kt
@@ -1,0 +1,213 @@
+package com.apptolast.invernaderos.features.auth
+
+import com.apptolast.invernaderos.features.auth.dto.request.RefreshRequest
+import com.apptolast.invernaderos.features.auth.dto.response.JwtResponse
+import com.apptolast.invernaderos.features.auth.refresh.application.usecase.AuthErrorException
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+/**
+ * HTTP contract tests for POST /api/v1/auth/refresh.
+ *
+ * Strategy: mock AuthRefreshService at the Spring bean level (@MockBean) so
+ * the full Spring Security / MockMvc / Jackson / validation stack is exercised
+ * without touching the DEV database or any real use case wiring.
+ *
+ * All assertions verify the *HTTP contract*: status code + JSON shape.
+ * Business-logic correctness is covered by RotateRefreshTokenUseCaseTest.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class RefreshTokenIntegrationTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    /**
+     * Mocking AuthRefreshService instead of the individual use cases because
+     * AuthController -> AuthService -> AuthRefreshService.refresh() is the
+     * single call site that produces the Result<JwtResponse> the controller
+     * unwraps into HTTP status codes.
+     */
+    @MockBean private lateinit var authRefreshService: AuthRefreshService
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    private val validJwtResponse = JwtResponse(
+        token = "header.payload.sig",
+        type = "Bearer",
+        username = "farmer@greenhouse.io",
+        roles = listOf("ROLE_USER"),
+        refreshToken = "new-opaque-refresh-token",
+        expiresIn = 900L,
+        refreshExpiresIn = 86400L
+    )
+
+    private fun refreshBody(token: String) =
+        objectMapper.writeValueAsString(mapOf("refreshToken" to token))
+
+    private fun stubRefreshSuccess() {
+        `when`(authRefreshService.refresh(RefreshRequest("valid-token")))
+            .thenReturn(Result.success(validJwtResponse))
+    }
+
+    private fun stubRefreshFailure(token: String, error: AuthError) {
+        `when`(authRefreshService.refresh(RefreshRequest(token)))
+            .thenReturn(Result.failure(AuthErrorException(error)))
+    }
+
+    // -------------------------------------------------------------------------
+    // 200 — successful rotation
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 200 with full JwtResponse when token rotates successfully`() {
+        stubRefreshSuccess()
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("valid-token"))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.token").value("header.payload.sig"))
+            .andExpect(jsonPath("$.type").value("Bearer"))
+            .andExpect(jsonPath("$.username").value("farmer@greenhouse.io"))
+            .andExpect(jsonPath("$.roles[0]").value("ROLE_USER"))
+            .andExpect(jsonPath("$.refreshToken").value("new-opaque-refresh-token"))
+            .andExpect(jsonPath("$.expiresIn").value(900))
+            .andExpect(jsonPath("$.refreshExpiresIn").value(86400))
+    }
+
+    // -------------------------------------------------------------------------
+    // 401 — invalid / expired / revoked / reused
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 401 when token is not found in the store`() {
+        stubRefreshFailure("unknown-token", AuthError.TokenNotFound)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("unknown-token"))
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 401 when token is expired`() {
+        stubRefreshFailure("expired-token", AuthError.TokenExpired)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("expired-token"))
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 401 when token was already explicitly revoked`() {
+        stubRefreshFailure("revoked-token", AuthError.TokenRevoked)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("revoked-token"))
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 401 when reuse of a revoked token is detected and whole family is revoked`() {
+        val familyId = UUID.fromString("cafebabe-cafe-babe-cafe-babecafebabe")
+        stubRefreshFailure("reused-token", AuthError.TokenReuseDetected(familyId = familyId, userId = 42L))
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("reused-token"))
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    // -------------------------------------------------------------------------
+    // 400 — malformed token value (business-level, not Jakarta validation)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 400 when the refresh token string is malformed according to business rules`() {
+        stubRefreshFailure("bad-token", AuthError.MalformedToken)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("bad-token"))
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    // -------------------------------------------------------------------------
+    // 503 — feature disabled
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 503 when the refresh token feature is administratively disabled`() {
+        stubRefreshFailure("any-token", AuthError.FeatureDisabled)
+
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshBody("any-token"))
+        )
+            .andExpect(status().isServiceUnavailable)
+    }
+
+    // -------------------------------------------------------------------------
+    // 400 — Jakarta @NotBlank validation (before any use case is invoked)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return 400 when refreshToken field is present but blank`() {
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"refreshToken":""}""")
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when refreshToken field is missing from request body`() {
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when request body is entirely absent`() {
+        mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/RefreshTokenIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/RefreshTokenIntegrationTest.kt
@@ -10,8 +10,8 @@ import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -41,7 +41,7 @@ class RefreshTokenIntegrationTest {
      * single call site that produces the Result<JwtResponse> the controller
      * unwraps into HTTP status codes.
      */
-    @MockBean private lateinit var authRefreshService: AuthRefreshService
+    @MockitoBean private lateinit var authRefreshService: AuthRefreshService
 
     // -------------------------------------------------------------------------
     // Fixtures

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/IssueRefreshTokenUseCaseTest.kt
@@ -1,0 +1,176 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.AccessTokenIssuer
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.UserClaimsLookup
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class IssueRefreshTokenUseCaseTest {
+
+    private val repo: RefreshTokenRepositoryPort = mockk(relaxed = true)
+    private val gen: OpaqueTokenGenerator = mockk()
+    private val accessIssuer: AccessTokenIssuer = mockk()
+    private val userClaims: UserClaimsLookup = mockk()
+
+    private val now: Instant = Instant.parse("2026-05-01T12:00:00Z")
+    private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
+    private val refreshTtl: Duration = Duration.ofSeconds(86400)
+
+    private val sut = IssueRefreshTokenUseCaseImpl(repo, gen, accessIssuer, userClaims, refreshTtl, clock)
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    private val userId = 7L
+    private val plainToken = "plain-opaque-token"
+    private val tokenHash = "sha256hexhash0000000000000000000000000000000000000000000000000000"
+    private val accessJwt = "header.payload.signature"
+    private val accessTtl = 900L
+    private val username = "farmer@greenhouse.io"
+    private val roles = listOf("ROLE_USER")
+    private val claims = mapOf<String, Any>("tenantId" to 3L, "role" to "USER")
+
+    private fun stubGenerator() {
+        every { gen.generate() } returns plainToken
+        every { gen.hash(plainToken) } returns tokenHash
+    }
+
+    private fun stubUserClaims() {
+        every { userClaims.loadForToken(userId) } returns
+            UserClaimsLookup.UserClaimsSnapshot(username = username, roles = roles, claims = claims)
+    }
+
+    private fun stubAccessIssuer() {
+        every { accessIssuer.issue(username, claims) } returns accessJwt
+        every { accessIssuer.accessTtlSeconds() } returns accessTtl
+    }
+
+    // -------------------------------------------------------------------------
+    // New family (login / register flow)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should generate new familyId when command carries no familyId`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+
+        val savedSlot = slot<RefreshToken>()
+        every { repo.save(capture(savedSlot)) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        val result = sut.execute(cmd)
+
+        val saved = savedSlot.captured
+        // A new UUID-based familyId must have been generated (not null, not the command's null)
+        assertThat(saved.familyId).isNotNull()
+        assertThat(saved.familyId.value).isInstanceOf(UUID::class.java)
+    }
+
+    @Test
+    fun `should persist token with correct fields when issuing for a new family`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+
+        val savedSlot = slot<RefreshToken>()
+        every { repo.save(capture(savedSlot)) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        sut.execute(cmd)
+
+        val saved = savedSlot.captured
+        assertThat(saved.userId).isEqualTo(userId)
+        assertThat(saved.tokenHash).isEqualTo(tokenHash)
+        assertThat(saved.revokedAt).isNull()
+        assertThat(saved.expiresAt).isEqualTo(now.plus(refreshTtl))
+        assertThat(saved.createdAt).isEqualTo(now)
+        assertThat(saved.id).isNull() // id is assigned by DB, must be null on save
+    }
+
+    @Test
+    fun `should return AuthTokensResult with correct TTLs and credentials when issuing new family`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+        every { repo.save(any()) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        val result = sut.execute(cmd)
+
+        assertThat(result.accessToken).isEqualTo(accessJwt)
+        assertThat(result.refreshToken).isEqualTo(plainToken)
+        assertThat(result.accessTtlSeconds).isEqualTo(accessTtl)
+        assertThat(result.refreshTtlSeconds).isEqualTo(refreshTtl.seconds)
+        assertThat(result.username).isEqualTo(username)
+        assertThat(result.roles).isEqualTo(roles)
+    }
+
+    // -------------------------------------------------------------------------
+    // Inherited family (rotation flow)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should persist token with exact inherited familyId when command carries an existing familyId`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+
+        val inheritedFamilyId = RefreshTokenFamilyId(UUID.fromString("cafebabe-cafe-babe-cafe-babecafebabe"))
+
+        val savedSlot = slot<RefreshToken>()
+        every { repo.save(capture(savedSlot)) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = inheritedFamilyId)
+        sut.execute(cmd)
+
+        val saved = savedSlot.captured
+        assertThat(saved.familyId).isEqualTo(inheritedFamilyId)
+    }
+
+    @Test
+    fun `should return plaintext token in result so caller can send it to the client`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+        every { repo.save(any()) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        val result = sut.execute(cmd)
+
+        // plainToken must appear in the result (for the client), not the hash
+        assertThat(result.refreshToken).isEqualTo(plainToken)
+        assertThat(result.refreshToken).isNotEqualTo(tokenHash)
+    }
+
+    @Test
+    fun `should invoke generate then hash in order and call repo save exactly once`() {
+        stubGenerator()
+        stubUserClaims()
+        stubAccessIssuer()
+        every { repo.save(any()) } answers { firstArg() }
+
+        val cmd = IssueRefreshTokenCommand(userId = userId, familyId = null)
+        sut.execute(cmd)
+
+        verify(exactly = 1) { gen.generate() }
+        verify(exactly = 1) { gen.hash(plainToken) }
+        verify(exactly = 1) { repo.save(any()) }
+        verify(exactly = 1) { accessIssuer.issue(username, claims) }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseTest.kt
@@ -72,7 +72,7 @@ class RotateRefreshTokenUseCaseTest {
 
         every { gen.hash(rawToken) } returns tokenHash
         every { repo.findByTokenHashLocking(tokenHash) } returns stored
-        every { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId)) } returns expectedTokens
+        every { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId, rotatedFromId = 99L)) } returns expectedTokens
 
         val result = sut.execute(rawToken)
 
@@ -82,7 +82,7 @@ class RotateRefreshTokenUseCaseTest {
         // Must revoke the consumed token using its Long id
         verify(exactly = 1) { repo.revoke(99L, now) }
         // Must issue new tokens preserving the same familyId
-        verify(exactly = 1) { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId)) }
+        verify(exactly = 1) { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId, rotatedFromId = 99L)) }
         // Must NOT revoke the whole family on a clean rotation
         verify(exactly = 0) { repo.revokeFamily(any(), any()) }
     }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/auth/refresh/application/usecase/RotateRefreshTokenUseCaseTest.kt
@@ -1,0 +1,221 @@
+package com.apptolast.invernaderos.features.auth.refresh.application.usecase
+
+import com.apptolast.invernaderos.features.auth.refresh.domain.error.AuthError
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.AuthTokensResult
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshToken
+import com.apptolast.invernaderos.features.auth.refresh.domain.model.RefreshTokenFamilyId
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenCommand
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.input.IssueRefreshTokenUseCase
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.OpaqueTokenGenerator
+import com.apptolast.invernaderos.features.auth.refresh.domain.port.output.RefreshTokenRepositoryPort
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class RotateRefreshTokenUseCaseTest {
+
+    private val repo: RefreshTokenRepositoryPort = mockk(relaxed = true)
+    private val gen: OpaqueTokenGenerator = mockk()
+    private val issueUseCase: IssueRefreshTokenUseCase = mockk()
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-01T12:00:00Z"), ZoneOffset.UTC)
+
+    private val sut = RotateRefreshTokenUseCaseImpl(repo, gen, issueUseCase, clock)
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    private val now: Instant = Instant.parse("2026-05-01T12:00:00Z")
+    private val familyId = RefreshTokenFamilyId(UUID.fromString("11111111-1111-1111-1111-111111111111"))
+    private val userId = 42L
+    private val tokenHash = "abc123hash"
+    private val rawToken = "plain-raw-token"
+
+    private fun buildStoredToken(
+        revokedAt: Instant? = null,
+        expiresAt: Instant = now.plusSeconds(3600)
+    ) = RefreshToken(
+        id = 99L,
+        userId = userId,
+        tokenHash = tokenHash,
+        familyId = familyId,
+        rotatedFromId = null,
+        expiresAt = expiresAt,
+        revokedAt = revokedAt,
+        createdAt = now.minusSeconds(60)
+    )
+
+    private fun buildTokensResult() = AuthTokensResult(
+        accessToken = "new-access-jwt",
+        refreshToken = "new-plain-refresh",
+        accessTtlSeconds = 900L,
+        refreshTtlSeconds = 86400L,
+        username = "user@example.com",
+        roles = listOf("ROLE_USER")
+    )
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should rotate token and inherit family when token is valid and not expired`() {
+        val stored = buildStoredToken()
+        val expectedTokens = buildTokensResult()
+
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns stored
+        every { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId)) } returns expectedTokens
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(expectedTokens)
+
+        // Must revoke the consumed token using its Long id
+        verify(exactly = 1) { repo.revoke(99L, now) }
+        // Must issue new tokens preserving the same familyId
+        verify(exactly = 1) { issueUseCase.execute(IssueRefreshTokenCommand(userId = userId, familyId = familyId)) }
+        // Must NOT revoke the whole family on a clean rotation
+        verify(exactly = 0) { repo.revokeFamily(any(), any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Expired token
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return TokenExpired failure when stored token has passed its expiry`() {
+        val expired = buildStoredToken(expiresAt = now.minusSeconds(1))
+
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns expired
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex).isNotNull()
+        assertThat(ex!!.error).isEqualTo(AuthError.TokenExpired)
+
+        // Expired path must never revoke or issue
+        verify(exactly = 0) { repo.revoke(any(), any()) }
+        verify(exactly = 0) { issueUseCase.execute(any()) }
+    }
+
+    @Test
+    fun `should return TokenExpired when token expires exactly at now (boundary)`() {
+        // isExpired uses !now.isBefore(expiresAt), so expiresAt == now is expired
+        val expired = buildStoredToken(expiresAt = now)
+
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns expired
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex!!.error).isEqualTo(AuthError.TokenExpired)
+    }
+
+    // -------------------------------------------------------------------------
+    // Reuse detection
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should revoke entire family and return TokenReuseDetected when token is already revoked`() {
+        val revokedAt = now.minusSeconds(30)
+        val revoked = buildStoredToken(revokedAt = revokedAt)
+
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns revoked
+        every { repo.revokeFamily(familyId, now) } returns 3
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex).isNotNull()
+        val error = ex!!.error
+        assertThat(error).isInstanceOf(AuthError.TokenReuseDetected::class.java)
+        val reuseError = error as AuthError.TokenReuseDetected
+        assertThat(reuseError.familyId).isEqualTo(familyId.value)
+        assertThat(reuseError.userId).isEqualTo(userId)
+
+        // Full family revocation must happen
+        verify(exactly = 1) { repo.revokeFamily(familyId, now) }
+        // Must NOT revoke a single token nor issue new tokens
+        verify(exactly = 0) { repo.revoke(any(), any()) }
+        verify(exactly = 0) { issueUseCase.execute(any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Token not found
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return TokenNotFound failure when hash does not match any stored token`() {
+        every { gen.hash(rawToken) } returns tokenHash
+        every { repo.findByTokenHashLocking(tokenHash) } returns null
+
+        val result = sut.execute(rawToken)
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex).isNotNull()
+        assertThat(ex!!.error).isEqualTo(AuthError.TokenNotFound)
+
+        verify(exactly = 0) { repo.revoke(any(), any()) }
+        verify(exactly = 0) { issueUseCase.execute(any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Malformed / blank token
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `should return MalformedToken failure for empty string without touching repo or generator`() {
+        val result = sut.execute("")
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex).isNotNull()
+        assertThat(ex!!.error).isEqualTo(AuthError.MalformedToken)
+
+        verify(exactly = 0) { gen.hash(any()) }
+        verify(exactly = 0) { repo.findByTokenHashLocking(any()) }
+        confirmVerified(gen, repo, issueUseCase)
+    }
+
+    @Test
+    fun `should return MalformedToken failure for blank whitespace-only token`() {
+        val result = sut.execute("   ")
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex!!.error).isEqualTo(AuthError.MalformedToken)
+
+        verify(exactly = 0) { gen.hash(any()) }
+        verify(exactly = 0) { repo.findByTokenHashLocking(any()) }
+        confirmVerified(gen, repo, issueUseCase)
+    }
+
+    @Test
+    fun `should return MalformedToken failure for tab-only token`() {
+        val result = sut.execute("\t")
+
+        assertThat(result.isFailure).isTrue()
+        val ex = result.exceptionOrNull() as? AuthErrorException
+        assertThat(ex!!.error).isEqualTo(AuthError.MalformedToken)
+
+        verify(exactly = 0) { gen.hash(any()) }
+        verify(exactly = 0) { repo.findByTokenHashLocking(any()) }
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,171 @@
+# =============================================================================
+# Test configuration — overrides src/main/resources/application.yaml
+# =============================================================================
+# Goal: NO @SpringBootTest in this codebase ever touches the shared PROD
+# database (greenhouse_metadata / greenhouse_timeseries).
+#
+# Strategy: route integration tests at the DEV databases (the same ones the
+# develop branch deploys against). DEV is throwaway and is rebuilt by
+# flyway-migrate on each push to develop, so tests can pollute it freely.
+#
+# Why not Testcontainers?
+#   - The org.testcontainers:postgresql dependency is on the classpath, but
+#     the local docker daemon API version (1.32) does not match what
+#     testcontainers 1.21.x expects (1.40+). Migrating to Testcontainers
+#     requires a docker upgrade plus dual-datasource @ServiceConnection
+#     wiring. Out of scope for the refresh-token PR; revisit when CI runners
+#     and dev workstations are aligned.
+#   - GitHub Actions runners use a current docker, so we keep the Testcontainers
+#     deps for that follow-up work.
+#
+# Hibernate `ddl-auto: update` lets new JPA entities (e.g. RefreshTokenEntity
+# during local feature development) materialize their tables without waiting
+# for Flyway. Pre-existing schema is left untouched. Flyway is fully disabled
+# from tests (see flyway.enabled below; FlywayConfig.kt honours the flag).
+#
+# JWT_SECRET / TTLs are test-only constants; nothing in src/test depends on
+# real production values.
+# =============================================================================
+
+spring:
+  application:
+    name: invernaderos-test
+
+  # TimescaleDB (primary) — DEV instance.
+  datasource:
+    url: jdbc:postgresql://138.199.157.58:30432/greenhouse_timeseries_dev
+    username: admin
+    password: AppToLast2023%
+    driver-class-name: org.postgresql.Driver
+    configuration:
+      maximum-pool-size: 5
+      minimum-idle: 1
+      connection-timeout: 5000
+
+  # Metadata — DEV instance.
+  datasource-metadata:
+    url: jdbc:postgresql://138.199.157.58:30433/greenhouse_metadata_dev
+    username: admin
+    password: AppToLast2023%
+    driver-class-name: org.postgresql.Driver
+    configuration:
+      maximum-pool-size: 5
+      minimum-idle: 1
+      connection-timeout: 5000
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: false
+        show_sql: false
+
+  flyway:
+    enabled: false
+
+  security:
+    jwt:
+      secret: dGVzdC1zZWNyZXQtMjU2LWJpdC1mb3ItdGVzdHMtb25seS1ub3QtZm9yLXByb2QxMjM=
+      access-expiration: 60000
+      refresh-expiration: 600000
+
+  mail:
+    host: localhost
+    port: 25
+    username: test@local
+    password: test
+    properties:
+      mail:
+        smtp:
+          auth: false
+
+  data:
+    redis:
+      host: 138.199.157.58
+      port: 30379
+      password: AppToLast2023%
+      database: 1
+      timeout: 5000ms
+      connect-timeout: 3000ms
+      client-name: invernaderos-test
+      client-type: lettuce
+      lettuce:
+        pool:
+          enabled: true
+          max-active: 4
+          max-idle: 2
+          min-idle: 1
+      repositories:
+        enabled: false
+
+  cache:
+    type: none
+
+  # MQTT — point at an unreachable broker; tests must not depend on MQTT.
+  # Note the `spring.` prefix: matches MqttConfig.kt @Value("\${spring.mqtt.*}").
+  mqtt:
+    broker:
+      url: tcp://localhost:11883
+    username: test
+    password: test
+    client:
+      id-prefix: test-client
+      clean-session: true
+      connection-timeout: 1
+      keep-alive-interval: 5
+      automatic-reconnect: false
+    topics:
+      greenhouse-multi-tenant: "GREENHOUSE/+"
+      greenhouse-status: "GREENHOUSE/STATUS"
+      sensors-pattern: "GREENHOUSE"
+      actuators-pattern: "greenhouse/+/actuators/#"
+      actuators-status: "greenhouse/+/actuators/status"
+      system-events: "system/events/#"
+      alerts: "greenhouse/+/alerts/#"
+      response: "GREENHOUSE/RESPONSE"
+    qos:
+      sensors: 0
+      actuators: 1
+      alerts: 2
+      default: 0
+    message:
+      retained: false
+      max-payload-size: 1048576
+
+# FlywayConfig.kt skips both migrate and validate when this flag is false.
+flyway:
+  enabled: false
+  auto-migrate: false
+
+auth:
+  refresh-token:
+    enabled: true
+
+greenhouse:
+  simulation:
+    enabled: false
+
+# Sensor / dedup / alert sections referenced by feature configs.
+sensor:
+  rate-limiter:
+    enabled: false
+    min-interval-seconds: 30
+    use-redis: false
+  deduplication:
+    enabled: false
+    window-seconds: 600
+    use-redis: false
+
+alert:
+  mqtt:
+    value-true-means: ACTIVE
+    echo:
+      enabled: false
+
+logging:
+  level:
+    root: WARN
+    com.apptolast.invernaderos: INFO
+    org.springframework.test: WARN

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -25,6 +25,14 @@
 #
 # JWT_SECRET / TTLs are test-only constants; nothing in src/test depends on
 # real production values.
+#
+# DB credentials are NOT committed: the password resolves from
+# INVERNADEROS_TEST_DB_PASSWORD (env var). To run @SpringBootTest locally,
+# export it in your shell before invoking gradle:
+#     export INVERNADEROS_TEST_DB_PASSWORD='<dev-db-password>'
+# In CI it is provided as a GitHub Actions secret. Tests that do not need
+# DB connectivity (unit tests with MockK / mocked use cases) run fine
+# without setting this variable.
 # =============================================================================
 
 spring:
@@ -35,7 +43,7 @@ spring:
   datasource:
     url: jdbc:postgresql://138.199.157.58:30432/greenhouse_timeseries_dev
     username: admin
-    password: AppToLast2023%
+    password: ${INVERNADEROS_TEST_DB_PASSWORD:no-password-set}
     driver-class-name: org.postgresql.Driver
     configuration:
       maximum-pool-size: 5
@@ -46,7 +54,7 @@ spring:
   datasource-metadata:
     url: jdbc:postgresql://138.199.157.58:30433/greenhouse_metadata_dev
     username: admin
-    password: AppToLast2023%
+    password: ${INVERNADEROS_TEST_DB_PASSWORD:no-password-set}
     driver-class-name: org.postgresql.Driver
     configuration:
       maximum-pool-size: 5
@@ -85,7 +93,7 @@ spring:
     redis:
       host: 138.199.157.58
       port: 30379
-      password: AppToLast2023%
+      password: ${INVERNADEROS_TEST_DB_PASSWORD:no-password-set}
       database: 1
       timeout: 5000ms
       connect-timeout: 3000ms


### PR DESCRIPTION
## Promotion to prod

Promotes the refresh-token feature merged into `develop` (PR #110) to production.

**Verified in dev:**
- Flyway V39 applied to `greenhouse_metadata_dev` (checksum -1923660648, valid)
- Pod `invernaderos-api-7446859489-4mmpt` running with image `apptolast/invernaderos-api:develop` (digest sha256:dd5af9947ae5...)
- `POST /api/v1/auth/refresh` returns the contract: 400/401 confirmed end-to-end via curl
- Swagger UI shows `/refresh` and the extended `JwtResponse` (7 fields, new ones nullable)

**Post-merge actions for prod (I will execute via kubectl):**
1. Apply K8s manifests in `apptolast-invernadero-api-prod` (configmap with renamed `access-expiration`, deployment with new `JWT_SECRET` env var). Secret was already pre-loaded with a fresh 256-bit value.
2. `kubectl rollout restart deployment/invernaderos-api -n apptolast-invernadero-api-prod`
3. Smoke test the refresh endpoint contract.

**One-time forced re-login impact for prod users:**
The new `JWT_SECRET` (rotated to a fresh value, different from dev) invalidates all currently signed access JWTs. Active prod users will see one `401` and the mobile app will fall back to its login screen. After re-login they receive both an access token (1h) and a refresh token (30d), and from there sessions stay alive transparently — this is the whole point of the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)