### PR TITLE
feat(alert): expose history + statistics + actor metadata

### DIFF
--- a/docs/architecture/alert-history-design.md
+++ b/docs/architecture/alert-history-design.md
@@ -1,0 +1,260 @@
+# Alert history (real) + statistics — Phase 2 design
+
+> Decision document for the redesign that exposes the existing `metadata.alert_state_changes` audit log as a first-class read API and adds derived statistics. Phase 1 audit lives in conversation history; this is the actionable design.
+
+## 1. Decisions
+
+| Topic | Decision | Rationale |
+|---|---|---|
+| Histórico semantics | "Histórico" = stream of transitions, not list of resolved alerts | One row per state change. Same alert with 17 cycles → 34 transition rows or 17 episode rows. |
+| Actor persistence | Add `actor_user_id`, `actor_kind`, `actor_ref` to `alert_state_changes` (V40) | Required to answer "who resolved this" historically. |
+| Backfill | Best-effort: latest API resolve per alert maps to `alerts.resolved_by_user_id`; older transitions stay NULL honestly. MQTT rows → `actor_kind='DEVICE'`, `actor_ref=NULL`. | No invention of data we never persisted. |
+| Legacy `AlertController` | Keep working but make legacy `resolve`/`reopen` delegate to the hexagonal use cases (which already write state_changes). Add `Deprecation: true` + `Sunset` headers. | Mobile keeps working untouched, history starts being captured for legacy paths immediately. |
+| Hypertable | NO in this iteration. Keep `alert_state_changes` in `metadata` schema as regular Postgres table. | Volume is low (alerts vs sensor readings). Cross-schema (metadata vs iot) hypertable adds complexity. Re-evaluate when volume justifies it. |
+| WebSocket broadcast | Add `AlertStateChangedWebSocketListener` → publish to `/topic/tenant/{tenantId}/alerts` with `AlertTransitionResponse` payload. | UI can react in real time without polling. |
+| Statistics scope | Recurrence + MTTR + Timeseries + Active-duration + By-actor + Summary. | Covers the user's "all the stats we can squeeze out". |
+
+## 2. Migration V40 — `actor` columns + backfill
+
+```sql
+-- V40__add_actor_to_alert_state_changes.sql
+
+ALTER TABLE metadata.alert_state_changes
+    ADD COLUMN actor_user_id BIGINT NULL REFERENCES metadata.users(id) ON DELETE SET NULL,
+    ADD COLUMN actor_kind    VARCHAR(16) NOT NULL DEFAULT 'SYSTEM'
+                CHECK (actor_kind IN ('USER', 'DEVICE', 'SYSTEM')),
+    ADD COLUMN actor_ref     VARCHAR(128) NULL;
+
+-- Best-effort backfill:
+-- 1) For source='MQTT' rows → actor_kind='DEVICE', actor_ref stays NULL (we never persisted gateway).
+UPDATE metadata.alert_state_changes
+   SET actor_kind = 'DEVICE'
+ WHERE source = 'MQTT';
+
+-- 2) For source='SYSTEM' rows → actor_kind='SYSTEM' (already default; explicit for clarity).
+UPDATE metadata.alert_state_changes
+   SET actor_kind = 'SYSTEM'
+ WHERE source = 'SYSTEM';
+
+-- 3) For source='API' rows → mark as USER. Try to recover actor_user_id from
+--    alerts.resolved_by_user_id, but ONLY for the latest 'to_resolved=true'
+--    transition per alert (older API transitions are unrecoverable).
+UPDATE metadata.alert_state_changes
+   SET actor_kind = 'USER'
+ WHERE source = 'API';
+
+WITH latest_resolution_per_alert AS (
+    SELECT DISTINCT ON (alert_id) id, alert_id
+      FROM metadata.alert_state_changes
+     WHERE source = 'API' AND to_resolved = TRUE
+     ORDER BY alert_id, at DESC
+)
+UPDATE metadata.alert_state_changes asc_row
+   SET actor_user_id = a.resolved_by_user_id
+  FROM latest_resolution_per_alert latest
+  JOIN metadata.alerts a ON a.id = latest.alert_id
+ WHERE asc_row.id = latest.id
+   AND a.resolved_by_user_id IS NOT NULL;
+
+-- Indexes for actor lookups (e.g., "alerts resolved by user X")
+CREATE INDEX idx_alert_state_changes_actor_user ON metadata.alert_state_changes(actor_user_id) WHERE actor_user_id IS NOT NULL;
+CREATE INDEX idx_alert_state_changes_actor_kind ON metadata.alert_state_changes(actor_kind);
+
+COMMENT ON COLUMN metadata.alert_state_changes.actor_user_id IS 'User who triggered this transition. Populated for source=API only.';
+COMMENT ON COLUMN metadata.alert_state_changes.actor_kind IS 'USER (API), DEVICE (MQTT), SYSTEM (auto/scheduler).';
+COMMENT ON COLUMN metadata.alert_state_changes.actor_ref IS 'Free-form actor reference: gateway/device id for DEVICE, job name for SYSTEM.';
+```
+
+## 3. Domain (pure Kotlin)
+
+```kotlin
+// features/alert/domain/model/AlertActor.kt
+sealed interface AlertActor {
+    data class User(val userId: Long, val username: String?, val displayName: String?) : AlertActor
+    data class Device(val deviceRef: String?) : AlertActor
+    data object System : AlertActor
+}
+
+// features/alert/domain/model/AlertTransition.kt — read-model enriquecido
+data class AlertTransition(
+    val transitionId: Long,
+    val at: Instant,
+    val fromResolved: Boolean,
+    val toResolved: Boolean,
+    val source: AlertSignalSource,
+    val rawValue: String?,
+    val actor: AlertActor,
+    // alert context
+    val alertId: Long,
+    val alertCode: String,
+    val alertMessage: String?,
+    val alertTypeId: Short?,
+    val alertTypeName: String?,
+    val severityId: Short?,
+    val severityName: String?,
+    val severityLevel: Short?,
+    val severityColor: String?,
+    // physical context
+    val sectorId: Long,
+    val sectorCode: String?,
+    val greenhouseId: Long?,
+    val greenhouseName: String?,
+    val tenantId: Long,
+    // temporal correlation
+    val previousTransitionAt: Instant?,
+    val episodeStartedAt: Instant?,
+    val episodeDurationSeconds: Long?,
+    // accumulated counters
+    val occurrenceNumber: Long,
+    val totalTransitionsSoFar: Long,
+)
+
+// features/alert/domain/model/AlertEpisode.kt
+data class AlertEpisode(
+    val alertId: Long,
+    val alertCode: String,
+    val triggeredAt: Instant,
+    val resolvedAt: Instant?,           // null if still open
+    val durationSeconds: Long?,         // null if still open
+    val triggerSource: AlertSignalSource,
+    val resolveSource: AlertSignalSource?,
+    val triggerActor: AlertActor,
+    val resolveActor: AlertActor?,
+    val severityId: Short?,
+    val severityName: String?,
+    val sectorId: Long,
+    val sectorCode: String?,
+)
+
+// features/alert/domain/port/output/AlertHistoryQueryPort.kt
+interface AlertHistoryQueryPort {
+    fun findTransitionsByAlertId(alertId: Long, tenantId: TenantId, order: SortOrder): List<AlertTransition>
+    fun findTransitions(query: AlertEventsQuery): PagedResult<AlertTransition>
+    fun findEpisodes(query: AlertEpisodesQuery): PagedResult<AlertEpisode>
+}
+
+// features/alert/domain/port/output/AlertStatsQueryPort.kt
+interface AlertStatsQueryPort {
+    fun recurrence(query: RecurrenceStatsQuery): List<RecurrenceBucket>
+    fun mttr(query: MttrStatsQuery): List<MttrBucket>
+    fun timeseries(query: TimeseriesStatsQuery): List<TimeseriesBucket>
+    fun activeDuration(query: ActiveDurationStatsQuery): List<ActiveDurationBucket>
+    fun byActor(query: ByActorStatsQuery): List<ByActorBucket>
+    fun summary(tenantId: TenantId, from: Instant, to: Instant): AlertStatsSummary
+}
+```
+
+## 4. REST endpoints (all hexagonal, all under `/api/v1/tenants/{tenantId}/...`)
+
+### Histórico (3)
+
+| Verb | Path | Purpose |
+|---|---|---|
+| GET | `/alerts/{alertId}/history?order=ASC\|DESC` | Timeline of transitions of one alert |
+| GET | `/alert-events?from=&to=&source=&severityId=&alertTypeId=&sectorId=&greenhouseId=&code=&actorUserId=&transitionKind=ANY\|OPEN\|CLOSE&page=&size=` | Paginated tenant-wide feed of transitions (this REPLACES the "Histórico" tab) |
+| GET | `/alert-events/episodes?from=&to=&severityId=&sectorId=&code=&onlyClosed=&page=&size=` | Episodes (open→close pairs) for the tenant |
+
+### Estadísticas (6)
+
+| Verb | Path |
+|---|---|
+| GET | `/alerts/stats/recurrence?from=&to=&groupBy=code\|type\|severity\|sector\|greenhouse&limit=` |
+| GET | `/alerts/stats/mttr?from=&to=&groupBy=severity\|type\|sector\|code` |
+| GET | `/alerts/stats/timeseries?from=&to=&bucket=hour\|day\|week\|month&groupBy=severity\|type` |
+| GET | `/alerts/stats/active-duration?from=&to=&groupBy=code\|sector` |
+| GET | `/alerts/stats/by-actor?from=&to=&role=resolver\|opener` |
+| GET | `/alerts/stats/summary?from=&to=` |
+
+### Endpoint adicional
+
+| Verb | Path | Purpose |
+|---|---|---|
+| GET | `/alerts/count/unresolved/sector/{sectorId}` | Existing service method, never exposed; expose now as hex equivalent |
+
+## 5. DTOs (one file per DTO)
+
+- `AlertTransitionResponse` (mirrors domain `AlertTransition` with primitives only)
+- `AlertActorResponse` (sealed-like JSON with `kind: "USER"|"DEVICE"|"SYSTEM"` + `userId`/`username`/`displayName`/`ref` as nullable)
+- `AlertEpisodeResponse`
+- `PagedResponse<T>` (generic) — items + page/size/total/hasMore
+- `RecurrenceBucketResponse`, `MttrBucketResponse`, `TimeseriesBucketResponse`, `ActiveDurationBucketResponse`, `ByActorBucketResponse`
+- `AlertStatsSummaryResponse` (totalActiveNow, openedToday, closedToday, mttrTodaySeconds, top3RecurrentCodesThisWeek)
+
+## 6. Native queries (illustrative — final SQL in adapter)
+
+`findTransitions` core query uses window functions for `previousTransitionAt`, `episodeStartedAt`, `occurrenceNumber`, `totalTransitionsSoFar`:
+
+```sql
+SELECT
+  asc.id, asc.at, asc.from_resolved, asc.to_resolved, asc.source, asc.raw_value,
+  asc.actor_user_id, asc.actor_kind, asc.actor_ref,
+  u.username, u.display_name,
+  a.id AS alert_id, a.code, a.message, a.alert_type_id, a.severity_id, a.sector_id, a.tenant_id,
+  at.name AS alert_type_name,
+  sev.name AS severity_name, sev.level AS severity_level, sev.color AS severity_color,
+  s.code AS sector_code, s.greenhouse_id,
+  g.name AS greenhouse_name,
+  LAG(asc.at) OVER (PARTITION BY asc.alert_id ORDER BY asc.at)                                AS previous_transition_at,
+  CASE WHEN asc.to_resolved = TRUE THEN
+    LAST_VALUE(CASE WHEN asc.to_resolved = FALSE THEN asc.at END)
+      OVER (PARTITION BY asc.alert_id ORDER BY asc.at
+            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+  END                                                                                        AS episode_started_at,
+  COUNT(*) FILTER (WHERE asc.to_resolved = FALSE)
+    OVER (PARTITION BY asc.alert_id ORDER BY asc.at
+          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                                  AS occurrence_number,
+  ROW_NUMBER() OVER (PARTITION BY asc.alert_id ORDER BY asc.at)                              AS total_transitions_so_far
+FROM metadata.alert_state_changes asc
+JOIN metadata.alerts a ON a.id = asc.alert_id
+LEFT JOIN metadata.users u ON u.id = asc.actor_user_id
+LEFT JOIN metadata.alert_types at ON at.id = a.alert_type_id
+LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
+LEFT JOIN metadata.sectors s ON s.id = a.sector_id
+LEFT JOIN metadata.greenhouses g ON g.id = s.greenhouse_id
+WHERE a.tenant_id = :tenantId
+  AND asc.at >= :from AND asc.at < :to
+  -- + dynamic filters
+ORDER BY asc.at DESC
+LIMIT :size OFFSET :offset;
+```
+
+## 7. Legacy patch
+
+`AlertController.resolve()` (line 346) and `reopen()` (line 375): refactor body to delegate to the hexagonal use cases (`ResolveAlertUseCaseImpl.resolve`/`reopen`). This:
+- Preserves the legacy URL/contract (no client breakage).
+- Makes every legacy resolve/reopen write a row to `alert_state_changes`.
+- Triggers `AlertStateChangedEvent` (FCM push + future WS broadcast).
+
+Add HTTP headers on all legacy endpoints:
+```
+Deprecation: true
+Sunset: <90 days from deploy>
+Link: <https://inverapi-prod.apptolast.com/swagger-ui.html#tenant-alerts>; rel="successor-version"
+```
+
+## 8. WebSocket broadcast
+
+New listener `AlertStateChangedWebSocketListener.kt`:
+- `@TransactionalEventListener(phase = AFTER_COMMIT)` on `AlertStateChangedEvent`
+- Map event → `AlertTransitionResponse` (using the same projection as REST, but for a single row)
+- `simpMessagingTemplate.convertAndSend("/topic/tenant/${event.alert.tenantId}/alerts", payload)`
+
+WebSocket security: existing `StompJwtAuthInterceptor` already handles auth.
+
+## 9. Tests
+
+- **Unit**: each use case (mocked ports), each domain mapping function.
+- **Integration** (`@SpringBootTest` + Testcontainers Postgres):
+  1. Create alert → MQTT activates (raw=1) → MQTT resolves (raw=0) → API reopens → API resolves: `/alerts/{id}/history` returns 5 transitions, `/alert-events/episodes` returns 2 episodes (one fully closed, one open→close).
+  2. 17 abrir/cerrar cycles → 34 transitions in history, 17 episodes in episodes endpoint.
+  3. Resolve via legacy `PUT /api/v1/alerts/{id}/resolve` → state_change row appears with `source=API`, `actor_user_id=...`.
+  4. Stats: `recurrence` returns alerts ordered by activation count; `mttr` matches manual computation.
+  5. WebSocket: subscribe to `/topic/tenant/{id}/alerts`, fire transition, receive payload.
+- **ArchUnit**: domain layer remains framework-free.
+- **Regression**: every legacy endpoint still returns the same shape (snapshot tests).
+
+## 10. Out of scope (explicit non-goals for this PR)
+
+- Hypertable migration of `alert_state_changes` (deferred).
+- Fixing nullables `alert_type_id`/`severity_id`/`message` on `alerts` (deferred — separate ticket once we confirm count of legacy NULLs).
+- Removing legacy `AlertController` (deprecated now, retired in a later PR after mobile migrates).

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
@@ -2,14 +2,21 @@ package com.apptolast.invernaderos.features.alert
 
 import com.apptolast.invernaderos.features.alert.Alert
 import com.apptolast.invernaderos.features.alert.AlertService
+import com.apptolast.invernaderos.features.alert.domain.error.AlertError
 import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
 import com.apptolast.invernaderos.features.alert.dto.response.AlertResponse
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertRestInboundAdapter
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * REST Controller para gestión de Alertas.
@@ -44,10 +51,30 @@ import org.springframework.web.bind.annotation.*
 @CrossOrigin(origins = ["*"]) // TODO: Restrict to specific origins in production
 @Validated
 class AlertController(
-    private val alertService: AlertService
+    private val alertService: AlertService,
+    private val restInboundAdapter: AlertRestInboundAdapter,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        /**
+         * Sunset date is 90 days after application startup. Computed once at class load time
+         * so the value is stable across requests and cheap to produce.
+         */
+        private val SUNSET_DATE: String = ZonedDateTime.now(ZoneOffset.UTC)
+            .plusDays(90)
+            .format(DateTimeFormatter.RFC_1123_DATE_TIME)
+
+        private fun deprecationHeaders(): HttpHeaders = HttpHeaders().apply {
+            set("Deprecation", "true")
+            set("Sunset", SUNSET_DATE)
+            set(
+                "Link",
+                """<https://inverapi-prod.apptolast.com/swagger-ui.html#tenant-alerts>; rel="successor-version""""
+            )
+        }
+    }
 
     /**
      * GET /api/alerts
@@ -85,7 +112,7 @@ class AlertController(
                 }
             }.take(limit).map { it.toResponse() }
 
-            ResponseEntity.ok(alerts)
+            ResponseEntity.ok().headers(deprecationHeaders()).body(alerts)
         } catch (e: Exception) {
             logger.error("Error getting alerts", e)
             ResponseEntity.internalServerError().build()
@@ -335,13 +362,16 @@ class AlertController(
     /**
      * PUT /api/alerts/{id}/resolve
      *
-     * Resuelve una alerta.
+     * Resuelve una alerta. Delegated to hexagonal use case so that an audit row is written
+     * to alert_state_changes and the AlertStateChangedEvent is published.
      *
      * Query params:
-     * - userId: UUID del usuario que resuelve (opcional)
-     * - userName: Nombre del usuario que resuelve (opcional)
+     * - userId: ID del usuario que resuelve (opcional)
+     * - userName: Nombre del usuario (ignorado, kept for backward compat)
      *
      * Response: Alert resuelto
+     *
+     * @deprecated Use POST /api/v1/tenants/{tenantId}/alerts/{alertId}/resolve
      */
     @PutMapping("/{id}/resolve")
     fun resolveAlert(
@@ -349,45 +379,64 @@ class AlertController(
         @RequestParam(required = false) userId: Long?,
         @RequestParam(required = false) userName: String?
     ): ResponseEntity<AlertResponse> {
-        logger.debug("PUT /api/alerts/$id/resolve - Resolving alert")
+        logger.debug("PUT /api/alerts/$id/resolve - Resolving alert (legacy)")
 
-        return try {
-            val resolved = alertService.resolve(id, userId, userName)
-            if (resolved != null) {
-                val hydrated = alertService.getById(id) ?: resolved
-                ResponseEntity.ok(hydrated.toResponse())
-            } else {
-                ResponseEntity.notFound().build()
+        val alert = alertService.getById(id) ?: return ResponseEntity.notFound().build()
+        val tenantId = TenantId(alert.tenantId)
+
+        return restInboundAdapter.resolve(id, tenantId, userId).fold(
+            onLeft = { error ->
+                when (error) {
+                    is AlertError.NotFound -> ResponseEntity.notFound().build()
+                    is AlertError.AlreadyResolved ->
+                        ResponseEntity.status(HttpStatus.CONFLICT).headers(deprecationHeaders()).build()
+                    else ->
+                        ResponseEntity.internalServerError().build()
+                }
+            },
+            onRight = { resolved ->
+                // Re-fetch with EntityGraph so the response includes joined fields (sectorCode, etc.)
+                val hydratedAlert = alertService.getById(id)
+                val response = hydratedAlert?.toResponse() ?: resolved.toResponse()
+                ResponseEntity.ok().headers(deprecationHeaders()).body(response)
             }
-        } catch (e: Exception) {
-            logger.error("Error resolving alert: $id", e)
-            ResponseEntity.internalServerError().build()
-        }
+        )
     }
 
     /**
      * PUT /api/alerts/{id}/reopen
      *
-     * Reabre una alerta resuelta.
+     * Reabre una alerta resuelta. Delegated to hexagonal use case so that an audit row is
+     * written to alert_state_changes and the AlertStateChangedEvent is published.
      *
      * Response: Alert reabierto
+     *
+     * @deprecated Use POST /api/v1/tenants/{tenantId}/alerts/{alertId}/reopen
      */
     @PutMapping("/{id}/reopen")
     fun reopenAlert(@PathVariable id: Long): ResponseEntity<AlertResponse> {
-        logger.debug("PUT /api/alerts/$id/reopen - Reopening alert")
+        logger.debug("PUT /api/alerts/$id/reopen - Reopening alert (legacy)")
 
-        return try {
-            val reopened = alertService.reopen(id)
-            if (reopened != null) {
-                val hydrated = alertService.getById(id) ?: reopened
-                ResponseEntity.ok(hydrated.toResponse())
-            } else {
-                ResponseEntity.notFound().build()
+        val alert = alertService.getById(id) ?: return ResponseEntity.notFound().build()
+        val tenantId = TenantId(alert.tenantId)
+
+        return restInboundAdapter.reopen(id, tenantId, actorUserId = null).fold(
+            onLeft = { error ->
+                when (error) {
+                    is AlertError.NotFound -> ResponseEntity.notFound().build()
+                    is AlertError.NotResolved ->
+                        ResponseEntity.status(HttpStatus.CONFLICT).headers(deprecationHeaders()).build()
+                    else ->
+                        ResponseEntity.internalServerError().build()
+                }
+            },
+            onRight = { reopened ->
+                // Re-fetch with EntityGraph so the response includes joined fields (sectorCode, etc.)
+                val hydratedAlert = alertService.getById(id)
+                val response = hydratedAlert?.toResponse() ?: reopened.toResponse()
+                ResponseEntity.ok().headers(deprecationHeaders()).body(response)
             }
-        } catch (e: Exception) {
-            logger.error("Error reopening alert: $id", e)
-            ResponseEntity.internalServerError().build()
-        }
+        )
     }
 
     /**

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
@@ -9,14 +9,10 @@ import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.Al
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 
 /**
  * REST Controller para gestión de Alertas.
@@ -57,24 +53,9 @@ class AlertController(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    companion object {
-        /**
-         * Sunset date is 90 days after application startup. Computed once at class load time
-         * so the value is stable across requests and cheap to produce.
-         */
-        private val SUNSET_DATE: String = ZonedDateTime.now(ZoneOffset.UTC)
-            .plusDays(90)
-            .format(DateTimeFormatter.RFC_1123_DATE_TIME)
-
-        private fun deprecationHeaders(): HttpHeaders = HttpHeaders().apply {
-            set("Deprecation", "true")
-            set("Sunset", SUNSET_DATE)
-            set(
-                "Link",
-                """<https://inverapi-prod.apptolast.com/swagger-ui.html#tenant-alerts>; rel="successor-version""""
-            )
-        }
-    }
+    // Deprecation/Sunset headers are applied to ALL responses by [LegacyAlertDeprecationFilter]
+    // (see infrastructure/config). This controller is being phased out in favour of the
+    // hexagonal /api/v1/tenants/{tenantId}/alerts/** routes.
 
     /**
      * GET /api/alerts
@@ -112,7 +93,7 @@ class AlertController(
                 }
             }.take(limit).map { it.toResponse() }
 
-            ResponseEntity.ok().headers(deprecationHeaders()).body(alerts)
+            ResponseEntity.ok(alerts)
         } catch (e: Exception) {
             logger.error("Error getting alerts", e)
             ResponseEntity.internalServerError().build()
@@ -389,7 +370,7 @@ class AlertController(
                 when (error) {
                     is AlertError.NotFound -> ResponseEntity.notFound().build()
                     is AlertError.AlreadyResolved ->
-                        ResponseEntity.status(HttpStatus.CONFLICT).headers(deprecationHeaders()).build()
+                        ResponseEntity.status(HttpStatus.CONFLICT).build()
                     else ->
                         ResponseEntity.internalServerError().build()
                 }
@@ -398,7 +379,7 @@ class AlertController(
                 // Re-fetch with EntityGraph so the response includes joined fields (sectorCode, etc.)
                 val hydratedAlert = alertService.getById(id)
                 val response = hydratedAlert?.toResponse() ?: resolved.toResponse()
-                ResponseEntity.ok().headers(deprecationHeaders()).body(response)
+                ResponseEntity.ok(response)
             }
         )
     }
@@ -425,7 +406,7 @@ class AlertController(
                 when (error) {
                     is AlertError.NotFound -> ResponseEntity.notFound().build()
                     is AlertError.NotResolved ->
-                        ResponseEntity.status(HttpStatus.CONFLICT).headers(deprecationHeaders()).build()
+                        ResponseEntity.status(HttpStatus.CONFLICT).build()
                     else ->
                         ResponseEntity.internalServerError().build()
                 }
@@ -434,7 +415,7 @@ class AlertController(
                 // Re-fetch with EntityGraph so the response includes joined fields (sectorCode, etc.)
                 val hydratedAlert = alertService.getById(id)
                 val response = hydratedAlert?.toResponse() ?: reopened.toResponse()
-                ResponseEntity.ok().headers(deprecationHeaders()).body(response)
+                ResponseEntity.ok(response)
             }
         )
     }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertRepository.kt
@@ -111,6 +111,11 @@ interface AlertRepository : JpaRepository<Alert, Long> {
     fun countBySectorIdAndIsResolvedFalse(sectorId: Long): Long
 
     /**
+     * Cuenta alertas no resueltas por sector validando tenant.
+     */
+    fun countByTenantIdAndSectorIdAndIsResolvedFalse(tenantId: Long, sectorId: Long): Long
+
+    /**
      * Cuenta alertas criticas no resueltas por tenant.
      * Requiere JOIN con alert_severities para filtrar por nombre.
      */

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertStateChange.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertStateChange.kt
@@ -38,7 +38,16 @@ data class AlertStateChange(
     val rawValue: String? = null,
 
     @Column(nullable = false)
-    val at: Instant = Instant.now()
+    val at: Instant = Instant.now(),
+
+    @Column(name = "actor_user_id")
+    val actorUserId: Long? = null,
+
+    @Column(name = "actor_kind", nullable = false, length = 16)
+    val actorKind: String = "SYSTEM",
+
+    @Column(name = "actor_ref", length = 128)
+    val actorRef: String? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertActiveDurationStatsUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertActiveDurationStatsUseCaseImpl.kt
@@ -1,0 +1,16 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.ActiveDurationBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertActiveDurationStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+
+class AlertActiveDurationStatsUseCaseImpl(
+    private val statsPort: AlertStatsQueryPort,
+) : AlertActiveDurationStatsUseCase {
+
+    override fun execute(query: ActiveDurationStatsQuery): List<ActiveDurationBucket> {
+        require(!query.from.isAfter(query.to)) { "from must not be after to" }
+        return statsPort.activeDuration(query)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertByActorStatsUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertByActorStatsUseCaseImpl.kt
@@ -1,0 +1,16 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.ByActorBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.ByActorStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertByActorStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+
+class AlertByActorStatsUseCaseImpl(
+    private val statsPort: AlertStatsQueryPort,
+) : AlertByActorStatsUseCase {
+
+    override fun execute(query: ByActorStatsQuery): List<ByActorBucket> {
+        require(!query.from.isAfter(query.to)) { "from must not be after to" }
+        return statsPort.byActor(query)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertMttrStatsUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertMttrStatsUseCaseImpl.kt
@@ -1,0 +1,16 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.MttrBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertMttrStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+
+class AlertMttrStatsUseCaseImpl(
+    private val statsPort: AlertStatsQueryPort,
+) : AlertMttrStatsUseCase {
+
+    override fun execute(query: MttrStatsQuery): List<MttrBucket> {
+        require(!query.from.isAfter(query.to)) { "from must not be after to" }
+        return statsPort.mttr(query)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertRecurrenceStatsUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertRecurrenceStatsUseCaseImpl.kt
@@ -1,0 +1,19 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.RecurrenceBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertRecurrenceStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+
+private const val MAX_LIMIT = 100
+
+class AlertRecurrenceStatsUseCaseImpl(
+    private val statsPort: AlertStatsQueryPort,
+) : AlertRecurrenceStatsUseCase {
+
+    override fun execute(query: RecurrenceStatsQuery): List<RecurrenceBucket> {
+        require(!query.from.isAfter(query.to)) { "from must not be after to" }
+        require(query.limit in 1..MAX_LIMIT) { "limit must be 1...$MAX_LIMIT" }
+        return statsPort.recurrence(query)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertSummaryStatsUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertSummaryStatsUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStatsSummary
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertSummaryStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+class AlertSummaryStatsUseCaseImpl(
+    private val statsPort: AlertStatsQueryPort,
+) : AlertSummaryStatsUseCase {
+
+    override fun execute(tenantId: TenantId, from: Instant, to: Instant): AlertStatsSummary {
+        require(!from.isAfter(to)) { "from must not be after to" }
+        return statsPort.summary(tenantId, from, to)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertTimeseriesStatsUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertTimeseriesStatsUseCaseImpl.kt
@@ -1,0 +1,16 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.TimeseriesDataPoint
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertTimeseriesStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+
+class AlertTimeseriesStatsUseCaseImpl(
+    private val statsPort: AlertStatsQueryPort,
+) : AlertTimeseriesStatsUseCase {
+
+    override fun execute(query: TimeseriesStatsQuery): List<TimeseriesDataPoint> {
+        require(!query.from.isAfter(query.to)) { "from must not be after to" }
+        return statsPort.timeseries(query)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ApplyAlertMqttSignalUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ApplyAlertMqttSignalUseCaseImpl.kt
@@ -1,6 +1,7 @@
 package com.apptolast.invernaderos.features.alert.application.usecase
 
 import com.apptolast.invernaderos.features.alert.domain.error.AlertError
+import com.apptolast.invernaderos.features.alert.domain.model.AlertActor
 import com.apptolast.invernaderos.features.alert.domain.model.AlertMqttSignal
 import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalDecision
 import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
@@ -80,6 +81,7 @@ class ApplyAlertMqttSignalUseCaseImpl(
         val persistedAlert = alertByCodeRepository.save(updatedAlert)
 
         // 7. Persist state change
+        // actor_ref is null because we do not have device id available at this point in the MQTT pipeline.
         val change = AlertStateChange(
             id = null,
             alertId = persistedAlert.id ?: throw IllegalStateException("Alert ID cannot be null after save"),
@@ -87,7 +89,8 @@ class ApplyAlertMqttSignalUseCaseImpl(
             toResolved = targetResolved,
             source = AlertSignalSource.MQTT,
             rawValue = signal.rawValue,
-            at = Instant.now()
+            at = Instant.now(),
+            actor = AlertActor.Device(deviceRef = null),
         )
         val persistedChange = stateChangePort.save(change)
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/CountUnresolvedAlertsBySectorUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/CountUnresolvedAlertsBySectorUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.port.input.CountUnresolvedAlertsBySectorUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertRepositoryPort
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+
+class CountUnresolvedAlertsBySectorUseCaseImpl(
+    private val repository: AlertRepositoryPort,
+) : CountUnresolvedAlertsBySectorUseCase {
+
+    override fun execute(sectorId: Long, tenantId: TenantId): Long {
+        require(sectorId > 0) { "sectorId must be positive" }
+        return repository.countUnresolvedBySectorAndTenant(sectorId, tenantId)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/FindAlertEpisodesUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/FindAlertEpisodesUseCaseImpl.kt
@@ -1,0 +1,25 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertEpisode
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEpisodesQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertEpisodesUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertHistoryQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.PagedResult
+
+private const val MAX_PAGE_SIZE = 200
+
+/**
+ * Plain Kotlin use case for alert episode queries. Validates inputs and delegates
+ * to [AlertHistoryQueryPort]. No Spring annotations — wiring is in AlertModuleConfig.
+ */
+class FindAlertEpisodesUseCaseImpl(
+    private val historyQueryPort: AlertHistoryQueryPort,
+) : FindAlertEpisodesUseCase {
+
+    override fun findEpisodes(query: AlertEpisodesQuery): PagedResult<AlertEpisode> {
+        require(!query.from.isAfter(query.to)) { "from must not be after to" }
+        require(query.page >= 0) { "page must be non-negative" }
+        require(query.size in 1..MAX_PAGE_SIZE) { "size must be 1...$MAX_PAGE_SIZE" }
+        return historyQueryPort.findEpisodes(query)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/FindAlertHistoryUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/FindAlertHistoryUseCaseImpl.kt
@@ -1,0 +1,37 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertTransition
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEventsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertHistoryUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertHistoryQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.PagedResult
+import com.apptolast.invernaderos.features.shared.domain.model.SortOrder
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+
+private const val MAX_PAGE_SIZE = 200
+private const val DEFAULT_PAGE_SIZE = 50
+
+/**
+ * Plain Kotlin use case for alert history queries. Validates inputs and delegates
+ * to [AlertHistoryQueryPort]. No Spring annotations — wiring is in AlertModuleConfig.
+ */
+class FindAlertHistoryUseCaseImpl(
+    private val historyQueryPort: AlertHistoryQueryPort,
+) : FindAlertHistoryUseCase {
+
+    override fun findTransitionsByAlertId(
+        alertId: Long,
+        tenantId: TenantId,
+        order: SortOrder,
+    ): List<AlertTransition> {
+        require(alertId > 0) { "alertId must be positive, got $alertId" }
+        return historyQueryPort.findTransitionsByAlertId(alertId, tenantId, order)
+    }
+
+    override fun findTransitions(query: AlertEventsQuery): PagedResult<AlertTransition> {
+        require(!query.from.isAfter(query.to)) { "from must not be after to" }
+        require(query.page >= 0) { "page must be non-negative" }
+        require(query.size in 1..MAX_PAGE_SIZE) { "size must be 1...$MAX_PAGE_SIZE" }
+        return historyQueryPort.findTransitions(query)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ResolveAlertUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ResolveAlertUseCaseImpl.kt
@@ -2,6 +2,7 @@ package com.apptolast.invernaderos.features.alert.application.usecase
 
 import com.apptolast.invernaderos.features.alert.domain.error.AlertError
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertActor
 import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
 import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
 import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
@@ -41,6 +42,11 @@ class ResolveAlertUseCaseImpl(
         )
 
         val persisted = repository.save(resolved)
+        val resolveActor: AlertActor = if (resolvedByUserId != null) {
+            AlertActor.User(userId = resolvedByUserId, username = null, displayName = null)
+        } else {
+            AlertActor.System
+        }
         val change = AlertStateChange(
             id = null,
             alertId = persisted.id ?: throw IllegalStateException("Alert ID cannot be null after save"),
@@ -48,7 +54,8 @@ class ResolveAlertUseCaseImpl(
             toResolved = true,
             source = AlertSignalSource.API,
             rawValue = null,
-            at = now
+            at = now,
+            actor = resolveActor,
         )
         val persistedChange = stateChangePort.save(change)
         eventPublisher.publish(persisted, persistedChange)
@@ -56,7 +63,7 @@ class ResolveAlertUseCaseImpl(
         return Either.Right(persisted)
     }
 
-    override fun reopen(id: Long, tenantId: TenantId): Either<AlertError, Alert> {
+    override fun reopen(id: Long, tenantId: TenantId, actorUserId: Long?): Either<AlertError, Alert> {
         val existing = repository.findByIdAndTenantId(id, tenantId)
             ?: return Either.Left(AlertError.NotFound(id, tenantId))
 
@@ -73,6 +80,11 @@ class ResolveAlertUseCaseImpl(
         )
 
         val persisted = repository.save(reopened)
+        val reopenActor: AlertActor = if (actorUserId != null) {
+            AlertActor.User(userId = actorUserId, username = null, displayName = null)
+        } else {
+            AlertActor.System
+        }
         val change = AlertStateChange(
             id = null,
             alertId = persisted.id ?: throw IllegalStateException("Alert ID cannot be null after save"),
@@ -80,7 +92,8 @@ class ResolveAlertUseCaseImpl(
             toResolved = false,
             source = AlertSignalSource.API,
             rawValue = null,
-            at = now
+            at = now,
+            actor = reopenActor,
         )
         val persistedChange = stateChangePort.save(change)
         eventPublisher.publish(persisted, persistedChange)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/ActiveDurationBucket.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/ActiveDurationBucket.kt
@@ -1,0 +1,7 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+data class ActiveDurationBucket(
+    val key: String,
+    val label: String,
+    val totalActiveSeconds: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertActor.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertActor.kt
@@ -1,0 +1,7 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+sealed interface AlertActor {
+    data class User(val userId: Long, val username: String?, val displayName: String?) : AlertActor
+    data class Device(val deviceRef: String?) : AlertActor
+    data object System : AlertActor
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertEpisode.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertEpisode.kt
@@ -1,0 +1,19 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+import java.time.Instant
+
+data class AlertEpisode(
+    val alertId: Long,
+    val alertCode: String,
+    val triggeredAt: Instant,
+    val resolvedAt: Instant?,
+    val durationSeconds: Long?,
+    val triggerSource: AlertSignalSource,
+    val resolveSource: AlertSignalSource?,
+    val triggerActor: AlertActor,
+    val resolveActor: AlertActor?,
+    val severityId: Short?,
+    val severityName: String?,
+    val sectorId: Long,
+    val sectorCode: String?,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertStateChange.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertStateChange.kt
@@ -9,5 +9,6 @@ data class AlertStateChange(
     val toResolved: Boolean,
     val source: AlertSignalSource,
     val rawValue: String?,          // null if source != MQTT
-    val at: Instant
+    val at: Instant,
+    val actor: AlertActor = AlertActor.System,
 )

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertStatsSummary.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertStatsSummary.kt
@@ -1,0 +1,9 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+data class AlertStatsSummary(
+    val totalActiveNow: Long,
+    val openedToday: Long,
+    val closedToday: Long,
+    val mttrTodaySeconds: Double?,
+    val top3RecurrentCodesThisWeek: List<String>,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertTransition.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertTransition.kt
@@ -1,0 +1,32 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+import java.time.Instant
+
+data class AlertTransition(
+    val transitionId: Long,
+    val at: Instant,
+    val fromResolved: Boolean,
+    val toResolved: Boolean,
+    val source: AlertSignalSource,
+    val rawValue: String?,
+    val actor: AlertActor,
+    val alertId: Long,
+    val alertCode: String,
+    val alertMessage: String?,
+    val alertTypeId: Short?,
+    val alertTypeName: String?,
+    val severityId: Short?,
+    val severityName: String?,
+    val severityLevel: Short?,
+    val severityColor: String?,
+    val sectorId: Long,
+    val sectorCode: String?,
+    val greenhouseId: Long?,
+    val greenhouseName: String?,
+    val tenantId: Long,
+    val previousTransitionAt: Instant?,
+    val episodeStartedAt: Instant?,
+    val episodeDurationSeconds: Long?,
+    val occurrenceNumber: Long,
+    val totalTransitionsSoFar: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/ByActorBucket.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/ByActorBucket.kt
@@ -1,0 +1,8 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+data class ByActorBucket(
+    val actorUserId: Long,
+    val username: String?,
+    val displayName: String?,
+    val count: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/MttrBucket.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/MttrBucket.kt
@@ -1,0 +1,11 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+data class MttrBucket(
+    val key: String,
+    val label: String,
+    val mttrSeconds: Double,
+    val p50Seconds: Double,
+    val p95Seconds: Double,
+    val p99Seconds: Double,
+    val sampleSize: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/RecurrenceBucket.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/RecurrenceBucket.kt
@@ -1,0 +1,10 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+import java.time.Instant
+
+data class RecurrenceBucket(
+    val key: String,
+    val label: String,
+    val count: Long,
+    val lastSeenAt: Instant,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/TimeseriesDataPoint.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/TimeseriesDataPoint.kt
@@ -1,0 +1,10 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+import java.time.Instant
+
+data class TimeseriesDataPoint(
+    val bucketStart: Instant,
+    val key: String,
+    val opened: Long,
+    val closed: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/TransitionKind.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/TransitionKind.kt
@@ -1,0 +1,3 @@
+package com.apptolast.invernaderos.features.alert.domain.model
+
+enum class TransitionKind { ANY, OPEN, CLOSE }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/ActiveDurationStatsQuery.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/ActiveDurationStatsQuery.kt
@@ -1,0 +1,13 @@
+package com.apptolast.invernaderos.features.alert.domain.model.query
+
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+enum class ActiveDurationGroupBy { CODE, SECTOR }
+
+data class ActiveDurationStatsQuery(
+    val tenantId: TenantId,
+    val from: Instant,
+    val to: Instant,
+    val groupBy: ActiveDurationGroupBy,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/AlertEpisodesQuery.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/AlertEpisodesQuery.kt
@@ -1,0 +1,16 @@
+package com.apptolast.invernaderos.features.alert.domain.model.query
+
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+data class AlertEpisodesQuery(
+    val tenantId: TenantId,
+    val from: Instant,
+    val to: Instant,
+    val severityIds: List<Short>,
+    val sectorIds: List<Long>,
+    val codes: List<String>,
+    val onlyClosed: Boolean,
+    val page: Int,
+    val size: Int,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/AlertEventsQuery.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/AlertEventsQuery.kt
@@ -1,0 +1,21 @@
+package com.apptolast.invernaderos.features.alert.domain.model.query
+
+import com.apptolast.invernaderos.features.alert.domain.model.TransitionKind
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+data class AlertEventsQuery(
+    val tenantId: TenantId,
+    val from: Instant,
+    val to: Instant,
+    val sources: List<String>,
+    val severityIds: List<Short>,
+    val alertTypeIds: List<Short>,
+    val sectorIds: List<Long>,
+    val greenhouseIds: List<Long>,
+    val codes: List<String>,
+    val actorUserIds: List<Long>,
+    val transitionKind: TransitionKind,
+    val page: Int,
+    val size: Int,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/ByActorStatsQuery.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/ByActorStatsQuery.kt
@@ -1,0 +1,13 @@
+package com.apptolast.invernaderos.features.alert.domain.model.query
+
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+enum class ActorStatsRole { RESOLVER, OPENER }
+
+data class ByActorStatsQuery(
+    val tenantId: TenantId,
+    val from: Instant,
+    val to: Instant,
+    val role: ActorStatsRole,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/MttrStatsQuery.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/MttrStatsQuery.kt
@@ -1,0 +1,13 @@
+package com.apptolast.invernaderos.features.alert.domain.model.query
+
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+enum class MttrGroupBy { SEVERITY, TYPE, SECTOR, CODE }
+
+data class MttrStatsQuery(
+    val tenantId: TenantId,
+    val from: Instant,
+    val to: Instant,
+    val groupBy: MttrGroupBy,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/RecurrenceStatsQuery.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/RecurrenceStatsQuery.kt
@@ -1,0 +1,14 @@
+package com.apptolast.invernaderos.features.alert.domain.model.query
+
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+enum class RecurrenceGroupBy { CODE, TYPE, SEVERITY, SECTOR, GREENHOUSE }
+
+data class RecurrenceStatsQuery(
+    val tenantId: TenantId,
+    val from: Instant,
+    val to: Instant,
+    val groupBy: RecurrenceGroupBy,
+    val limit: Int,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/TimeseriesStatsQuery.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/query/TimeseriesStatsQuery.kt
@@ -1,0 +1,16 @@
+package com.apptolast.invernaderos.features.alert.domain.model.query
+
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+enum class TimeseriesBucket { HOUR, DAY, WEEK, MONTH }
+
+enum class TimeseriesGroupBy { SEVERITY, TYPE }
+
+data class TimeseriesStatsQuery(
+    val tenantId: TenantId,
+    val from: Instant,
+    val to: Instant,
+    val bucket: TimeseriesBucket,
+    val groupBy: TimeseriesGroupBy,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertActiveDurationStatsUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertActiveDurationStatsUseCase.kt
@@ -1,0 +1,8 @@
+package com.apptolast.invernaderos.features.alert.domain.port.input
+
+import com.apptolast.invernaderos.features.alert.domain.model.ActiveDurationBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationStatsQuery
+
+interface AlertActiveDurationStatsUseCase {
+    fun execute(query: ActiveDurationStatsQuery): List<ActiveDurationBucket>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertByActorStatsUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertByActorStatsUseCase.kt
@@ -1,0 +1,8 @@
+package com.apptolast.invernaderos.features.alert.domain.port.input
+
+import com.apptolast.invernaderos.features.alert.domain.model.ByActorBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.ByActorStatsQuery
+
+interface AlertByActorStatsUseCase {
+    fun execute(query: ByActorStatsQuery): List<ByActorBucket>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertMttrStatsUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertMttrStatsUseCase.kt
@@ -1,0 +1,8 @@
+package com.apptolast.invernaderos.features.alert.domain.port.input
+
+import com.apptolast.invernaderos.features.alert.domain.model.MttrBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrStatsQuery
+
+interface AlertMttrStatsUseCase {
+    fun execute(query: MttrStatsQuery): List<MttrBucket>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertRecurrenceStatsUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertRecurrenceStatsUseCase.kt
@@ -1,0 +1,8 @@
+package com.apptolast.invernaderos.features.alert.domain.port.input
+
+import com.apptolast.invernaderos.features.alert.domain.model.RecurrenceBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceStatsQuery
+
+interface AlertRecurrenceStatsUseCase {
+    fun execute(query: RecurrenceStatsQuery): List<RecurrenceBucket>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertSummaryStatsUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertSummaryStatsUseCase.kt
@@ -1,0 +1,9 @@
+package com.apptolast.invernaderos.features.alert.domain.port.input
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStatsSummary
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+interface AlertSummaryStatsUseCase {
+    fun execute(tenantId: TenantId, from: Instant, to: Instant): AlertStatsSummary
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertTimeseriesStatsUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/AlertTimeseriesStatsUseCase.kt
@@ -1,0 +1,8 @@
+package com.apptolast.invernaderos.features.alert.domain.port.input
+
+import com.apptolast.invernaderos.features.alert.domain.model.TimeseriesDataPoint
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesStatsQuery
+
+interface AlertTimeseriesStatsUseCase {
+    fun execute(query: TimeseriesStatsQuery): List<TimeseriesDataPoint>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/CountUnresolvedAlertsBySectorUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/CountUnresolvedAlertsBySectorUseCase.kt
@@ -1,0 +1,7 @@
+package com.apptolast.invernaderos.features.alert.domain.port.input
+
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+
+interface CountUnresolvedAlertsBySectorUseCase {
+    fun execute(sectorId: Long, tenantId: TenantId): Long
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/FindAlertEpisodesUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/FindAlertEpisodesUseCase.kt
@@ -1,0 +1,9 @@
+package com.apptolast.invernaderos.features.alert.domain.port.input
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertEpisode
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEpisodesQuery
+import com.apptolast.invernaderos.features.shared.domain.model.PagedResult
+
+interface FindAlertEpisodesUseCase {
+    fun findEpisodes(query: AlertEpisodesQuery): PagedResult<AlertEpisode>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/FindAlertHistoryUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/FindAlertHistoryUseCase.kt
@@ -1,0 +1,12 @@
+package com.apptolast.invernaderos.features.alert.domain.port.input
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertTransition
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEventsQuery
+import com.apptolast.invernaderos.features.shared.domain.model.PagedResult
+import com.apptolast.invernaderos.features.shared.domain.model.SortOrder
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+
+interface FindAlertHistoryUseCase {
+    fun findTransitionsByAlertId(alertId: Long, tenantId: TenantId, order: SortOrder): List<AlertTransition>
+    fun findTransitions(query: AlertEventsQuery): PagedResult<AlertTransition>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/ResolveAlertUseCase.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/input/ResolveAlertUseCase.kt
@@ -7,5 +7,5 @@ import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 
 interface ResolveAlertUseCase {
     fun resolve(id: Long, tenantId: TenantId, resolvedByUserId: Long?): Either<AlertError, Alert>
-    fun reopen(id: Long, tenantId: TenantId): Either<AlertError, Alert>
+    fun reopen(id: Long, tenantId: TenantId, actorUserId: Long? = null): Either<AlertError, Alert>
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertHistoryQueryPort.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertHistoryQueryPort.kt
@@ -1,0 +1,15 @@
+package com.apptolast.invernaderos.features.alert.domain.port.output
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertEpisode
+import com.apptolast.invernaderos.features.alert.domain.model.AlertTransition
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEpisodesQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEventsQuery
+import com.apptolast.invernaderos.features.shared.domain.model.PagedResult
+import com.apptolast.invernaderos.features.shared.domain.model.SortOrder
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+
+interface AlertHistoryQueryPort {
+    fun findTransitionsByAlertId(alertId: Long, tenantId: TenantId, order: SortOrder): List<AlertTransition>
+    fun findTransitions(query: AlertEventsQuery): PagedResult<AlertTransition>
+    fun findEpisodes(query: AlertEpisodesQuery): PagedResult<AlertEpisode>
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertRepositoryPort.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertRepositoryPort.kt
@@ -8,4 +8,5 @@ interface AlertRepositoryPort {
     fun findAllByTenantId(tenantId: TenantId): List<Alert>
     fun save(alert: Alert): Alert
     fun delete(id: Long, tenantId: TenantId): Boolean
+    fun countUnresolvedBySectorAndTenant(sectorId: Long, tenantId: TenantId): Long
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertStatsQueryPort.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/port/output/AlertStatsQueryPort.kt
@@ -1,0 +1,24 @@
+package com.apptolast.invernaderos.features.alert.domain.port.output
+
+import com.apptolast.invernaderos.features.alert.domain.model.ActiveDurationBucket
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStatsSummary
+import com.apptolast.invernaderos.features.alert.domain.model.ByActorBucket
+import com.apptolast.invernaderos.features.alert.domain.model.MttrBucket
+import com.apptolast.invernaderos.features.alert.domain.model.RecurrenceBucket
+import com.apptolast.invernaderos.features.alert.domain.model.TimeseriesDataPoint
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.ByActorStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesStatsQuery
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import java.time.Instant
+
+interface AlertStatsQueryPort {
+    fun recurrence(query: RecurrenceStatsQuery): List<RecurrenceBucket>
+    fun mttr(query: MttrStatsQuery): List<MttrBucket>
+    fun timeseries(query: TimeseriesStatsQuery): List<TimeseriesDataPoint>
+    fun activeDuration(query: ActiveDurationStatsQuery): List<ActiveDurationBucket>
+    fun byActor(query: ByActorStatsQuery): List<ByActorBucket>
+    fun summary(tenantId: TenantId, from: Instant, to: Instant): AlertStatsSummary
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/mapper/AlertHistoryMappers.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/mapper/AlertHistoryMappers.kt
@@ -1,0 +1,154 @@
+package com.apptolast.invernaderos.features.alert.dto.mapper
+
+import com.apptolast.invernaderos.features.alert.domain.model.ActiveDurationBucket
+import com.apptolast.invernaderos.features.alert.domain.model.AlertActor
+import com.apptolast.invernaderos.features.alert.domain.model.AlertEpisode
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStatsSummary
+import com.apptolast.invernaderos.features.alert.domain.model.AlertTransition
+import com.apptolast.invernaderos.features.alert.domain.model.ByActorBucket
+import com.apptolast.invernaderos.features.alert.domain.model.MttrBucket
+import com.apptolast.invernaderos.features.alert.domain.model.RecurrenceBucket
+import com.apptolast.invernaderos.features.alert.domain.model.TimeseriesDataPoint
+import com.apptolast.invernaderos.features.alert.dto.response.ActiveDurationBucketResponse
+import com.apptolast.invernaderos.features.alert.dto.response.AlertActorResponse
+import com.apptolast.invernaderos.features.alert.dto.response.AlertEpisodeResponse
+import com.apptolast.invernaderos.features.alert.dto.response.AlertStatsSummaryResponse
+import com.apptolast.invernaderos.features.alert.dto.response.AlertTransitionResponse
+import com.apptolast.invernaderos.features.alert.dto.response.ByActorBucketResponse
+import com.apptolast.invernaderos.features.alert.dto.response.MttrBucketResponse
+import com.apptolast.invernaderos.features.alert.dto.response.PagedResponse
+import com.apptolast.invernaderos.features.alert.dto.response.RecurrenceBucketResponse
+import com.apptolast.invernaderos.features.alert.dto.response.TimeseriesDataPointResponse
+import com.apptolast.invernaderos.features.shared.domain.model.PagedResult
+
+// --- AlertActor → AlertActorResponse ---
+
+fun AlertActor.toResponse(): AlertActorResponse = when (this) {
+    is AlertActor.User -> AlertActorResponse(
+        kind = "USER",
+        userId = userId,
+        username = username,
+        displayName = displayName,
+        ref = null,
+    )
+    is AlertActor.Device -> AlertActorResponse(
+        kind = "DEVICE",
+        userId = null,
+        username = null,
+        displayName = null,
+        ref = deviceRef,
+    )
+    AlertActor.System -> AlertActorResponse(
+        kind = "SYSTEM",
+        userId = null,
+        username = null,
+        displayName = null,
+        ref = null,
+    )
+}
+
+// --- AlertTransition → AlertTransitionResponse ---
+
+fun AlertTransition.toResponse() = AlertTransitionResponse(
+    transitionId = transitionId,
+    at = at,
+    fromResolved = fromResolved,
+    toResolved = toResolved,
+    source = source.name,
+    rawValue = rawValue,
+    actor = actor.toResponse(),
+    alertId = alertId,
+    alertCode = alertCode,
+    alertMessage = alertMessage,
+    alertTypeId = alertTypeId,
+    alertTypeName = alertTypeName,
+    severityId = severityId,
+    severityName = severityName,
+    severityLevel = severityLevel,
+    severityColor = severityColor,
+    sectorId = sectorId,
+    sectorCode = sectorCode,
+    greenhouseId = greenhouseId,
+    greenhouseName = greenhouseName,
+    tenantId = tenantId,
+    previousTransitionAt = previousTransitionAt,
+    episodeStartedAt = episodeStartedAt,
+    episodeDurationSeconds = episodeDurationSeconds,
+    occurrenceNumber = occurrenceNumber,
+    totalTransitionsSoFar = totalTransitionsSoFar,
+)
+
+// --- AlertEpisode → AlertEpisodeResponse ---
+
+fun AlertEpisode.toResponse() = AlertEpisodeResponse(
+    alertId = alertId,
+    alertCode = alertCode,
+    triggeredAt = triggeredAt,
+    resolvedAt = resolvedAt,
+    durationSeconds = durationSeconds,
+    triggerSource = triggerSource.name,
+    resolveSource = resolveSource?.name,
+    triggerActor = triggerActor.toResponse(),
+    resolveActor = resolveActor?.toResponse(),
+    severityId = severityId,
+    severityName = severityName,
+    sectorId = sectorId,
+    sectorCode = sectorCode,
+)
+
+// --- PagedResult → PagedResponse ---
+
+fun <T, R> PagedResult<T>.toResponse(mapper: (T) -> R) = PagedResponse(
+    items = items.map(mapper),
+    page = page,
+    size = size,
+    total = total,
+    hasMore = hasMore,
+)
+
+// --- Stats domain → response ---
+
+fun RecurrenceBucket.toResponse() = RecurrenceBucketResponse(
+    key = key,
+    label = label,
+    count = count,
+    lastSeenAt = lastSeenAt,
+)
+
+fun MttrBucket.toResponse() = MttrBucketResponse(
+    key = key,
+    label = label,
+    mttrSeconds = mttrSeconds,
+    p50Seconds = p50Seconds,
+    p95Seconds = p95Seconds,
+    p99Seconds = p99Seconds,
+    sampleSize = sampleSize,
+)
+
+fun TimeseriesDataPoint.toResponse() = TimeseriesDataPointResponse(
+    bucketStart = bucketStart,
+    key = key,
+    opened = opened,
+    closed = closed,
+)
+
+fun ActiveDurationBucket.toResponse() = ActiveDurationBucketResponse(
+    key = key,
+    label = label,
+    totalActiveSeconds = totalActiveSeconds,
+)
+
+fun ByActorBucket.toResponse() = ByActorBucketResponse(
+    actorUserId = actorUserId,
+    username = username,
+    displayName = displayName,
+    count = count,
+)
+
+fun AlertStatsSummary.toResponse() = AlertStatsSummaryResponse(
+    totalActiveNow = totalActiveNow,
+    openedToday = openedToday,
+    closedToday = closedToday,
+    mttrTodaySeconds = mttrTodaySeconds,
+    top3RecurrentCodesThisWeek = top3RecurrentCodesThisWeek,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/mapper/AlertMappers.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/mapper/AlertMappers.kt
@@ -3,6 +3,7 @@ package com.apptolast.invernaderos.features.alert.dto.mapper
 import com.apptolast.invernaderos.features.alert.Alert as AlertEntity
 import com.apptolast.invernaderos.features.alert.AlertStateChange as AlertStateChangeEntity
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertActor
 import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
 import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
 import com.apptolast.invernaderos.features.alert.domain.port.input.CreateAlertCommand
@@ -112,15 +113,34 @@ fun AlertStateChangeEntity.toDomain() = AlertStateChange(
     toResolved = toResolved,
     source = AlertSignalSource.valueOf(source),
     rawValue = rawValue,
-    at = at
+    at = at,
+    actor = when (actorKind) {
+        "USER" -> AlertActor.User(
+            userId = actorUserId ?: 0L,
+            username = null,        // hydrated by read adapter via JOIN; not available here
+            displayName = null,
+        )
+        "DEVICE" -> AlertActor.Device(deviceRef = actorRef)
+        else -> AlertActor.System
+    }
 )
 
-fun AlertStateChange.toEntity() = AlertStateChangeEntity(
-    id = id,
-    alertId = alertId,
-    fromResolved = fromResolved,
-    toResolved = toResolved,
-    source = source.name,
-    rawValue = rawValue,
-    at = at
-)
+fun AlertStateChange.toEntity(): AlertStateChangeEntity {
+    val (actorKind, actorUserId, actorRef) = when (val a = actor) {
+        is AlertActor.User -> Triple("USER", a.userId, null)
+        is AlertActor.Device -> Triple("DEVICE", null, a.deviceRef)
+        AlertActor.System -> Triple("SYSTEM", null, null)
+    }
+    return AlertStateChangeEntity(
+        id = id,
+        alertId = alertId,
+        fromResolved = fromResolved,
+        toResolved = toResolved,
+        source = source.name,
+        rawValue = rawValue,
+        at = at,
+        actorKind = actorKind,
+        actorUserId = actorUserId,
+        actorRef = actorRef,
+    )
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertReopenRequest.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertReopenRequest.kt
@@ -1,0 +1,9 @@
+package com.apptolast.invernaderos.features.alert.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request body for reopening a resolved alert")
+data class AlertReopenRequest(
+    @Schema(description = "ID of the user who is reopening the alert. Null = system actor.", example = "42")
+    val actorUserId: Long? = null,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/ActiveDurationBucketResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/ActiveDurationBucketResponse.kt
@@ -1,0 +1,10 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Total time an alert type (or sector) kept alerts active")
+data class ActiveDurationBucketResponse(
+    @Schema(description = "Group key") val key: String,
+    @Schema(description = "Human-readable label for the key") val label: String,
+    @Schema(description = "Sum of all episode durations in seconds") val totalActiveSeconds: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/AlertActorResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/AlertActorResponse.kt
@@ -1,0 +1,17 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Actor who triggered the alert state transition. Shape is flat for client convenience.")
+data class AlertActorResponse(
+    @Schema(description = "Actor kind: USER, DEVICE, or SYSTEM", example = "USER", allowableValues = ["USER", "DEVICE", "SYSTEM"])
+    val kind: String,
+    @Schema(description = "User ID — populated only when kind=USER", example = "42")
+    val userId: Long? = null,
+    @Schema(description = "Username — populated only when kind=USER and hydrated via JOIN", example = "john.doe")
+    val username: String? = null,
+    @Schema(description = "Display name — populated only when kind=USER and hydrated via JOIN", example = "John Doe")
+    val displayName: String? = null,
+    @Schema(description = "Free-form reference — populated only when kind=DEVICE", example = "gw-001")
+    val ref: String? = null,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/AlertEpisodeResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/AlertEpisodeResponse.kt
@@ -1,0 +1,21 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "An open→close pair for an alert (one activation cycle)")
+data class AlertEpisodeResponse(
+    @Schema(description = "Alert ID") val alertId: Long,
+    @Schema(description = "Alert code") val alertCode: String,
+    @Schema(description = "When the alert was activated (opened)") val triggeredAt: Instant,
+    @Schema(description = "When the alert was resolved (closed). Null if still open.") val resolvedAt: Instant?,
+    @Schema(description = "Episode duration in seconds. Null if still open.") val durationSeconds: Long?,
+    @Schema(description = "Signal source that opened this episode") val triggerSource: String,
+    @Schema(description = "Signal source that closed this episode. Null if still open.") val resolveSource: String?,
+    @Schema(description = "Actor who opened this episode") val triggerActor: AlertActorResponse,
+    @Schema(description = "Actor who closed this episode. Null if still open.") val resolveActor: AlertActorResponse?,
+    @Schema(description = "Severity ID") val severityId: Short?,
+    @Schema(description = "Severity name") val severityName: String?,
+    @Schema(description = "Sector ID") val sectorId: Long,
+    @Schema(description = "Sector code") val sectorCode: String?,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/AlertStatsSummaryResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/AlertStatsSummaryResponse.kt
@@ -1,0 +1,12 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Dashboard summary of alert statistics for a tenant")
+data class AlertStatsSummaryResponse(
+    @Schema(description = "Total number of alerts currently active (not resolved)") val totalActiveNow: Long,
+    @Schema(description = "Number of alerts opened today (UTC day)") val openedToday: Long,
+    @Schema(description = "Number of alerts closed today (UTC day)") val closedToday: Long,
+    @Schema(description = "Average time to resolve in seconds, calculated for today. Null if no episodes closed today.") val mttrTodaySeconds: Double?,
+    @Schema(description = "Top 3 most recurrent alert codes this week (last 7 days)") val top3RecurrentCodesThisWeek: List<String>,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/AlertTransitionResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/AlertTransitionResponse.kt
@@ -1,0 +1,34 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "A single alert state transition row, enriched with alert and physical context")
+data class AlertTransitionResponse(
+    @Schema(description = "Unique ID of this transition row") val transitionId: Long,
+    @Schema(description = "Timestamp when the transition occurred") val at: Instant,
+    @Schema(description = "Previous is_resolved value") val fromResolved: Boolean,
+    @Schema(description = "New is_resolved value") val toResolved: Boolean,
+    @Schema(description = "Signal source: MQTT, API, or SYSTEM") val source: String,
+    @Schema(description = "Raw MQTT payload value, null for API/SYSTEM transitions") val rawValue: String?,
+    @Schema(description = "Actor who caused this transition") val actor: AlertActorResponse,
+    @Schema(description = "Alert ID") val alertId: Long,
+    @Schema(description = "Alert code, e.g. ALT-00001") val alertCode: String,
+    @Schema(description = "Alert message") val alertMessage: String?,
+    @Schema(description = "Alert type ID") val alertTypeId: Short?,
+    @Schema(description = "Alert type name") val alertTypeName: String?,
+    @Schema(description = "Severity ID") val severityId: Short?,
+    @Schema(description = "Severity name") val severityName: String?,
+    @Schema(description = "Severity level (higher = more severe)") val severityLevel: Short?,
+    @Schema(description = "Severity display color") val severityColor: String?,
+    @Schema(description = "Sector ID") val sectorId: Long,
+    @Schema(description = "Sector code") val sectorCode: String?,
+    @Schema(description = "Greenhouse ID") val greenhouseId: Long?,
+    @Schema(description = "Greenhouse name") val greenhouseName: String?,
+    @Schema(description = "Tenant ID") val tenantId: Long,
+    @Schema(description = "Timestamp of the immediately previous transition for the same alert") val previousTransitionAt: Instant?,
+    @Schema(description = "Timestamp when the current episode started (i.e., when to_resolved flipped to false)") val episodeStartedAt: Instant?,
+    @Schema(description = "Duration of the current episode in seconds (only present on CLOSE transitions)") val episodeDurationSeconds: Long?,
+    @Schema(description = "How many times this alert has opened up to this transition") val occurrenceNumber: Long,
+    @Schema(description = "Total number of transitions for this alert up to this point") val totalTransitionsSoFar: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/ByActorBucketResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/ByActorBucketResponse.kt
@@ -1,0 +1,11 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Activity count per user actor (resolver or opener)")
+data class ByActorBucketResponse(
+    @Schema(description = "User ID of the actor") val actorUserId: Long,
+    @Schema(description = "Username of the actor") val username: String?,
+    @Schema(description = "Display name of the actor") val displayName: String?,
+    @Schema(description = "Number of transitions attributed to this actor in the time range") val count: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/MttrBucketResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/MttrBucketResponse.kt
@@ -1,0 +1,14 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Mean time to resolve (MTTR) statistics bucket")
+data class MttrBucketResponse(
+    @Schema(description = "Group key") val key: String,
+    @Schema(description = "Human-readable label for the key") val label: String,
+    @Schema(description = "Average MTTR in seconds") val mttrSeconds: Double,
+    @Schema(description = "50th percentile MTTR in seconds") val p50Seconds: Double,
+    @Schema(description = "95th percentile MTTR in seconds") val p95Seconds: Double,
+    @Schema(description = "99th percentile MTTR in seconds") val p99Seconds: Double,
+    @Schema(description = "Number of closed episodes used for this computation") val sampleSize: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/PagedResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/PagedResponse.kt
@@ -1,0 +1,12 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Generic paginated response wrapper")
+data class PagedResponse<T>(
+    @Schema(description = "Items on the current page") val items: List<T>,
+    @Schema(description = "Zero-based page index", example = "0") val page: Int,
+    @Schema(description = "Page size", example = "50") val size: Int,
+    @Schema(description = "Total number of items matching the query", example = "243") val total: Long,
+    @Schema(description = "True if there are more pages after this one") val hasMore: Boolean,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/RecurrenceBucketResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/RecurrenceBucketResponse.kt
@@ -1,0 +1,12 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "Recurrence statistics bucket: how many times an alert (by group) activated")
+data class RecurrenceBucketResponse(
+    @Schema(description = "Group key (e.g. alert code, severity name, sector ID)") val key: String,
+    @Schema(description = "Human-readable label for the key") val label: String,
+    @Schema(description = "Number of activations in the time range") val count: Long,
+    @Schema(description = "Most recent activation timestamp") val lastSeenAt: Instant,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/TimeseriesDataPointResponse.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/response/TimeseriesDataPointResponse.kt
@@ -1,0 +1,12 @@
+package com.apptolast.invernaderos.features.alert.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "One time-bucket + group data point for the alert timeseries chart")
+data class TimeseriesDataPointResponse(
+    @Schema(description = "Start of the time bucket (UTC)") val bucketStart: Instant,
+    @Schema(description = "Group key (severity name or type name depending on groupBy parameter)") val key: String,
+    @Schema(description = "Number of alerts opened in this bucket") val opened: Long,
+    @Schema(description = "Number of alerts closed in this bucket") val closed: Long,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertHistoryController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertHistoryController.kt
@@ -1,0 +1,216 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.input
+
+import com.apptolast.invernaderos.features.alert.AlertRepository
+import com.apptolast.invernaderos.features.alert.domain.model.TransitionKind
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEpisodesQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEventsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertEpisodesUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertHistoryUseCase
+import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
+import com.apptolast.invernaderos.features.alert.dto.response.AlertEpisodeResponse
+import com.apptolast.invernaderos.features.alert.dto.response.AlertTransitionResponse
+import com.apptolast.invernaderos.features.alert.dto.response.PagedResponse
+import com.apptolast.invernaderos.features.shared.domain.model.SortOrder
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+private const val DEFAULT_PAGE_SIZE = 50
+private const val MAX_PAGE_SIZE = 200
+private const val DEFAULT_PAGE = 0
+
+@RestController
+@RequestMapping("/api/v1/tenants/{tenantId}")
+@Tag(name = "Alert History", description = "Audit log of alert state transitions and episode pairs")
+class AlertHistoryController(
+    private val findHistoryUseCase: FindAlertHistoryUseCase,
+    private val findEpisodesUseCase: FindAlertEpisodesUseCase,
+    /**
+     * We inject the JPA repository directly here for the countUnresolved query.
+     * This count is a simple aggregate with no domain logic, and adding it to the
+     * domain port would bloat the port for a single infrastructure-convenience method.
+     */
+    private val alertJpaRepository: AlertRepository,
+) {
+
+    // -------------------------------------------------------------------
+    // GET /api/v1/tenants/{tenantId}/alerts/{alertId}/history
+    // -------------------------------------------------------------------
+
+    @GetMapping("/alerts/{alertId}/history")
+    @Operation(
+        summary = "Get full transition timeline for a single alert",
+        description = "Returns every state transition for the alert ordered by time. " +
+                "No pagination — the list for a single alert is always small.",
+    )
+    @ApiResponse(responseCode = "200", description = "Timeline returned (may be empty if alert not found or not owned by tenant)")
+    fun getAlertHistory(
+        @PathVariable tenantId: Long,
+        @PathVariable alertId: Long,
+        @Parameter(description = "Sort order for transitions: ASC (oldest first) or DESC (newest first)")
+        @RequestParam(defaultValue = "DESC") order: SortOrder,
+    ): ResponseEntity<List<AlertTransitionResponse>> {
+        val transitions = findHistoryUseCase.findTransitionsByAlertId(
+            alertId = alertId,
+            tenantId = TenantId(tenantId),
+            order = order,
+        )
+        return ResponseEntity.ok(transitions.map { it.toResponse() })
+    }
+
+    // -------------------------------------------------------------------
+    // GET /api/v1/tenants/{tenantId}/alert-events
+    // -------------------------------------------------------------------
+
+    @GetMapping("/alert-events")
+    @Operation(
+        summary = "Paginated tenant-wide feed of alert state transitions",
+        description = "This is the new \"Histórico\" feed. Each row represents one state change " +
+                "(open or close) across all alerts of the tenant. Supports rich filtering.",
+    )
+    @ApiResponse(responseCode = "200", description = "Paged list of transitions")
+    fun getAlertEvents(
+        @PathVariable tenantId: Long,
+        @Parameter(description = "Start of the time range (ISO-8601 UTC). Defaults to 30 days ago.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @Parameter(description = "End of the time range (ISO-8601 UTC). Defaults to now.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        @Parameter(description = "Filter by source. Comma-separated list of: MQTT, API, SYSTEM.")
+        @RequestParam(required = false) source: List<String>?,
+        @Parameter(description = "Filter by severity ID. Comma-separated list.")
+        @RequestParam(required = false) severityId: List<Short>?,
+        @Parameter(description = "Filter by alert type ID. Comma-separated list.")
+        @RequestParam(required = false) alertTypeId: List<Short>?,
+        @Parameter(description = "Filter by sector ID. Comma-separated list.")
+        @RequestParam(required = false) sectorId: List<Long>?,
+        @Parameter(description = "Filter by greenhouse ID. Comma-separated list.")
+        @RequestParam(required = false) greenhouseId: List<Long>?,
+        @Parameter(description = "Filter by alert code. Comma-separated list.")
+        @RequestParam(required = false) code: List<String>?,
+        @Parameter(description = "Filter by actor user ID. Comma-separated list.")
+        @RequestParam(required = false) actorUserId: List<Long>?,
+        @Parameter(description = "Transition kind filter: ANY, OPEN, CLOSE.")
+        @RequestParam(defaultValue = "ANY") transitionKind: TransitionKind,
+        @RequestParam(defaultValue = "$DEFAULT_PAGE") page: Int,
+        @RequestParam(defaultValue = "$DEFAULT_PAGE_SIZE") size: Int,
+    ): ResponseEntity<PagedResponse<AlertTransitionResponse>> {
+        val effectiveSize = size.coerceAtMost(MAX_PAGE_SIZE).coerceAtLeast(1)
+        val effectivePage = page.coerceAtLeast(0)
+        val effectiveFrom = from ?: Instant.now().minus(30, ChronoUnit.DAYS)
+        val effectiveTo = to ?: Instant.now()
+
+        val query = AlertEventsQuery(
+            tenantId = TenantId(tenantId),
+            from = effectiveFrom,
+            to = effectiveTo,
+            sources = source ?: emptyList(),
+            severityIds = severityId ?: emptyList(),
+            alertTypeIds = alertTypeId ?: emptyList(),
+            sectorIds = sectorId ?: emptyList(),
+            greenhouseIds = greenhouseId ?: emptyList(),
+            codes = code ?: emptyList(),
+            actorUserIds = actorUserId ?: emptyList(),
+            transitionKind = transitionKind,
+            page = effectivePage,
+            size = effectiveSize,
+        )
+
+        val result = findHistoryUseCase.findTransitions(query)
+        val response = PagedResponse(
+            items = result.items.map { it.toResponse() },
+            page = result.page,
+            size = result.size,
+            total = result.total,
+            hasMore = result.hasMore,
+        )
+        return ResponseEntity.ok(response)
+    }
+
+    // -------------------------------------------------------------------
+    // GET /api/v1/tenants/{tenantId}/alert-events/episodes
+    // -------------------------------------------------------------------
+
+    @GetMapping("/alert-events/episodes")
+    @Operation(
+        summary = "Paginated list of alert episodes (open→close pairs)",
+        description = "Each episode represents one activation cycle of an alert. " +
+                "An open episode (not yet closed) will have resolvedAt=null and durationSeconds=null.",
+    )
+    @ApiResponse(responseCode = "200", description = "Paged list of episodes")
+    fun getAlertEpisodes(
+        @PathVariable tenantId: Long,
+        @Parameter(description = "Start of the time range (ISO-8601 UTC). Defaults to 30 days ago.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @Parameter(description = "End of the time range (ISO-8601 UTC). Defaults to now.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        @Parameter(description = "Filter by severity ID. Comma-separated list.")
+        @RequestParam(required = false) severityId: List<Short>?,
+        @Parameter(description = "Filter by sector ID. Comma-separated list.")
+        @RequestParam(required = false) sectorId: List<Long>?,
+        @Parameter(description = "Filter by alert code. Comma-separated list.")
+        @RequestParam(required = false) code: List<String>?,
+        @Parameter(description = "When true, only return fully closed episodes (resolvedAt != null).")
+        @RequestParam(defaultValue = "false") onlyClosed: Boolean,
+        @RequestParam(defaultValue = "$DEFAULT_PAGE") page: Int,
+        @RequestParam(defaultValue = "$DEFAULT_PAGE_SIZE") size: Int,
+    ): ResponseEntity<PagedResponse<AlertEpisodeResponse>> {
+        val effectiveSize = size.coerceAtMost(MAX_PAGE_SIZE).coerceAtLeast(1)
+        val effectivePage = page.coerceAtLeast(0)
+        val effectiveFrom = from ?: Instant.now().minus(30, ChronoUnit.DAYS)
+        val effectiveTo = to ?: Instant.now()
+
+        val query = AlertEpisodesQuery(
+            tenantId = TenantId(tenantId),
+            from = effectiveFrom,
+            to = effectiveTo,
+            severityIds = severityId ?: emptyList(),
+            sectorIds = sectorId ?: emptyList(),
+            codes = code ?: emptyList(),
+            onlyClosed = onlyClosed,
+            page = effectivePage,
+            size = effectiveSize,
+        )
+
+        val result = findEpisodesUseCase.findEpisodes(query)
+        val response = PagedResponse(
+            items = result.items.map { it.toResponse() },
+            page = result.page,
+            size = result.size,
+            total = result.total,
+            hasMore = result.hasMore,
+        )
+        return ResponseEntity.ok(response)
+    }
+
+    // -------------------------------------------------------------------
+    // GET /api/v1/tenants/{tenantId}/alerts/count/unresolved/sector/{sectorId}
+    // -------------------------------------------------------------------
+
+    @GetMapping("/alerts/count/unresolved/sector/{sectorId}")
+    @Operation(
+        summary = "Count unresolved alerts for a specific sector",
+        description = "Returns the count of currently active (unresolved) alerts in the given sector " +
+                "scoped to the tenant. Eliminates the need for the client to load the full list and filter locally.",
+    )
+    @ApiResponse(responseCode = "200", description = "Count of unresolved alerts")
+    fun countUnresolvedBySector(
+        @PathVariable tenantId: Long,
+        @PathVariable sectorId: Long,
+    ): ResponseEntity<Map<String, Long>> {
+        // Verify sectorId belongs to the tenant by counting unresolved alerts that match both.
+        // The JPA repository already has the countBySectorIdAndIsResolvedFalse method.
+        val count = alertJpaRepository.countBySectorIdAndIsResolvedFalse(sectorId)
+        return ResponseEntity.ok(mapOf("count" to count))
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertHistoryController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertHistoryController.kt
@@ -1,9 +1,9 @@
 package com.apptolast.invernaderos.features.alert.infrastructure.adapter.input
 
-import com.apptolast.invernaderos.features.alert.AlertRepository
 import com.apptolast.invernaderos.features.alert.domain.model.TransitionKind
 import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEpisodesQuery
 import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEventsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.CountUnresolvedAlertsBySectorUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertEpisodesUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertHistoryUseCase
 import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
@@ -36,12 +36,7 @@ private const val DEFAULT_PAGE = 0
 class AlertHistoryController(
     private val findHistoryUseCase: FindAlertHistoryUseCase,
     private val findEpisodesUseCase: FindAlertEpisodesUseCase,
-    /**
-     * We inject the JPA repository directly here for the countUnresolved query.
-     * This count is a simple aggregate with no domain logic, and adding it to the
-     * domain port would bloat the port for a single infrastructure-convenience method.
-     */
-    private val alertJpaRepository: AlertRepository,
+    private val countUnresolvedBySectorUseCase: CountUnresolvedAlertsBySectorUseCase,
 ) {
 
     // -------------------------------------------------------------------
@@ -201,16 +196,17 @@ class AlertHistoryController(
     @Operation(
         summary = "Count unresolved alerts for a specific sector",
         description = "Returns the count of currently active (unresolved) alerts in the given sector " +
-                "scoped to the tenant. Eliminates the need for the client to load the full list and filter locally.",
+                "scoped to the tenant. Eliminates the need for the client to load the full list and filter locally. " +
+                "DESIGN: if the sectorId does not belong to the tenant in the path, this endpoint responds " +
+                "200 with count=0 (silent denial — does not leak whether the sector exists in another tenant). " +
+                "Callers must NOT use this endpoint to probe sector ownership.",
     )
-    @ApiResponse(responseCode = "200", description = "Count of unresolved alerts")
+    @ApiResponse(responseCode = "200", description = "Count of unresolved alerts (0 if sector not owned by tenant)")
     fun countUnresolvedBySector(
         @PathVariable tenantId: Long,
         @PathVariable sectorId: Long,
     ): ResponseEntity<Map<String, Long>> {
-        // Verify sectorId belongs to the tenant by counting unresolved alerts that match both.
-        // The JPA repository already has the countBySectorIdAndIsResolvedFalse method.
-        val count = alertJpaRepository.countBySectorIdAndIsResolvedFalse(sectorId)
+        val count = countUnresolvedBySectorUseCase.execute(sectorId, TenantId(tenantId))
         return ResponseEntity.ok(mapOf("count" to count))
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
@@ -28,6 +28,6 @@ class AlertRestInboundAdapter(
         resolveUseCase.resolve(id, tenantId, resolvedByUserId)
 
     @Transactional("metadataTransactionManager")
-    fun reopen(id: Long, tenantId: TenantId): Either<AlertError, Alert> =
-        resolveUseCase.reopen(id, tenantId)
+    fun reopen(id: Long, tenantId: TenantId, actorUserId: Long? = null): Either<AlertError, Alert> =
+        resolveUseCase.reopen(id, tenantId, actorUserId)
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertStatsController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertStatsController.kt
@@ -1,0 +1,250 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.input
+
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActorStatsRole
+import com.apptolast.invernaderos.features.alert.domain.model.query.ByActorStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertActiveDurationStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertByActorStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertMttrStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertRecurrenceStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertSummaryStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertTimeseriesStatsUseCase
+import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
+import com.apptolast.invernaderos.features.alert.dto.response.ActiveDurationBucketResponse
+import com.apptolast.invernaderos.features.alert.dto.response.AlertStatsSummaryResponse
+import com.apptolast.invernaderos.features.alert.dto.response.ByActorBucketResponse
+import com.apptolast.invernaderos.features.alert.dto.response.MttrBucketResponse
+import com.apptolast.invernaderos.features.alert.dto.response.RecurrenceBucketResponse
+import com.apptolast.invernaderos.features.alert.dto.response.TimeseriesDataPointResponse
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+private const val DEFAULT_RECURRENCE_LIMIT = 10
+
+@RestController
+@RequestMapping("/api/v1/tenants/{tenantId}/alerts/stats")
+@Tag(name = "Alert Statistics", description = "Derived statistics computed from the alert_state_changes audit log")
+class AlertStatsController(
+    private val recurrenceUseCase: AlertRecurrenceStatsUseCase,
+    private val mttrUseCase: AlertMttrStatsUseCase,
+    private val timeseriesUseCase: AlertTimeseriesStatsUseCase,
+    private val activeDurationUseCase: AlertActiveDurationStatsUseCase,
+    private val byActorUseCase: AlertByActorStatsUseCase,
+    private val summaryUseCase: AlertSummaryStatsUseCase,
+) {
+
+    // -------------------------------------------------------------------
+    // GET /recurrence
+    // -------------------------------------------------------------------
+
+    @GetMapping("/recurrence")
+    @Operation(
+        summary = "Alert recurrence ranking",
+        description = "Returns alerts ranked by how many times they activated within the time range. " +
+                "Useful for identifying the noisiest alerts.",
+    )
+    @ApiResponse(responseCode = "200", description = "List of recurrence buckets, sorted by count DESC")
+    fun recurrence(
+        @PathVariable tenantId: Long,
+        @Parameter(description = "Start of the time range (ISO-8601 UTC). Defaults to 30 days ago.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @Parameter(description = "End of the time range (ISO-8601 UTC). Defaults to now.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        @Parameter(description = "Grouping dimension: CODE, TYPE, SEVERITY, SECTOR, GREENHOUSE")
+        @RequestParam(defaultValue = "CODE") groupBy: RecurrenceGroupBy,
+        @Parameter(description = "Maximum number of buckets to return. Max 100.")
+        @RequestParam(defaultValue = "$DEFAULT_RECURRENCE_LIMIT") limit: Int,
+    ): ResponseEntity<List<RecurrenceBucketResponse>> {
+        val effectiveFrom = from ?: Instant.now().minus(30, ChronoUnit.DAYS)
+        val effectiveTo = to ?: Instant.now()
+        val effectiveLimit = limit.coerceIn(1, 100)
+
+        val query = RecurrenceStatsQuery(
+            tenantId = TenantId(tenantId),
+            from = effectiveFrom,
+            to = effectiveTo,
+            groupBy = groupBy,
+            limit = effectiveLimit,
+        )
+        return ResponseEntity.ok(recurrenceUseCase.execute(query).map { it.toResponse() })
+    }
+
+    // -------------------------------------------------------------------
+    // GET /mttr
+    // -------------------------------------------------------------------
+
+    @GetMapping("/mttr")
+    @Operation(
+        summary = "Mean time to resolve (MTTR) statistics",
+        description = "For each group, returns average MTTR and percentiles (p50, p95, p99) in seconds. " +
+                "Only considers fully closed episodes within the time range.",
+    )
+    @ApiResponse(responseCode = "200", description = "List of MTTR buckets, sorted by avg MTTR DESC")
+    fun mttr(
+        @PathVariable tenantId: Long,
+        @Parameter(description = "Start of the time range (ISO-8601 UTC). Defaults to 30 days ago.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @Parameter(description = "End of the time range (ISO-8601 UTC). Defaults to now.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        @Parameter(description = "Grouping dimension: SEVERITY, TYPE, SECTOR, CODE")
+        @RequestParam(defaultValue = "SEVERITY") groupBy: MttrGroupBy,
+    ): ResponseEntity<List<MttrBucketResponse>> {
+        val effectiveFrom = from ?: Instant.now().minus(30, ChronoUnit.DAYS)
+        val effectiveTo = to ?: Instant.now()
+
+        val query = MttrStatsQuery(
+            tenantId = TenantId(tenantId),
+            from = effectiveFrom,
+            to = effectiveTo,
+            groupBy = groupBy,
+        )
+        return ResponseEntity.ok(mttrUseCase.execute(query).map { it.toResponse() })
+    }
+
+    // -------------------------------------------------------------------
+    // GET /timeseries
+    // -------------------------------------------------------------------
+
+    @GetMapping("/timeseries")
+    @Operation(
+        summary = "Alert timeseries data",
+        description = "Returns opened and closed counts per time bucket per group. " +
+                "Use bucket=day for daily charts, bucket=hour for intraday drilldown.",
+    )
+    @ApiResponse(responseCode = "200", description = "List of (bucketStart, key, opened, closed) data points, sorted by time ASC")
+    fun timeseries(
+        @PathVariable tenantId: Long,
+        @Parameter(description = "Start of the time range (ISO-8601 UTC). Defaults to 30 days ago.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @Parameter(description = "End of the time range (ISO-8601 UTC). Defaults to now.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        @Parameter(description = "Bucket granularity: HOUR, DAY, WEEK, MONTH")
+        @RequestParam(defaultValue = "DAY") bucket: TimeseriesBucket,
+        @Parameter(description = "Grouping dimension: SEVERITY, TYPE")
+        @RequestParam(defaultValue = "SEVERITY") groupBy: TimeseriesGroupBy,
+    ): ResponseEntity<List<TimeseriesDataPointResponse>> {
+        val effectiveFrom = from ?: Instant.now().minus(30, ChronoUnit.DAYS)
+        val effectiveTo = to ?: Instant.now()
+
+        val query = TimeseriesStatsQuery(
+            tenantId = TenantId(tenantId),
+            from = effectiveFrom,
+            to = effectiveTo,
+            bucket = bucket,
+            groupBy = groupBy,
+        )
+        return ResponseEntity.ok(timeseriesUseCase.execute(query).map { it.toResponse() })
+    }
+
+    // -------------------------------------------------------------------
+    // GET /active-duration
+    // -------------------------------------------------------------------
+
+    @GetMapping("/active-duration")
+    @Operation(
+        summary = "Total active time per group",
+        description = "Sums the duration of all closed episodes per group (code or sector) " +
+                "to show which alerts kept systems degraded the longest.",
+    )
+    @ApiResponse(responseCode = "200", description = "List of active-duration buckets, sorted by total DESC")
+    fun activeDuration(
+        @PathVariable tenantId: Long,
+        @Parameter(description = "Start of the time range (ISO-8601 UTC). Defaults to 30 days ago.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @Parameter(description = "End of the time range (ISO-8601 UTC). Defaults to now.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        @Parameter(description = "Grouping dimension: CODE, SECTOR")
+        @RequestParam(defaultValue = "CODE") groupBy: ActiveDurationGroupBy,
+    ): ResponseEntity<List<ActiveDurationBucketResponse>> {
+        val effectiveFrom = from ?: Instant.now().minus(30, ChronoUnit.DAYS)
+        val effectiveTo = to ?: Instant.now()
+
+        val query = ActiveDurationStatsQuery(
+            tenantId = TenantId(tenantId),
+            from = effectiveFrom,
+            to = effectiveTo,
+            groupBy = groupBy,
+        )
+        return ResponseEntity.ok(activeDurationUseCase.execute(query).map { it.toResponse() })
+    }
+
+    // -------------------------------------------------------------------
+    // GET /by-actor
+    // -------------------------------------------------------------------
+
+    @GetMapping("/by-actor")
+    @Operation(
+        summary = "Alert activity ranked by user actor",
+        description = "Shows which users resolved (or opened) the most alerts in the time range. " +
+                "Only USER-kind actors appear; DEVICE and SYSTEM are excluded.",
+    )
+    @ApiResponse(responseCode = "200", description = "List of per-user activity counts, sorted by count DESC")
+    fun byActor(
+        @PathVariable tenantId: Long,
+        @Parameter(description = "Start of the time range (ISO-8601 UTC). Defaults to 30 days ago.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @Parameter(description = "End of the time range (ISO-8601 UTC). Defaults to now.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        @Parameter(description = "Which action to count: RESOLVER (closed alerts) or OPENER (opened alerts)")
+        @RequestParam(defaultValue = "RESOLVER") role: ActorStatsRole,
+    ): ResponseEntity<List<ByActorBucketResponse>> {
+        val effectiveFrom = from ?: Instant.now().minus(30, ChronoUnit.DAYS)
+        val effectiveTo = to ?: Instant.now()
+
+        val query = ByActorStatsQuery(
+            tenantId = TenantId(tenantId),
+            from = effectiveFrom,
+            to = effectiveTo,
+            role = role,
+        )
+        return ResponseEntity.ok(byActorUseCase.execute(query).map { it.toResponse() })
+    }
+
+    // -------------------------------------------------------------------
+    // GET /summary
+    // -------------------------------------------------------------------
+
+    @GetMapping("/summary")
+    @Operation(
+        summary = "Dashboard summary of alert statistics",
+        description = "Returns 5 pre-computed summary metrics for the tenant: " +
+                "totalActiveNow, openedToday, closedToday, mttrTodaySeconds, and the top 3 recurring alert codes this week. " +
+                "The from/to parameters currently only affect the top-3 codes sub-query; " +
+                "totalActiveNow and today metrics always use the current UTC day.",
+    )
+    @ApiResponse(responseCode = "200", description = "Summary object")
+    fun summary(
+        @PathVariable tenantId: Long,
+        @Parameter(description = "Start of the reference time range (ISO-8601 UTC). Defaults to 30 days ago.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @Parameter(description = "End of the reference time range (ISO-8601 UTC). Defaults to now.")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+    ): ResponseEntity<AlertStatsSummaryResponse> {
+        val effectiveFrom = from ?: Instant.now().minus(30, ChronoUnit.DAYS)
+        val effectiveTo = to ?: Instant.now()
+
+        return ResponseEntity.ok(
+            summaryUseCase.execute(TenantId(tenantId), effectiveFrom, effectiveTo).toResponse()
+        )
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
@@ -8,6 +8,7 @@ import com.apptolast.invernaderos.features.alert.domain.port.input.UpdateAlertUs
 import com.apptolast.invernaderos.features.alert.dto.mapper.toCommand
 import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
 import com.apptolast.invernaderos.features.alert.dto.request.AlertCreateRequest
+import com.apptolast.invernaderos.features.alert.dto.request.AlertReopenRequest
 import com.apptolast.invernaderos.features.alert.dto.request.AlertResolveRequest
 import com.apptolast.invernaderos.features.alert.dto.request.AlertUpdateRequest
 import com.apptolast.invernaderos.features.alert.dto.response.AlertResponse
@@ -152,9 +153,10 @@ class TenantAlertController(
     @Operation(summary = "Reabrir una alerta resuelta")
     fun reopen(
         @PathVariable tenantId: Long,
-        @PathVariable alertId: Long
+        @PathVariable alertId: Long,
+        @RequestBody(required = false) request: AlertReopenRequest?
     ): ResponseEntity<Any> {
-        return restInboundAdapter.reopen(alertId, TenantId(tenantId)).fold(
+        return restInboundAdapter.reopen(alertId, TenantId(tenantId), request?.actorUserId).fold(
             onLeft = { error ->
                 // reopen() can only emit NotFound or NotResolved.
                 // AlreadyResolved is reachable only from resolve() — handled in /resolve above.

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryJpaRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryJpaRepository.kt
@@ -1,0 +1,38 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.AlertStateChange
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+/**
+ * Spring Data JPA repository for alert_state_changes read-side queries.
+ *
+ * This repository is limited to ownership checks. All complex queries with window
+ * functions or dynamic WHERE clauses are handled in [AlertHistoryQueryAdapter]
+ * via the injected JdbcTemplate, which gives explicit control over the SQL and avoids
+ * the friction of mapping native query projections through Spring Data.
+ */
+@Repository
+interface AlertHistoryJpaRepository : JpaRepository<AlertStateChange, Long> {
+
+    /**
+     * Verify that an alert belongs to the given tenant before running the full
+     * per-alert timeline query. Cheap: uses the PK on alert_state_changes + PK on alerts.
+     */
+    @Query(
+        value = """
+            SELECT COUNT(*)
+              FROM metadata.alert_state_changes asc
+              JOIN metadata.alerts a ON a.id = asc.alert_id
+             WHERE asc.alert_id = :alertId
+               AND a.tenant_id = :tenantId
+        """,
+        nativeQuery = true
+    )
+    fun countByAlertIdAndTenantId(
+        @Param("alertId") alertId: Long,
+        @Param("tenantId") tenantId: Long,
+    ): Long
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapter.kt
@@ -14,6 +14,7 @@ import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
@@ -45,6 +46,7 @@ class AlertHistoryQueryAdapter(
     // findTransitionsByAlertId  — single-alert timeline
     // -------------------------------------------------------------------
 
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun findTransitionsByAlertId(
         alertId: Long,
         tenantId: TenantId,
@@ -67,6 +69,7 @@ class AlertHistoryQueryAdapter(
     // findTransitions — paginated tenant-wide feed
     // -------------------------------------------------------------------
 
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun findTransitions(query: AlertEventsQuery): PagedResult<AlertTransition> {
         val (whereClauses, params) = buildTransitionWhere(query)
         val countSql = countTransitionSql(whereClauses)
@@ -92,6 +95,7 @@ class AlertHistoryQueryAdapter(
     // findEpisodes — open→close pairs
     // -------------------------------------------------------------------
 
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun findEpisodes(query: AlertEpisodesQuery): PagedResult<AlertEpisode> {
         val (whereClauses, params) = buildEpisodesWhere(query)
 
@@ -103,11 +107,14 @@ class AlertHistoryQueryAdapter(
         """.trimIndent()
         val total = jdbc.queryForObject(countSql, Long::class.java, *params.toTypedArray()) ?: 0L
 
+        // SQL-safe: query.size is enforced by the use case to be in 1..200, query.page >= 0.
+        // Use Long arithmetic to avoid Int overflow on very large page numbers.
+        val safeOffset = (query.page.toLong() * query.size).toString()
         val dataSql = """
             $episodeCoreSql
             $whereClauses
             ORDER BY open_at DESC
-            LIMIT ${query.size} OFFSET ${query.page * query.size}
+            LIMIT ${query.size} OFFSET $safeOffset
         """.trimIndent()
 
         val items = jdbc.query(dataSql, ::mapEpisode, *params.toTypedArray())
@@ -163,8 +170,10 @@ class AlertHistoryQueryAdapter(
           LAG(asc.at)
             OVER (PARTITION BY asc.alert_id ORDER BY asc.at)
                                          AS previous_transition_at,
+          -- PG16 does not support LAST_VALUE(... IGNORE NULLS); use MAX over CASE
+          -- which naturally ignores NULLs and returns the most recent OPEN before this row.
           CASE WHEN asc.to_resolved = TRUE THEN
-            LAST_VALUE(CASE WHEN asc.to_resolved = FALSE THEN asc.at END IGNORE NULLS)
+            MAX(CASE WHEN asc.to_resolved = FALSE THEN asc.at END)
               OVER (PARTITION BY asc.alert_id ORDER BY asc.at
                     ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
           END                            AS episode_started_at,

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapter.kt
@@ -1,0 +1,431 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertActor
+import com.apptolast.invernaderos.features.alert.domain.model.AlertEpisode
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertTransition
+import com.apptolast.invernaderos.features.alert.domain.model.TransitionKind
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEpisodesQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEventsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertHistoryQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.PagedResult
+import com.apptolast.invernaderos.features.shared.domain.model.SortOrder
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Instant
+
+/**
+ * Read-side adapter for the alert history queries.
+ *
+ * All queries use [JdbcTemplate] against the metadata datasource because:
+ * 1. The per-alert timeline and the tenant-wide feed both use SQL window functions
+ *    (LAG, LAST_VALUE, ROW_NUMBER) which Spring Data JPA cannot express through JPQL.
+ * 2. Dynamic WHERE clauses (up to 8 optional filters) are far cleaner to build with
+ *    a StringBuilder + param list than through JPA Criteria or QueryDSL.
+ *
+ * The [AlertHistoryJpaRepository] is only used for the cheap tenant-ownership check.
+ *
+ * Design note for the single-row WebSocket path:
+ * Instead of calling [findTransitionsByAlertId] for one row on every state change event
+ * (which pays the full window-function cost), [AlertStateChangedWebSocketListener]
+ * constructs the [AlertTransition] directly from the event payload plus a one-row
+ * users-table lookup. This adapter does not expose a "get one" method deliberately.
+ */
+@Component
+class AlertHistoryQueryAdapter(
+    @Qualifier("metadataJdbcTemplate") private val jdbc: JdbcTemplate,
+    private val jpaRepository: AlertHistoryJpaRepository,
+) : AlertHistoryQueryPort {
+
+    // -------------------------------------------------------------------
+    // findTransitionsByAlertId  — single-alert timeline
+    // -------------------------------------------------------------------
+
+    override fun findTransitionsByAlertId(
+        alertId: Long,
+        tenantId: TenantId,
+        order: SortOrder,
+    ): List<AlertTransition> {
+        // Ownership check: if no rows → either no such alert or it belongs to another tenant.
+        if (jpaRepository.countByAlertIdAndTenantId(alertId, tenantId.value) == 0L) return emptyList()
+
+        val orderDir = if (order == SortOrder.ASC) "ASC" else "DESC"
+        val sql = transitionSql(
+            extraWhere = "AND asc.alert_id = ?",
+            orderDir = orderDir,
+            limit = "ALL",
+            offset = "0",
+        )
+        return jdbc.query(sql, ::mapTransition, tenantId.value, Timestamp.from(Instant.EPOCH), Timestamp.from(FAR_FUTURE), alertId)
+    }
+
+    // -------------------------------------------------------------------
+    // findTransitions — paginated tenant-wide feed
+    // -------------------------------------------------------------------
+
+    override fun findTransitions(query: AlertEventsQuery): PagedResult<AlertTransition> {
+        val (whereClauses, params) = buildTransitionWhere(query)
+        val countSql = countTransitionSql(whereClauses)
+        val total = jdbc.queryForObject(countSql, Long::class.java, *params.toTypedArray()) ?: 0L
+
+        val dataSql = transitionSql(
+            extraWhere = whereClauses,
+            orderDir = "DESC",
+            limit = query.size.toString(),
+            offset = (query.page * query.size).toString(),
+        )
+        val items = jdbc.query(dataSql, ::mapTransition, *params.toTypedArray())
+        return PagedResult(
+            items = items,
+            page = query.page,
+            size = query.size,
+            total = total,
+            hasMore = (query.page.toLong() + 1) * query.size < total,
+        )
+    }
+
+    // -------------------------------------------------------------------
+    // findEpisodes — open→close pairs
+    // -------------------------------------------------------------------
+
+    override fun findEpisodes(query: AlertEpisodesQuery): PagedResult<AlertEpisode> {
+        val (whereClauses, params) = buildEpisodesWhere(query)
+
+        val countSql = """
+            SELECT COUNT(*) FROM (
+              $episodeCoreSql
+              $whereClauses
+            ) ep
+        """.trimIndent()
+        val total = jdbc.queryForObject(countSql, Long::class.java, *params.toTypedArray()) ?: 0L
+
+        val dataSql = """
+            $episodeCoreSql
+            $whereClauses
+            ORDER BY open_at DESC
+            LIMIT ${query.size} OFFSET ${query.page * query.size}
+        """.trimIndent()
+
+        val items = jdbc.query(dataSql, ::mapEpisode, *params.toTypedArray())
+        return PagedResult(
+            items = items,
+            page = query.page,
+            size = query.size,
+            total = total,
+            hasMore = (query.page.toLong() + 1) * query.size < total,
+        )
+    }
+
+    // -------------------------------------------------------------------
+    // SQL helpers
+    // -------------------------------------------------------------------
+
+    /**
+     * Core window-function query for alert transitions.
+     * Parameters (in order): tenantId, fromInstant, toInstant, [extraWhere params...]
+     */
+    private fun transitionSql(
+        extraWhere: String,
+        orderDir: String,
+        limit: String,
+        offset: String,
+    ): String = """
+        SELECT
+          asc.id                         AS transition_id,
+          asc.at,
+          asc.from_resolved,
+          asc.to_resolved,
+          asc.source,
+          asc.raw_value,
+          asc.actor_kind,
+          asc.actor_user_id,
+          asc.actor_ref,
+          u.username,
+          u.display_name,
+          a.id                           AS alert_id,
+          a.code                         AS alert_code,
+          a.message                      AS alert_message,
+          a.alert_type_id,
+          a.severity_id,
+          a.sector_id,
+          a.tenant_id,
+          at2.name                       AS alert_type_name,
+          sev.name                       AS severity_name,
+          sev.level                      AS severity_level,
+          sev.color                      AS severity_color,
+          sec.code                       AS sector_code,
+          sec.greenhouse_id,
+          g.name                         AS greenhouse_name,
+          LAG(asc.at)
+            OVER (PARTITION BY asc.alert_id ORDER BY asc.at)
+                                         AS previous_transition_at,
+          CASE WHEN asc.to_resolved = TRUE THEN
+            LAST_VALUE(CASE WHEN asc.to_resolved = FALSE THEN asc.at END IGNORE NULLS)
+              OVER (PARTITION BY asc.alert_id ORDER BY asc.at
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+          END                            AS episode_started_at,
+          NULLIF(
+            COUNT(*) FILTER (WHERE asc.to_resolved = FALSE)
+              OVER (PARTITION BY asc.alert_id ORDER BY asc.at
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+            0
+          )                              AS occurrence_number,
+          ROW_NUMBER()
+            OVER (PARTITION BY asc.alert_id ORDER BY asc.at)
+                                         AS total_transitions_so_far
+        FROM metadata.alert_state_changes asc
+        JOIN metadata.alerts a      ON a.id = asc.alert_id
+        LEFT JOIN metadata.users u  ON u.id = asc.actor_user_id
+        LEFT JOIN metadata.alert_types at2  ON at2.id = a.alert_type_id
+        LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
+        LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
+        LEFT JOIN metadata.greenhouses g ON g.id = sec.greenhouse_id
+        WHERE a.tenant_id = ?
+          AND asc.at >= ?
+          AND asc.at < ?
+          $extraWhere
+        ORDER BY asc.at $orderDir
+        LIMIT $limit OFFSET $offset
+    """.trimIndent()
+
+    private fun countTransitionSql(whereClauses: String): String = """
+        SELECT COUNT(*)
+          FROM metadata.alert_state_changes asc
+          JOIN metadata.alerts a      ON a.id = asc.alert_id
+          LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
+         WHERE a.tenant_id = ?
+           AND asc.at >= ?
+           AND asc.at < ?
+           $whereClauses
+    """.trimIndent()
+
+    /**
+     * Builds the extra WHERE fragment and associated positional parameters for [findTransitions].
+     * Returns the clauses string (beginning with AND if non-empty or empty string) and params list.
+     * The fixed params (tenantId, from, to) are always first in the returned list.
+     */
+    private fun buildTransitionWhere(query: AlertEventsQuery): Pair<String, MutableList<Any>> {
+        val clauses = StringBuilder()
+        val params = mutableListOf<Any>(
+            query.tenantId.value,
+            Timestamp.from(query.from),
+            Timestamp.from(query.to),
+        )
+
+        if (query.sources.isNotEmpty()) {
+            clauses.append(" AND asc.source = ANY(?::VARCHAR[])")
+            params.add(query.sources.toTypedArray<String>().joinToPostgresArray())
+        }
+        if (query.severityIds.isNotEmpty()) {
+            clauses.append(" AND a.severity_id = ANY(?::SMALLINT[])")
+            params.add(query.severityIds.joinToString(",", "{", "}"))
+        }
+        if (query.alertTypeIds.isNotEmpty()) {
+            clauses.append(" AND a.alert_type_id = ANY(?::SMALLINT[])")
+            params.add(query.alertTypeIds.joinToString(",", "{", "}"))
+        }
+        if (query.sectorIds.isNotEmpty()) {
+            clauses.append(" AND a.sector_id = ANY(?::BIGINT[])")
+            params.add(query.sectorIds.joinToString(",", "{", "}"))
+        }
+        if (query.greenhouseIds.isNotEmpty()) {
+            clauses.append(" AND sec.greenhouse_id = ANY(?::BIGINT[])")
+            params.add(query.greenhouseIds.joinToString(",", "{", "}"))
+        }
+        if (query.codes.isNotEmpty()) {
+            clauses.append(" AND a.code = ANY(?::VARCHAR[])")
+            params.add(query.codes.toTypedArray<String>().joinToPostgresArray())
+        }
+        if (query.actorUserIds.isNotEmpty()) {
+            clauses.append(" AND asc.actor_user_id = ANY(?::BIGINT[])")
+            params.add(query.actorUserIds.joinToString(",", "{", "}"))
+        }
+        when (query.transitionKind) {
+            TransitionKind.OPEN -> clauses.append(" AND asc.to_resolved = FALSE")
+            TransitionKind.CLOSE -> clauses.append(" AND asc.to_resolved = TRUE")
+            TransitionKind.ANY -> { /* no clause */ }
+        }
+
+        return Pair(clauses.toString(), params)
+    }
+
+    private val episodeCoreSql: String = """
+        SELECT
+          a.id                        AS alert_id,
+          a.code                      AS alert_code,
+          open_asc.at                 AS open_at,
+          close_asc.at                AS close_at,
+          EXTRACT(EPOCH FROM (close_asc.at - open_asc.at))::BIGINT
+                                      AS duration_seconds,
+          open_asc.source             AS trigger_source,
+          close_asc.source            AS resolve_source,
+          open_asc.actor_kind         AS trigger_actor_kind,
+          open_asc.actor_user_id      AS trigger_actor_user_id,
+          open_asc.actor_ref          AS trigger_actor_ref,
+          open_u.username             AS trigger_username,
+          open_u.display_name         AS trigger_display_name,
+          close_asc.actor_kind        AS resolve_actor_kind,
+          close_asc.actor_user_id     AS resolve_actor_user_id,
+          close_asc.actor_ref         AS resolve_actor_ref,
+          close_u.username            AS resolve_username,
+          close_u.display_name        AS resolve_display_name,
+          a.severity_id,
+          sev.name                    AS severity_name,
+          a.sector_id,
+          sec.code                    AS sector_code
+        FROM (
+          SELECT alert_id, at, source, actor_kind, actor_user_id, actor_ref,
+                 LEAD(id) OVER (PARTITION BY alert_id ORDER BY at)  AS next_id
+            FROM metadata.alert_state_changes
+           WHERE to_resolved = FALSE
+        ) open_asc
+        JOIN metadata.alert_state_changes close_asc
+          ON close_asc.id = open_asc.next_id
+         AND close_asc.to_resolved = TRUE
+        JOIN metadata.alerts a ON a.id = open_asc.alert_id
+        LEFT JOIN metadata.users open_u  ON open_u.id  = open_asc.actor_user_id
+        LEFT JOIN metadata.users close_u ON close_u.id = close_asc.actor_user_id
+        LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
+        LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
+    """.trimIndent()
+
+    private fun buildEpisodesWhere(query: AlertEpisodesQuery): Pair<String, MutableList<Any>> {
+        val clauses = StringBuilder("WHERE a.tenant_id = ? AND open_asc.at >= ? AND open_asc.at < ?")
+        val params = mutableListOf<Any>(
+            query.tenantId.value,
+            Timestamp.from(query.from),
+            Timestamp.from(query.to),
+        )
+
+        if (query.severityIds.isNotEmpty()) {
+            clauses.append(" AND a.severity_id = ANY(?::SMALLINT[])")
+            params.add(query.severityIds.joinToString(",", "{", "}"))
+        }
+        if (query.sectorIds.isNotEmpty()) {
+            clauses.append(" AND a.sector_id = ANY(?::BIGINT[])")
+            params.add(query.sectorIds.joinToString(",", "{", "}"))
+        }
+        if (query.codes.isNotEmpty()) {
+            clauses.append(" AND a.code = ANY(?::VARCHAR[])")
+            params.add(query.codes.toTypedArray<String>().joinToPostgresArray())
+        }
+        if (query.onlyClosed) {
+            clauses.append(" AND close_asc.at IS NOT NULL")
+        }
+
+        return Pair(clauses.toString(), params)
+    }
+
+    // -------------------------------------------------------------------
+    // Row mappers
+    // -------------------------------------------------------------------
+
+    private fun mapTransition(rs: ResultSet, @Suppress("UNUSED_PARAMETER") rowNum: Int): AlertTransition {
+        val actorKind = rs.getString("actor_kind") ?: "SYSTEM"
+        val actorUserId = rs.getLong("actor_user_id").takeIf { !rs.wasNull() }
+        val actorRef = rs.getString("actor_ref")
+        val username = rs.getString("username")
+        val displayName = rs.getString("display_name")
+        val actor: AlertActor = when (actorKind) {
+            "USER" -> AlertActor.User(
+                userId = actorUserId ?: 0L,
+                username = username,
+                displayName = displayName,
+            )
+            "DEVICE" -> AlertActor.Device(deviceRef = actorRef)
+            else -> AlertActor.System
+        }
+
+        val episodeStartedAt = rs.getTimestamp("episode_started_at")?.toInstant()
+        val previousTransitionAt = rs.getTimestamp("previous_transition_at")?.toInstant()
+        val episodeDurationSeconds: Long? = if (episodeStartedAt != null) {
+            val closedAt = rs.getTimestamp("at").toInstant()
+            closedAt.epochSecond - episodeStartedAt.epochSecond
+        } else null
+
+        return AlertTransition(
+            transitionId = rs.getLong("transition_id"),
+            at = rs.getTimestamp("at").toInstant(),
+            fromResolved = rs.getBoolean("from_resolved"),
+            toResolved = rs.getBoolean("to_resolved"),
+            source = AlertSignalSource.valueOf(rs.getString("source")),
+            rawValue = rs.getString("raw_value"),
+            actor = actor,
+            alertId = rs.getLong("alert_id"),
+            alertCode = rs.getString("alert_code"),
+            alertMessage = rs.getString("alert_message"),
+            alertTypeId = rs.getShort("alert_type_id").takeIf { !rs.wasNull() },
+            alertTypeName = rs.getString("alert_type_name"),
+            severityId = rs.getShort("severity_id").takeIf { !rs.wasNull() },
+            severityName = rs.getString("severity_name"),
+            severityLevel = rs.getShort("severity_level").takeIf { !rs.wasNull() },
+            severityColor = rs.getString("severity_color"),
+            sectorId = rs.getLong("sector_id"),
+            sectorCode = rs.getString("sector_code"),
+            greenhouseId = rs.getLong("greenhouse_id").takeIf { !rs.wasNull() },
+            greenhouseName = rs.getString("greenhouse_name"),
+            tenantId = rs.getLong("tenant_id"),
+            previousTransitionAt = previousTransitionAt,
+            episodeStartedAt = episodeStartedAt,
+            episodeDurationSeconds = episodeDurationSeconds,
+            occurrenceNumber = rs.getLong("occurrence_number").takeIf { !rs.wasNull() } ?: 0L,
+            totalTransitionsSoFar = rs.getLong("total_transitions_so_far"),
+        )
+    }
+
+    private fun mapEpisode(rs: ResultSet, @Suppress("UNUSED_PARAMETER") rowNum: Int): AlertEpisode {
+        fun actorFrom(kind: String?, userId: Long?, ref: String?, username: String?, displayName: String?): AlertActor =
+            when (kind) {
+                "USER" -> AlertActor.User(userId = userId ?: 0L, username = username, displayName = displayName)
+                "DEVICE" -> AlertActor.Device(deviceRef = ref)
+                else -> AlertActor.System
+            }
+
+        val triggerActor = actorFrom(
+            rs.getString("trigger_actor_kind"),
+            rs.getLong("trigger_actor_user_id").takeIf { !rs.wasNull() },
+            rs.getString("trigger_actor_ref"),
+            rs.getString("trigger_username"),
+            rs.getString("trigger_display_name"),
+        )
+        val resolveActorKind = rs.getString("resolve_actor_kind")
+        val resolveActor: AlertActor? = if (resolveActorKind != null) {
+            actorFrom(
+                resolveActorKind,
+                rs.getLong("resolve_actor_user_id").takeIf { !rs.wasNull() },
+                rs.getString("resolve_actor_ref"),
+                rs.getString("resolve_username"),
+                rs.getString("resolve_display_name"),
+            )
+        } else null
+
+        val resolveSourceStr = rs.getString("resolve_source")
+        return AlertEpisode(
+            alertId = rs.getLong("alert_id"),
+            alertCode = rs.getString("alert_code"),
+            triggeredAt = rs.getTimestamp("open_at").toInstant(),
+            resolvedAt = rs.getTimestamp("close_at")?.toInstant(),
+            durationSeconds = rs.getLong("duration_seconds").takeIf { !rs.wasNull() },
+            triggerSource = AlertSignalSource.valueOf(rs.getString("trigger_source")),
+            resolveSource = resolveSourceStr?.let { AlertSignalSource.valueOf(it) },
+            triggerActor = triggerActor,
+            resolveActor = resolveActor,
+            severityId = rs.getShort("severity_id").takeIf { !rs.wasNull() },
+            severityName = rs.getString("severity_name"),
+            sectorId = rs.getLong("sector_id"),
+            sectorCode = rs.getString("sector_code"),
+        )
+    }
+
+    companion object {
+        /** Far-future sentinel used when the caller doesn't specify a time window. */
+        private val FAR_FUTURE: Instant = Instant.parse("2099-01-01T00:00:00Z")
+
+        private fun Array<String>.joinToPostgresArray(): String =
+            joinToString(",", "{", "}")
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapter.kt
@@ -37,4 +37,8 @@ class AlertRepositoryAdapter(
         jpaRepository.delete(entity)
         return true
     }
+
+    override fun countUnresolvedBySectorAndTenant(sectorId: Long, tenantId: TenantId): Long {
+        return jpaRepository.countByTenantIdAndSectorIdAndIsResolvedFalse(tenantId.value, sectorId)
+    }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedWebSocketListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedWebSocketListener.kt
@@ -1,0 +1,71 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertTransition
+import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
+import org.slf4j.LoggerFactory
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * Listens for [AlertStateChangedEvent] and broadcasts a lightweight [AlertTransition]-derived
+ * payload to the WebSocket topic `/topic/tenant/{tenantId}/alerts` after the transaction commits.
+ *
+ * Design rationale for the single-row construction approach:
+ * Re-querying the database for the full window-function projection on every state change would
+ * pay the cost of the window query (LAG, LAST_VALUE, ROW_NUMBER over all transitions for that
+ * alert) for what is effectively a single-row push. Instead, we build an [AlertTransition]
+ * directly from the in-memory event payload. The window fields (previousTransitionAt,
+ * episodeStartedAt, episodeDurationSeconds, occurrenceNumber, totalTransitionsSoFar) are
+ * left as best-effort defaults — the UI can request the full history endpoint if it needs
+ * precise window values. This keeps the WS broadcast O(1) database cost.
+ */
+@Component
+class AlertStateChangedWebSocketListener(
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onAlertStateChanged(event: AlertStateChangedEvent) {
+        val alert = event.alert
+        val change = event.change
+
+        val transition = AlertTransition(
+            transitionId = change.id ?: 0L,
+            at = change.at,
+            fromResolved = change.fromResolved,
+            toResolved = change.toResolved,
+            source = change.source,
+            rawValue = change.rawValue,
+            actor = change.actor,
+            alertId = alert.id ?: 0L,
+            alertCode = alert.code,
+            alertMessage = alert.message,
+            alertTypeId = alert.alertTypeId,
+            alertTypeName = alert.alertTypeName,
+            severityId = alert.severityId,
+            severityName = alert.severityName,
+            severityLevel = alert.severityLevel,
+            severityColor = null,           // not available on domain Alert; enriched on read path
+            sectorId = alert.sectorId.value,
+            sectorCode = alert.sectorCode,
+            greenhouseId = null,            // not available on domain Alert; enriched on read path
+            greenhouseName = null,
+            tenantId = alert.tenantId.value,
+            previousTransitionAt = null,    // window value — not recomputed here; see class javadoc
+            episodeStartedAt = null,
+            episodeDurationSeconds = null,
+            occurrenceNumber = 0L,
+            totalTransitionsSoFar = 0L,
+        )
+
+        val topic = "/topic/tenant/${alert.tenantId.value}/alerts"
+        logger.debug(
+            "Broadcasting AlertStateChangedEvent to {} — alertId={}, toResolved={}",
+            topic, alert.id, change.toResolved
+        )
+        messagingTemplate.convertAndSend(topic, transition.toResponse())
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedWebSocketListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStateChangedWebSocketListener.kt
@@ -57,8 +57,10 @@ class AlertStateChangedWebSocketListener(
             previousTransitionAt = null,    // window value — not recomputed here; see class javadoc
             episodeStartedAt = null,
             episodeDurationSeconds = null,
-            occurrenceNumber = 0L,
-            totalTransitionsSoFar = 0L,
+            // Sentinel >= 1: this very transition is the most recent one.
+            // Real exact counts are available via GET /alerts/{id}/history.
+            occurrenceNumber = if (!change.toResolved) 1L else 0L,
+            totalTransitionsSoFar = 1L,
         )
 
         val topic = "/topic/tenant/${alert.tenantId.value}/alerts"

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapter.kt
@@ -22,6 +22,7 @@ import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.ZoneOffset
@@ -41,7 +42,10 @@ class AlertStatsQueryAdapter(
     // recurrence
     // -------------------------------------------------------------------
 
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun recurrence(query: RecurrenceStatsQuery): List<RecurrenceBucket> {
+        // SQL-safe: groupByCol/labelCol are derived from a closed enum (RecurrenceGroupBy)
+        // via recurrenceGroupByColumns(). No external input flows into the SQL string.
         val (groupByCol, labelCol) = recurrenceGroupByColumns(query.groupBy)
         val sql = """
             SELECT $groupByCol AS key, $labelCol AS label,
@@ -91,7 +95,9 @@ class AlertStatsQueryAdapter(
     // mttr
     // -------------------------------------------------------------------
 
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun mttr(query: MttrStatsQuery): List<MttrBucket> {
+        // SQL-safe: groupByCol/labelCol come from a closed enum (MttrGroupBy).
         val (groupByCol, labelCol) = mttrGroupByColumns(query.groupBy)
         val sql = """
             SELECT $groupByCol AS key, $labelCol AS label,
@@ -153,7 +159,9 @@ class AlertStatsQueryAdapter(
     // timeseries
     // -------------------------------------------------------------------
 
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun timeseries(query: TimeseriesStatsQuery): List<TimeseriesDataPoint> {
+        // SQL-safe: truncUnit and groupByCol come from closed enums (TimeseriesBucket, TimeseriesGroupBy).
         val truncUnit = when (query.bucket) {
             TimeseriesBucket.HOUR -> "hour"
             TimeseriesBucket.DAY -> "day"
@@ -202,7 +210,9 @@ class AlertStatsQueryAdapter(
     // activeDuration
     // -------------------------------------------------------------------
 
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun activeDuration(query: ActiveDurationStatsQuery): List<ActiveDurationBucket> {
+        // SQL-safe: groupByCol/labelCol come from a closed enum (ActiveDurationGroupBy).
         val (groupByCol, labelCol) = activeDurationGroupByColumns(query.groupBy)
         val sql = """
             SELECT $groupByCol AS key, $labelCol AS label,
@@ -248,6 +258,7 @@ class AlertStatsQueryAdapter(
     // byActor
     // -------------------------------------------------------------------
 
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun byActor(query: ByActorStatsQuery): List<ByActorBucket> {
         val toResolved = query.role == ActorStatsRole.RESOLVER
         val sql = """
@@ -287,9 +298,15 @@ class AlertStatsQueryAdapter(
     // summary
     // -------------------------------------------------------------------
 
+    /**
+     * Summary across 5 sub-queries. The `from`/`to` parameters are intentionally ignored
+     * here: the summary is always "today" + "this week" by contract. The port signature
+     * keeps them for API symmetry but they may be removed in a follow-up.
+     */
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun summary(tenantId: TenantId, from: Instant, to: Instant): AlertStatsSummary {
         val todayStart = ZonedDateTime.now(ZoneOffset.UTC).toLocalDate().atStartOfDay(ZoneOffset.UTC).toInstant()
-        val todayEnd = todayStart.plusSeconds(86400)
+        val todayEnd = ZonedDateTime.ofInstant(todayStart, ZoneOffset.UTC).plusDays(1).toInstant()
         val weekStart = ZonedDateTime.now(ZoneOffset.UTC).toLocalDate()
             .minusDays(6).atStartOfDay(ZoneOffset.UTC).toInstant()
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapter.kt
@@ -1,0 +1,356 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.domain.model.ActiveDurationBucket
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStatsSummary
+import com.apptolast.invernaderos.features.alert.domain.model.ByActorBucket
+import com.apptolast.invernaderos.features.alert.domain.model.MttrBucket
+import com.apptolast.invernaderos.features.alert.domain.model.RecurrenceBucket
+import com.apptolast.invernaderos.features.alert.domain.model.TimeseriesDataPoint
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActorStatsRole
+import com.apptolast.invernaderos.features.alert.domain.model.query.ByActorStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+/**
+ * Statistics adapter. Uses [JdbcTemplate] against the metadata (Postgres) datasource.
+ * All functions are read-only. We do not use Timescale `time_bucket` because
+ * `alert_state_changes` is a plain Postgres table, not a hypertable.
+ */
+@Component
+class AlertStatsQueryAdapter(
+    @Qualifier("metadataJdbcTemplate") private val jdbc: JdbcTemplate,
+) : AlertStatsQueryPort {
+
+    // -------------------------------------------------------------------
+    // recurrence
+    // -------------------------------------------------------------------
+
+    override fun recurrence(query: RecurrenceStatsQuery): List<RecurrenceBucket> {
+        val (groupByCol, labelCol) = recurrenceGroupByColumns(query.groupBy)
+        val sql = """
+            SELECT $groupByCol AS key, $labelCol AS label,
+                   COUNT(*) AS cnt,
+                   MAX(asc.at) AS last_seen_at
+              FROM metadata.alert_state_changes asc
+              JOIN metadata.alerts a      ON a.id = asc.alert_id
+              LEFT JOIN metadata.alert_types at2  ON at2.id = a.alert_type_id
+              LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
+              LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
+              LEFT JOIN metadata.greenhouses g ON g.id = sec.greenhouse_id
+             WHERE a.tenant_id = ?
+               AND asc.to_resolved = FALSE
+               AND asc.at >= ?
+               AND asc.at < ?
+             GROUP BY key, label
+             ORDER BY cnt DESC
+             LIMIT ?
+        """.trimIndent()
+
+        return jdbc.query(sql,
+            { rs, _ ->
+                RecurrenceBucket(
+                    key = rs.getString("key") ?: "unknown",
+                    label = rs.getString("label") ?: "unknown",
+                    count = rs.getLong("cnt"),
+                    lastSeenAt = rs.getTimestamp("last_seen_at").toInstant(),
+                )
+            },
+            query.tenantId.value,
+            Timestamp.from(query.from),
+            Timestamp.from(query.to),
+            query.limit,
+        )
+    }
+
+    private fun recurrenceGroupByColumns(groupBy: RecurrenceGroupBy): Pair<String, String> =
+        when (groupBy) {
+            RecurrenceGroupBy.CODE -> Pair("a.code", "a.code")
+            RecurrenceGroupBy.TYPE -> Pair("CAST(a.alert_type_id AS TEXT)", "COALESCE(at2.name, 'unknown')")
+            RecurrenceGroupBy.SEVERITY -> Pair("CAST(a.severity_id AS TEXT)", "COALESCE(sev.name, 'unknown')")
+            RecurrenceGroupBy.SECTOR -> Pair("CAST(a.sector_id AS TEXT)", "COALESCE(sec.code, 'unknown')")
+            RecurrenceGroupBy.GREENHOUSE -> Pair("CAST(sec.greenhouse_id AS TEXT)", "COALESCE(g.name, 'unknown')")
+        }
+
+    // -------------------------------------------------------------------
+    // mttr
+    // -------------------------------------------------------------------
+
+    override fun mttr(query: MttrStatsQuery): List<MttrBucket> {
+        val (groupByCol, labelCol) = mttrGroupByColumns(query.groupBy)
+        val sql = """
+            SELECT $groupByCol AS key, $labelCol AS label,
+                   AVG(EXTRACT(EPOCH FROM (cl.at - op.at)))             AS mttr_avg,
+                   PERCENTILE_CONT(0.5) WITHIN GROUP
+                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - op.at)))     AS p50,
+                   PERCENTILE_CONT(0.95) WITHIN GROUP
+                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - op.at)))     AS p95,
+                   PERCENTILE_CONT(0.99) WITHIN GROUP
+                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - op.at)))     AS p99,
+                   COUNT(*)                                              AS sample_size
+              FROM (
+                SELECT op.alert_id,
+                       op.at,
+                       LEAD(op.at) OVER (PARTITION BY op.alert_id ORDER BY op.at) AS close_at,
+                       LEAD(op.id) OVER (PARTITION BY op.alert_id ORDER BY op.at) AS close_id
+                  FROM metadata.alert_state_changes op
+                 WHERE op.to_resolved = FALSE
+              ) pairs
+              JOIN metadata.alert_state_changes cl ON cl.id = pairs.close_id AND cl.to_resolved = TRUE
+              JOIN metadata.alerts a      ON a.id = pairs.alert_id
+              LEFT JOIN metadata.alert_types at2  ON at2.id = a.alert_type_id
+              LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
+              LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
+             WHERE a.tenant_id = ?
+               AND pairs.at >= ?
+               AND pairs.at < ?
+             GROUP BY key, label
+             ORDER BY mttr_avg DESC
+        """.trimIndent()
+
+        return jdbc.query(sql,
+            { rs, _ ->
+                MttrBucket(
+                    key = rs.getString("key") ?: "unknown",
+                    label = rs.getString("label") ?: "unknown",
+                    mttrSeconds = rs.getDouble("mttr_avg"),
+                    p50Seconds = rs.getDouble("p50"),
+                    p95Seconds = rs.getDouble("p95"),
+                    p99Seconds = rs.getDouble("p99"),
+                    sampleSize = rs.getLong("sample_size"),
+                )
+            },
+            query.tenantId.value,
+            Timestamp.from(query.from),
+            Timestamp.from(query.to),
+        )
+    }
+
+    private fun mttrGroupByColumns(groupBy: MttrGroupBy): Pair<String, String> =
+        when (groupBy) {
+            MttrGroupBy.CODE -> Pair("a.code", "a.code")
+            MttrGroupBy.TYPE -> Pair("CAST(a.alert_type_id AS TEXT)", "COALESCE(at2.name, 'unknown')")
+            MttrGroupBy.SEVERITY -> Pair("CAST(a.severity_id AS TEXT)", "COALESCE(sev.name, 'unknown')")
+            MttrGroupBy.SECTOR -> Pair("CAST(a.sector_id AS TEXT)", "COALESCE(sec.code, 'unknown')")
+        }
+
+    // -------------------------------------------------------------------
+    // timeseries
+    // -------------------------------------------------------------------
+
+    override fun timeseries(query: TimeseriesStatsQuery): List<TimeseriesDataPoint> {
+        val truncUnit = when (query.bucket) {
+            TimeseriesBucket.HOUR -> "hour"
+            TimeseriesBucket.DAY -> "day"
+            TimeseriesBucket.WEEK -> "week"
+            TimeseriesBucket.MONTH -> "month"
+        }
+        val (groupByCol, _) = timeseriesGroupByColumns(query.groupBy)
+        val sql = """
+            SELECT date_trunc('$truncUnit', asc.at AT TIME ZONE 'UTC') AS bucket_start,
+                   $groupByCol                                          AS key,
+                   COUNT(*) FILTER (WHERE asc.to_resolved = FALSE)     AS opened,
+                   COUNT(*) FILTER (WHERE asc.to_resolved = TRUE)      AS closed
+              FROM metadata.alert_state_changes asc
+              JOIN metadata.alerts a      ON a.id = asc.alert_id
+              LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
+              LEFT JOIN metadata.alert_types at2      ON at2.id = a.alert_type_id
+             WHERE a.tenant_id = ?
+               AND asc.at >= ?
+               AND asc.at < ?
+             GROUP BY bucket_start, key
+             ORDER BY bucket_start ASC, key ASC
+        """.trimIndent()
+
+        return jdbc.query(sql,
+            { rs, _ ->
+                TimeseriesDataPoint(
+                    bucketStart = rs.getTimestamp("bucket_start").toInstant(),
+                    key = rs.getString("key") ?: "unknown",
+                    opened = rs.getLong("opened"),
+                    closed = rs.getLong("closed"),
+                )
+            },
+            query.tenantId.value,
+            Timestamp.from(query.from),
+            Timestamp.from(query.to),
+        )
+    }
+
+    private fun timeseriesGroupByColumns(groupBy: TimeseriesGroupBy): Pair<String, String> =
+        when (groupBy) {
+            TimeseriesGroupBy.SEVERITY -> Pair("COALESCE(sev.name, 'unknown')", "COALESCE(sev.name, 'unknown')")
+            TimeseriesGroupBy.TYPE -> Pair("COALESCE(at2.name, 'unknown')", "COALESCE(at2.name, 'unknown')")
+        }
+
+    // -------------------------------------------------------------------
+    // activeDuration
+    // -------------------------------------------------------------------
+
+    override fun activeDuration(query: ActiveDurationStatsQuery): List<ActiveDurationBucket> {
+        val (groupByCol, labelCol) = activeDurationGroupByColumns(query.groupBy)
+        val sql = """
+            SELECT $groupByCol AS key, $labelCol AS label,
+                   SUM(EXTRACT(EPOCH FROM (cl.at - op.at)))::BIGINT AS total_active_seconds
+              FROM (
+                SELECT op.alert_id,
+                       op.at,
+                       LEAD(op.id) OVER (PARTITION BY op.alert_id ORDER BY op.at) AS close_id
+                  FROM metadata.alert_state_changes op
+                 WHERE op.to_resolved = FALSE
+              ) pairs
+              JOIN metadata.alert_state_changes cl ON cl.id = pairs.close_id AND cl.to_resolved = TRUE
+              JOIN metadata.alerts a      ON a.id = pairs.alert_id
+              LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
+             WHERE a.tenant_id = ?
+               AND pairs.at >= ?
+               AND pairs.at < ?
+             GROUP BY key, label
+             ORDER BY total_active_seconds DESC
+        """.trimIndent()
+
+        return jdbc.query(sql,
+            { rs, _ ->
+                ActiveDurationBucket(
+                    key = rs.getString("key") ?: "unknown",
+                    label = rs.getString("label") ?: "unknown",
+                    totalActiveSeconds = rs.getLong("total_active_seconds"),
+                )
+            },
+            query.tenantId.value,
+            Timestamp.from(query.from),
+            Timestamp.from(query.to),
+        )
+    }
+
+    private fun activeDurationGroupByColumns(groupBy: ActiveDurationGroupBy): Pair<String, String> =
+        when (groupBy) {
+            ActiveDurationGroupBy.CODE -> Pair("a.code", "a.code")
+            ActiveDurationGroupBy.SECTOR -> Pair("CAST(a.sector_id AS TEXT)", "COALESCE(sec.code, 'unknown')")
+        }
+
+    // -------------------------------------------------------------------
+    // byActor
+    // -------------------------------------------------------------------
+
+    override fun byActor(query: ByActorStatsQuery): List<ByActorBucket> {
+        val toResolved = query.role == ActorStatsRole.RESOLVER
+        val sql = """
+            SELECT asc.actor_user_id,
+                   u.username,
+                   u.display_name,
+                   COUNT(*) AS cnt
+              FROM metadata.alert_state_changes asc
+              JOIN metadata.alerts a ON a.id = asc.alert_id
+              LEFT JOIN metadata.users u ON u.id = asc.actor_user_id
+             WHERE a.tenant_id = ?
+               AND asc.actor_kind = 'USER'
+               AND asc.to_resolved = ?
+               AND asc.at >= ?
+               AND asc.at < ?
+             GROUP BY asc.actor_user_id, u.username, u.display_name
+             ORDER BY cnt DESC
+        """.trimIndent()
+
+        return jdbc.query(sql,
+            { rs, _ ->
+                ByActorBucket(
+                    actorUserId = rs.getLong("actor_user_id"),
+                    username = rs.getString("username"),
+                    displayName = rs.getString("display_name"),
+                    count = rs.getLong("cnt"),
+                )
+            },
+            query.tenantId.value,
+            toResolved,
+            Timestamp.from(query.from),
+            Timestamp.from(query.to),
+        )
+    }
+
+    // -------------------------------------------------------------------
+    // summary
+    // -------------------------------------------------------------------
+
+    override fun summary(tenantId: TenantId, from: Instant, to: Instant): AlertStatsSummary {
+        val todayStart = ZonedDateTime.now(ZoneOffset.UTC).toLocalDate().atStartOfDay(ZoneOffset.UTC).toInstant()
+        val todayEnd = todayStart.plusSeconds(86400)
+        val weekStart = ZonedDateTime.now(ZoneOffset.UTC).toLocalDate()
+            .minusDays(6).atStartOfDay(ZoneOffset.UTC).toInstant()
+
+        val totalActiveNow = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM metadata.alerts WHERE tenant_id = ? AND is_resolved = FALSE",
+            Long::class.java,
+            tenantId.value,
+        ) ?: 0L
+
+        val openedToday = jdbc.queryForObject(
+            """SELECT COUNT(*) FROM metadata.alert_state_changes asc
+               JOIN metadata.alerts a ON a.id = asc.alert_id
+               WHERE a.tenant_id = ? AND asc.to_resolved = FALSE
+                 AND asc.at >= ? AND asc.at < ?""",
+            Long::class.java,
+            tenantId.value, Timestamp.from(todayStart), Timestamp.from(todayEnd),
+        ) ?: 0L
+
+        val closedToday = jdbc.queryForObject(
+            """SELECT COUNT(*) FROM metadata.alert_state_changes asc
+               JOIN metadata.alerts a ON a.id = asc.alert_id
+               WHERE a.tenant_id = ? AND asc.to_resolved = TRUE
+                 AND asc.at >= ? AND asc.at < ?""",
+            Long::class.java,
+            tenantId.value, Timestamp.from(todayStart), Timestamp.from(todayEnd),
+        ) ?: 0L
+
+        val mttrTodaySeconds = jdbc.queryForObject(
+            """SELECT AVG(EXTRACT(EPOCH FROM (cl.at - op.at)))
+               FROM (
+                 SELECT op.alert_id, op.at,
+                        LEAD(op.id) OVER (PARTITION BY op.alert_id ORDER BY op.at) AS close_id
+                   FROM metadata.alert_state_changes op
+                  WHERE op.to_resolved = FALSE
+               ) pairs
+               JOIN metadata.alert_state_changes cl ON cl.id = pairs.close_id AND cl.to_resolved = TRUE
+               JOIN metadata.alerts a ON a.id = pairs.alert_id
+               WHERE a.tenant_id = ? AND pairs.at >= ? AND pairs.at < ?""",
+            Double::class.java,
+            tenantId.value, Timestamp.from(todayStart), Timestamp.from(todayEnd),
+        )
+
+        val top3Codes = jdbc.query(
+            """SELECT a.code, COUNT(*) AS cnt
+               FROM metadata.alert_state_changes asc
+               JOIN metadata.alerts a ON a.id = asc.alert_id
+               WHERE a.tenant_id = ? AND asc.to_resolved = FALSE
+                 AND asc.at >= ? AND asc.at < ?
+               GROUP BY a.code
+               ORDER BY cnt DESC
+               LIMIT 3""",
+            { rs, _ -> rs.getString("code") },
+            tenantId.value, Timestamp.from(weekStart), Timestamp.from(Instant.now()),
+        )
+
+        return AlertStatsSummary(
+            totalActiveNow = totalActiveNow,
+            openedToday = openedToday,
+            closedToday = closedToday,
+            mttrTodaySeconds = mttrTodaySeconds,
+            top3RecurrentCodesThisWeek = top3Codes,
+        )
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertModuleConfig.kt
@@ -7,6 +7,7 @@ import com.apptolast.invernaderos.features.alert.application.usecase.AlertRecurr
 import com.apptolast.invernaderos.features.alert.application.usecase.AlertSummaryStatsUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.AlertTimeseriesStatsUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.ApplyAlertMqttSignalUseCaseImpl
+import com.apptolast.invernaderos.features.alert.application.usecase.CountUnresolvedAlertsBySectorUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.CreateAlertUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.DeleteAlertUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.FindAlertEpisodesUseCaseImpl
@@ -21,6 +22,7 @@ import com.apptolast.invernaderos.features.alert.domain.port.input.AlertRecurren
 import com.apptolast.invernaderos.features.alert.domain.port.input.AlertSummaryStatsUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.AlertTimeseriesStatsUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.ApplyAlertMqttSignalUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.CountUnresolvedAlertsBySectorUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.CreateAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.DeleteAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertEpisodesUseCase
@@ -101,6 +103,11 @@ class AlertModuleConfig {
     fun findAlertEpisodesUseCase(
         historyQueryPort: AlertHistoryQueryPort,
     ): FindAlertEpisodesUseCase = FindAlertEpisodesUseCaseImpl(historyQueryPort)
+
+    @Bean
+    fun countUnresolvedAlertsBySectorUseCase(
+        repository: AlertRepositoryPort,
+    ): CountUnresolvedAlertsBySectorUseCase = CountUnresolvedAlertsBySectorUseCaseImpl(repository)
 
     // -------------------------------------------------------------------
     // Stats use cases

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertModuleConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/AlertModuleConfig.kt
@@ -1,24 +1,42 @@
 package com.apptolast.invernaderos.features.alert.infrastructure.config
 
+import com.apptolast.invernaderos.features.alert.application.usecase.AlertActiveDurationStatsUseCaseImpl
+import com.apptolast.invernaderos.features.alert.application.usecase.AlertByActorStatsUseCaseImpl
+import com.apptolast.invernaderos.features.alert.application.usecase.AlertMttrStatsUseCaseImpl
+import com.apptolast.invernaderos.features.alert.application.usecase.AlertRecurrenceStatsUseCaseImpl
+import com.apptolast.invernaderos.features.alert.application.usecase.AlertSummaryStatsUseCaseImpl
+import com.apptolast.invernaderos.features.alert.application.usecase.AlertTimeseriesStatsUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.ApplyAlertMqttSignalUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.CreateAlertUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.DeleteAlertUseCaseImpl
+import com.apptolast.invernaderos.features.alert.application.usecase.FindAlertEpisodesUseCaseImpl
+import com.apptolast.invernaderos.features.alert.application.usecase.FindAlertHistoryUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.FindAlertUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.ResolveAlertUseCaseImpl
 import com.apptolast.invernaderos.features.alert.application.usecase.UpdateAlertUseCaseImpl
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertActiveDurationStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertByActorStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertMttrStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertRecurrenceStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertSummaryStatsUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.AlertTimeseriesStatsUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.ApplyAlertMqttSignalUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.CreateAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.DeleteAlertUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertEpisodesUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertHistoryUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.ResolveAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.input.UpdateAlertUseCase
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertByCodeRepositoryPort
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertCodeGenerator
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertHistoryQueryPort
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertRepositoryPort
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertSectorValidationPort
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertSignalDecisionPort
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangePersistencePort
 import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangedEventPublisherPort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -69,4 +87,52 @@ class AlertModuleConfig {
         stateChangePort = stateChangePort,
         eventPublisher = eventPublisher
     )
+
+    // -------------------------------------------------------------------
+    // History use cases
+    // -------------------------------------------------------------------
+
+    @Bean
+    fun findAlertHistoryUseCase(
+        historyQueryPort: AlertHistoryQueryPort,
+    ): FindAlertHistoryUseCase = FindAlertHistoryUseCaseImpl(historyQueryPort)
+
+    @Bean
+    fun findAlertEpisodesUseCase(
+        historyQueryPort: AlertHistoryQueryPort,
+    ): FindAlertEpisodesUseCase = FindAlertEpisodesUseCaseImpl(historyQueryPort)
+
+    // -------------------------------------------------------------------
+    // Stats use cases
+    // -------------------------------------------------------------------
+
+    @Bean
+    fun alertRecurrenceStatsUseCase(
+        statsPort: AlertStatsQueryPort,
+    ): AlertRecurrenceStatsUseCase = AlertRecurrenceStatsUseCaseImpl(statsPort)
+
+    @Bean
+    fun alertMttrStatsUseCase(
+        statsPort: AlertStatsQueryPort,
+    ): AlertMttrStatsUseCase = AlertMttrStatsUseCaseImpl(statsPort)
+
+    @Bean
+    fun alertTimeseriesStatsUseCase(
+        statsPort: AlertStatsQueryPort,
+    ): AlertTimeseriesStatsUseCase = AlertTimeseriesStatsUseCaseImpl(statsPort)
+
+    @Bean
+    fun alertActiveDurationStatsUseCase(
+        statsPort: AlertStatsQueryPort,
+    ): AlertActiveDurationStatsUseCase = AlertActiveDurationStatsUseCaseImpl(statsPort)
+
+    @Bean
+    fun alertByActorStatsUseCase(
+        statsPort: AlertStatsQueryPort,
+    ): AlertByActorStatsUseCase = AlertByActorStatsUseCaseImpl(statsPort)
+
+    @Bean
+    fun alertSummaryStatsUseCase(
+        statsPort: AlertStatsQueryPort,
+    ): AlertSummaryStatsUseCase = AlertSummaryStatsUseCaseImpl(statsPort)
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/LegacyAlertDeprecationFilter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/config/LegacyAlertDeprecationFilter.kt
@@ -1,0 +1,48 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Adds RFC 8594 (Sunset) and RFC 9745 (Deprecation) headers to every response from the
+ * legacy /api/v1/alerts endpoints. The hexagonal replacements live under
+ * /api/v1/tenants/{tenantId}/alerts and are pointed to via the Link header.
+ *
+ * Computed once at startup so all responses carry the same Sunset value.
+ */
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE)
+class LegacyAlertDeprecationFilter : OncePerRequestFilter() {
+
+    private val sunsetDate: String = ZonedDateTime.now(ZoneOffset.UTC)
+        .plusDays(90)
+        .format(DateTimeFormatter.RFC_1123_DATE_TIME)
+
+    private val linkHeader: String =
+        "<https://inverapi-prod.apptolast.com/swagger-ui.html#tenant-alerts>; rel=\"successor-version\""
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            val uri = request.requestURI
+            if (uri == "/api/v1/alerts" || uri.startsWith("/api/v1/alerts/")) {
+                response.setHeader("Deprecation", "true")
+                response.setHeader("Sunset", sunsetDate)
+                response.setHeader("Link", linkHeader)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/shared/domain/model/PagedResult.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/shared/domain/model/PagedResult.kt
@@ -1,0 +1,9 @@
+package com.apptolast.invernaderos.features.shared.domain.model
+
+data class PagedResult<T>(
+    val items: List<T>,
+    val page: Int,
+    val size: Int,
+    val total: Long,
+    val hasMore: Boolean,
+)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/shared/domain/model/SortOrder.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/shared/domain/model/SortOrder.kt
@@ -1,0 +1,3 @@
+package com.apptolast.invernaderos.features.shared.domain.model
+
+enum class SortOrder { ASC, DESC }

--- a/src/main/resources/db/migration/V40__add_actor_to_alert_state_changes.sql
+++ b/src/main/resources/db/migration/V40__add_actor_to_alert_state_changes.sql
@@ -1,0 +1,62 @@
+-- =============================================================================
+-- V40: Add actor metadata to alert_state_changes
+-- =============================================================================
+-- Adds actor_user_id, actor_kind, actor_ref columns so the audit trail can
+-- answer "who triggered this transition" historically (USER for API,
+-- DEVICE for MQTT, SYSTEM for scheduler/automatic).
+--
+-- Best-effort backfill:
+--   - source=MQTT  → actor_kind='DEVICE' (no per-row gateway info recoverable)
+--   - source=SYSTEM → actor_kind='SYSTEM'
+--   - source=API   → actor_kind='USER'; for the LATEST API close per alert,
+--                    copy alerts.resolved_by_user_id into actor_user_id.
+--                    Older API transitions stay with actor_user_id=NULL
+--                    honestly (data was never persisted).
+-- =============================================================================
+
+ALTER TABLE metadata.alert_state_changes
+    ADD COLUMN actor_user_id BIGINT NULL REFERENCES metadata.users(id) ON DELETE SET NULL,
+    ADD COLUMN actor_kind    VARCHAR(16) NOT NULL DEFAULT 'SYSTEM'
+                CHECK (actor_kind IN ('USER', 'DEVICE', 'SYSTEM')),
+    ADD COLUMN actor_ref     VARCHAR(128) NULL;
+
+-- Backfill 1: MQTT rows
+UPDATE metadata.alert_state_changes
+   SET actor_kind = 'DEVICE'
+ WHERE source = 'MQTT';
+
+-- Backfill 2: SYSTEM rows (default already 'SYSTEM' but explicit for clarity if any pre-existed)
+UPDATE metadata.alert_state_changes
+   SET actor_kind = 'SYSTEM'
+ WHERE source = 'SYSTEM';
+
+-- Backfill 3: API rows base
+UPDATE metadata.alert_state_changes
+   SET actor_kind = 'USER'
+ WHERE source = 'API';
+
+-- Backfill 4: latest API close per alert → recover actor_user_id from alerts.resolved_by_user_id
+WITH latest_resolution_per_alert AS (
+    SELECT DISTINCT ON (alert_id) id, alert_id
+      FROM metadata.alert_state_changes
+     WHERE source = 'API' AND to_resolved = TRUE
+     ORDER BY alert_id, at DESC
+)
+UPDATE metadata.alert_state_changes asc_row
+   SET actor_user_id = a.resolved_by_user_id
+  FROM latest_resolution_per_alert latest
+  JOIN metadata.alerts a ON a.id = latest.alert_id
+ WHERE asc_row.id = latest.id
+   AND a.resolved_by_user_id IS NOT NULL;
+
+-- Indexes for actor lookups
+CREATE INDEX idx_alert_state_changes_actor_user
+    ON metadata.alert_state_changes(actor_user_id)
+ WHERE actor_user_id IS NOT NULL;
+
+CREATE INDEX idx_alert_state_changes_actor_kind
+    ON metadata.alert_state_changes(actor_kind);
+
+COMMENT ON COLUMN metadata.alert_state_changes.actor_user_id IS 'User who triggered this transition. Populated for source=API only.';
+COMMENT ON COLUMN metadata.alert_state_changes.actor_kind   IS 'USER (API), DEVICE (MQTT), SYSTEM (auto/scheduler).';
+COMMENT ON COLUMN metadata.alert_state_changes.actor_ref    IS 'Free-form actor reference: gateway/device id for DEVICE, job name for SYSTEM.';

--- a/src/test/kotlin/com/apptolast/invernaderos/ArchitectureTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/ArchitectureTest.kt
@@ -16,6 +16,77 @@ import org.springframework.web.bind.annotation.RestController
 )
 class ArchitectureTest {
 
+    // --- Alert history + stats hexagonal rules ---
+
+    @ArchTest
+    val alertDomainMustNotDependOnSpring: ArchRule =
+            noClasses()
+                    .that()
+                    .resideInAPackage("..features.alert.domain..")
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAnyPackage(
+                            "org.springframework..",
+                            "jakarta.persistence..",
+                            "jakarta.validation..",
+                            "org.hibernate.."
+                    )
+                    .because("Alert domain layer must be pure Kotlin with zero framework dependencies")
+
+    @ArchTest
+    val alertDomainMustNotDependOnInfrastructure: ArchRule =
+            noClasses()
+                    .that()
+                    .resideInAPackage("..features.alert.domain..")
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAPackage("..features.alert.infrastructure..")
+                    .because("Alert domain must not depend on alert infrastructure (dependency inversion)")
+
+    @ArchTest
+    val alertDomainMustNotDependOnDto: ArchRule =
+            noClasses()
+                    .that()
+                    .resideInAPackage("..features.alert.domain..")
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAPackage("..features.alert.dto..")
+                    .because("Alert domain must not depend on DTOs")
+
+    @ArchTest
+    val alertUseCaseImplsMustImplementInputPort: ArchRule =
+            classes()
+                    .that()
+                    .resideInAPackage("..features.alert.application.usecase..")
+                    .and()
+                    .haveNameMatching(".*UseCaseImpl")
+                    .should()
+                    .implement(
+                            com.tngtech.archunit.base.DescribedPredicate.describe(
+                                    "an interface residing in domain/port/input package"
+                            ) { iface: com.tngtech.archunit.core.domain.JavaClass ->
+                                iface.name.contains(".domain.port.input.")
+                            }
+                    )
+                    .because("Every *UseCaseImpl must implement a use case interface from domain/port/input/")
+
+    @ArchTest
+    val alertQueryAdaptersMustImplementOutputPort: ArchRule =
+            classes()
+                    .that()
+                    .resideInAPackage("..features.alert.infrastructure.adapter.output..")
+                    .and()
+                    .haveNameMatching(".*QueryAdapter")
+                    .should()
+                    .implement(
+                            com.tngtech.archunit.base.DescribedPredicate.describe(
+                                    "an interface residing in domain/port/output package"
+                            ) { iface: com.tngtech.archunit.core.domain.JavaClass ->
+                                iface.name.contains(".domain.port.output.")
+                            }
+                    )
+                    .because("Every *QueryAdapter must implement a port interface from domain/port/output/")
+
     @ArchTest
     val controllersShouldNotAccessRepositoriesDirectly: ArchRule =
             noClasses()

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertActiveDurationStatsUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertActiveDurationStatsUseCaseTest.kt
@@ -1,0 +1,110 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.ActiveDurationBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AlertActiveDurationStatsUseCaseTest {
+
+    private val statsPort = mockk<AlertStatsQueryPort>()
+    private val useCase = AlertActiveDurationStatsUseCaseImpl(statsPort)
+
+    private val tenantId = TenantId(10L)
+    private val now = Instant.parse("2026-01-01T12:00:00Z")
+    private val from = now.minusSeconds(86400)
+
+    private fun buildQuery(
+        from: Instant = this.from,
+        to: Instant = this.now,
+        groupBy: ActiveDurationGroupBy = ActiveDurationGroupBy.CODE,
+    ) = ActiveDurationStatsQuery(
+        tenantId = tenantId,
+        from = from,
+        to = to,
+        groupBy = groupBy,
+    )
+
+    @Test
+    fun `should return port result unchanged when query is valid`() {
+        val query = buildQuery()
+        val expected = listOf(
+            ActiveDurationBucket(key = "ALT-001", label = "ALT-001", totalActiveSeconds = 7200L)
+        )
+        every { statsPort.activeDuration(query) } returns expected
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should propagate query to the port including groupBy`() {
+        val querySlot = slot<ActiveDurationStatsQuery>()
+        val query = buildQuery(groupBy = ActiveDurationGroupBy.SECTOR)
+        every { statsPort.activeDuration(capture(querySlot)) } returns emptyList()
+
+        useCase.execute(query)
+
+        assertThat(querySlot.captured.groupBy).isEqualTo(ActiveDurationGroupBy.SECTOR)
+        assertThat(querySlot.captured.tenantId).isEqualTo(tenantId)
+    }
+
+    @Test
+    fun `should throw when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(1))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("from must not be after to")
+    }
+
+    @Test
+    fun `should return empty list when port returns empty`() {
+        val query = buildQuery()
+        every { statsPort.activeDuration(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should not call port when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(3600))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        verify(exactly = 0) { statsPort.activeDuration(any()) }
+    }
+
+    @Test
+    fun `should support groupBy SECTOR`() {
+        val query = buildQuery(groupBy = ActiveDurationGroupBy.SECTOR)
+        every { statsPort.activeDuration(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    fun `should accept from equal to to`() {
+        val query = buildQuery(from = now, to = now)
+        every { statsPort.activeDuration(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertByActorStatsUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertByActorStatsUseCaseTest.kt
@@ -1,0 +1,116 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.ByActorBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActorStatsRole
+import com.apptolast.invernaderos.features.alert.domain.model.query.ByActorStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AlertByActorStatsUseCaseTest {
+
+    private val statsPort = mockk<AlertStatsQueryPort>()
+    private val useCase = AlertByActorStatsUseCaseImpl(statsPort)
+
+    private val tenantId = TenantId(10L)
+    private val now = Instant.parse("2026-01-01T12:00:00Z")
+    private val from = now.minusSeconds(86400)
+
+    private fun buildQuery(
+        from: Instant = this.from,
+        to: Instant = this.now,
+        role: ActorStatsRole = ActorStatsRole.RESOLVER,
+    ) = ByActorStatsQuery(
+        tenantId = tenantId,
+        from = from,
+        to = to,
+        role = role,
+    )
+
+    @Test
+    fun `should return port result unchanged when query is valid`() {
+        val query = buildQuery()
+        val expected = listOf(
+            ByActorBucket(actorUserId = 42L, username = "user42", displayName = "User 42", count = 5L)
+        )
+        every { statsPort.byActor(query) } returns expected
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should propagate role RESOLVER to the port`() {
+        val querySlot = slot<ByActorStatsQuery>()
+        val query = buildQuery(role = ActorStatsRole.RESOLVER)
+        every { statsPort.byActor(capture(querySlot)) } returns emptyList()
+
+        useCase.execute(query)
+
+        assertThat(querySlot.captured.role).isEqualTo(ActorStatsRole.RESOLVER)
+        assertThat(querySlot.captured.tenantId).isEqualTo(tenantId)
+    }
+
+    @Test
+    fun `should propagate role OPENER to the port`() {
+        val querySlot = slot<ByActorStatsQuery>()
+        val query = buildQuery(role = ActorStatsRole.OPENER)
+        every { statsPort.byActor(capture(querySlot)) } returns emptyList()
+
+        useCase.execute(query)
+
+        assertThat(querySlot.captured.role).isEqualTo(ActorStatsRole.OPENER)
+    }
+
+    @Test
+    fun `should throw when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(1))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("from must not be after to")
+    }
+
+    @Test
+    fun `should return empty list when port returns empty`() {
+        val query = buildQuery()
+        every { statsPort.byActor(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should not call port when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(3600))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        verify(exactly = 0) { statsPort.byActor(any()) }
+    }
+
+    @Test
+    fun `should return multiple actors ordered by count`() {
+        val query = buildQuery()
+        val expected = listOf(
+            ByActorBucket(actorUserId = 42L, username = "user42", displayName = "User 42", count = 10L),
+            ByActorBucket(actorUserId = 7L, username = "user7", displayName = "User 7", count = 3L),
+        )
+        every { statsPort.byActor(query) } returns expected
+
+        val result = useCase.execute(query)
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0].count).isGreaterThan(result[1].count)
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertMttrStatsUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertMttrStatsUseCaseTest.kt
@@ -1,0 +1,120 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.MttrBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AlertMttrStatsUseCaseTest {
+
+    private val statsPort = mockk<AlertStatsQueryPort>()
+    private val useCase = AlertMttrStatsUseCaseImpl(statsPort)
+
+    private val tenantId = TenantId(10L)
+    private val now = Instant.parse("2026-01-01T12:00:00Z")
+    private val from = now.minusSeconds(86400)
+
+    private fun buildQuery(
+        from: Instant = this.from,
+        to: Instant = this.now,
+        groupBy: MttrGroupBy = MttrGroupBy.SEVERITY,
+    ) = MttrStatsQuery(
+        tenantId = tenantId,
+        from = from,
+        to = to,
+        groupBy = groupBy,
+    )
+
+    @Test
+    fun `should return port result unchanged when query is valid`() {
+        val query = buildQuery()
+        val expected = listOf(
+            MttrBucket(
+                key = "WARNING",
+                label = "Warning",
+                mttrSeconds = 1800.0,
+                p50Seconds = 1200.0,
+                p95Seconds = 3600.0,
+                p99Seconds = 7200.0,
+                sampleSize = 5L,
+            )
+        )
+        every { statsPort.mttr(query) } returns expected
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should propagate query to the port unchanged`() {
+        val querySlot = slot<MttrStatsQuery>()
+        val query = buildQuery(groupBy = MttrGroupBy.CODE)
+        every { statsPort.mttr(capture(querySlot)) } returns emptyList()
+
+        useCase.execute(query)
+
+        assertThat(querySlot.captured.groupBy).isEqualTo(MttrGroupBy.CODE)
+        assertThat(querySlot.captured.tenantId).isEqualTo(tenantId)
+    }
+
+    @Test
+    fun `should throw when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(1))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("from must not be after to")
+    }
+
+    @Test
+    fun `should return empty list when port returns empty`() {
+        val query = buildQuery()
+        every { statsPort.mttr(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should not call port when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(3600))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        verify(exactly = 0) { statsPort.mttr(any()) }
+    }
+
+    @Test
+    fun `should support all groupBy variants`() {
+        MttrGroupBy.entries.forEach { groupBy ->
+            val query = buildQuery(groupBy = groupBy)
+            every { statsPort.mttr(query) } returns emptyList()
+
+            val result = useCase.execute(query)
+
+            assertThat(result).isNotNull
+        }
+    }
+
+    @Test
+    fun `should accept from equal to to (point-in-time boundary)`() {
+        val query = buildQuery(from = now, to = now)
+        every { statsPort.mttr(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertRecurrenceStatsUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertRecurrenceStatsUseCaseTest.kt
@@ -1,0 +1,132 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.RecurrenceBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AlertRecurrenceStatsUseCaseTest {
+
+    private val statsPort = mockk<AlertStatsQueryPort>()
+    private val useCase = AlertRecurrenceStatsUseCaseImpl(statsPort)
+
+    private val tenantId = TenantId(10L)
+    private val now = Instant.parse("2026-01-01T12:00:00Z")
+    private val from = now.minusSeconds(86400)
+
+    private fun buildQuery(
+        from: Instant = this.from,
+        to: Instant = this.now,
+        groupBy: RecurrenceGroupBy = RecurrenceGroupBy.CODE,
+        limit: Int = 10,
+    ) = RecurrenceStatsQuery(
+        tenantId = tenantId,
+        from = from,
+        to = to,
+        groupBy = groupBy,
+        limit = limit,
+    )
+
+    @Test
+    fun `should return port result unchanged when query is valid`() {
+        val query = buildQuery()
+        val expected = listOf(
+            RecurrenceBucket(key = "ALT-001", label = "ALT-001", count = 17L, lastSeenAt = now)
+        )
+        every { statsPort.recurrence(query) } returns expected
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should propagate query to the port unchanged`() {
+        val querySlot = slot<RecurrenceStatsQuery>()
+        val query = buildQuery(groupBy = RecurrenceGroupBy.SEVERITY, limit = 5)
+        every { statsPort.recurrence(capture(querySlot)) } returns emptyList()
+
+        useCase.execute(query)
+
+        assertThat(querySlot.captured.groupBy).isEqualTo(RecurrenceGroupBy.SEVERITY)
+        assertThat(querySlot.captured.limit).isEqualTo(5)
+        assertThat(querySlot.captured.tenantId).isEqualTo(tenantId)
+    }
+
+    @Test
+    fun `should throw when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(1))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("from must not be after to")
+    }
+
+    @Test
+    fun `should throw when limit exceeds 100`() {
+        val query = buildQuery(limit = 101)
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("limit must be")
+    }
+
+    @Test
+    fun `should throw when limit is zero`() {
+        val query = buildQuery(limit = 0)
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `should accept limit of exactly 100 as valid upper bound`() {
+        val query = buildQuery(limit = 100)
+        every { statsPort.recurrence(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should return empty list when port returns empty`() {
+        val query = buildQuery()
+        every { statsPort.recurrence(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should not call port when validation fails`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(3600))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        verify(exactly = 0) { statsPort.recurrence(any()) }
+    }
+
+    @Test
+    fun `should support all groupBy variants`() {
+        RecurrenceGroupBy.entries.forEach { groupBy ->
+            val query = buildQuery(groupBy = groupBy)
+            every { statsPort.recurrence(query) } returns emptyList()
+
+            val result = useCase.execute(query)
+
+            assertThat(result).isNotNull
+        }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertSummaryStatsUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertSummaryStatsUseCaseTest.kt
@@ -1,0 +1,119 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStatsSummary
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AlertSummaryStatsUseCaseTest {
+
+    private val statsPort = mockk<AlertStatsQueryPort>()
+    private val useCase = AlertSummaryStatsUseCaseImpl(statsPort)
+
+    private val tenantId = TenantId(10L)
+    private val now = Instant.parse("2026-01-01T12:00:00Z")
+    private val from = now.minusSeconds(86400)
+
+    @Test
+    fun `should return port result unchanged when parameters are valid`() {
+        val expected = AlertStatsSummary(
+            totalActiveNow = 3L,
+            openedToday = 7L,
+            closedToday = 4L,
+            mttrTodaySeconds = 1234.5,
+            top3RecurrentCodesThisWeek = listOf("ALT-001", "ALT-002", "ALT-003"),
+        )
+        every { statsPort.summary(tenantId, from, now) } returns expected
+
+        val result = useCase.execute(tenantId, from, now)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should propagate tenantId to the port unchanged`() {
+        val tenantSlot = slot<TenantId>()
+        val fromSlot = slot<Instant>()
+        val toSlot = slot<Instant>()
+        every { statsPort.summary(capture(tenantSlot), capture(fromSlot), capture(toSlot)) } returns AlertStatsSummary(
+            totalActiveNow = 0L, openedToday = 0L, closedToday = 0L,
+            mttrTodaySeconds = null, top3RecurrentCodesThisWeek = emptyList()
+        )
+
+        useCase.execute(TenantId(999L), from, now)
+
+        assertThat(tenantSlot.captured.value).isEqualTo(999L)
+        assertThat(fromSlot.captured).isEqualTo(from)
+        assertThat(toSlot.captured).isEqualTo(now)
+    }
+
+    @Test
+    fun `should throw when from is after to`() {
+        assertThatThrownBy { useCase.execute(tenantId, now, now.minusSeconds(1)) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("from must not be after to")
+    }
+
+    @Test
+    fun `should not call port when from is after to`() {
+        assertThatThrownBy { useCase.execute(tenantId, now, now.minusSeconds(3600)) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        verify(exactly = 0) { statsPort.summary(any(), any(), any()) }
+    }
+
+    @Test
+    fun `should handle null mttrTodaySeconds in summary`() {
+        val expected = AlertStatsSummary(
+            totalActiveNow = 0L,
+            openedToday = 0L,
+            closedToday = 0L,
+            mttrTodaySeconds = null,
+            top3RecurrentCodesThisWeek = emptyList(),
+        )
+        every { statsPort.summary(tenantId, from, now) } returns expected
+
+        val result = useCase.execute(tenantId, from, now)
+
+        assertThat(result.mttrTodaySeconds).isNull()
+    }
+
+    @Test
+    fun `should handle empty top3 recurrent codes`() {
+        val expected = AlertStatsSummary(
+            totalActiveNow = 1L,
+            openedToday = 1L,
+            closedToday = 0L,
+            mttrTodaySeconds = null,
+            top3RecurrentCodesThisWeek = emptyList(),
+        )
+        every { statsPort.summary(tenantId, from, now) } returns expected
+
+        val result = useCase.execute(tenantId, from, now)
+
+        assertThat(result.top3RecurrentCodesThisWeek).isEmpty()
+    }
+
+    @Test
+    fun `should accept from equal to to (point-in-time query)`() {
+        val expectedSummary = AlertStatsSummary(
+            totalActiveNow = 2L,
+            openedToday = 0L,
+            closedToday = 0L,
+            mttrTodaySeconds = null,
+            top3RecurrentCodesThisWeek = emptyList(),
+        )
+        every { statsPort.summary(tenantId, now, now) } returns expectedSummary
+
+        val result = useCase.execute(tenantId, now, now)
+
+        assertThat(result.totalActiveNow).isEqualTo(2L)
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertTimeseriesStatsUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/AlertTimeseriesStatsUseCaseTest.kt
@@ -1,0 +1,119 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.TimeseriesDataPoint
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStatsQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AlertTimeseriesStatsUseCaseTest {
+
+    private val statsPort = mockk<AlertStatsQueryPort>()
+    private val useCase = AlertTimeseriesStatsUseCaseImpl(statsPort)
+
+    private val tenantId = TenantId(10L)
+    private val now = Instant.parse("2026-01-01T12:00:00Z")
+    private val from = now.minusSeconds(86400 * 7)
+
+    private fun buildQuery(
+        from: Instant = this.from,
+        to: Instant = this.now,
+        bucket: TimeseriesBucket = TimeseriesBucket.DAY,
+        groupBy: TimeseriesGroupBy = TimeseriesGroupBy.SEVERITY,
+    ) = TimeseriesStatsQuery(
+        tenantId = tenantId,
+        from = from,
+        to = to,
+        bucket = bucket,
+        groupBy = groupBy,
+    )
+
+    @Test
+    fun `should return port result unchanged when query is valid`() {
+        val query = buildQuery()
+        val expected = listOf(
+            TimeseriesDataPoint(
+                bucketStart = now.minusSeconds(86400),
+                key = "WARNING",
+                opened = 3L,
+                closed = 2L,
+            )
+        )
+        every { statsPort.timeseries(query) } returns expected
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should propagate query to the port including bucket granularity`() {
+        val querySlot = slot<TimeseriesStatsQuery>()
+        val query = buildQuery(bucket = TimeseriesBucket.HOUR, groupBy = TimeseriesGroupBy.TYPE)
+        every { statsPort.timeseries(capture(querySlot)) } returns emptyList()
+
+        useCase.execute(query)
+
+        assertThat(querySlot.captured.bucket).isEqualTo(TimeseriesBucket.HOUR)
+        assertThat(querySlot.captured.groupBy).isEqualTo(TimeseriesGroupBy.TYPE)
+        assertThat(querySlot.captured.tenantId).isEqualTo(tenantId)
+    }
+
+    @Test
+    fun `should throw when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(1))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("from must not be after to")
+    }
+
+    @Test
+    fun `should return empty list when port returns empty`() {
+        val query = buildQuery()
+        every { statsPort.timeseries(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should not call port when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(3600))
+
+        assertThatThrownBy { useCase.execute(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        verify(exactly = 0) { statsPort.timeseries(any()) }
+    }
+
+    @Test
+    fun `should support WEEK bucket granularity`() {
+        val query = buildQuery(bucket = TimeseriesBucket.WEEK)
+        every { statsPort.timeseries(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    fun `should support MONTH bucket granularity`() {
+        val query = buildQuery(bucket = TimeseriesBucket.MONTH)
+        every { statsPort.timeseries(query) } returns emptyList()
+
+        val result = useCase.execute(query)
+
+        assertThat(result).isNotNull
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/FindAlertEpisodesUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/FindAlertEpisodesUseCaseTest.kt
@@ -1,0 +1,187 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertActor
+import com.apptolast.invernaderos.features.alert.domain.model.AlertEpisode
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEpisodesQuery
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertHistoryQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.PagedResult
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class FindAlertEpisodesUseCaseTest {
+
+    private val historyQueryPort = mockk<AlertHistoryQueryPort>()
+    private val useCase = FindAlertEpisodesUseCaseImpl(historyQueryPort)
+
+    private val tenantId = TenantId(10L)
+    private val now = Instant.parse("2026-01-01T12:00:00Z")
+    private val from = now.minusSeconds(86400)
+
+    private fun buildQuery(
+        page: Int = 0,
+        size: Int = 50,
+        from: Instant = this.from,
+        to: Instant = this.now,
+        onlyClosed: Boolean = true,
+    ) = AlertEpisodesQuery(
+        tenantId = tenantId,
+        from = from,
+        to = to,
+        severityIds = emptyList(),
+        sectorIds = emptyList(),
+        codes = emptyList(),
+        onlyClosed = onlyClosed,
+        page = page,
+        size = size,
+    )
+
+    private fun buildEpisode(resolvedAt: Instant? = now) = AlertEpisode(
+        alertId = 100L,
+        alertCode = "ALT-00001",
+        triggeredAt = from.plusSeconds(60),
+        resolvedAt = resolvedAt,
+        durationSeconds = if (resolvedAt != null) 3600L else null,
+        triggerSource = AlertSignalSource.MQTT,
+        resolveSource = if (resolvedAt != null) AlertSignalSource.API else null,
+        triggerActor = AlertActor.Device(null),
+        resolveActor = if (resolvedAt != null) AlertActor.User(42L, "user42", null) else null,
+        severityId = null,
+        severityName = null,
+        sectorId = 20L,
+        sectorCode = "SEC-001",
+    )
+
+    @Test
+    fun `should return paged episodes when query is valid`() {
+        val query = buildQuery()
+        val expected = PagedResult(
+            items = listOf(buildEpisode()),
+            page = 0,
+            size = 50,
+            total = 1L,
+            hasMore = false,
+        )
+        every { historyQueryPort.findEpisodes(query) } returns expected
+
+        val result = useCase.findEpisodes(query)
+
+        assertThat(result).isEqualTo(expected)
+        verify(exactly = 1) { historyQueryPort.findEpisodes(query) }
+    }
+
+    @Test
+    fun `should throw when from is after to`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(1))
+
+        assertThatThrownBy { useCase.findEpisodes(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("from must not be after to")
+    }
+
+    @Test
+    fun `should accept from equal to to (same instant boundary)`() {
+        val query = buildQuery(from = now, to = now)
+        every { historyQueryPort.findEpisodes(query) } returns PagedResult(
+            items = emptyList(), page = 0, size = 50, total = 0L, hasMore = false
+        )
+
+        val result = useCase.findEpisodes(query)
+
+        assertThat(result.items).isEmpty()
+    }
+
+    @Test
+    fun `should throw when page is negative`() {
+        val query = buildQuery(page = -1)
+
+        assertThatThrownBy { useCase.findEpisodes(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("page must be non-negative")
+    }
+
+    @Test
+    fun `should accept page zero as valid lower bound`() {
+        val query = buildQuery(page = 0)
+        every { historyQueryPort.findEpisodes(query) } returns PagedResult(
+            items = emptyList(), page = 0, size = 50, total = 0L, hasMore = false
+        )
+
+        val result = useCase.findEpisodes(query)
+
+        assertThat(result.page).isEqualTo(0)
+    }
+
+    @Test
+    fun `should throw when size exceeds 200`() {
+        val query = buildQuery(size = 201)
+
+        assertThatThrownBy { useCase.findEpisodes(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("size must be")
+    }
+
+    @Test
+    fun `should throw when size is zero`() {
+        val query = buildQuery(size = 0)
+
+        assertThatThrownBy { useCase.findEpisodes(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `should accept size of exactly 200 as valid upper bound`() {
+        val query = buildQuery(size = 200)
+        every { historyQueryPort.findEpisodes(query) } returns PagedResult(
+            items = emptyList(), page = 0, size = 200, total = 0L, hasMore = false
+        )
+
+        val result = useCase.findEpisodes(query)
+
+        assertThat(result.size).isEqualTo(200)
+    }
+
+    @Test
+    fun `should return empty list when port returns no episodes`() {
+        val query = buildQuery()
+        every { historyQueryPort.findEpisodes(query) } returns PagedResult(
+            items = emptyList(), page = 0, size = 50, total = 0L, hasMore = false
+        )
+
+        val result = useCase.findEpisodes(query)
+
+        assertThat(result.items).isEmpty()
+        assertThat(result.total).isZero()
+    }
+
+    @Test
+    fun `should return episode with null resolvedAt when onlyClosed is false`() {
+        val query = buildQuery(onlyClosed = false)
+        val openEpisode = buildEpisode(resolvedAt = null)
+        every { historyQueryPort.findEpisodes(query) } returns PagedResult(
+            items = listOf(openEpisode), page = 0, size = 50, total = 1L, hasMore = false
+        )
+
+        val result = useCase.findEpisodes(query)
+
+        assertThat(result.items).hasSize(1)
+        assertThat(result.items.first().resolvedAt).isNull()
+        assertThat(result.items.first().durationSeconds).isNull()
+    }
+
+    @Test
+    fun `should not call port when from-after-to validation fails`() {
+        val query = buildQuery(from = now, to = now.minusSeconds(3600))
+
+        assertThatThrownBy { useCase.findEpisodes(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        verify(exactly = 0) { historyQueryPort.findEpisodes(any()) }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/FindAlertHistoryUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/FindAlertHistoryUseCaseTest.kt
@@ -1,0 +1,297 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.AlertActor
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertTransition
+import com.apptolast.invernaderos.features.alert.domain.model.TransitionKind
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEventsQuery
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertHistoryQueryPort
+import com.apptolast.invernaderos.features.shared.domain.model.PagedResult
+import com.apptolast.invernaderos.features.shared.domain.model.SortOrder
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class FindAlertHistoryUseCaseTest {
+
+    private val historyQueryPort = mockk<AlertHistoryQueryPort>()
+    private val useCase = FindAlertHistoryUseCaseImpl(historyQueryPort)
+
+    private val tenantId = TenantId(10L)
+    private val now = Instant.parse("2026-01-01T12:00:00Z")
+
+    private fun buildTransition(id: Long = 1L, toResolved: Boolean = false) = AlertTransition(
+        transitionId = id,
+        at = now,
+        fromResolved = !toResolved,
+        toResolved = toResolved,
+        source = AlertSignalSource.MQTT,
+        rawValue = "1",
+        actor = AlertActor.Device(null),
+        alertId = 100L,
+        alertCode = "ALT-00001",
+        alertMessage = "Test alert",
+        alertTypeId = null,
+        alertTypeName = null,
+        severityId = null,
+        severityName = null,
+        severityLevel = null,
+        severityColor = null,
+        sectorId = 20L,
+        sectorCode = "SEC-001",
+        greenhouseId = 5L,
+        greenhouseName = "Greenhouse Norte",
+        tenantId = tenantId.value,
+        previousTransitionAt = null,
+        episodeStartedAt = null,
+        episodeDurationSeconds = null,
+        occurrenceNumber = 1L,
+        totalTransitionsSoFar = 1L,
+    )
+
+    @Test
+    fun `should return transitions for a valid alertId and tenantId`() {
+        val expected = listOf(buildTransition(1L), buildTransition(2L))
+        every { historyQueryPort.findTransitionsByAlertId(100L, tenantId, SortOrder.ASC) } returns expected
+
+        val result = useCase.findTransitionsByAlertId(100L, tenantId, SortOrder.ASC)
+
+        assertThat(result).hasSize(2)
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should propagate tenantId to the port unchanged`() {
+        val tenantSlot = slot<TenantId>()
+        every { historyQueryPort.findTransitionsByAlertId(any(), capture(tenantSlot), any()) } returns emptyList()
+
+        useCase.findTransitionsByAlertId(42L, TenantId(999L), SortOrder.DESC)
+
+        assertThat(tenantSlot.captured.value).isEqualTo(999L)
+    }
+
+    @Test
+    fun `should propagate ASC order to the port`() {
+        val orderSlot = slot<SortOrder>()
+        every { historyQueryPort.findTransitionsByAlertId(any(), any(), capture(orderSlot)) } returns emptyList()
+
+        useCase.findTransitionsByAlertId(1L, tenantId, SortOrder.ASC)
+
+        assertThat(orderSlot.captured).isEqualTo(SortOrder.ASC)
+    }
+
+    @Test
+    fun `should propagate DESC order to the port`() {
+        val orderSlot = slot<SortOrder>()
+        every { historyQueryPort.findTransitionsByAlertId(any(), any(), capture(orderSlot)) } returns emptyList()
+
+        useCase.findTransitionsByAlertId(1L, tenantId, SortOrder.DESC)
+
+        assertThat(orderSlot.captured).isEqualTo(SortOrder.DESC)
+    }
+
+    @Test
+    fun `should return empty list when port returns empty for findTransitionsByAlertId`() {
+        every { historyQueryPort.findTransitionsByAlertId(any(), any(), any()) } returns emptyList()
+
+        val result = useCase.findTransitionsByAlertId(1L, tenantId, SortOrder.ASC)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should throw when alertId is not positive`() {
+        assertThatThrownBy { useCase.findTransitionsByAlertId(0L, tenantId, SortOrder.ASC) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("alertId must be positive")
+    }
+
+    @Test
+    fun `should throw when alertId is negative`() {
+        assertThatThrownBy { useCase.findTransitionsByAlertId(-1L, tenantId, SortOrder.ASC) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `should delegate findTransitions to port and return result unchanged`() {
+        val query = AlertEventsQuery(
+            tenantId = tenantId,
+            from = now.minusSeconds(3600),
+            to = now,
+            sources = emptyList(),
+            severityIds = emptyList(),
+            alertTypeIds = emptyList(),
+            sectorIds = emptyList(),
+            greenhouseIds = emptyList(),
+            codes = emptyList(),
+            actorUserIds = emptyList(),
+            transitionKind = TransitionKind.ANY,
+            page = 0,
+            size = 50,
+        )
+        val pagedResult = PagedResult(
+            items = listOf(buildTransition()),
+            page = 0,
+            size = 50,
+            total = 1L,
+            hasMore = false,
+        )
+        every { historyQueryPort.findTransitions(query) } returns pagedResult
+
+        val result = useCase.findTransitions(query)
+
+        assertThat(result).isEqualTo(pagedResult)
+        verify(exactly = 1) { historyQueryPort.findTransitions(query) }
+    }
+
+    @Test
+    fun `should throw when from is after to in findTransitions`() {
+        val query = AlertEventsQuery(
+            tenantId = tenantId,
+            from = now,
+            to = now.minusSeconds(1),
+            sources = emptyList(),
+            severityIds = emptyList(),
+            alertTypeIds = emptyList(),
+            sectorIds = emptyList(),
+            greenhouseIds = emptyList(),
+            codes = emptyList(),
+            actorUserIds = emptyList(),
+            transitionKind = TransitionKind.ANY,
+            page = 0,
+            size = 50,
+        )
+
+        assertThatThrownBy { useCase.findTransitions(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("from must not be after to")
+    }
+
+    @Test
+    fun `should throw when page is negative in findTransitions`() {
+        val query = AlertEventsQuery(
+            tenantId = tenantId,
+            from = now.minusSeconds(3600),
+            to = now,
+            sources = emptyList(),
+            severityIds = emptyList(),
+            alertTypeIds = emptyList(),
+            sectorIds = emptyList(),
+            greenhouseIds = emptyList(),
+            codes = emptyList(),
+            actorUserIds = emptyList(),
+            transitionKind = TransitionKind.ANY,
+            page = -1,
+            size = 50,
+        )
+
+        assertThatThrownBy { useCase.findTransitions(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("page must be non-negative")
+    }
+
+    @Test
+    fun `should throw when size exceeds 200 in findTransitions`() {
+        val query = AlertEventsQuery(
+            tenantId = tenantId,
+            from = now.minusSeconds(3600),
+            to = now,
+            sources = emptyList(),
+            severityIds = emptyList(),
+            alertTypeIds = emptyList(),
+            sectorIds = emptyList(),
+            greenhouseIds = emptyList(),
+            codes = emptyList(),
+            actorUserIds = emptyList(),
+            transitionKind = TransitionKind.ANY,
+            page = 0,
+            size = 201,
+        )
+
+        assertThatThrownBy { useCase.findTransitions(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("size must be")
+    }
+
+    @Test
+    fun `should throw when size is zero in findTransitions`() {
+        val query = AlertEventsQuery(
+            tenantId = tenantId,
+            from = now.minusSeconds(3600),
+            to = now,
+            sources = emptyList(),
+            severityIds = emptyList(),
+            alertTypeIds = emptyList(),
+            sectorIds = emptyList(),
+            greenhouseIds = emptyList(),
+            codes = emptyList(),
+            actorUserIds = emptyList(),
+            transitionKind = TransitionKind.ANY,
+            page = 0,
+            size = 0,
+        )
+
+        assertThatThrownBy { useCase.findTransitions(query) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `should accept size of exactly 200 in findTransitions`() {
+        val query = AlertEventsQuery(
+            tenantId = tenantId,
+            from = now.minusSeconds(3600),
+            to = now,
+            sources = emptyList(),
+            severityIds = emptyList(),
+            alertTypeIds = emptyList(),
+            sectorIds = emptyList(),
+            greenhouseIds = emptyList(),
+            codes = emptyList(),
+            actorUserIds = emptyList(),
+            transitionKind = TransitionKind.ANY,
+            page = 0,
+            size = 200,
+        )
+        every { historyQueryPort.findTransitions(query) } returns PagedResult(
+            items = emptyList(), page = 0, size = 200, total = 0L, hasMore = false
+        )
+
+        val result = useCase.findTransitions(query)
+
+        assertThat(result.size).isEqualTo(200)
+    }
+
+    @Test
+    fun `should return empty paged result when port returns empty for findTransitions`() {
+        val query = AlertEventsQuery(
+            tenantId = tenantId,
+            from = now.minusSeconds(3600),
+            to = now,
+            sources = emptyList(),
+            severityIds = emptyList(),
+            alertTypeIds = emptyList(),
+            sectorIds = emptyList(),
+            greenhouseIds = emptyList(),
+            codes = emptyList(),
+            actorUserIds = emptyList(),
+            transitionKind = TransitionKind.ANY,
+            page = 0,
+            size = 50,
+        )
+        every { historyQueryPort.findTransitions(query) } returns PagedResult(
+            items = emptyList(), page = 0, size = 50, total = 0L, hasMore = false
+        )
+
+        val result = useCase.findTransitions(query)
+
+        assertThat(result.items).isEmpty()
+        assertThat(result.total).isZero()
+        assertThat(result.hasMore).isFalse()
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ResolveAlertUseCaseImplActorTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ResolveAlertUseCaseImplActorTest.kt
@@ -1,0 +1,238 @@
+package com.apptolast.invernaderos.features.alert.application.usecase
+
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertActor
+import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
+import com.apptolast.invernaderos.features.alert.domain.model.AlertStateChange
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertRepositoryPort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangePersistencePort
+import com.apptolast.invernaderos.features.alert.domain.port.output.AlertStateChangedEventPublisherPort
+import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Unit tests focused on the actor-writing extension in [ResolveAlertUseCaseImpl].
+ * Verifies that the correct [AlertActor] is captured in the persisted [AlertStateChange]
+ * for both resolve and reopen flows, with and without a userId.
+ */
+class ResolveAlertUseCaseImplActorTest {
+
+    private val repository = mockk<AlertRepositoryPort>()
+    private val stateChangePort = mockk<AlertStateChangePersistencePort>()
+    private val eventPublisher = mockk<AlertStateChangedEventPublisherPort>()
+    private val useCase = ResolveAlertUseCaseImpl(repository, stateChangePort, eventPublisher)
+
+    private val tenantId = TenantId(10L)
+
+    private val unresolvedAlert = Alert(
+        id = 1L,
+        code = "ALT-00001",
+        tenantId = tenantId,
+        sectorId = SectorId(20L),
+        sectorCode = null,
+        alertTypeId = null,
+        alertTypeName = null,
+        severityId = null,
+        severityName = null,
+        severityLevel = null,
+        message = "Active alert",
+        description = null,
+        clientName = null,
+        isResolved = false,
+        resolvedAt = null,
+        resolvedByUserId = null,
+        resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    private val resolvedAlert = unresolvedAlert.copy(
+        isResolved = true,
+        resolvedAt = Instant.parse("2026-01-01T06:00:00Z"),
+        resolvedByUserId = 42L,
+    )
+
+    // -----------------------------------------------------------------------
+    // resolve() actor tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `resolve with userId should persist AlertActor dot User with correct userId`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns unresolvedAlert
+        every { repository.save(any()) } answers { firstArg<Alert>().copy(id = 1L, isResolved = true) }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        val result = useCase.resolve(1L, tenantId, resolvedByUserId = 42L)
+
+        assertThat(result).isInstanceOf(Either.Right::class.java)
+        val actor = changeSlot.captured.actor
+        assertThat(actor).isInstanceOf(AlertActor.User::class.java)
+        assertThat((actor as AlertActor.User).userId).isEqualTo(42L)
+    }
+
+    @Test
+    fun `resolve with userId should set source to API`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns unresolvedAlert
+        every { repository.save(any()) } answers { firstArg<Alert>().copy(id = 1L, isResolved = true) }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.resolve(1L, tenantId, resolvedByUserId = 42L)
+
+        assertThat(changeSlot.captured.source).isEqualTo(AlertSignalSource.API)
+    }
+
+    @Test
+    fun `resolve with userId should set toResolved=true and fromResolved=false`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns unresolvedAlert
+        every { repository.save(any()) } answers { firstArg<Alert>().copy(id = 1L, isResolved = true) }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.resolve(1L, tenantId, resolvedByUserId = 42L)
+
+        assertThat(changeSlot.captured.toResolved).isTrue()
+        assertThat(changeSlot.captured.fromResolved).isFalse()
+    }
+
+    @Test
+    fun `resolve without userId should persist AlertActor dot System`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns unresolvedAlert
+        every { repository.save(any()) } answers { firstArg<Alert>().copy(id = 1L, isResolved = true) }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.resolve(1L, tenantId, resolvedByUserId = null)
+
+        assertThat(changeSlot.captured.actor).isEqualTo(AlertActor.System)
+    }
+
+    @Test
+    fun `resolve with different userId values should each map to AlertActor dot User with correct userId`() {
+        listOf(1L, 100L, Long.MAX_VALUE).forEach { userId ->
+            every { repository.findByIdAndTenantId(1L, tenantId) } returns unresolvedAlert
+            every { repository.save(any()) } answers { firstArg<Alert>().copy(id = 1L, isResolved = true) }
+            val changeSlot = slot<AlertStateChange>()
+            every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+            justRun { eventPublisher.publish(any(), any()) }
+
+            useCase.resolve(1L, tenantId, resolvedByUserId = userId)
+
+            val actor = changeSlot.captured.actor
+            assertThat(actor).isInstanceOf(AlertActor.User::class.java)
+            assertThat((actor as AlertActor.User).userId).isEqualTo(userId)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // reopen() actor tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `reopen with actorUserId should persist AlertActor dot User with correct userId`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns resolvedAlert
+        every { repository.save(any()) } answers {
+            firstArg<Alert>().copy(id = 1L, isResolved = false, resolvedAt = null, resolvedByUserId = null)
+        }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 100L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        val result = useCase.reopen(1L, tenantId, actorUserId = 42L)
+
+        assertThat(result).isInstanceOf(Either.Right::class.java)
+        val actor = changeSlot.captured.actor
+        assertThat(actor).isInstanceOf(AlertActor.User::class.java)
+        assertThat((actor as AlertActor.User).userId).isEqualTo(42L)
+    }
+
+    @Test
+    fun `reopen with actorUserId should set source to API`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns resolvedAlert
+        every { repository.save(any()) } answers {
+            firstArg<Alert>().copy(id = 1L, isResolved = false, resolvedAt = null, resolvedByUserId = null)
+        }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 100L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.reopen(1L, tenantId, actorUserId = 42L)
+
+        assertThat(changeSlot.captured.source).isEqualTo(AlertSignalSource.API)
+    }
+
+    @Test
+    fun `reopen with actorUserId should set fromResolved=true and toResolved=false`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns resolvedAlert
+        every { repository.save(any()) } answers {
+            firstArg<Alert>().copy(id = 1L, isResolved = false, resolvedAt = null, resolvedByUserId = null)
+        }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 100L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.reopen(1L, tenantId, actorUserId = 42L)
+
+        assertThat(changeSlot.captured.fromResolved).isTrue()
+        assertThat(changeSlot.captured.toResolved).isFalse()
+    }
+
+    @Test
+    fun `reopen without actorUserId should persist AlertActor dot System`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns resolvedAlert
+        every { repository.save(any()) } answers {
+            firstArg<Alert>().copy(id = 1L, isResolved = false, resolvedAt = null, resolvedByUserId = null)
+        }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 100L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.reopen(1L, tenantId, actorUserId = null)
+
+        assertThat(changeSlot.captured.actor).isEqualTo(AlertActor.System)
+    }
+
+    @Test
+    fun `reopen with default actorUserId omitted should persist AlertActor dot System`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns resolvedAlert
+        every { repository.save(any()) } answers {
+            firstArg<Alert>().copy(id = 1L, isResolved = false, resolvedAt = null, resolvedByUserId = null)
+        }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 100L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        // Call with default actorUserId (null)
+        useCase.reopen(1L, tenantId)
+
+        assertThat(changeSlot.captured.actor).isEqualTo(AlertActor.System)
+    }
+
+    @Test
+    fun `resolve should not populate username or displayName (those are hydrated at query time)`() {
+        every { repository.findByIdAndTenantId(1L, tenantId) } returns unresolvedAlert
+        every { repository.save(any()) } answers { firstArg<Alert>().copy(id = 1L, isResolved = true) }
+        val changeSlot = slot<AlertStateChange>()
+        every { stateChangePort.save(capture(changeSlot)) } answers { firstArg<AlertStateChange>().copy(id = 99L) }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        useCase.resolve(1L, tenantId, resolvedByUserId = 42L)
+
+        val actor = changeSlot.captured.actor as AlertActor.User
+        assertThat(actor.username).isNull()
+        assertThat(actor.displayName).isNull()
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 of the alert history rework: exposes the existing append-only `metadata.alert_state_changes` audit log (V37) as a first-class read API and adds derived statistics. Closes the conceptual gap where the mobile "Histórico" tab showed one row per alert instead of one row per state transition.

## Changes

- **V40 Flyway**: adds `actor_user_id`, `actor_kind`, `actor_ref` to `alert_state_changes` with best-effort backfill (latest API close → `alerts.resolved_by_user_id`, MQTT → `DEVICE`, others → `SYSTEM`).
- **3 new history endpoints** under `/api/v1/tenants/{tenantId}/...`:
  - `GET /alerts/{alertId}/history?order=ASC|DESC` — full timeline of one alert.
  - `GET /alert-events?...filters...&page=&size=` — paginated tenant-wide feed of transitions (replaces conceptually the legacy `/history` endpoint).
  - `GET /alert-events/episodes` — open→close episode pairs.
- **6 new stats endpoints** under `/api/v1/tenants/{tenantId}/alerts/stats/...`: recurrence, mttr, timeseries, active-duration, by-actor, summary.
- **1 new count endpoint**: `GET /alerts/count/unresolved/sector/{sectorId}` (was missing).
- **Legacy `AlertController`**: `resolve`/`reopen` now delegate to hexagonal use cases (so they finally write to `alert_state_changes`). All legacy responses carry `Deprecation: true` + `Sunset` (90d) + `Link` headers via `LegacyAlertDeprecationFilter`.
- **WebSocket broadcast**: new `AlertStateChangedWebSocketListener` emits each transition to `/topic/tenant/{tenantId}/alerts` after commit.
- **80 unit tests + 5 ArchUnit rules**.
- **Native SQL with window functions** (`LAG`, `MAX(CASE) OVER`, `ROW_NUMBER`, `PERCENTILE_CONT`) targeting PostgreSQL 16.

## Design doc

`docs/architecture/alert-history-design.md`

## Test plan

- [x] `./gradlew compileKotlin` — green, 0 warnings
- [x] `./gradlew compileTestKotlin` — green, 0 warnings
- [x] `./gradlew test --tests "*alert*" --tests "*ArchitectureTest*"` — all pass
- [ ] CI build + flyway-migrate workflows green on develop
- [ ] Smoke `POST /api/v1/auth/login` on inverapi-dev and `GET /api/v1/tenants/{tenantId}/alerts/stats/summary` returns 200
- [ ] Swagger live spec includes the 10 new endpoints
- [ ] Verify deprecation headers on a legacy response
- [ ] After CI for develop is green, merge to main and repeat smoke against inverapi-prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)