### PR TITLE
hotfix(notification): switch dedup query to native JSONB ->> operator

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/NotificationLogJpaRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/NotificationLogJpaRepository.kt
@@ -32,16 +32,23 @@ interface NotificationLogJpaRepository : JpaRepository<NotificationLogEntity, Lo
      * Deduplication check for the AlertAgingDetector: returns true if a notification
      * of [type] referencing [alertId] was already SENT after [since].
      *
-     * The LIKE-based JSONB scan is acceptable at MVP volume.
-     * MVP: si el volumen lo justifica, indexar alert_id como columna dedicada en notification_log.
+     * Native query because payload_json is JSONB and Hibernate's HQL `LIKE` rejects
+     * JSONB columns ("Operand of 'like' is not a string"). The JSONB ->> operator
+     * extracts a top-level field as text, which is index-friendly and unambiguous.
+     * If notification_log volume grows, index alert_id as a dedicated column.
      */
-    @Query("""
-        SELECT COUNT(n) > 0 FROM NotificationLogEntity n
-        WHERE n.notificationType = :type
-          AND n.payloadJson LIKE CONCAT('%"alertId":"', :alertId, '"%')
-          AND n.status = 'SENT'
-          AND n.sentAt > :since
-    """)
+    @Query(
+        value = """
+            SELECT EXISTS (
+                SELECT 1 FROM metadata.notification_log
+                WHERE notification_type = :type
+                  AND (payload_json->>'alertId') = CAST(:alertId AS text)
+                  AND status = 'SENT'
+                  AND sent_at > :since
+            )
+        """,
+        nativeQuery = true
+    )
     fun hasRecentSentForAlert(
         @Param("type") type: String,
         @Param("alertId") alertId: Long,


### PR DESCRIPTION
## Why

After PR #113 merged, the new pod entered CrashLoopBackOff. Spring Data validates repository methods at startup; \`hasRecentSentForAlert\` used a JPQL \`LIKE\` over a JSONB column, which Hibernate rejects:

\`\`\`
SemanticException: Operand of 'like' is of type 'java.lang.String' which is not a string
(its JDBC type code is not string-like)
\`\`\`

Pod \`invernaderos-api-f7f576d6f-6p9mr\` reached 5 restarts in ~10 min; the previous pod (\`d78c87c95-2nnwk\`) kept serving traffic so there was zero client-facing impact, but the new image could not roll out.

## Fix

Switch to a native PostgreSQL query using the JSONB \`->>\` operator (extract field as text). Standard idiom, index-friendly, and unambiguous regardless of how the JSON serializes \`alertId\` (number vs quoted string — both \`{"alertId":42}\` and \`{"alertId":"42"}\` match \`(payload_json->>'alertId') = '42'\`).

## Test plan

- [x] \`./gradlew compileKotlin\` BUILD SUCCESSFUL
- [ ] Merge → CI re-builds image → \`kubectl rollout restart\` dev → pod becomes Ready 1/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)