### PR TITLE
ci: gate gradle test before docker build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -31,6 +31,49 @@ env:
   IMAGE_NAME: apptolast/invernaderos-api
 
 jobs:
+  # Job de tests: actúa como gate antes del build de Docker.
+  # Necesario para que SQL drift y otros bugs no lleguen a prod (ver PR-CI:
+  # historico-de-alertas + plan en docs/architecture/ — si el job falla,
+  # no se sube imagen).
+  # NOT workflow_run: el flujo de migraciones no requiere re-ejecutar tests
+  # del codigo; el commit ya pasó por test cuando se merged.
+  test:
+    name: Run gradle tests
+    runs-on: ubuntu-latest
+    if: |
+      always() && (
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')) ||
+        (github.event_name == 'pull_request') ||
+        (github.event_name == 'workflow_dispatch')
+      )
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run gradle test
+        env:
+          INVERNADEROS_TEST_DB_PASSWORD: ${{ secrets.INVERNADEROS_TEST_DB_PASSWORD }}
+        run: ./gradlew compileKotlin compileTestKotlin test --warning-mode=all --no-daemon
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            build/reports/tests/
+            build/test-results/
+          retention-days: 7
+
   # Job para verificar si las migraciones se completaron correctamente
   check-migrations:
     name: Check Migration Status
@@ -53,10 +96,13 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    # Solo depender de check-migrations si el evento es workflow_run
-    needs: [check-migrations]
+    # Build only if tests passed (or were skipped because not applicable, e.g. workflow_run from migrations).
+    # Migrations branch (workflow_run) keeps its existing gate via check-migrations.
+    needs: [test, check-migrations]
     if: |
       always() && (
+        (needs.test.result == 'success' || needs.test.result == 'skipped')
+      ) && (
         (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')) ||
         (github.event_name == 'pull_request') ||
         (github.event_name == 'workflow_dispatch') ||


### PR DESCRIPTION
## Summary

Adds a `test` job to `.github/workflows/build-and-push.yml` that runs `./gradlew compileKotlin compileTestKotlin test --warning-mode=all` before the docker build. The build job now requires `test` to succeed (or be skipped when triggered by the `workflow_run` from Flyway migrations, which does not need to re-run code tests).

## Why this is critical

PR #112 (alert history feature) shipped to production with **two runtime BLOCKERs**:
- SQL alias `asc` is a PG reserved word — breaks 11 native queries.
- `u.display_name` references a column that does not exist in `metadata.users`.

Both were caught only by manual SQL repro against the live DB **after** release. The reason they slipped through is that CI never ran `./gradlew test` — it only built and pushed the docker image. With this gate in place, any future SQL drift, missing column, compile error, or test regression blocks the merge.

This is the prerequisite PR of a 9-PR rollout that fixes the 22 bugs found in the audit. See `/home/admin/.claude/plans/si-a-todo-y-floofy-emerson.md` (local).

## Test plan

- [x] Local `./gradlew test` with `INVERNADEROS_TEST_DB_PASSWORD` set: 337 tests, 0 fails, 0 errors, 0 skipped, BUILD SUCCESSFUL in 2m 18s.
- [ ] CI runs the new `test` job on this PR and passes.
- [ ] On purpose-failing test commit (separate dry-run later), CI rejects build correctly.

## Notes

- `INVERNADEROS_TEST_DB_PASSWORD` secret already configured in GHA (referenced by `src/test/resources/application.yaml`).
- Test reports upload on failure (`actions/upload-artifact@v4`) so regressions are debuggable without re-running locally.
- The `workflow_run` trigger (Flyway migrations) keeps its existing path: it still goes through `check-migrations` and skips the `test` job (skip = pass for the OR gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)