### PR TITLE
merge: deploy CI test gate to prod (#119)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -31,6 +31,49 @@ env:
   IMAGE_NAME: apptolast/invernaderos-api
 
 jobs:
+  # Job de tests: actúa como gate antes del build de Docker.
+  # Necesario para que SQL drift y otros bugs no lleguen a prod (ver PR-CI:
+  # historico-de-alertas + plan en docs/architecture/ — si el job falla,
+  # no se sube imagen).
+  # NOT workflow_run: el flujo de migraciones no requiere re-ejecutar tests
+  # del codigo; el commit ya pasó por test cuando se merged.
+  test:
+    name: Run gradle tests
+    runs-on: ubuntu-latest
+    if: |
+      always() && (
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')) ||
+        (github.event_name == 'pull_request') ||
+        (github.event_name == 'workflow_dispatch')
+      )
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run gradle test
+        env:
+          INVERNADEROS_TEST_DB_PASSWORD: ${{ secrets.INVERNADEROS_TEST_DB_PASSWORD }}
+        run: ./gradlew compileKotlin compileTestKotlin test --warning-mode=all --no-daemon
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            build/reports/tests/
+            build/test-results/
+          retention-days: 7
+
   # Job para verificar si las migraciones se completaron correctamente
   check-migrations:
     name: Check Migration Status
@@ -53,10 +96,13 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    # Solo depender de check-migrations si el evento es workflow_run
-    needs: [check-migrations]
+    # Build only if tests passed (or were skipped because not applicable, e.g. workflow_run from migrations).
+    # Migrations branch (workflow_run) keeps its existing gate via check-migrations.
+    needs: [test, check-migrations]
     if: |
       always() && (
+        (needs.test.result == 'success' || needs.test.result == 'skipped')
+      ) && (
         (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')) ||
         (github.event_name == 'pull_request') ||
         (github.event_name == 'workflow_dispatch') ||

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "406c17ac-70ca-4acb-a7b5-10cdee6d289e",
+          "id": "5aa4bbeb-5e3a-4a7a-959a-62052004e8d4",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "564e5ac1-dc0b-4285-998c-3d58e9240d06",
+              "id": "4d66d31c-46e4-489a-8a78-3051a95e0d0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "6e042888-0a31-44b5-889c-d60c0ba0c379",
+          "id": "c9771026-4fd9-494d-8024-730d1d044df2",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "7fa356a6-9f7f-47eb-84db-a5313f072ba8",
+              "id": "ebf536a2-d64d-4b08-9b17-906cb9c6e10f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "3d068126-06d6-4466-ae9f-82e97af2ed4d",
+          "id": "2ebcff6b-8e7d-41fc-973e-c3152add5297",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "44cfe04f-7865-411e-9f6a-ad10e3665e5d",
+              "id": "a35d1b31-a1e9-48b6-bf9a-60560acf33c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "3ef3b6ca-9cda-4f0f-8f98-04630e4559cf",
+          "id": "260cf67a-d9c7-4ef3-8b10-bf5e4afd677b",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "fa1277aa-86ed-4515-9241-4f1a185691ce",
+              "id": "b3e03598-602d-429b-9486-311be11ca871",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "c5d0b4d5-97bb-4b58-8409-b0e0751ae536",
+          "id": "2784c04f-3634-4cbb-8e6e-f70c51b3dfbb",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "ab0cf314-7a64-4c81-b4e7-7538daec8a0d",
+              "id": "0351b247-458c-423a-a587-70bfaab7f023",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "38d58505-4443-4523-a5f2-e018baefee21",
+          "id": "0d1a7f21-56cd-4c5d-b827-e2d2a1137252",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "ddb04b15-aa62-4ca2-9d3a-67c1e75dd763",
+              "id": "ef6d42da-e55d-4c90-a6d9-f7e02d7e71c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "94cdcc65-26c2-4081-9328-52fbee11148b",
+          "id": "e5cdbcbf-30b9-44f0-9f2e-c517638bd11c",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "85a97e10-909f-4985-b56e-dd3086f14427",
+              "id": "339e8749-1eaf-4a35-a920-7fcae414652f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "b5892ef0-3217-48bc-8fc9-1c77594d60b7",
+          "id": "4d5c603a-e3b0-4489-9ef4-abb3b2f9dadd",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "f40bac1b-2117-41ae-9aa0-4ba6f8171fb2",
+              "id": "aed5d591-29aa-4a19-949b-742e98ff495e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "c227a73a-f80f-4e86-a08e-951f2acbd54b",
+          "id": "c62e1cad-cdca-46ea-bcfb-449c9d246cb7",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "8c6e3fd1-a80d-4847-8fcd-e384a3187043",
+              "id": "6a17b855-0a44-4458-954c-b33fd36240e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "e502966d-0e09-4b31-9042-32868c7046d8",
+          "id": "6df78713-a587-489a-b831-b60df3b2bcea",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "a25fea4a-a144-40c5-b38b-843b9e0a02f3",
+              "id": "86945688-4966-4332-973b-5106b550fec9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "bca82d19-3004-42b8-81d6-dc9e04389a35",
+          "id": "5b22c5a9-47b1-41d4-a124-dd675cd3e87e",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "ed080e42-8092-4d26-8a63-f47552a3c5f8",
+              "id": "75941ec0-f588-48ef-82f8-30f0af797250",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "532d7725-4bb9-4785-a666-88539a25bf54",
+          "id": "41a57d3e-f156-4c92-8728-f5339c280350",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "ec767842-520b-4374-b473-8baf92f24c73",
+              "id": "7f1c2c9f-c1e3-4a36-be41-986f3495a675",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "016f54fa-50cd-4497-b20a-6354fcd3556a",
+          "id": "7de771bf-0724-402a-bb67-307d297f3da9",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "560ff477-f863-4636-8368-8631d6c2d424",
+              "id": "5ac2d205-1de1-49e8-92d0-a707cd6a9cfc",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "8bf110c1-4771-4d64-b139-6b0bd19079ec",
+          "id": "cf7c8d23-32c7-4ae1-b700-f313cde418c0",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "5cce2ffd-4e69-48d8-8a6f-930a839be8e4",
+              "id": "ac527eb6-ebe5-445c-a11b-2a9bc0f76611",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "e51cf7fb-e898-4b8f-b4a7-a625cb5a6585",
+          "id": "46ee4746-895d-4b5a-910b-185ad6ea687d",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "3602a2d2-fcea-4370-86ff-fb2ac3b0fe7c",
+              "id": "767f0ef4-12cb-45ab-8c03-e95060837167",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "f5ab6b89-08a7-4870-8e54-f6fca23d76e6",
+          "id": "57d2c26b-e9c4-4813-99ad-5dca3bbaa277",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "5f32a256-d5c2-4404-a832-e792d35344b4",
+              "id": "42037746-aa22-457c-b71c-a5ff23cb9687",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "c40d96ab-63a5-41f3-b45b-b15fb5b6dcc3",
+          "id": "1957692b-9a5c-476d-8781-f93475967d2c",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "4bdf4a46-d521-48d4-ba78-3c4f6dad9ce5",
+              "id": "58c8153e-3c13-4be6-8fa4-bbfbc874669f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "8d9db433-b631-47f8-a6c1-476202c453a6",
+          "id": "93802dc0-5fea-4270-896b-87ec60e25cef",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "63181bf5-1b35-400f-bd2b-a545ae737b29",
+              "id": "189b181b-e79f-47d9-84e5-681e0a75691f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "28d6f379-3086-43ff-8e0c-929c227eb196",
+          "id": "4c673d8a-2555-4572-a995-890234711e5b",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "a43bf79b-dc01-4287-9733-99caf58ddcb7",
+              "id": "c82d9f44-e603-45d3-b329-3de9e08b6d8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\",\n  \"key_4\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "3644f725-aa3c-4651-a6ff-773979674231",
+          "id": "c3f6ea06-feb7-40bf-9c9b-c32e8c0f04a0",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "2367f8ae-f086-440c-95dd-c985ad138a6d",
+              "id": "ee4c9381-bd06-4cf7-9a35-0a6f34698047",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "eaec3024-f7cc-43e4-bed0-3f0c2ad53ab4",
+          "id": "e8c9fe34-376f-46b2-a024-dd7b1c558167",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "8c6e88fd-5f62-4ff9-8411-14404f300771",
+              "id": "eac574ff-ef7a-4ee8-9816-7e0337145d85",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "0afbf70a-3fef-45d7-853c-2c278f6c0cd8",
+          "id": "eba1e114-c490-4c7f-8589-1959924a8a66",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "54575b82-1f1e-4ef8-8f5b-4b771e190696",
+              "id": "18674144-1a18-4277-9317-e33e957e72ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "deb9a6b4-f97f-40cf-a01e-df2fa9925882",
+          "id": "c28ff888-9f35-4ecf-a241-80b63012b5b7",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "0c12c7e5-ebdb-4014-a7ec-65bb2c592851",
+              "id": "9bd0195d-5b01-40f5-b9aa-c175b899317c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "8ee729f1-fa52-4d1e-8fcd-1c33b2ce4ced",
+          "id": "2428a3e1-e93b-4d3a-ad40-e2dbd6e40ff7",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "558e30db-8aa9-4608-8d26-78f70b3d3867",
+              "id": "1ca624e3-e62f-4311-b178-6f84b36c80fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "00ec393d-b5c2-4f11-b2d1-67d1860be7fc",
+          "id": "df770180-1d74-4c02-a205-3d57d0ccdf0f",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "d0412bf9-d972-4267-8502-155ef5299dfa",
+              "id": "8ec210a8-eae5-4080-852a-7414469e234f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "e1e314eb-2eda-467a-adae-d66f194971fd",
+          "id": "6d81d425-390e-4f78-95cd-f52f943a3feb",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "b8636884-058c-4d17-b453-44a01ce2a9cc",
+              "id": "76106061-3f4c-497b-aacb-d76838745534",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "3f267c3d-3c4d-4b21-aaf9-257886b3986c",
+          "id": "8b7e8550-90da-4a11-ad39-9f8c350978c6",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "447efcd4-7fc7-4bcd-aff1-a1ec33a36ab8",
+              "id": "58e13ebf-9619-47d0-9607-dff50019d33b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "0eae3eb0-1f67-424a-91e2-383aebaad596",
+          "id": "5a1bfbba-3324-4285-a8d7-7c982d6266e9",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "4bc2e401-c210-422f-b7d5-9e6aa733a447",
+              "id": "74344796-c30e-40bb-b916-d8dd8c61b74e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "9d5c9cf5-08b3-4b7c-a026-c963129f2aac",
+          "id": "29aa8f0c-f711-41ce-b460-00148a9a0ce0",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "abdda56a-dc23-4c0a-bfc4-dd7a8c3306aa",
+              "id": "e1fadc7c-465b-4f69-b72d-b1f673e57e71",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": true,\n        \"key_1\": false\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": 7276,\n        \"key_2\": 9271\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 1333,\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 3364.953914229627,\n        \"key_1\": 3304,\n        \"key_2\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "26b71dfc-b6fc-48eb-b3a4-a0aa034bcff8",
+          "id": "bbeadfc8-26aa-42ee-a76a-6ef814a6b09a",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "d8834ae4-9075-4a66-97cf-de641afe3d67",
+              "id": "a361fb31-2f43-4e9d-b3d4-d4d603dafb71",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "0692bcb0-437e-46e7-a267-40ea3e0f8613",
+          "id": "b6452ccf-cd12-45c1-b21b-e01a2233675a",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#b9A735\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#Fe6C38\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "cc91005b-d500-4be8-8e59-6be8282ec420",
+              "id": "f68114b8-54fb-4a5d-9dc4-70e31d5bf39e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#b9A735\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#Fe6C38\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "8466f86f-588c-4b12-abc5-3f565e2c6bc7",
+          "id": "f899f547-ac8e-4a9c-9ca1-608be440d5ae",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "3555faaa-8a65-4a34-a1f7-84956e61eb34",
+              "id": "fb2928d0-8fc8-4488-8185-2c1f016b1197",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "4aa15d9d-a0c7-46c1-b83d-8f8c7c9abf28",
+          "id": "5ba662dd-a077-4955-b09f-2a4986475f45",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "5960851d-8da0-4ccd-8af0-11acd5eac41e",
+              "id": "46e0503e-787b-42f3-b6cc-778f27ccb049",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "d205f184-8956-4d0c-af59-207465427bbc",
+          "id": "40344cc7-3881-4f7f-a8ef-6d6226e9feee",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cdCfe0\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4Bbc1A\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "0a24b93d-6ca2-4409-af96-23651ea5ce20",
+              "id": "2adda55e-6ad8-4f2a-b7f2-2e0316321250",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cdCfe0\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4Bbc1A\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "d9dc6bdb-271d-49b6-8a15-0319481f5438",
+          "id": "4eb46aa0-fbaa-4b0e-a01c-fd055314a8d4",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "037aa4af-a333-4bf5-bc88-a4b3f6b4910d",
+              "id": "d450d9d9-fb7b-4307-975c-1a3701ffab4c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "036881bf-8e4b-4c3c-ac4d-49cc8f03a873",
+          "id": "667873e6-c1c5-429a-84af-c729f6033131",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "aa05b2e3-8044-47ed-9761-37d8fdd96a9f",
+              "id": "6e27eccf-f1fc-48a0-900f-08203fd691cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "358a8f74-25c8-48b4-b74c-0db7eed9d653",
+          "id": "bc3adc0e-4943-4873-95d4-ad37b9e242dd",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "de499043-8843-45f3-a98e-ba1daacb4831",
+              "id": "af9e8ec7-9874-4bb0-b8b9-1210c9a2478e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "a9340af3-74ca-435f-a0b4-33e59411177f",
+          "id": "2ae1e9b2-1f7b-4fb0-ab92-ff79b575a598",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "6212cb8e-e8f0-45cc-989b-050cd644c283",
+              "id": "bb27dad7-712d-4dda-8d92-216173a65e06",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "b464649b-ec5f-4e9c-b80b-cb3addef8d47",
+          "id": "58afbc23-294b-4854-a8bb-1b91961eca8b",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "2b1c736e-d5ec-43cd-b00c-f64d599685a0",
+              "id": "40ff8174-4ed4-437b-96e3-01977a2df3c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "f731bd37-7cce-4d93-baf1-29bbe518ea6f",
+          "id": "54e29f32-d30a-4fe1-85e4-23b5072ad62d",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "5b093730-8182-4ee3-9e9f-20cbaaf716cf",
+              "id": "8c1d356b-d9b3-460d-9725-32998a35d50d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "06342518-592a-4aec-837c-e119804301a5",
+          "id": "8e1d589e-aa4b-46d6-9a5d-e9eb6a8e2130",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "2f10aaa6-949c-45d4-901b-00a9b297c132",
+              "id": "e784b84d-cd71-4153-a879-d628dcb9caa6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "3c579231-c939-411f-aa77-e8a251131d32",
+          "id": "6188d7fb-e4ef-4f22-8694-3e541feedb35",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "5e15273f-47ec-4452-93b8-110d54a4737c",
+              "id": "9974a492-0288-42ed-81d3-abb6264a3117",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "2e4d59b6-2304-43ba-9058-b85fe5314d50",
+          "id": "01f2cc9d-e5d6-449a-98fd-5224423a9f56",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "702a39d3-f9c5-4cad-87f6-e784e67b8db5",
+              "id": "eab1cc61-3baf-4886-bc2b-0c77d56c962a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "c72535b6-ef24-4791-b282-1589c1143d99",
+          "id": "bbd62631-b997-4fd1-9946-9570b43552ec",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "380f79ad-6385-4c5d-990f-089016e09d56",
+              "id": "57db4c65-a1ad-4718-83d6-8d3d1354edec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "43f501c9-551a-4079-b41d-8ae34f816f67",
+          "id": "75844c2d-cffe-48d4-a089-df2900cf46b5",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "4b59fb1a-987b-4d85-ab90-fbf0423002aa",
+              "id": "26a4e646-5c24-4cc1-a347-e6435df44b16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "69e30307-e866-4c69-a62c-dcbe7e7d1ad5",
+          "id": "fdce95ea-d7c1-4189-b79c-da5a925ce434",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "90fa8eff-d6bc-4286-97aa-4c4873d181c9",
+              "id": "bd77157e-b7a2-40b7-9f46-d0882ab53e1d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "4c5821a3-813c-40f2-921e-f81572bdc122",
+          "id": "406e928d-d940-4956-bdd4-24ff98c5b6bb",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "256ba46a-4879-48e3-884d-529eeddb0fa0",
+              "id": "0ed2afc1-d9a4-4871-9c4d-77e888c92529",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "bc31e0e3-4a8b-48d3-bbda-1c97ef217ffa",
+          "id": "e590ed7b-5226-4cd1-bb81-2e5c838f2f7e",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "3ed653b9-a197-4f48-a254-360b8550ff40",
+              "id": "048d1778-0a6e-490d-88bd-53bfaf42611f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "0cc7925c-8e6a-43e9-b0c3-86e7f20c062c",
+          "id": "edafb45a-4c98-4848-bf98-9b419b1cb038",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "f91e9898-888a-46c2-8adc-60d126c3e660",
+              "id": "d0d7ae81-abf9-4887-8818-09f8c1317b0b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "5c87e186-41e6-4f09-a64d-a5d4b0731f4b",
+          "id": "098404aa-a5ef-4176-a5db-6e632880b2b8",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "52525c49-9be8-4bb6-a370-8de66581e37a",
+              "id": "5b8809ec-9cbd-4881-8bd3-28872b57627d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "77b333e9-76ab-4af4-b0cf-0dded7bc402f",
+          "id": "754f1124-aa25-4389-bec4-bab0ace3f0fa",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "d1d9254d-8102-4eb9-ac97-1e9c9231a580",
+              "id": "b05ccae6-b807-480b-b200-e0b7046a7061",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "1ed21600-7ee6-4e4f-a1af-c4066d46d265",
+          "id": "0889b4b6-bba7-4ea7-9cbd-fec29202f6d9",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "9f1a831b-ade4-4db0-9854-ba85e92363a2",
+              "id": "47750a66-ff71-4d0c-918a-46ba761f712b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "02606ef4-658c-4f72-9fce-48c863511e0d",
+          "id": "553f937e-6bec-45fc-8a5f-add0c94d7557",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "77c10bf7-f097-4c69-82b3-b104a51852fd",
+              "id": "f56f3fb1-0712-4825-adc8-3dd985b1a96d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "16ec4dbc-6ccb-4c12-9787-a4ef85530c8f",
+          "id": "a7228ac6-87b5-46c1-8e44-2cc7ccc88e2d",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "5b0e078a-fbfe-4c2d-8c13-645ebaa49444",
+              "id": "fb4b2fed-f1f4-4940-bbaa-4846108fb84a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "b785d495-4fd6-4e8e-b370-556a86c392b2",
+          "id": "540b1e7a-b29b-48ac-85fc-c5b1c3a2d75f",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "ae2c5a3d-9f70-403a-a2c8-5d66a8cf9c7b",
+              "id": "93a5a267-6ae3-4938-8b55-f3d62a2f87a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "432091e1-dace-4f8a-81a1-1180b766e059",
+          "id": "2bdc85d3-e902-462e-bdd2-f8956925b377",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "689b6213-aa45-4140-ba63-547dedc00aaa",
+              "id": "bdf34d6c-5acf-4e98-8e4c-dcb5d72ac539",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "71aafd1b-729f-4740-8de3-1f8ba7465f05",
+          "id": "1562aeb7-9add-41b0-adff-f2e1a081066b",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "d63de4c4-a824-4cfa-9858-8aaac77e0b05",
+              "id": "ab93d852-6a88-48ce-9422-ffbcfbbcab7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "371d33d9-0924-46d3-840e-3128b9d078fa",
+          "id": "8eb4edbe-1828-44d0-bb57-c0610f999809",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "15bd6402-0f5a-44b5-8731-5e6503ed3e77",
+              "id": "e9ebc3ae-d358-40d0-8fb1-4f94e3228344",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "93cc655d-a572-4404-81f8-ac6740ae0e04",
+          "id": "a1eff31e-5461-44fc-adc5-ba97695b08cf",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "0eeec06a-34ea-44a4-bd04-357608a09eeb",
+              "id": "9a389cd7-7254-41ab-bfc0-c00f700c7712",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "4d163a4b-223b-4733-b879-012ca915a253",
+          "id": "ee35cd64-6ddb-4103-819a-162b04be1462",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "408bab72-2fd8-49f4-95cf-4baf142df2a9",
+              "id": "7b7fd876-61e5-4d1b-8f06-ac1552725488",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "0840d817-97df-4708-b3cc-fd780595c355",
+          "id": "7d4e29f0-f90b-4863-8637-6c1e4dcf410d",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "224c7480-d69e-4aa8-99fa-1d5ec03b4ad1",
+              "id": "e59b2ac9-b292-445f-b4a6-5baf3251b43c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "81d7f8a7-4893-424e-9a46-5e8e3128e541",
+          "id": "0a0b528b-b529-4b47-94f7-a6c08acfb69d",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "d0dd3646-3002-4128-b03a-a63d608ca885",
+              "id": "d59528b9-de06-49c1-86ff-316f16d55215",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "a349baf1-9d16-4a0f-bd27-76aef1bcae56",
+          "id": "e96f88e4-69f3-4075-b581-71aba8f0b334",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7566,7 +7566,7 @@
           },
           "response": [
             {
-              "id": "1cd5ab1c-f740-4e10-9677-8f1658e6c452",
+              "id": "47376496-8566-41b7-9697-5d6e4eb0047b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7655,7 +7655,7 @@
           }
         },
         {
-          "id": "d100b4ca-0520-47a7-a6b8-14b4450a129a",
+          "id": "707c0055-a9a5-4aec-a933-46479580fbd7",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7722,7 +7722,7 @@
           },
           "response": [
             {
-              "id": "7a891f6b-cb06-4148-9e94-c131ea77a342",
+              "id": "ceb4665c-7912-4e5d-80d8-0b1fb8f9e39c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7817,7 +7817,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "3005596d-10ba-480d-bfd4-2d179c0151be",
+          "id": "b03843ce-de05-4b37-91cc-6311908a1aa6",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7870,7 +7870,7 @@
           },
           "response": [
             {
-              "id": "4ae100af-a562-4105-9924-9c11968e024b",
+              "id": "6c82a887-4e92-4514-ace6-d3235dc5c411",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7945,7 +7945,7 @@
           }
         },
         {
-          "id": "408c73fd-03f0-4dee-be90-f3a3c0532e98",
+          "id": "02143659-d290-4569-aaeb-9bd38c401ae7",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -8011,7 +8011,7 @@
           },
           "response": [
             {
-              "id": "000c35a6-29bd-4849-b642-c33987b87563",
+              "id": "66cbedd9-5457-4026-8002-4391c54dbb80",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8099,7 +8099,7 @@
           }
         },
         {
-          "id": "2e87108d-ae96-4bd0-8cd1-0a52f61d0d1f",
+          "id": "36b31a15-c2ca-492b-90f3-09f4065d35a2",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8146,7 +8146,7 @@
           },
           "response": [
             {
-              "id": "3c0c6aaf-a61e-4a2d-91fd-06afef346af0",
+              "id": "9e676590-ce3c-433f-89d6-c5c3f7e4b15b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8211,7 +8211,7 @@
           }
         },
         {
-          "id": "d7fc9dc3-18dc-42b5-8f58-1c4303eb9e36",
+          "id": "307334b2-b9e2-4530-ad0f-c793e66c1abe",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8253,7 +8253,7 @@
           },
           "response": [
             {
-              "id": "4a7dfa66-f66e-4820-8fb0-9215cbbfe7e8",
+              "id": "3e4956a8-bd8e-4c34-981e-feb7a160fdef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8317,7 +8317,7 @@
           }
         },
         {
-          "id": "33d2fc66-f154-4cfc-8d2a-2505bdfcbe52",
+          "id": "163967a3-a269-417c-979b-21b1dece2d1e",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8372,7 +8372,7 @@
           },
           "response": [
             {
-              "id": "cdd1dd88-91fe-4d7d-9b90-4dbda9125582",
+              "id": "86d641cb-d5cb-4e98-aa62-dde4a8684944",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8455,7 +8455,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "6943bf80-cab3-4100-a84b-447e3e05d5f1",
+          "id": "29a2cf73-566d-4939-8197-f4e9b66d5758",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8496,7 +8496,7 @@
           },
           "response": [
             {
-              "id": "7b874e42-35fd-4ca8-a2d0-1e79e7d845e3",
+              "id": "7ed0aebe-a3dc-434e-82af-8035b08f3b86",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8559,7 +8559,7 @@
           }
         },
         {
-          "id": "491fce50-1a1e-4baa-80db-7edd94108ba6",
+          "id": "bb297287-ed8b-4780-b24b-2c35077c6c2d",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8613,7 +8613,7 @@
           },
           "response": [
             {
-              "id": "2bd235c9-fc8b-478c-9638-95209d7b85e1",
+              "id": "f7b5758f-c9f8-47a2-8eff-3938bfd59f59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8689,7 +8689,7 @@
           }
         },
         {
-          "id": "d23ad232-b2c4-4c6e-a528-db6d0ea1e6bd",
+          "id": "30362ecf-9e02-409e-a058-2b9e5078257b",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8724,7 +8724,7 @@
           },
           "response": [
             {
-              "id": "bb183226-9b58-4875-999a-fabbe52f3b6d",
+              "id": "3e2246d5-579f-42e9-a41b-0b30d2b39555",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8777,7 +8777,7 @@
           }
         },
         {
-          "id": "51f9820a-81dd-4a68-954f-b0895a789b14",
+          "id": "6d4c2901-82e5-4a9e-86bd-aa27acb11d5e",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8834,7 +8834,7 @@
           },
           "response": [
             {
-              "id": "dae8fcc2-47ac-4588-bd42-58fb34c044ea",
+              "id": "b2eb6d9c-98a4-4e65-bc23-53a8b85bb4ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8913,7 +8913,7 @@
           }
         },
         {
-          "id": "703c5463-1f90-4b2a-91a0-6145f261fb80",
+          "id": "39fe4963-5574-49f5-8122-67cf65d9e38f",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8955,7 +8955,7 @@
           },
           "response": [
             {
-              "id": "c6334016-f7e7-414f-97a8-e558598dc07a",
+              "id": "7e3c5009-6411-45c5-b682-8a0d90f239df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9025,7 +9025,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "f502cc2e-16e3-47c1-abbf-5aa752bc21a3",
+          "id": "b11cc71b-8a43-49e5-b1c1-4e1cddfdcfee",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9078,7 +9078,7 @@
           },
           "response": [
             {
-              "id": "836c1ba0-c412-406e-a555-daa0753b5df1",
+              "id": "2edc209f-cfaa-43d7-8094-37a62947672f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9153,7 +9153,7 @@
           }
         },
         {
-          "id": "679d226a-82e6-4711-8012-cda42751e9ac",
+          "id": "b3f89485-f210-46fc-968a-9a092845e665",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9219,7 +9219,7 @@
           },
           "response": [
             {
-              "id": "2f51116d-119f-4dea-8a4b-7e52da1251bd",
+              "id": "6890956e-ff5e-4a9e-b38a-7d3065fc10e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9307,7 +9307,7 @@
           }
         },
         {
-          "id": "f20f45ec-7666-4a6c-9da1-228a4685cff1",
+          "id": "1e4e7f30-d00b-4f32-acf5-245979ef52a0",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9354,7 +9354,7 @@
           },
           "response": [
             {
-              "id": "06100bf5-bf0c-402b-ad9c-9131105a8b49",
+              "id": "8ff93b69-85ff-43c7-af68-13880049a84c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9419,7 +9419,7 @@
           }
         },
         {
-          "id": "dbb5d23f-07f8-40d0-8319-147bac9b5152",
+          "id": "8049b2a9-b90a-4da4-adc3-6fa43e18f6c2",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9461,7 +9461,7 @@
           },
           "response": [
             {
-              "id": "f596690d-34f5-4c0e-af5e-3b8c1d22b4b6",
+              "id": "e6521bed-f46e-40ba-b8c6-2d01253e46d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9525,7 +9525,7 @@
           }
         },
         {
-          "id": "fe656b76-f6be-4d4c-aa6e-1dd0b32186a7",
+          "id": "868fa9c5-d2f6-498d-9221-5c9aac114876",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9580,7 +9580,7 @@
           },
           "response": [
             {
-              "id": "2e00cf92-b199-46a0-ab89-9d5b36fbdc84",
+              "id": "d34ff5e9-7272-44f4-aed2-ff78f34f3617",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9663,7 +9663,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "8c8f8b5c-78ff-40d7-9eec-e5ea64605e67",
+          "id": "ebd5586f-e3a8-4dfe-b44c-f88f47b4aa71",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9705,7 +9705,7 @@
           },
           "response": [
             {
-              "id": "15f69d1f-d2c9-44bf-ad83-e46ef3fa4e9c",
+              "id": "534eadb9-f025-4001-b1d6-29761e123889",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9769,7 +9769,7 @@
           }
         },
         {
-          "id": "235a7a63-bce3-4f73-bee2-612566feeb1f",
+          "id": "5a059f4a-8b5d-41ea-bbfc-33cbadcb9340",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9824,7 +9824,7 @@
           },
           "response": [
             {
-              "id": "594c5880-dcd9-46ee-892c-23ec5d56e6c0",
+              "id": "2d245820-1db8-478f-89b9-5d2046d1b87c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9901,7 +9901,7 @@
           }
         },
         {
-          "id": "abeab229-4fc5-4d50-9ae6-e1051928e30f",
+          "id": "c36a1348-2b61-4c38-863d-9571ad9eda97",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9937,7 +9937,7 @@
           },
           "response": [
             {
-              "id": "fb13fa1e-e9ea-4995-a85a-e58827cea2f2",
+              "id": "2d89ec74-8c93-4c87-b288-535c34ba6b94",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9991,7 +9991,7 @@
           }
         },
         {
-          "id": "576862ff-e338-4a2b-9f94-bbabcc72a210",
+          "id": "962c7a70-e85d-46cc-807a-8c2693f13f7b",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -10021,7 +10021,7 @@
           },
           "response": [
             {
-              "id": "b8b0f2e4-78e6-4e9a-9d37-3bc38fd9df11",
+              "id": "ec913c20-41f0-4737-87b3-e4882f708db0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10073,7 +10073,7 @@
           }
         },
         {
-          "id": "633600ca-f04b-4427-b65a-491346bdde6f",
+          "id": "af8646a3-1958-4b9c-a4dc-e44f7d6f141f",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10116,7 +10116,7 @@
           },
           "response": [
             {
-              "id": "bbcd9cb6-38a7-4eb4-a285-724716c55816",
+              "id": "42b8920f-d488-4f88-a1d8-b0899768b753",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10187,7 +10187,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "d71dcc25-172c-4b69-b5dc-aa8e10100072",
+          "id": "4d21718e-2a52-4731-96a8-8074cdcf3fb7",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10229,7 +10229,7 @@
           },
           "response": [
             {
-              "id": "9ad11c5c-e762-4267-85e9-bb9b73aa026a",
+              "id": "a2754b11-d0df-4349-bf5b-777d4084a953",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10287,7 +10287,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0d03eee7-8e4c-4be9-9d54-db0fcddee016",
+              "id": "2dfe183b-5f1c-458e-8e24-049ea5e830e3",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10351,7 +10351,7 @@
           }
         },
         {
-          "id": "bd4a0b38-f683-4b1e-adc5-79abb3d0bfde",
+          "id": "5857f40b-179b-4759-9585-cf8c1a9b7dbf",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10406,7 +10406,7 @@
           },
           "response": [
             {
-              "id": "8c00c95b-b5b5-498d-a142-7f4ce0c853f6",
+              "id": "5d39740f-78ee-43d5-88df-60ba208a5456",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10477,7 +10477,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "39ca6735-ea11-4beb-9385-7ef5c8d0a9f3",
+              "id": "1d2d453e-6193-45fa-8127-551446bdef1d",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10548,7 +10548,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "59e24558-926b-40da-b506-5a9859d8a414",
+              "id": "8c8b9748-9b3f-4341-9ece-c51eb80aadbd",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10625,7 +10625,7 @@
           }
         },
         {
-          "id": "1e2710b2-5321-4555-a00d-db852e05590f",
+          "id": "74e918b8-8a40-4c54-961a-a16dbf15d56e",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10661,7 +10661,7 @@
           },
           "response": [
             {
-              "id": "ac3caed3-d444-4bc8-a9c2-933b1806bc78",
+              "id": "4b6f22c7-b8ce-406c-8b6a-c4f70b32b78b",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10709,7 +10709,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "aa706f80-8a11-4b8d-9f41-9a6eb52f8997",
+              "id": "a0e36661-3cc4-4ec3-9145-71b7695fbdb8",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10757,7 +10757,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "9b323c28-caa3-436d-8f6a-fc3105dde941",
+              "id": "f3f06065-28b6-436c-ac36-5bc7176a6d4b",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
           }
         },
         {
-          "id": "d474ebcb-3923-4610-8e09-c6fdf05e7ac9",
+          "id": "f4ed1140-12d5-446f-91bf-a60b4f859756",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10841,7 +10841,7 @@
           },
           "response": [
             {
-              "id": "eb9c14d8-fc3e-4982-b4cd-08e616f53129",
+              "id": "67a0b5f7-ce1a-4142-a70c-5c5ab0512a82",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10893,7 +10893,7 @@
           }
         },
         {
-          "id": "fcd81e04-9648-4c9e-af00-ac7182cf8097",
+          "id": "fe7b3818-5ab5-4600-9dcd-6acf575d73c7",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10936,7 +10936,7 @@
           },
           "response": [
             {
-              "id": "4a44a9af-579f-477b-a2db-ba8831a57ea6",
+              "id": "b42394f6-8b04-450c-8452-8f0d29792617",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10995,7 +10995,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1c8a7146-330e-4b1c-8416-7399a559401e",
+              "id": "3ae9f407-8900-44e1-acb3-51c703a7406e",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11066,7 +11066,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "0731f5d2-3cd8-46d6-a1ed-b17e9470660e",
+          "id": "b66d4bd7-472e-460e-b581-1dff8b76bca8",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11150,7 +11150,7 @@
           },
           "response": [
             {
-              "id": "2efccf2c-a14c-46c7-8839-ce50e2c1447f",
+              "id": "3b7407ba-82ff-48b5-a1e9-e23b5c4874b0",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11253,7 +11253,7 @@
           }
         },
         {
-          "id": "525b4a0d-4295-4a9c-9292-9c35c982a195",
+          "id": "5ab2c95c-7d47-4f97-b6a3-b7b7657440ad",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11319,7 +11319,7 @@
           },
           "response": [
             {
-              "id": "94c9ca78-bb94-4394-bf10-842c8427151a",
+              "id": "608124a4-9115-4cb2-87c7-8c1c8d9d931c",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11404,7 +11404,7 @@
           }
         },
         {
-          "id": "c6ddbbd2-9170-4cbd-be79-c75d6016df45",
+          "id": "c75f0ccf-97af-44db-b6a4-1e2fa96451ab",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11488,7 +11488,7 @@
           },
           "response": [
             {
-              "id": "47458cfd-c8ee-4de7-a696-dcfb9a0e96a0",
+              "id": "dc884180-024b-4396-bf59-1ffdfbb25ce3",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11591,7 +11591,7 @@
           }
         },
         {
-          "id": "b4292662-4380-478c-89b3-90383ced7ac4",
+          "id": "3be13b45-b5e9-478f-a737-1fe7f67d8d87",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11666,7 +11666,7 @@
           },
           "response": [
             {
-              "id": "8186b627-7fe8-41b9-ae75-c722040f51b8",
+              "id": "2aa953ed-5af4-4fc7-b170-93f6e45fe4b3",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11760,7 +11760,7 @@
           }
         },
         {
-          "id": "bd6d4120-9764-483e-acbb-425db3573579",
+          "id": "2b9ac915-cbeb-473f-bc9f-269de92895b8",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11835,7 +11835,7 @@
           },
           "response": [
             {
-              "id": "abb14797-05ca-4677-8f5a-628425154aab",
+              "id": "720f3ac2-97e2-45f3-bca4-1083ca82a268",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11929,7 +11929,7 @@
           }
         },
         {
-          "id": "4f9567ac-4320-4dc9-85c4-db7ab86f4dca",
+          "id": "fac32095-5275-43b7-965d-147448b39fea",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -12004,7 +12004,7 @@
           },
           "response": [
             {
-              "id": "4c1a2d4d-7c62-4cce-a125-57acd0863a97",
+              "id": "99310179-6111-4fdd-bfa0-4ab03755cfb7",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12104,7 +12104,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "74726c61-f506-4cef-a7ae-71d37b88a72e",
+          "id": "e4957521-fb2c-48e4-b463-3574f105369b",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12170,7 +12170,7 @@
           },
           "response": [
             {
-              "id": "c3563848-0347-41c8-9577-59b738709bcf",
+              "id": "db562b58-2030-40a2-9fd3-d6e680574eb1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12244,7 +12244,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12261,7 +12261,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "76f5ca1c-a8f3-4f0f-8a25-dba19d370994",
+          "id": "33cff2c2-e456-4ff8-ad5e-2eecedbbc3fa",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12303,7 +12303,7 @@
           },
           "response": [
             {
-              "id": "7999ff93-22b1-441b-a5f6-b3a879b485c7",
+              "id": "8a5c8e1f-8770-4e78-b0e9-8fffe2ffea20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12373,7 +12373,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "4f69f9a9-ac6f-4819-835f-21367b2b6392",
+          "id": "703cd00a-2e5e-4065-a61c-604aff4b3d48",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12412,7 +12412,7 @@
           },
           "response": [
             {
-              "id": "9501a658-4b4c-47e3-89b7-1f9dc79d0b24",
+              "id": "1223fe86-f88d-4095-ba5f-9fe2b3959545",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12465,7 +12465,7 @@
           }
         },
         {
-          "id": "c56f4830-49e4-4bd9-b244-1617f5762388",
+          "id": "83db07c1-a2cc-4d9a-94a2-d77520a7e581",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12497,7 +12497,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ru-PS\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"01:38\",\n  \"quietHoursEnd\": \"20:21\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"nz-BN\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:07\",\n  \"quietHoursEnd\": \"22:38\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12517,7 +12517,7 @@
           },
           "response": [
             {
-              "id": "86cee215-8953-4341-9a43-fb9e59779c0a",
+              "id": "744ec9cc-588f-457d-8f63-493ddc6dc5a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12555,7 +12555,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ru-PS\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"01:38\",\n  \"quietHoursEnd\": \"20:21\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"nz-BN\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:07\",\n  \"quietHoursEnd\": \"22:38\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12589,7 +12589,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "b26be6e4-bd70-4b5d-8c6e-12013d52203b",
+          "id": "8b08eaee-4805-45bf-b73a-b58b6ac8c78b",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12631,7 +12631,7 @@
           },
           "response": [
             {
-              "id": "0d4e4c97-fade-43c3-921c-bb6f8823e025",
+              "id": "f4b27685-5ad4-4430-906d-091649d861bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12695,7 +12695,7 @@
           }
         },
         {
-          "id": "a2ddb836-1251-48a9-88aa-ad02875c4cee",
+          "id": "16440487-99b5-4ec2-8ce3-9e015b0f523c",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12738,7 +12738,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#E7AFDc\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5eFebB\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12750,7 +12750,7 @@
           },
           "response": [
             {
-              "id": "04fc3be3-bf30-4f59-b2d7-7f580840a524",
+              "id": "cf37f4ea-c989-4e7a-a9e4-8e1b3f1007da",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12799,7 +12799,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#E7AFDc\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5eFebB\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12827,7 +12827,7 @@
           }
         },
         {
-          "id": "2dbd68b5-d5ec-4425-9301-dafc38a0b7b6",
+          "id": "72b03769-d9b3-42f9-bb40-300f9e63f0e9",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12863,7 +12863,7 @@
           },
           "response": [
             {
-              "id": "a8c685ba-98f0-40cd-97a7-2d5f0a1e3f43",
+              "id": "a4d2df68-d587-42b3-a4fa-796f888763ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12917,7 +12917,7 @@
           }
         },
         {
-          "id": "967d5988-5030-45fe-a8c9-ebf483ab9eb5",
+          "id": "817c741f-e4ce-4dd1-9d61-9c91c592d656",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12947,7 +12947,7 @@
           },
           "response": [
             {
-              "id": "2f2bbec6-ecc5-4994-bef0-0a9f8caac250",
+              "id": "b55ec0c9-2ada-498b-843d-03dd52826a7d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12999,7 +12999,7 @@
           }
         },
         {
-          "id": "5d0d2bac-e9b2-426f-8bef-b8e9f60e6003",
+          "id": "d7e9c4fd-fd8d-4bc3-b449-d39439472bb5",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -13030,7 +13030,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#32D69D\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E673BA\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -13042,7 +13042,7 @@
           },
           "response": [
             {
-              "id": "93b2d7ae-b1e9-45fb-b033-46f814f16c49",
+              "id": "c9e57a98-1d8b-4008-99dc-94e8bc18f5f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13079,7 +13079,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#32D69D\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E673BA\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13107,7 +13107,7 @@
           }
         },
         {
-          "id": "abe7b7ad-6055-4ddd-9292-4f650a60ef4b",
+          "id": "fac3f824-b96b-45a5-8e04-0ceff805d8ea",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13138,7 +13138,7 @@
           },
           "response": [
             {
-              "id": "c52aff7c-ea3f-40a5-9e35-57f1266763a6",
+              "id": "5ca5667e-5887-47ba-a990-e1924fab81ae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13197,7 +13197,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "3dde5fb9-6ad3-4630-93e1-dd9be6917df4",
+          "id": "7a9b075e-a026-45ce-9727-569e62cf6b66",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13250,7 +13250,7 @@
           },
           "response": [
             {
-              "id": "4414b6ca-34c0-41e9-979c-02194994ae11",
+              "id": "c46934bd-9f6b-4f7b-af9c-dbccb0e8cc05",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13325,7 +13325,7 @@
           }
         },
         {
-          "id": "4477a6ed-af2f-4e13-b2a0-59179ce8a7b3",
+          "id": "768b3039-5523-4c0e-b5c8-3c057074c3d5",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13391,7 +13391,7 @@
           },
           "response": [
             {
-              "id": "e5f49baf-2b2d-4fd4-b185-7d39cab5d178",
+              "id": "6581203c-9424-4732-a654-f21e153b5d30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13479,7 +13479,7 @@
           }
         },
         {
-          "id": "46528e87-48df-4e96-aaf9-57ddf8b7112b",
+          "id": "8d076aed-4fa1-40f0-bfa4-17fb932dc92e",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13526,7 +13526,7 @@
           },
           "response": [
             {
-              "id": "15571723-c112-46e3-a100-1485dbd09bd3",
+              "id": "81c01b22-f9ce-404c-a828-a77b93329fe3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13591,7 +13591,7 @@
           }
         },
         {
-          "id": "abd2da39-2abd-499e-9724-ded48e3d8cc5",
+          "id": "0abba96c-2ff5-441d-958c-21e80e98d49c",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13633,7 +13633,7 @@
           },
           "response": [
             {
-              "id": "03a6b0d7-af6e-476c-81bd-75ef5e4bd8c5",
+              "id": "7f17acb8-96e0-449e-879b-443190a28c25",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13697,7 +13697,7 @@
           }
         },
         {
-          "id": "e650980c-ef78-40e8-8412-596ec383b532",
+          "id": "b8017ee1-51eb-4175-8209-94233fa66b92",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13752,7 +13752,7 @@
           },
           "response": [
             {
-              "id": "e85a949b-32df-48fa-a9d6-431233fbd3bd",
+              "id": "b1040996-643e-4d4f-8f5e-7622b788055b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13829,7 +13829,7 @@
           }
         },
         {
-          "id": "362016ad-2ebc-446c-9495-08941e02781a",
+          "id": "bdb4ab29-d7ab-4e5f-833f-e91e89dbcd2a",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13883,7 +13883,7 @@
           },
           "response": [
             {
-              "id": "bdd9e7f5-25db-4d60-abae-53169f72295a",
+              "id": "6cbeca70-2442-499e-8b36-d49636dffc31",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13959,7 +13959,7 @@
           }
         },
         {
-          "id": "59c12058-2d39-445b-b309-8d441672c5d7",
+          "id": "02a0e91e-9a25-4bfc-a696-ff192337ada5",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -14025,7 +14025,7 @@
           },
           "response": [
             {
-              "id": "2839e39a-c6e8-47e3-957b-a80f068ace05",
+              "id": "31d675b9-324c-49ac-a7bf-f977f6c8f268",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14113,7 +14113,7 @@
           }
         },
         {
-          "id": "f36eda4b-041d-4459-8385-ba8a808dd7d7",
+          "id": "b738fc1c-e2f1-4f6e-b6e5-72926e21c5af",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14191,7 +14191,7 @@
           },
           "response": [
             {
-              "id": "8417c96a-e552-4aba-bbe6-b778f5a52f69",
+              "id": "a0bebb53-6d49-4486-b13e-073e1579d6f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14291,7 +14291,7 @@
           }
         },
         {
-          "id": "6ba071de-c4f8-47f5-a6ee-febd02148482",
+          "id": "fd080fef-b00b-4585-9810-f439d4f4228a",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14357,7 +14357,7 @@
           },
           "response": [
             {
-              "id": "d7cef286-20ce-418a-9241-991e5c274838",
+              "id": "7e108d66-411f-49b8-93bf-718d76e478eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14445,7 +14445,7 @@
           }
         },
         {
-          "id": "45f9f5f6-29ab-4df9-88e1-4fd059ccc571",
+          "id": "97444aea-258e-4779-bec1-9fd171fe0cce",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14500,7 +14500,7 @@
           },
           "response": [
             {
-              "id": "f7acdf3b-2647-4b43-a13f-7224fe8d3c11",
+              "id": "e6dd9284-a3bb-4cf9-b7da-406c6661bef8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14583,7 +14583,7 @@
       "description": "",
       "item": [
         {
-          "id": "e5a92f07-3b3e-4705-96b3-56d334f2af6e",
+          "id": "b7a1f07b-cec2-4ed2-a6d1-c3bd5f31125b",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14624,7 +14624,7 @@
           },
           "response": [
             {
-              "id": "a448b68c-103c-4999-9d83-a222526cc3e9",
+              "id": "43a3f9a9-4bf9-44e8-a420-17419e514458",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14687,7 +14687,7 @@
           }
         },
         {
-          "id": "63361b3a-a475-4ebf-b492-24b83e18b40e",
+          "id": "73d9c643-2ae1-42e1-9700-4cc9472541b1",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14741,7 +14741,7 @@
           },
           "response": [
             {
-              "id": "a8df4873-6e38-411b-b757-8158c6dc0a5c",
+              "id": "df43586e-1f09-4e6f-b56c-e1e5d62dd958",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14817,7 +14817,7 @@
           }
         },
         {
-          "id": "24e1095b-6cde-4eaf-80a4-b50acf9419c0",
+          "id": "36d2185b-4380-46dd-a7c3-a38461de5fe8",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14852,7 +14852,7 @@
           },
           "response": [
             {
-              "id": "b80e2be7-eac4-406b-9485-0f602f3c8cc9",
+              "id": "4e79d934-b867-4efa-a5f2-af0d07e74deb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14905,7 +14905,7 @@
           }
         },
         {
-          "id": "e31a518d-b0ad-4e1d-99b3-569418709332",
+          "id": "832aa929-6578-4213-b490-36fb2ce5381f",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14966,7 +14966,7 @@
           },
           "response": [
             {
-              "id": "d6945b67-3853-4c3e-9fda-1cb375eaaa17",
+              "id": "4fa55cac-98a8-4dad-81e8-7b14662060bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15049,7 +15049,7 @@
           }
         },
         {
-          "id": "c6597bad-ef13-469d-9588-af4720c3a3d2",
+          "id": "fa2ec0c7-66e4-4956-8577-e94f5e3fe75a",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15091,7 +15091,7 @@
           },
           "response": [
             {
-              "id": "8ff552f6-9b53-4ae4-9d1b-114c517591b7",
+              "id": "b830a018-5f09-41cd-bc69-84d5ca39d273",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15155,7 +15155,7 @@
           }
         },
         {
-          "id": "e7c19c7c-d9bf-48ee-b151-f4f2c6e08273",
+          "id": "651fd6cc-a741-4696-bfa6-2b75b0ae4c38",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15230,7 +15230,7 @@
           },
           "response": [
             {
-              "id": "2bcd5f6d-c592-44e8-a262-2a35e9985f56",
+              "id": "90067e84-7fab-4b70-b053-4b8595f1697d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15327,7 +15327,7 @@
           }
         },
         {
-          "id": "2f9a2081-801f-4448-b9ff-26ca34c72eb1",
+          "id": "4e93a4f4-c668-4e44-95cd-52bfeee99c54",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15369,7 +15369,7 @@
           },
           "response": [
             {
-              "id": "940b7af4-3bf6-495b-bd83-aa3c16c4a0e8",
+              "id": "71c85c09-a0d7-4982-a4bb-ffee33e3e139",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15433,7 +15433,7 @@
           }
         },
         {
-          "id": "31103b95-6e57-45b3-8c86-6e10494ee26b",
+          "id": "df8cd601-057a-4476-8b29-73d3656672dd",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15476,7 +15476,7 @@
           },
           "response": [
             {
-              "id": "288b476b-0699-4a22-b4b6-5dd730849310",
+              "id": "c62a9772-05fb-428a-910b-3a316fcd93f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15541,7 +15541,7 @@
           }
         },
         {
-          "id": "b4a59e91-bb53-4bf7-aaf4-2cdfb88084ca",
+          "id": "f9d7b20d-2204-483a-af3b-885f0097e725",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15584,7 +15584,7 @@
           },
           "response": [
             {
-              "id": "c2101b5f-12e3-4158-87b8-4205e2046f38",
+              "id": "19cc7376-df70-468d-8af7-e71f9a91d33f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15649,7 +15649,7 @@
           }
         },
         {
-          "id": "e3b49b87-5266-4bcb-8fee-207462650a4d",
+          "id": "b59e366f-64de-48c6-bf9c-2b24e5e98e1f",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15701,7 +15701,7 @@
           },
           "response": [
             {
-              "id": "400a5494-906e-4a96-a4d5-b2d13bf38352",
+              "id": "a9f09802-d8ca-4b09-87a6-e3b3741009bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15775,7 +15775,7 @@
           }
         },
         {
-          "id": "ba9c6f74-ad22-4f3d-a557-fae8ac0eade1",
+          "id": "6ac71ff7-38e3-4791-845c-6395422b21d4",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15817,7 +15817,7 @@
           },
           "response": [
             {
-              "id": "e6c2855c-1f36-40ff-8b70-d4ad730179a6",
+              "id": "c0c9cac6-d49b-41f3-96ed-070a407aa256",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15881,7 +15881,7 @@
           }
         },
         {
-          "id": "9b720281-070c-4b18-9a30-03507419e636",
+          "id": "d93eca8b-14aa-4639-95a6-d082f638beee",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15934,7 +15934,7 @@
           },
           "response": [
             {
-              "id": "79628121-54f4-4c56-99d8-e3bbe9f3da01",
+              "id": "f4b8729f-3787-4494-910f-e2427b934bd2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16009,7 +16009,7 @@
           }
         },
         {
-          "id": "2ff36473-3e6a-44cb-8cee-c1fd77cc702b",
+          "id": "88ac6898-fa0c-4fcc-8c7a-36bde180f870",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -16062,7 +16062,7 @@
           },
           "response": [
             {
-              "id": "d82416f2-2d3a-4d87-a153-31dabd7746b4",
+              "id": "835cba32-ba28-4cd1-bd91-7e34bb41a58a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16137,7 +16137,7 @@
           }
         },
         {
-          "id": "cd2aa4c6-5ae8-4aa1-b600-096bfe0df6e7",
+          "id": "0a686e73-78c7-4425-ae1b-d37a8e135d83",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16181,7 +16181,7 @@
           },
           "response": [
             {
-              "id": "ea1a4308-43f5-4c18-a553-157068cb755d",
+              "id": "d0b7f71d-b3a8-4241-a8ef-93d477f74016",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16236,7 +16236,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16247,7 +16247,7 @@
           }
         },
         {
-          "id": "575ba5e0-1e8f-4987-a354-2e514f9899c3",
+          "id": "97c363af-ae11-47ed-a093-0be51fa622b0",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16291,7 +16291,7 @@
           },
           "response": [
             {
-              "id": "87718d2d-9115-4a6f-b80a-dc16865b7a82",
+              "id": "fb0255ae-0390-4674-ae06-54ef8d894437",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16346,7 +16346,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16363,7 +16363,7 @@
       "description": "",
       "item": [
         {
-          "id": "80b4abd9-de5c-4e64-9984-379b4c6afc73",
+          "id": "0e61bbfc-30bd-4f7c-93f0-412cdcef9b16",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16405,7 +16405,7 @@
           },
           "response": [
             {
-              "id": "0b871a74-27a9-49b2-a98d-8428c75eca3a",
+              "id": "9d62130f-7659-46a8-87e7-c1a076705800",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16454,7 +16454,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "115e7caa-94f0-4a49-a5c8-c3cbaa2f1f48",
+              "id": "28192961-acd0-47df-b229-56c42944a4d7",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16509,7 +16509,7 @@
           }
         },
         {
-          "id": "5196cdd1-b299-40ab-add4-1dbdd96c99d2",
+          "id": "c1d742e1-ebfc-406c-9787-d773a972a7eb",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16555,7 +16555,7 @@
           },
           "response": [
             {
-              "id": "da9eb440-f0c7-4c3e-9a17-7e7401cabaa2",
+              "id": "e29f49ec-8937-4fdc-8ee9-4932a6c6ab9d",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16614,7 +16614,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "99603ecd-617d-40e9-a0ce-5dee9b644f2a",
+              "id": "f5dfa9cc-d49c-4512-8e98-9f2af3a1f092",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16679,7 +16679,7 @@
           }
         },
         {
-          "id": "f34fd665-0a51-434d-b841-6539aa974686",
+          "id": "040b05f1-d440-4db0-abbc-34c42b3eabfa",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16725,7 +16725,7 @@
           },
           "response": [
             {
-              "id": "7ad84728-49a3-4cc9-9b31-855d71fb482f",
+              "id": "77d9dead-71cf-4afc-9617-76c763757668",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16784,7 +16784,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "075fe2ba-3d2e-4b4c-879f-c8feeb8a0d26",
+              "id": "e55bb463-4de5-4ca0-9a3c-fd8faa3a0a63",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16843,7 +16843,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b878ceca-f873-4f46-9910-c297e7a7920e",
+              "id": "58b2003e-e09f-4dbc-9079-8c02325cb482",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16902,7 +16902,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "60de200c-82ef-4493-9559-cc4c02a9ae65",
+              "id": "46428d00-6348-4deb-be5e-409ec3154c88",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16967,7 +16967,7 @@
           }
         },
         {
-          "id": "30da763d-1be4-4727-83e4-00fd47975d87",
+          "id": "77f04dd5-439a-4bd1-801d-f2a92118357c",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -17013,7 +17013,7 @@
           },
           "response": [
             {
-              "id": "0fc1ff35-510d-4dc9-8b65-84d68bdb557e",
+              "id": "89ce5dee-b09c-4e2a-9465-3b2b08a514f6",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -17072,7 +17072,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "18b190ca-3d58-458c-88c8-564807767cd4",
+              "id": "319a05df-24d0-478c-9f98-08be75a6a002",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17137,7 +17137,7 @@
           }
         },
         {
-          "id": "c53eee61-7a94-4d3d-8599-45629af7f08a",
+          "id": "8e30806d-87d5-4f02-8dad-05aeb98c3c3e",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17179,7 +17179,7 @@
           },
           "response": [
             {
-              "id": "6429b13c-58c0-45dc-9bd1-c3f3dae604b8",
+              "id": "009f6b95-fe2c-4773-b0b1-035dfad04a25",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17240,7 +17240,7 @@
       "description": "",
       "item": [
         {
-          "id": "a9545754-97d4-4f70-a15a-3fb02b767f26",
+          "id": "b6eff30e-c7b2-4a79-86a4-fcb7ce0d53f4",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17289,7 +17289,7 @@
           },
           "response": [
             {
-              "id": "2efbbd34-067f-4b3e-acc0-9079e2239783",
+              "id": "0b36844a-ce56-4ab5-b5d3-9dd8115ff73a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17349,7 +17349,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17360,7 +17360,7 @@
           }
         },
         {
-          "id": "4afbe969-ecec-489a-85c1-a4f5da46c2df",
+          "id": "6ec9a115-b96f-4144-bba3-17337625d66b",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17409,7 +17409,7 @@
           },
           "response": [
             {
-              "id": "5f039d66-0b8d-4b23-910d-df55b78930e1",
+              "id": "d5d4c4ee-5cb3-463c-bc50-87ccb844a45e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17480,7 +17480,7 @@
           }
         },
         {
-          "id": "c6ae60a7-d01a-4b14-abf9-90099e186ebe",
+          "id": "de9671bc-7b3f-49d1-aa6e-6169fd6ea7b4",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17529,7 +17529,7 @@
           },
           "response": [
             {
-              "id": "8ea2d9e6-e400-481a-a2c1-f38c3b3a7515",
+              "id": "e4aee7c8-31d1-4f30-84f1-f80674a2389b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17600,7 +17600,7 @@
           }
         },
         {
-          "id": "c568069b-2166-4c5c-88fa-71f53a1eb8cc",
+          "id": "082335ab-0c19-42f7-919c-e6a87b39aa10",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17649,7 +17649,7 @@
           },
           "response": [
             {
-              "id": "39cbcce6-b60e-4f5c-928e-28fa8c88598f",
+              "id": "e4d65644-409e-47f3-b6fb-0952cf8e53f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17726,7 +17726,7 @@
       "description": "",
       "item": [
         {
-          "id": "65cd0c79-acad-4437-8293-6113c8ce12d7",
+          "id": "82561ff9-45a5-4fa9-9818-0f150e2cc7ae",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17766,7 +17766,7 @@
           },
           "response": [
             {
-              "id": "b898982c-8537-459f-a8ec-efe42d94d09c",
+              "id": "4b533d92-4c06-4288-a3fd-0f51494dc141",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17828,7 +17828,7 @@
           }
         },
         {
-          "id": "096547b4-f6c6-432a-8a2a-d897c269855a",
+          "id": "fa593348-6f82-410e-a4a3-7f538dbdb14b",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17858,7 +17858,7 @@
           },
           "response": [
             {
-              "id": "6467278a-d1c5-4613-a98a-bdcf44ea11ca",
+              "id": "0fba3555-ad4a-4cbb-bae8-5d14f024539a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17899,7 +17899,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17910,7 +17910,7 @@
           }
         },
         {
-          "id": "1cb0a766-81bb-4ccb-900b-91f5522c5cca",
+          "id": "fdbb228b-9603-445d-bf7b-5232663ca4b3",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17962,7 +17962,7 @@
           },
           "response": [
             {
-              "id": "e876276d-ed7d-4e29-a0d4-f7eeedc7a3a4",
+              "id": "b182b10b-0ae7-45db-86bb-01a78eaafe1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18042,7 +18042,7 @@
       "description": "",
       "item": [
         {
-          "id": "b56d09fa-7f64-4741-abf6-bb1c0326841c",
+          "id": "ef1baf0c-9ce2-4d64-ba6a-45d516d1f211",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -18071,7 +18071,7 @@
           },
           "response": [
             {
-              "id": "ab478174-7619-4a83-ac20-599a1adc3477",
+              "id": "1629a88e-808f-472e-b709-39c3380399eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18122,7 +18122,7 @@
           }
         },
         {
-          "id": "0d7c9c15-4d03-40f1-b043-5d1008a04187",
+          "id": "1ae9b883-b8d4-439a-8b02-dd133f3326ca",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18163,7 +18163,7 @@
           },
           "response": [
             {
-              "id": "7c504e05-af79-45ad-8046-923baf310f1b",
+              "id": "0dbe4ea8-16f9-4a28-9b71-54224dcdc70c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18232,7 +18232,7 @@
       "description": "",
       "item": [
         {
-          "id": "7392af0d-2c4f-41e2-99cc-42feba7d1eeb",
+          "id": "4379472b-cb42-49d9-a4b6-1a925115ab31",
           "name": "health",
           "request": {
             "name": "health",
@@ -18261,7 +18261,7 @@
           },
           "response": [
             {
-              "id": "6e012218-8fc8-4225-a3b0-524ed03b061d",
+              "id": "e1c61424-0fa4-4ab1-a3f9-ecfcc54a94a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18301,7 +18301,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18318,7 +18318,7 @@
       "description": "",
       "item": [
         {
-          "id": "a1fe586f-ba17-4209-aad9-aaac21bb386e",
+          "id": "43f1253d-465d-465b-8399-f206e385632f",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18370,7 +18370,7 @@
           },
           "response": [
             {
-              "id": "65a5ee50-9f79-4a21-8467-e93fa82266d4",
+              "id": "ef1933f5-6122-425b-b492-b9e87ebe74c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18444,7 +18444,7 @@
           }
         },
         {
-          "id": "6e6a7b27-1c9d-4acb-acb7-3bb52f2e54e7",
+          "id": "1bb8fe0f-dce9-4712-a5bf-53bc6d40e508",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18485,7 +18485,7 @@
           },
           "response": [
             {
-              "id": "f6118fe5-8731-4cae-b31c-9e1f1c11edad",
+              "id": "17ee9c65-95af-451d-a32b-40b7acd5a91a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18537,7 +18537,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_3\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18548,7 +18548,7 @@
           }
         },
         {
-          "id": "08a75441-ad36-4c5e-b219-e9189a538eb1",
+          "id": "b51b338b-271b-41f2-af06-477bada4d7a2",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18578,7 +18578,7 @@
           },
           "response": [
             {
-              "id": "417e8f1a-58c8-4c6a-80cc-a48350c7384f",
+              "id": "4e30a084-32e3-4ab5-84d2-0b3ca83c480f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18619,7 +18619,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\",\n  \"key_4\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18650,9 +18650,9 @@
     }
   ],
   "info": {
-    "_postman_id": "5125999c-804a-468f-b28f-161c8b5720b5",
+    "_postman_id": "b5b22cac-2bef-46cf-9340-a794ea99b596",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-03 22:56 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-03 23:10 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "5aa4bbeb-5e3a-4a7a-959a-62052004e8d4",
+          "id": "3aa8eb2e-e9f7-46af-8580-a118da5da9cf",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "4d66d31c-46e4-489a-8a78-3051a95e0d0e",
+              "id": "0a4b72bf-92ca-4927-80a7-4cd22c990840",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "c9771026-4fd9-494d-8024-730d1d044df2",
+          "id": "89e104c8-767e-4ee5-8003-3ba31440de05",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "ebf536a2-d64d-4b08-9b17-906cb9c6e10f",
+              "id": "6ac82cd2-958e-4d4f-9d21-f266c99f7f5d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "2ebcff6b-8e7d-41fc-973e-c3152add5297",
+          "id": "7c947c6f-191d-401f-b45a-d8c5413ea393",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "a35d1b31-a1e9-48b6-bf9a-60560acf33c9",
+              "id": "d124eccf-d590-48b5-babd-14732744bd41",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "260cf67a-d9c7-4ef3-8b10-bf5e4afd677b",
+          "id": "5402a489-eb31-4c38-9327-288a6d5c69af",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "b3e03598-602d-429b-9486-311be11ca871",
+              "id": "d0a77186-41f1-4ac9-b277-51cf94c48df9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "2784c04f-3634-4cbb-8e6e-f70c51b3dfbb",
+          "id": "9181418f-8e36-4268-9c87-636425bce98c",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "0351b247-458c-423a-a587-70bfaab7f023",
+              "id": "fbc5ae64-a2ea-43ef-9dbb-0aca7e790530",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "0d1a7f21-56cd-4c5d-b827-e2d2a1137252",
+          "id": "770b44c8-ae50-4593-8ebb-434db7b90c1e",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "ef6d42da-e55d-4c90-a6d9-f7e02d7e71c7",
+              "id": "3592da04-71df-4a78-9f6c-4a4bbedc9fee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "e5cdbcbf-30b9-44f0-9f2e-c517638bd11c",
+          "id": "7ca628a6-8ed8-40ad-bc89-69377ce591e2",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "339e8749-1eaf-4a35-a920-7fcae414652f",
+              "id": "2f415e48-11de-4661-9b5f-32db2b32d5b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "4d5c603a-e3b0-4489-9ef4-abb3b2f9dadd",
+          "id": "abe8ac12-c98d-40d0-9cb8-e0f04b08e50f",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "aed5d591-29aa-4a19-949b-742e98ff495e",
+              "id": "69e7697d-7495-4375-b816-e7abd09bb53f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "c62e1cad-cdca-46ea-bcfb-449c9d246cb7",
+          "id": "d4e0bf0f-fa1d-4677-b63c-edda41508c21",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "6a17b855-0a44-4458-954c-b33fd36240e6",
+              "id": "bf54da93-1328-4f43-8cf5-3b3bcd1b586c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "6df78713-a587-489a-b831-b60df3b2bcea",
+          "id": "3af0a276-8cf8-45d9-aa9c-9f60be47730a",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "86945688-4966-4332-973b-5106b550fec9",
+              "id": "a0f9ce8a-0b5d-43e2-8045-50e18e54051c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "5b22c5a9-47b1-41d4-a124-dd675cd3e87e",
+          "id": "2226cf01-ae93-4411-85d4-6bf1b10d356f",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "75941ec0-f588-48ef-82f8-30f0af797250",
+              "id": "c7431c3f-185a-4ef5-8e56-d9d7e4d1383d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "41a57d3e-f156-4c92-8728-f5339c280350",
+          "id": "efc4d3f8-7579-4eb7-ba73-9a717975245c",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "7f1c2c9f-c1e3-4a36-be41-986f3495a675",
+              "id": "45e4bf94-31f2-4239-991d-d2ff241725fd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "7de771bf-0724-402a-bb67-307d297f3da9",
+          "id": "367f01be-7f8d-4ece-bb30-f51edf7a7053",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "5ac2d205-1de1-49e8-92d0-a707cd6a9cfc",
+              "id": "83f56fbb-5dfd-4918-a598-d86bde719d6d",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "cf7c8d23-32c7-4ae1-b700-f313cde418c0",
+          "id": "f27116e9-e36b-4a2c-9d00-1fc90f413595",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "ac527eb6-ebe5-445c-a11b-2a9bc0f76611",
+              "id": "a5e4238b-c3dc-4919-b0ee-9b5bb0bd799c",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "46ee4746-895d-4b5a-910b-185ad6ea687d",
+          "id": "7400a933-2eb9-41a3-a31f-25e49d4d00ce",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "767f0ef4-12cb-45ab-8c03-e95060837167",
+              "id": "a4266ce0-6189-4dc4-bc88-5f0d5f00d103",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "57d2c26b-e9c4-4813-99ad-5dca3bbaa277",
+          "id": "4b87e78a-afc7-45b3-adf1-3e770a85d08a",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "42037746-aa22-457c-b71c-a5ff23cb9687",
+              "id": "0d2799e6-d92e-479e-a4ff-aca28175fe4e",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "1957692b-9a5c-476d-8781-f93475967d2c",
+          "id": "7c3e01f4-e39b-4b7e-a85c-192dc64ca617",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "58c8153e-3c13-4be6-8fa4-bbfbc874669f",
+              "id": "2b0dbbae-c790-418a-be93-0b47f5227dd5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "93802dc0-5fea-4270-896b-87ec60e25cef",
+          "id": "7ca0d650-1cfc-40e8-9200-6d11f27de177",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "189b181b-e79f-47d9-84e5-681e0a75691f",
+              "id": "d26c8862-4ce0-41bf-9fa8-74222a4bd36e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "4c673d8a-2555-4572-a995-890234711e5b",
+          "id": "cee24244-fac7-44e0-8d07-74b94673dd52",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "c82d9f44-e603-45d3-b329-3de9e08b6d8b",
+              "id": "b7395c29-ae12-4721-9eff-a1a77fec563c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "c3f6ea06-feb7-40bf-9c9b-c32e8c0f04a0",
+          "id": "6933bd3a-4504-42d9-a45d-697982852d1f",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "ee4c9381-bd06-4cf7-9a35-0a6f34698047",
+              "id": "4a36a78c-fa59-4a0f-a6cc-37d432938b46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "e8c9fe34-376f-46b2-a024-dd7b1c558167",
+          "id": "ca6feb60-b571-4bcb-9a15-7f8e808bc973",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "eac574ff-ef7a-4ee8-9816-7e0337145d85",
+              "id": "3b28e37e-7cd2-4017-847a-466943934008",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "eba1e114-c490-4c7f-8589-1959924a8a66",
+          "id": "1c6eb589-81a7-4e8a-8344-d47ce03a457c",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "18674144-1a18-4277-9317-e33e957e72ef",
+              "id": "9be3dfd3-49e8-448b-9cdf-97a873b4d14a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "c28ff888-9f35-4ecf-a241-80b63012b5b7",
+          "id": "2e38a545-ccb9-4426-be76-108ba4bd2003",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "9bd0195d-5b01-40f5-b9aa-c175b899317c",
+              "id": "cf10be2d-e133-43b8-8779-cb9b980b8904",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "2428a3e1-e93b-4d3a-ad40-e2dbd6e40ff7",
+          "id": "819adb92-5e1b-42ff-a29d-d1049d5c0ae9",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "1ca624e3-e62f-4311-b178-6f84b36c80fa",
+              "id": "3318941a-f23b-4e1e-8c50-9f78a7fa9740",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "df770180-1d74-4c02-a205-3d57d0ccdf0f",
+          "id": "47ae905c-36fd-4cc6-8ed6-8ff287577c93",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "8ec210a8-eae5-4080-852a-7414469e234f",
+              "id": "ff2283b8-bacf-464f-83e3-f331c421d6dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "6d81d425-390e-4f78-95cd-f52f943a3feb",
+          "id": "71e52d41-e739-466d-b083-3385b38a3788",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "76106061-3f4c-497b-aacb-d76838745534",
+              "id": "e4cfaf51-c430-45ef-b10a-3e2eb141b070",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "8b7e8550-90da-4a11-ad39-9f8c350978c6",
+          "id": "91e03d0d-7729-4d09-9026-64ee67b11cd9",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "58e13ebf-9619-47d0-9607-dff50019d33b",
+              "id": "579602a2-d1f6-4f1c-a403-fe7cdeb2eec2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "5a1bfbba-3324-4285-a8d7-7c982d6266e9",
+          "id": "19e882b8-467b-4a15-b686-e09af91c3991",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "74344796-c30e-40bb-b916-d8dd8c61b74e",
+              "id": "95529a68-88a5-4c91-a3d5-89098c145ead",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "29aa8f0c-f711-41ce-b460-00148a9a0ce0",
+          "id": "1a94112d-caf8-4073-9bb9-0de9975fb200",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "e1fadc7c-465b-4f69-b72d-b1f673e57e71",
+              "id": "830c0337-dc2f-438e-bce4-bcf90bcc4918",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 1333,\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 3364.953914229627,\n        \"key_1\": 3304,\n        \"key_2\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": 4218\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": 7410.856595184474,\n        \"key_2\": 6333.228787550451,\n        \"key_3\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "bbeadfc8-26aa-42ee-a76a-6ef814a6b09a",
+          "id": "3f3a242f-2844-4c5b-876e-7d1fb192b656",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "a361fb31-2f43-4e9d-b3d4-d4d603dafb71",
+              "id": "cc1a022f-67ed-43f3-acc7-9378ef45dbaa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "b6452ccf-cd12-45c1-b21b-e01a2233675a",
+          "id": "702d3ba4-b100-4481-b514-7373cdaa1140",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#Fe6C38\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a57E67\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "f68114b8-54fb-4a5d-9dc4-70e31d5bf39e",
+              "id": "5eb9f6b6-e570-4a3e-a829-52b645cb5b6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#Fe6C38\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a57E67\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "f899f547-ac8e-4a9c-9ca1-608be440d5ae",
+          "id": "7ae5d91f-eb27-4517-88f8-aef830389bfe",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "fb2928d0-8fc8-4488-8185-2c1f016b1197",
+              "id": "c71c189e-5c4c-41a4-83d6-b79d2df09e11",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "5ba662dd-a077-4955-b09f-2a4986475f45",
+          "id": "7a051efc-8193-44c3-93fa-d1f06fbefee3",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "46e0503e-787b-42f3-b6cc-778f27ccb049",
+              "id": "c11de4b2-a8fc-4459-93b7-76c4e2a4e9ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "40344cc7-3881-4f7f-a8ef-6d6226e9feee",
+          "id": "279892b3-603e-4453-8b36-a1f16db9519f",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4Bbc1A\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1f5ffE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "2adda55e-6ad8-4f2a-b7f2-2e0316321250",
+              "id": "a4486b53-ce49-4783-8aa4-676f2ce2d857",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4Bbc1A\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1f5ffE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "4eb46aa0-fbaa-4b0e-a01c-fd055314a8d4",
+          "id": "7c79909b-53f9-4fb7-87c8-e5354b8f378a",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "d450d9d9-fb7b-4307-975c-1a3701ffab4c",
+              "id": "7dfd3933-283d-46e7-bb17-6fdd08a81aba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "667873e6-c1c5-429a-84af-c729f6033131",
+          "id": "a6708c47-d5ae-4592-9946-3d6bcd56f800",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "6e27eccf-f1fc-48a0-900f-08203fd691cf",
+              "id": "3e45dab9-f1f7-4806-a7f3-12f201d4220c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "bc3adc0e-4943-4873-95d4-ad37b9e242dd",
+          "id": "447140b1-1010-4af7-a29b-4adc1a0a78c6",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "af9e8ec7-9874-4bb0-b8b9-1210c9a2478e",
+              "id": "4c68503b-6b5a-4c12-a8ad-c27d1422fe5d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "2ae1e9b2-1f7b-4fb0-ab92-ff79b575a598",
+          "id": "e920a107-2605-46f3-ab7d-f817de7a0304",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "bb27dad7-712d-4dda-8d92-216173a65e06",
+              "id": "c2885289-b8f7-487d-bce6-0e5730cb3673",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "58afbc23-294b-4854-a8bb-1b91961eca8b",
+          "id": "9e744ce2-0b58-4350-ab9a-557a11c5141b",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "40ff8174-4ed4-437b-96e3-01977a2df3c4",
+              "id": "5dec0e8b-d537-4408-a06c-a2e74f4155ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "54e29f32-d30a-4fe1-85e4-23b5072ad62d",
+          "id": "47a369cf-15be-4eca-81f0-5d065096c265",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "8c1d356b-d9b3-460d-9725-32998a35d50d",
+              "id": "7a5867cd-b793-4d39-8300-73a762fc6201",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "8e1d589e-aa4b-46d6-9a5d-e9eb6a8e2130",
+          "id": "2fab968c-ef53-4347-acd1-840b292e4058",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "e784b84d-cd71-4153-a879-d628dcb9caa6",
+              "id": "edfe9dbd-19a7-45db-b66c-48387d329543",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
+              "body": "{\n  \"key_0\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "6188d7fb-e4ef-4f22-8694-3e541feedb35",
+          "id": "54059961-7c29-43f0-b15d-e42ab7a27153",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "9974a492-0288-42ed-81d3-abb6264a3117",
+              "id": "1e7558d2-f144-4ac2-a5d1-4e867bc11d54",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "01f2cc9d-e5d6-449a-98fd-5224423a9f56",
+          "id": "10588c9b-8ff1-4a12-8b3f-e71ac624a68a",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "eab1cc61-3baf-4886-bc2b-0c77d56c962a",
+              "id": "1e730628-78cf-4583-874b-bb8d86cd9ec1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "bbd62631-b997-4fd1-9946-9570b43552ec",
+          "id": "9ec1b6a6-f881-46e2-971a-3c25f1e4f4f3",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "57db4c65-a1ad-4718-83d6-8d3d1354edec",
+              "id": "e7671ac9-afca-4335-b5ff-5b958eb0cb76",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "75844c2d-cffe-48d4-a089-df2900cf46b5",
+          "id": "75547756-b38b-4bbb-8db8-1c58d41f4e9b",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "26a4e646-5c24-4cc1-a347-e6435df44b16",
+              "id": "34a08680-2375-4713-aea3-a45cd550923a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "fdce95ea-d7c1-4189-b79c-da5a925ce434",
+          "id": "fd01d602-b85d-4522-bce6-7d5b87a52ec3",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "bd77157e-b7a2-40b7-9f46-d0882ab53e1d",
+              "id": "8ac4be3b-4b02-4ab7-85b1-09bef438f234",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "406e928d-d940-4956-bdd4-24ff98c5b6bb",
+          "id": "53eb4969-4224-42be-adba-6414784654a4",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "0ed2afc1-d9a4-4871-9c4d-77e888c92529",
+              "id": "b277094d-f866-4f70-b5a2-a2979cfab0f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "e590ed7b-5226-4cd1-bb81-2e5c838f2f7e",
+          "id": "2fd8b0e2-c390-4c8b-a31c-557fa44b6b12",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "048d1778-0a6e-490d-88bd-53bfaf42611f",
+              "id": "d3b129ff-b566-47a2-b05e-1cb37cccfc33",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "edafb45a-4c98-4848-bf98-9b419b1cb038",
+          "id": "7b291ff4-1d27-4a03-84ed-a08f1bec33e2",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "d0d7ae81-abf9-4887-8818-09f8c1317b0b",
+              "id": "4313fdcd-327d-458a-95bf-d647aa906d4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "098404aa-a5ef-4176-a5db-6e632880b2b8",
+          "id": "d5c9d910-cc25-4e88-bf9a-2dab4e541da8",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "5b8809ec-9cbd-4881-8bd3-28872b57627d",
+              "id": "afe80899-9c12-4677-a8a3-595ab76914d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "754f1124-aa25-4389-bec4-bab0ace3f0fa",
+          "id": "ece2a2ca-3ce5-4006-9c4e-ca5b72259e5a",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "b05ccae6-b807-480b-b200-e0b7046a7061",
+              "id": "7a5718fc-caa4-47d4-891a-ecdcd83eaa86",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "0889b4b6-bba7-4ea7-9cbd-fec29202f6d9",
+          "id": "36a18e15-a304-4ed1-98c2-ff2aac2b33ca",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "47750a66-ff71-4d0c-918a-46ba761f712b",
+              "id": "caff1b48-2cd2-4387-aced-3f4f9c7059ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "553f937e-6bec-45fc-8a5f-add0c94d7557",
+          "id": "4f90528f-847b-4739-a554-19bcccfbaceb",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "f56f3fb1-0712-4825-adc8-3dd985b1a96d",
+              "id": "02a1be2c-0d9c-49b2-9744-bd8b6ed83d34",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "a7228ac6-87b5-46c1-8e44-2cc7ccc88e2d",
+          "id": "f0121f6b-9f78-4c56-a3ec-19b6793416b8",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "fb4b2fed-f1f4-4940-bbaa-4846108fb84a",
+              "id": "3a1216b8-0577-4f19-ab7f-5d12d76bfc5c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "540b1e7a-b29b-48ac-85fc-c5b1c3a2d75f",
+          "id": "33a1f224-bf9c-4e2e-9c26-2132d0a8388a",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "93a5a267-6ae3-4938-8b55-f3d62a2f87a5",
+              "id": "30a91ea0-b086-473f-a67d-36da6d91c07d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "2bdc85d3-e902-462e-bdd2-f8956925b377",
+          "id": "d436d2e3-b6e9-485e-ac32-dd4176c21861",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "bdf34d6c-5acf-4e98-8e4c-dcb5d72ac539",
+              "id": "a1fc43d2-9834-449d-ae72-3d5ef3980707",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "1562aeb7-9add-41b0-adff-f2e1a081066b",
+          "id": "ea728afa-3f9e-4e85-a31a-4861e565aa82",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "ab93d852-6a88-48ce-9422-ffbcfbbcab7e",
+              "id": "b3d6c521-be19-4ada-b37e-2250ed120584",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "8eb4edbe-1828-44d0-bb57-c0610f999809",
+          "id": "efe45393-0b15-4bd8-8192-b905b21bce0d",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "e9ebc3ae-d358-40d0-8fb1-4f94e3228344",
+              "id": "9bd16905-4a45-4d43-acd7-a48639709fed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "a1eff31e-5461-44fc-adc5-ba97695b08cf",
+          "id": "bb4d17b7-fc52-436d-8922-be7e4b884f6c",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "9a389cd7-7254-41ab-bfc0-c00f700c7712",
+              "id": "2b3a64d3-bab6-4a44-bd4e-ff96dc066599",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "ee35cd64-6ddb-4103-819a-162b04be1462",
+          "id": "6024de80-020f-4752-aad9-b49240f101f6",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "7b7fd876-61e5-4d1b-8f06-ac1552725488",
+              "id": "128ac5ba-c117-4e28-9079-4173593b18bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "7d4e29f0-f90b-4863-8637-6c1e4dcf410d",
+          "id": "f3421903-2498-409c-a4ca-b983818fe8bb",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "e59b2ac9-b292-445f-b4a6-5baf3251b43c",
+              "id": "a99f9755-a1ab-4f7a-a04a-fdea830fac56",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "0a0b528b-b529-4b47-94f7-a6c08acfb69d",
+          "id": "1a87df5b-757c-4e02-933b-ad8562d60736",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "d59528b9-de06-49c1-86ff-316f16d55215",
+              "id": "6beeedc4-d381-4e66-8e7c-6ea56214cd95",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "e96f88e4-69f3-4075-b581-71aba8f0b334",
+          "id": "bc47adb2-f54b-480e-aa4b-2a802c07e29a",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7566,7 +7566,7 @@
           },
           "response": [
             {
-              "id": "47376496-8566-41b7-9697-5d6e4eb0047b",
+              "id": "12e7c09d-efc0-4e49-855c-7e3b0946b401",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7655,7 +7655,7 @@
           }
         },
         {
-          "id": "707c0055-a9a5-4aec-a933-46479580fbd7",
+          "id": "1c126107-e4ae-423c-bfe1-ebb55d81fbdc",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7722,7 +7722,7 @@
           },
           "response": [
             {
-              "id": "ceb4665c-7912-4e5d-80d8-0b1fb8f9e39c",
+              "id": "3867bfab-3ee4-4b27-b2e7-084ac9a31212",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7817,7 +7817,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "b03843ce-de05-4b37-91cc-6311908a1aa6",
+          "id": "e9ff3a04-472c-4736-bd1d-3424543f7aa6",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7870,7 +7870,7 @@
           },
           "response": [
             {
-              "id": "6c82a887-4e92-4514-ace6-d3235dc5c411",
+              "id": "eb8a797b-23f3-4cc9-b6fb-f6d724629d43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7945,7 +7945,7 @@
           }
         },
         {
-          "id": "02143659-d290-4569-aaeb-9bd38c401ae7",
+          "id": "5fefaee9-5049-41cc-98e6-7bffcdabbc74",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -8011,7 +8011,7 @@
           },
           "response": [
             {
-              "id": "66cbedd9-5457-4026-8002-4391c54dbb80",
+              "id": "d00bdfca-33ea-4654-9d20-be4f0a7a1e7e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8099,7 +8099,7 @@
           }
         },
         {
-          "id": "36b31a15-c2ca-492b-90f3-09f4065d35a2",
+          "id": "4f6100ea-ca12-46ff-8547-0fd3c510e9e5",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8146,7 +8146,7 @@
           },
           "response": [
             {
-              "id": "9e676590-ce3c-433f-89d6-c5c3f7e4b15b",
+              "id": "f6cd40e2-4a0e-45e0-a1b1-5cef18220560",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8211,7 +8211,7 @@
           }
         },
         {
-          "id": "307334b2-b9e2-4530-ad0f-c793e66c1abe",
+          "id": "f81fbc5b-de35-4460-b4e2-53ac79ad0991",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8253,7 +8253,7 @@
           },
           "response": [
             {
-              "id": "3e4956a8-bd8e-4c34-981e-feb7a160fdef",
+              "id": "12f42e16-3178-4c3a-86fc-150eee9b8b65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8317,7 +8317,7 @@
           }
         },
         {
-          "id": "163967a3-a269-417c-979b-21b1dece2d1e",
+          "id": "4cfc8c21-33b5-44a6-b7d3-600ac559c4aa",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8372,7 +8372,7 @@
           },
           "response": [
             {
-              "id": "86d641cb-d5cb-4e98-aa62-dde4a8684944",
+              "id": "ca771faa-5807-496d-9668-49b66c748728",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8455,7 +8455,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "29a2cf73-566d-4939-8197-f4e9b66d5758",
+          "id": "27be4916-173a-438d-b1d9-ecc2e5abe40b",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8496,7 +8496,7 @@
           },
           "response": [
             {
-              "id": "7ed0aebe-a3dc-434e-82af-8035b08f3b86",
+              "id": "72fa2559-1985-4bf8-be8b-34a0418e9c64",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8559,7 +8559,7 @@
           }
         },
         {
-          "id": "bb297287-ed8b-4780-b24b-2c35077c6c2d",
+          "id": "e75ad076-1d77-4d7d-9718-5081897f5ca5",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8613,7 +8613,7 @@
           },
           "response": [
             {
-              "id": "f7b5758f-c9f8-47a2-8eff-3938bfd59f59",
+              "id": "943656b6-a03a-4589-8eae-8a9b26740ce2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8689,7 +8689,7 @@
           }
         },
         {
-          "id": "30362ecf-9e02-409e-a058-2b9e5078257b",
+          "id": "b1bf0f00-57ee-41e6-8df9-6ac0f1a3716f",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8724,7 +8724,7 @@
           },
           "response": [
             {
-              "id": "3e2246d5-579f-42e9-a41b-0b30d2b39555",
+              "id": "82f4e4fb-2d14-4a4c-870b-fe8f15961cce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8777,7 +8777,7 @@
           }
         },
         {
-          "id": "6d4c2901-82e5-4a9e-86bd-aa27acb11d5e",
+          "id": "b44b3f81-7c74-4dc5-9b32-898eedb8c858",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8834,7 +8834,7 @@
           },
           "response": [
             {
-              "id": "b2eb6d9c-98a4-4e65-bc23-53a8b85bb4ba",
+              "id": "97fe35ef-84c2-45c8-8965-1a65ece77460",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8913,7 +8913,7 @@
           }
         },
         {
-          "id": "39fe4963-5574-49f5-8122-67cf65d9e38f",
+          "id": "6fc9b563-d687-4ba7-bf97-17b73270beef",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8955,7 +8955,7 @@
           },
           "response": [
             {
-              "id": "7e3c5009-6411-45c5-b682-8a0d90f239df",
+              "id": "380ddf0f-ab0f-47d5-8db5-f0c12e01bc39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9025,7 +9025,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "b11cc71b-8a43-49e5-b1c1-4e1cddfdcfee",
+          "id": "dadbe54a-dd13-480d-846b-103bf40d67ab",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9078,7 +9078,7 @@
           },
           "response": [
             {
-              "id": "2edc209f-cfaa-43d7-8094-37a62947672f",
+              "id": "8d166ee4-78d9-41db-96bc-0dd318a50882",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9153,7 +9153,7 @@
           }
         },
         {
-          "id": "b3f89485-f210-46fc-968a-9a092845e665",
+          "id": "b9714b11-0b46-480b-8c01-f69e4d052597",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9219,7 +9219,7 @@
           },
           "response": [
             {
-              "id": "6890956e-ff5e-4a9e-b38a-7d3065fc10e3",
+              "id": "0f542e35-3e7c-4e2e-b7f1-117c81caf98b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9307,7 +9307,7 @@
           }
         },
         {
-          "id": "1e4e7f30-d00b-4f32-acf5-245979ef52a0",
+          "id": "4c943354-94fe-4f90-b86b-c0b4588d8347",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9354,7 +9354,7 @@
           },
           "response": [
             {
-              "id": "8ff93b69-85ff-43c7-af68-13880049a84c",
+              "id": "bc98f053-1592-467b-86bf-f3048ee0be69",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9419,7 +9419,7 @@
           }
         },
         {
-          "id": "8049b2a9-b90a-4da4-adc3-6fa43e18f6c2",
+          "id": "1cf3821d-7f8a-4097-9c53-d0eb4e93519c",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9461,7 +9461,7 @@
           },
           "response": [
             {
-              "id": "e6521bed-f46e-40ba-b8c6-2d01253e46d9",
+              "id": "f2018056-9532-4dd5-9de1-1969c9e84e43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9525,7 +9525,7 @@
           }
         },
         {
-          "id": "868fa9c5-d2f6-498d-9221-5c9aac114876",
+          "id": "239957d7-3fd4-42bb-ad96-e1c6767dc2a6",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9580,7 +9580,7 @@
           },
           "response": [
             {
-              "id": "d34ff5e9-7272-44f4-aed2-ff78f34f3617",
+              "id": "6be6fe00-c1ab-46c1-866e-2fde18e86c3d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9663,7 +9663,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "ebd5586f-e3a8-4dfe-b44c-f88f47b4aa71",
+          "id": "d403d36d-063d-4bc8-8b1f-f3e0c902f2c6",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9705,7 +9705,7 @@
           },
           "response": [
             {
-              "id": "534eadb9-f025-4001-b1d6-29761e123889",
+              "id": "92cedfae-cecb-4944-8489-3429835c2a04",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9769,7 +9769,7 @@
           }
         },
         {
-          "id": "5a059f4a-8b5d-41ea-bbfc-33cbadcb9340",
+          "id": "a74ffd1e-0f56-42ae-a654-245e206c6e38",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9824,7 +9824,7 @@
           },
           "response": [
             {
-              "id": "2d245820-1db8-478f-89b9-5d2046d1b87c",
+              "id": "b2c83eae-d21d-4cb5-8224-0c7a40209d46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9901,7 +9901,7 @@
           }
         },
         {
-          "id": "c36a1348-2b61-4c38-863d-9571ad9eda97",
+          "id": "ba7e6e07-6ac4-4252-a5ac-b9f88788e490",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9937,7 +9937,7 @@
           },
           "response": [
             {
-              "id": "2d89ec74-8c93-4c87-b288-535c34ba6b94",
+              "id": "8ec26c58-d248-4adf-acbf-22195495d27c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9991,7 +9991,7 @@
           }
         },
         {
-          "id": "962c7a70-e85d-46cc-807a-8c2693f13f7b",
+          "id": "a5d12a88-2cd4-4618-84b0-5f3ce7b22580",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -10021,7 +10021,7 @@
           },
           "response": [
             {
-              "id": "ec913c20-41f0-4737-87b3-e4882f708db0",
+              "id": "dad58e6b-15ed-4eb8-b845-039312fa2c8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10073,7 +10073,7 @@
           }
         },
         {
-          "id": "af8646a3-1958-4b9c-a4dc-e44f7d6f141f",
+          "id": "bd11c458-1064-462f-9213-6d6263fea0fe",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10116,7 +10116,7 @@
           },
           "response": [
             {
-              "id": "42b8920f-d488-4f88-a1d8-b0899768b753",
+              "id": "d8453933-a486-4935-ae16-d1dc61c67872",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10187,7 +10187,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "4d21718e-2a52-4731-96a8-8074cdcf3fb7",
+          "id": "af59e526-c3c8-4807-9158-843e81151fa2",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10229,7 +10229,7 @@
           },
           "response": [
             {
-              "id": "a2754b11-d0df-4349-bf5b-777d4084a953",
+              "id": "cfd0dd9b-3f02-4584-8f8c-bd6ed0271882",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10287,7 +10287,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "2dfe183b-5f1c-458e-8e24-049ea5e830e3",
+              "id": "dae4f38b-eeb7-46c8-a7e0-a7d76a99e9b6",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10351,7 +10351,7 @@
           }
         },
         {
-          "id": "5857f40b-179b-4759-9585-cf8c1a9b7dbf",
+          "id": "d18bfd54-0e5d-49fb-90ed-8cfb58363704",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10406,7 +10406,7 @@
           },
           "response": [
             {
-              "id": "5d39740f-78ee-43d5-88df-60ba208a5456",
+              "id": "8b8403a4-082b-4e00-b54f-bd75028a1af4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10477,7 +10477,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1d2d453e-6193-45fa-8127-551446bdef1d",
+              "id": "95bed3a8-7009-43d4-b4c8-32cbf94002e3",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10548,7 +10548,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8c8b9748-9b3f-4341-9ece-c51eb80aadbd",
+              "id": "0661f363-1062-4c19-9a7a-ff08ad86ec91",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10625,7 +10625,7 @@
           }
         },
         {
-          "id": "74e918b8-8a40-4c54-961a-a16dbf15d56e",
+          "id": "23f39b3b-7e29-4a24-be16-9ffe3f936d13",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10661,7 +10661,7 @@
           },
           "response": [
             {
-              "id": "4b6f22c7-b8ce-406c-8b6a-c4f70b32b78b",
+              "id": "d5b12d6b-b0e7-4244-99e1-79a36d3350db",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10709,7 +10709,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a0e36661-3cc4-4ec3-9145-71b7695fbdb8",
+              "id": "6492ab23-fdf9-47cb-bc87-8c79cdc57a85",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10757,7 +10757,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f3f06065-28b6-436c-ac36-5bc7176a6d4b",
+              "id": "8fc35e0a-3225-4c59-8688-1f211a50b59b",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
           }
         },
         {
-          "id": "f4ed1140-12d5-446f-91bf-a60b4f859756",
+          "id": "3e291f16-f8dd-45cf-9a4b-83616d60ea3f",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10841,7 +10841,7 @@
           },
           "response": [
             {
-              "id": "67a0b5f7-ce1a-4142-a70c-5c5ab0512a82",
+              "id": "2c53bd93-6b15-4679-ab10-28d4f9d2fc1b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10893,7 +10893,7 @@
           }
         },
         {
-          "id": "fe7b3818-5ab5-4600-9dcd-6acf575d73c7",
+          "id": "c93b9710-a900-4652-9e27-b753e41c6539",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10936,7 +10936,7 @@
           },
           "response": [
             {
-              "id": "b42394f6-8b04-450c-8452-8f0d29792617",
+              "id": "fed7cb7f-5e98-4b26-9636-13f11250a5f7",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10995,7 +10995,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3ae9f407-8900-44e1-acb3-51c703a7406e",
+              "id": "6095f852-eebb-4c4d-a257-17f8b20e32ea",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11066,7 +11066,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "b66d4bd7-472e-460e-b581-1dff8b76bca8",
+          "id": "33b05a56-e965-4814-a435-0763479ccdc3",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11150,7 +11150,7 @@
           },
           "response": [
             {
-              "id": "3b7407ba-82ff-48b5-a1e9-e23b5c4874b0",
+              "id": "4666bcc4-57c6-49eb-857d-f2d6953b891f",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11253,7 +11253,7 @@
           }
         },
         {
-          "id": "5ab2c95c-7d47-4f97-b6a3-b7b7657440ad",
+          "id": "c0d1b7d3-3658-4c0b-88b3-4e8b277dddad",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11319,7 +11319,7 @@
           },
           "response": [
             {
-              "id": "608124a4-9115-4cb2-87c7-8c1c8d9d931c",
+              "id": "736823ad-2bf5-46ee-88ea-813155fd897c",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11404,7 +11404,7 @@
           }
         },
         {
-          "id": "c75f0ccf-97af-44db-b6a4-1e2fa96451ab",
+          "id": "c4aab1b8-9564-4233-8f93-711c7352fb1f",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11488,7 +11488,7 @@
           },
           "response": [
             {
-              "id": "dc884180-024b-4396-bf59-1ffdfbb25ce3",
+              "id": "850c4bdf-9c6f-4d56-845a-dad4e2d2f175",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11591,7 +11591,7 @@
           }
         },
         {
-          "id": "3be13b45-b5e9-478f-a737-1fe7f67d8d87",
+          "id": "b3c0d375-ac97-4ef9-aba6-4cda52023c85",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11666,7 +11666,7 @@
           },
           "response": [
             {
-              "id": "2aa953ed-5af4-4fc7-b170-93f6e45fe4b3",
+              "id": "1998529f-deae-4550-863d-c23086db65ef",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11760,7 +11760,7 @@
           }
         },
         {
-          "id": "2b9ac915-cbeb-473f-bc9f-269de92895b8",
+          "id": "7e3d58b1-8862-42de-99d7-1a3370a4d74d",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11835,7 +11835,7 @@
           },
           "response": [
             {
-              "id": "720f3ac2-97e2-45f3-bca4-1083ca82a268",
+              "id": "7fd41185-d905-49a8-b6d4-b1a6cb900a19",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11929,7 +11929,7 @@
           }
         },
         {
-          "id": "fac32095-5275-43b7-965d-147448b39fea",
+          "id": "cd970118-c70e-4669-95a6-1e52c843ed37",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -12004,7 +12004,7 @@
           },
           "response": [
             {
-              "id": "99310179-6111-4fdd-bfa0-4ab03755cfb7",
+              "id": "fa89a9c8-cd98-4ecd-b07d-37967f938b63",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12104,7 +12104,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "e4957521-fb2c-48e4-b463-3574f105369b",
+          "id": "073440bf-0787-4caf-a2f8-f2012575eeec",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12170,7 +12170,7 @@
           },
           "response": [
             {
-              "id": "db562b58-2030-40a2-9fd3-d6e680574eb1",
+              "id": "0325e60b-fa3f-4f49-994d-7d669e82a802",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12244,7 +12244,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
+              "body": "{\n  \"key_0\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12261,7 +12261,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "33cff2c2-e456-4ff8-ad5e-2eecedbbc3fa",
+          "id": "671c7e54-3530-4c12-8b34-d4b0cb956e56",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12303,7 +12303,7 @@
           },
           "response": [
             {
-              "id": "8a5c8e1f-8770-4e78-b0e9-8fffe2ffea20",
+              "id": "616fc086-0e36-45b9-a0a0-f17955f3461a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12373,7 +12373,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "703cd00a-2e5e-4065-a61c-604aff4b3d48",
+          "id": "2674c642-c629-417c-82ee-819fcc388e29",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12412,7 +12412,7 @@
           },
           "response": [
             {
-              "id": "1223fe86-f88d-4095-ba5f-9fe2b3959545",
+              "id": "2e5b6116-97c6-4b27-940c-44e033b76399",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12465,7 +12465,7 @@
           }
         },
         {
-          "id": "83db07c1-a2cc-4d9a-94a2-d77520a7e581",
+          "id": "4381e40b-68d6-488a-8149-44bf9ac1c44d",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12497,7 +12497,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"nz-BN\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:07\",\n  \"quietHoursEnd\": \"22:38\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"aj-YR\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"22:14\",\n  \"quietHoursEnd\": \"16:44\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12517,7 +12517,7 @@
           },
           "response": [
             {
-              "id": "744ec9cc-588f-457d-8f63-493ddc6dc5a7",
+              "id": "183aaf0b-d08c-4cee-9618-c1588edc3029",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12555,7 +12555,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"nz-BN\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:07\",\n  \"quietHoursEnd\": \"22:38\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"aj-YR\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"22:14\",\n  \"quietHoursEnd\": \"16:44\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12589,7 +12589,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "8b08eaee-4805-45bf-b73a-b58b6ac8c78b",
+          "id": "e01ab9bf-4eea-408d-a006-f33747b9683f",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12631,7 +12631,7 @@
           },
           "response": [
             {
-              "id": "f4b27685-5ad4-4430-906d-091649d861bf",
+              "id": "aec96e14-e881-4a6b-acc8-6c85e9e2111d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12695,7 +12695,7 @@
           }
         },
         {
-          "id": "16440487-99b5-4ec2-8ce3-9e015b0f523c",
+          "id": "22117922-f3a9-4b8f-be0c-93290b7b81a7",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12738,7 +12738,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5eFebB\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#3C2c43\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12750,7 +12750,7 @@
           },
           "response": [
             {
-              "id": "cf37f4ea-c989-4e7a-a9e4-8e1b3f1007da",
+              "id": "ba0d17da-63cf-48dc-9da1-19b67eab3070",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12799,7 +12799,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#5eFebB\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#3C2c43\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12827,7 +12827,7 @@
           }
         },
         {
-          "id": "72b03769-d9b3-42f9-bb40-300f9e63f0e9",
+          "id": "679236de-f96a-4577-ad9a-5a5d162fc17e",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12863,7 +12863,7 @@
           },
           "response": [
             {
-              "id": "a4d2df68-d587-42b3-a4fa-796f888763ab",
+              "id": "bba432f6-b9f9-4e55-b332-e95a44515edd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12917,7 +12917,7 @@
           }
         },
         {
-          "id": "817c741f-e4ce-4dd1-9d61-9c91c592d656",
+          "id": "1db211fc-f28d-4102-9301-3688d4a9b35c",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12947,7 +12947,7 @@
           },
           "response": [
             {
-              "id": "b55ec0c9-2ada-498b-843d-03dd52826a7d",
+              "id": "347225b3-8166-4c19-ac03-ed5848a8232f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12999,7 +12999,7 @@
           }
         },
         {
-          "id": "d7e9c4fd-fd8d-4bc3-b449-d39439472bb5",
+          "id": "bf0d994b-8c61-4fcb-ba59-3bd59b69aaba",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -13030,7 +13030,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E673BA\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#245acc\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -13042,7 +13042,7 @@
           },
           "response": [
             {
-              "id": "c9e57a98-1d8b-4008-99dc-94e8bc18f5f6",
+              "id": "5e3e98ae-8d2a-47e8-bda7-97522d43e74a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13079,7 +13079,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E673BA\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#245acc\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13107,7 +13107,7 @@
           }
         },
         {
-          "id": "fac3f824-b96b-45a5-8e04-0ceff805d8ea",
+          "id": "caa7c07a-12bf-4171-a722-e266c90c23c0",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13138,7 +13138,7 @@
           },
           "response": [
             {
-              "id": "5ca5667e-5887-47ba-a990-e1924fab81ae",
+              "id": "7fde997a-aa9b-4495-9067-10e36bad4dbf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13197,7 +13197,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "7a9b075e-a026-45ce-9727-569e62cf6b66",
+          "id": "5f5ffa58-d80b-4635-8dc4-ec190cf6d759",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13250,7 +13250,7 @@
           },
           "response": [
             {
-              "id": "c46934bd-9f6b-4f7b-af9c-dbccb0e8cc05",
+              "id": "5e9471f0-6c37-49f4-9c99-3454131c12eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13325,7 +13325,7 @@
           }
         },
         {
-          "id": "768b3039-5523-4c0e-b5c8-3c057074c3d5",
+          "id": "b1e980bf-c8b0-4aef-a77d-019b0f2bae00",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13391,7 +13391,7 @@
           },
           "response": [
             {
-              "id": "6581203c-9424-4732-a654-f21e153b5d30",
+              "id": "d5a49e65-5d95-495e-b932-204b59ed34b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13479,7 +13479,7 @@
           }
         },
         {
-          "id": "8d076aed-4fa1-40f0-bfa4-17fb932dc92e",
+          "id": "bf7a3691-d131-431f-8044-137ffd400486",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13526,7 +13526,7 @@
           },
           "response": [
             {
-              "id": "81c01b22-f9ce-404c-a828-a77b93329fe3",
+              "id": "ea0d985b-5163-47af-a771-11dfa98e5d5b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13591,7 +13591,7 @@
           }
         },
         {
-          "id": "0abba96c-2ff5-441d-958c-21e80e98d49c",
+          "id": "b6841365-5d27-407e-980a-61c9b6ef5340",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13633,7 +13633,7 @@
           },
           "response": [
             {
-              "id": "7f17acb8-96e0-449e-879b-443190a28c25",
+              "id": "362a85ef-58ec-438b-a0c7-5351cf3a9a75",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13697,7 +13697,7 @@
           }
         },
         {
-          "id": "b8017ee1-51eb-4175-8209-94233fa66b92",
+          "id": "bd360aac-3527-4a80-bc53-c279dad31321",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13752,7 +13752,7 @@
           },
           "response": [
             {
-              "id": "b1040996-643e-4d4f-8f5e-7622b788055b",
+              "id": "f020808a-0b37-48e9-8c8b-b7d72b943967",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13829,7 +13829,7 @@
           }
         },
         {
-          "id": "bdb4ab29-d7ab-4e5f-833f-e91e89dbcd2a",
+          "id": "5db744b2-5fdd-4bef-858c-7b7791ab1dc1",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13883,7 +13883,7 @@
           },
           "response": [
             {
-              "id": "6cbeca70-2442-499e-8b36-d49636dffc31",
+              "id": "d1458b3f-d3f2-4376-94ec-e912ba157acf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13959,7 +13959,7 @@
           }
         },
         {
-          "id": "02a0e91e-9a25-4bfc-a696-ff192337ada5",
+          "id": "b7901c28-fa2a-48ed-aa3a-abaa674f5167",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -14025,7 +14025,7 @@
           },
           "response": [
             {
-              "id": "31d675b9-324c-49ac-a7bf-f977f6c8f268",
+              "id": "f57ffeb7-4143-408f-8791-a108d0b9c0cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14113,7 +14113,7 @@
           }
         },
         {
-          "id": "b738fc1c-e2f1-4f6e-b6e5-72926e21c5af",
+          "id": "087addf2-2736-401b-8ab9-d8d47626c2b8",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14191,7 +14191,7 @@
           },
           "response": [
             {
-              "id": "a0bebb53-6d49-4486-b13e-073e1579d6f9",
+              "id": "fada11aa-e484-4d90-9b2b-c0fa047acd04",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14291,7 +14291,7 @@
           }
         },
         {
-          "id": "fd080fef-b00b-4585-9810-f439d4f4228a",
+          "id": "3edae1e2-bdda-4f12-8cde-d503894da232",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14357,7 +14357,7 @@
           },
           "response": [
             {
-              "id": "7e108d66-411f-49b8-93bf-718d76e478eb",
+              "id": "0606aa4c-6adf-49d2-8d1f-8ba0e984ac15",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14445,7 +14445,7 @@
           }
         },
         {
-          "id": "97444aea-258e-4779-bec1-9fd171fe0cce",
+          "id": "ba8e1bf4-3807-4c99-93ae-232ef46474c9",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14500,7 +14500,7 @@
           },
           "response": [
             {
-              "id": "e6dd9284-a3bb-4cf9-b7da-406c6661bef8",
+              "id": "3ecf3434-a0a7-460e-9cc5-c55d427b0652",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14583,7 +14583,7 @@
       "description": "",
       "item": [
         {
-          "id": "b7a1f07b-cec2-4ed2-a6d1-c3bd5f31125b",
+          "id": "8994c1e6-091a-4fbb-859d-8741f39cc9c7",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14624,7 +14624,7 @@
           },
           "response": [
             {
-              "id": "43a3f9a9-4bf9-44e8-a420-17419e514458",
+              "id": "9097b361-55c5-4ad0-98d9-fc3dd8c9a1fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14687,7 +14687,7 @@
           }
         },
         {
-          "id": "73d9c643-2ae1-42e1-9700-4cc9472541b1",
+          "id": "46a2f619-ea62-4655-9a55-e24a401de627",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14741,7 +14741,7 @@
           },
           "response": [
             {
-              "id": "df43586e-1f09-4e6f-b56c-e1e5d62dd958",
+              "id": "3ea2f652-3a68-4c2b-945c-980439b579a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14817,7 +14817,7 @@
           }
         },
         {
-          "id": "36d2185b-4380-46dd-a7c3-a38461de5fe8",
+          "id": "30960123-7001-4a99-9552-1bbc086e61b9",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14852,7 +14852,7 @@
           },
           "response": [
             {
-              "id": "4e79d934-b867-4efa-a5f2-af0d07e74deb",
+              "id": "3fde248b-9e88-4a29-ba8e-f6c71d3ef251",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14905,7 +14905,7 @@
           }
         },
         {
-          "id": "832aa929-6578-4213-b490-36fb2ce5381f",
+          "id": "025ad0e1-3201-4b61-8b51-2d26e07e3972",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14966,7 +14966,7 @@
           },
           "response": [
             {
-              "id": "4fa55cac-98a8-4dad-81e8-7b14662060bd",
+              "id": "50fa1d22-3dc4-4a5e-9dad-4c5fa800aad9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15049,7 +15049,7 @@
           }
         },
         {
-          "id": "fa2ec0c7-66e4-4956-8577-e94f5e3fe75a",
+          "id": "9fbe8ede-f7a8-4bf4-85a8-87dcce35f82f",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15091,7 +15091,7 @@
           },
           "response": [
             {
-              "id": "b830a018-5f09-41cd-bc69-84d5ca39d273",
+              "id": "4513b89f-eca8-4f46-9e98-99112b3ec2e5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15155,7 +15155,7 @@
           }
         },
         {
-          "id": "651fd6cc-a741-4696-bfa6-2b75b0ae4c38",
+          "id": "69aee3f0-0b15-4df6-b8de-43dd288881b5",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15230,7 +15230,7 @@
           },
           "response": [
             {
-              "id": "90067e84-7fab-4b70-b053-4b8595f1697d",
+              "id": "73875328-38f1-4a2a-8361-d1632b6c7607",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15327,7 +15327,7 @@
           }
         },
         {
-          "id": "4e93a4f4-c668-4e44-95cd-52bfeee99c54",
+          "id": "aebce18b-d5d7-49e6-aae5-3a414820cf3a",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15369,7 +15369,7 @@
           },
           "response": [
             {
-              "id": "71c85c09-a0d7-4982-a4bb-ffee33e3e139",
+              "id": "a72f9d55-e6ae-442e-924f-c2eb7ec8a823",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15433,7 +15433,7 @@
           }
         },
         {
-          "id": "df8cd601-057a-4476-8b29-73d3656672dd",
+          "id": "f25b301c-8cb8-4b26-9bca-c5ac4b816576",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15476,7 +15476,7 @@
           },
           "response": [
             {
-              "id": "c62a9772-05fb-428a-910b-3a316fcd93f3",
+              "id": "3255ca8a-7d78-4e5c-a57b-32349ea2eca5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15541,7 +15541,7 @@
           }
         },
         {
-          "id": "f9d7b20d-2204-483a-af3b-885f0097e725",
+          "id": "e791c865-8dd7-4c58-937d-0abe4e404f06",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15584,7 +15584,7 @@
           },
           "response": [
             {
-              "id": "19cc7376-df70-468d-8af7-e71f9a91d33f",
+              "id": "38b02b45-04c2-4b7c-9eff-f65ab590938f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15649,7 +15649,7 @@
           }
         },
         {
-          "id": "b59e366f-64de-48c6-bf9c-2b24e5e98e1f",
+          "id": "912359ed-0622-4479-9686-2ef71b80e438",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15701,7 +15701,7 @@
           },
           "response": [
             {
-              "id": "a9f09802-d8ca-4b09-87a6-e3b3741009bb",
+              "id": "e9bbc42e-0d4a-4a72-94cb-c959b789b7c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15775,7 +15775,7 @@
           }
         },
         {
-          "id": "6ac71ff7-38e3-4791-845c-6395422b21d4",
+          "id": "3d147643-ea96-407b-a1d0-2c783ef9ec58",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15817,7 +15817,7 @@
           },
           "response": [
             {
-              "id": "c0c9cac6-d49b-41f3-96ed-070a407aa256",
+              "id": "64d86ac3-e361-4c6d-90c5-31a57f788170",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15881,7 +15881,7 @@
           }
         },
         {
-          "id": "d93eca8b-14aa-4639-95a6-d082f638beee",
+          "id": "17f405d8-4a18-4ae8-89c9-3d5891eab2f8",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15934,7 +15934,7 @@
           },
           "response": [
             {
-              "id": "f4b8729f-3787-4494-910f-e2427b934bd2",
+              "id": "36733095-a5a8-406a-b125-6f4cd7379ca3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16009,7 +16009,7 @@
           }
         },
         {
-          "id": "88ac6898-fa0c-4fcc-8c7a-36bde180f870",
+          "id": "4e7bd156-2cb7-49f5-a816-a15c5645458b",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -16062,7 +16062,7 @@
           },
           "response": [
             {
-              "id": "835cba32-ba28-4cd1-bd91-7e34bb41a58a",
+              "id": "0d391120-f088-4a8c-b3a6-a35dd33df3cd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16137,7 +16137,7 @@
           }
         },
         {
-          "id": "0a686e73-78c7-4425-ae1b-d37a8e135d83",
+          "id": "e640a3c1-c405-42cc-bf7f-3b72868fd81d",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16181,7 +16181,7 @@
           },
           "response": [
             {
-              "id": "d0b7f71d-b3a8-4241-a8ef-93d477f74016",
+              "id": "bea7a166-34ae-455c-9833-a70e99c839b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16236,7 +16236,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16247,7 +16247,7 @@
           }
         },
         {
-          "id": "97c363af-ae11-47ed-a093-0be51fa622b0",
+          "id": "b1a423d3-7c25-4d9b-a34c-1d62c146b652",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16291,7 +16291,7 @@
           },
           "response": [
             {
-              "id": "fb0255ae-0390-4674-ae06-54ef8d894437",
+              "id": "6e3c63af-db30-4590-91d5-f3ff0982b6fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16346,7 +16346,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16363,7 +16363,7 @@
       "description": "",
       "item": [
         {
-          "id": "0e61bbfc-30bd-4f7c-93f0-412cdcef9b16",
+          "id": "20e0e040-5ebb-4e00-a7c2-e36f202cabdb",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16405,7 +16405,7 @@
           },
           "response": [
             {
-              "id": "9d62130f-7659-46a8-87e7-c1a076705800",
+              "id": "b960a591-45d2-4a21-9d33-2614f93176d3",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16454,7 +16454,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "28192961-acd0-47df-b229-56c42944a4d7",
+              "id": "4dfa31cc-0e0c-4bf2-82d3-705dae16cd3b",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16509,7 +16509,7 @@
           }
         },
         {
-          "id": "c1d742e1-ebfc-406c-9787-d773a972a7eb",
+          "id": "28f4667f-6a8f-4fa2-b886-7149ecb8b099",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16555,7 +16555,7 @@
           },
           "response": [
             {
-              "id": "e29f49ec-8937-4fdc-8ee9-4932a6c6ab9d",
+              "id": "9bf03bee-8225-4801-8bc0-8898175a76bd",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16614,7 +16614,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f5dfa9cc-d49c-4512-8e98-9f2af3a1f092",
+              "id": "ff0e6b9b-c350-42f4-9851-972ca8d66d55",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16679,7 +16679,7 @@
           }
         },
         {
-          "id": "040b05f1-d440-4db0-abbc-34c42b3eabfa",
+          "id": "4ece3f2a-3051-4be4-9fb4-69249864681e",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16725,7 +16725,7 @@
           },
           "response": [
             {
-              "id": "77d9dead-71cf-4afc-9617-76c763757668",
+              "id": "80c45c8e-e778-4c34-907e-2307a4d8d528",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16784,7 +16784,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e55bb463-4de5-4ca0-9a3c-fd8faa3a0a63",
+              "id": "50fa6cc9-1945-48b5-b3cd-c1e9b0750b4d",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16843,7 +16843,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "58b2003e-e09f-4dbc-9079-8c02325cb482",
+              "id": "bc9d99a8-a207-46fe-b81b-27d5ebe061c5",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16902,7 +16902,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "46428d00-6348-4deb-be5e-409ec3154c88",
+              "id": "da5d36d5-7898-46e2-9d37-e79548249df6",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16967,7 +16967,7 @@
           }
         },
         {
-          "id": "77f04dd5-439a-4bd1-801d-f2a92118357c",
+          "id": "5bc40566-3812-44c9-b7fe-18a4d9ecca3b",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -17013,7 +17013,7 @@
           },
           "response": [
             {
-              "id": "89ce5dee-b09c-4e2a-9465-3b2b08a514f6",
+              "id": "a2f8f5d4-1911-4671-97be-411cc5f569f4",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -17072,7 +17072,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "319a05df-24d0-478c-9f98-08be75a6a002",
+              "id": "a63d7398-aa48-4a1b-9e0c-6d78bdcdcf32",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17137,7 +17137,7 @@
           }
         },
         {
-          "id": "8e30806d-87d5-4f02-8dad-05aeb98c3c3e",
+          "id": "baaa4aee-7020-49d0-b454-842f1c22b728",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17179,7 +17179,7 @@
           },
           "response": [
             {
-              "id": "009f6b95-fe2c-4773-b0b1-035dfad04a25",
+              "id": "23d8e13b-7d45-4b3e-826d-d40fc6b43b0c",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17240,7 +17240,7 @@
       "description": "",
       "item": [
         {
-          "id": "b6eff30e-c7b2-4a79-86a4-fcb7ce0d53f4",
+          "id": "cb30cb04-987d-4b35-93fb-09c54ab02ea7",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17289,7 +17289,7 @@
           },
           "response": [
             {
-              "id": "0b36844a-ce56-4ab5-b5d3-9dd8115ff73a",
+              "id": "809e0ec4-1e29-44fc-ab72-4ebdf71621c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17349,7 +17349,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
+              "body": "{\n  \"key_0\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17360,7 +17360,7 @@
           }
         },
         {
-          "id": "6ec9a115-b96f-4144-bba3-17337625d66b",
+          "id": "bb8d7349-0088-45e4-8d86-b1f57e1718ae",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17409,7 +17409,7 @@
           },
           "response": [
             {
-              "id": "d5d4c4ee-5cb3-463c-bc50-87ccb844a45e",
+              "id": "da6c619d-d0e7-4056-96a1-8c7570912d9a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17480,7 +17480,7 @@
           }
         },
         {
-          "id": "de9671bc-7b3f-49d1-aa6e-6169fd6ea7b4",
+          "id": "dc1bf625-0534-4108-8e47-bf8dd0e14064",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17529,7 +17529,7 @@
           },
           "response": [
             {
-              "id": "e4aee7c8-31d1-4f30-84f1-f80674a2389b",
+              "id": "35afcbc5-cd25-4465-aabb-1fdb38e5c7a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17600,7 +17600,7 @@
           }
         },
         {
-          "id": "082335ab-0c19-42f7-919c-e6a87b39aa10",
+          "id": "0b4b122f-be0a-4389-b3cf-38edef8f2a22",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17649,7 +17649,7 @@
           },
           "response": [
             {
-              "id": "e4d65644-409e-47f3-b6fb-0952cf8e53f0",
+              "id": "036d70e3-5bd4-47d5-bef9-b2144de25f3d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17726,7 +17726,7 @@
       "description": "",
       "item": [
         {
-          "id": "82561ff9-45a5-4fa9-9818-0f150e2cc7ae",
+          "id": "9842eb89-ad88-493e-b7e6-601f494e5903",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17766,7 +17766,7 @@
           },
           "response": [
             {
-              "id": "4b533d92-4c06-4288-a3fd-0f51494dc141",
+              "id": "95fcfacc-d825-482c-8dd3-26cebccf7f50",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17828,7 +17828,7 @@
           }
         },
         {
-          "id": "fa593348-6f82-410e-a4a3-7f538dbdb14b",
+          "id": "52f46ad7-71b1-451a-b2b5-2ee9bf259340",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17858,7 +17858,7 @@
           },
           "response": [
             {
-              "id": "0fba3555-ad4a-4cbb-bae8-5d14f024539a",
+              "id": "801c97ce-aca9-4d84-b92e-8032cd98b511",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17899,7 +17899,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
+              "body": "{\n  \"key_0\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17910,7 +17910,7 @@
           }
         },
         {
-          "id": "fdbb228b-9603-445d-bf7b-5232663ca4b3",
+          "id": "adb50c8d-9810-4811-ab6b-27dcb5bfc233",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17962,7 +17962,7 @@
           },
           "response": [
             {
-              "id": "b182b10b-0ae7-45db-86bb-01a78eaafe1c",
+              "id": "ee0b800d-57a9-40fb-8bc1-9287dd65e581",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18042,7 +18042,7 @@
       "description": "",
       "item": [
         {
-          "id": "ef1baf0c-9ce2-4d64-ba6a-45d516d1f211",
+          "id": "bfac743f-946a-4e35-a1a5-dcda29ac0724",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -18071,7 +18071,7 @@
           },
           "response": [
             {
-              "id": "1629a88e-808f-472e-b709-39c3380399eb",
+              "id": "2529227d-3806-4abd-b153-42a088471679",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18122,7 +18122,7 @@
           }
         },
         {
-          "id": "1ae9b883-b8d4-439a-8b02-dd133f3326ca",
+          "id": "39db10cd-b105-4417-8f1f-292aac6d2855",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18163,7 +18163,7 @@
           },
           "response": [
             {
-              "id": "0dbe4ea8-16f9-4a28-9b71-54224dcdc70c",
+              "id": "4e7a5b4b-3090-47b7-9481-e1fc8a7859f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18232,7 +18232,7 @@
       "description": "",
       "item": [
         {
-          "id": "4379472b-cb42-49d9-a4b6-1a925115ab31",
+          "id": "2b03801b-d039-463b-a4ed-73f27cda634e",
           "name": "health",
           "request": {
             "name": "health",
@@ -18261,7 +18261,7 @@
           },
           "response": [
             {
-              "id": "e1c61424-0fa4-4ab1-a3f9-ecfcc54a94a8",
+              "id": "f6a70970-57a2-4699-9975-1cd72a579934",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18301,7 +18301,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\",\n  \"key_2\": false,\n  \"key_3\": 8075,\n  \"key_4\": 2803\n}",
+              "body": "{\n  \"key_0\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18318,7 +18318,7 @@
       "description": "",
       "item": [
         {
-          "id": "43f1253d-465d-465b-8399-f206e385632f",
+          "id": "921f0f11-ead3-4dc8-909c-ac28d22b5fc8",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18370,7 +18370,7 @@
           },
           "response": [
             {
-              "id": "ef1933f5-6122-425b-b492-b9e87ebe74c3",
+              "id": "d5d9d1fb-0aff-4731-8f70-0fe3ef5781f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18444,7 +18444,7 @@
           }
         },
         {
-          "id": "1bb8fe0f-dce9-4712-a5bf-53bc6d40e508",
+          "id": "466cce72-b43e-409a-abc4-5e0c39d2a2cd",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18485,7 +18485,7 @@
           },
           "response": [
             {
-              "id": "17ee9c65-95af-451d-a32b-40b7acd5a91a",
+              "id": "2f421da0-084b-4393-8a4f-373d1e98adf3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18537,7 +18537,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18548,7 +18548,7 @@
           }
         },
         {
-          "id": "b51b338b-271b-41f2-af06-477bada4d7a2",
+          "id": "ff8ec9d7-a1e5-445b-94d5-7ac0caeb8cab",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18578,7 +18578,7 @@
           },
           "response": [
             {
-              "id": "4e30a084-32e3-4ab5-84d2-0b3ca83c480f",
+              "id": "6cf293be-3689-4b13-9bba-fb76ef9edf26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18619,7 +18619,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18650,9 +18650,9 @@
     }
   ],
   "info": {
-    "_postman_id": "b5b22cac-2bef-46cf-9340-a794ea99b596",
+    "_postman_id": "9836aac1-c2c6-44d3-8b68-5e1fef83eba9",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-03 23:10 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-03 23:12 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }


### PR DESCRIPTION
## Summary

Promotes PR #119 (`ci: gate gradle test before docker build`) from `develop` to `main`. Single commit, low-risk: it only adds a `test` job to the GitHub Actions workflow before the docker build. It does NOT change runtime behavior of the prod pods.

## What gets deployed

Nothing to the running pods. Only the workflow on `main` will start running `./gradlew test` before tagging the `latest` docker image.

## Test plan

- [x] CI on `develop` already verified the test job + build job pass with the secret in place.
- [ ] After merge: any future push to `main` will gate-test before docker build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)