### PR TITLE
fix(alert): repair SQL drift breaking history+stats endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ test_output*.txt
 fix_imports.py
 fix_missing_imports.py
 fix_packages.py
+.claude/

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryJpaRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryJpaRepository.kt
@@ -24,9 +24,9 @@ interface AlertHistoryJpaRepository : JpaRepository<AlertStateChange, Long> {
     @Query(
         value = """
             SELECT COUNT(*)
-              FROM metadata.alert_state_changes asc
-              JOIN metadata.alerts a ON a.id = asc.alert_id
-             WHERE asc.alert_id = :alertId
+              FROM metadata.alert_state_changes c
+              JOIN metadata.alerts a ON a.id = c.alert_id
+             WHERE c.alert_id = :alertId
                AND a.tenant_id = :tenantId
         """,
         nativeQuery = true

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapter.kt
@@ -57,7 +57,7 @@ class AlertHistoryQueryAdapter(
 
         val orderDir = if (order == SortOrder.ASC) "ASC" else "DESC"
         val sql = transitionSql(
-            extraWhere = "AND asc.alert_id = ?",
+            extraWhere = "AND c.alert_id = ?",
             orderDir = orderDir,
             limit = "ALL",
             offset = "0",
@@ -142,17 +142,16 @@ class AlertHistoryQueryAdapter(
         offset: String,
     ): String = """
         SELECT
-          asc.id                         AS transition_id,
-          asc.at,
-          asc.from_resolved,
-          asc.to_resolved,
-          asc.source,
-          asc.raw_value,
-          asc.actor_kind,
-          asc.actor_user_id,
-          asc.actor_ref,
+          c.id                           AS transition_id,
+          c.at,
+          c.from_resolved,
+          c.to_resolved,
+          c.source,
+          c.raw_value,
+          c.actor_kind,
+          c.actor_user_id,
+          c.actor_ref,
           u.username,
-          u.display_name,
           a.id                           AS alert_id,
           a.code                         AS alert_code,
           a.message                      AS alert_message,
@@ -167,48 +166,48 @@ class AlertHistoryQueryAdapter(
           sec.code                       AS sector_code,
           sec.greenhouse_id,
           g.name                         AS greenhouse_name,
-          LAG(asc.at)
-            OVER (PARTITION BY asc.alert_id ORDER BY asc.at)
+          LAG(c.at)
+            OVER (PARTITION BY c.alert_id ORDER BY c.at)
                                          AS previous_transition_at,
           -- PG16 does not support LAST_VALUE(... IGNORE NULLS); use MAX over CASE
           -- which naturally ignores NULLs and returns the most recent OPEN before this row.
-          CASE WHEN asc.to_resolved = TRUE THEN
-            MAX(CASE WHEN asc.to_resolved = FALSE THEN asc.at END)
-              OVER (PARTITION BY asc.alert_id ORDER BY asc.at
+          CASE WHEN c.to_resolved = TRUE THEN
+            MAX(CASE WHEN c.to_resolved = FALSE THEN c.at END)
+              OVER (PARTITION BY c.alert_id ORDER BY c.at
                     ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
           END                            AS episode_started_at,
           NULLIF(
-            COUNT(*) FILTER (WHERE asc.to_resolved = FALSE)
-              OVER (PARTITION BY asc.alert_id ORDER BY asc.at
+            COUNT(*) FILTER (WHERE c.to_resolved = FALSE)
+              OVER (PARTITION BY c.alert_id ORDER BY c.at
                     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
             0
           )                              AS occurrence_number,
           ROW_NUMBER()
-            OVER (PARTITION BY asc.alert_id ORDER BY asc.at)
+            OVER (PARTITION BY c.alert_id ORDER BY c.at)
                                          AS total_transitions_so_far
-        FROM metadata.alert_state_changes asc
-        JOIN metadata.alerts a      ON a.id = asc.alert_id
-        LEFT JOIN metadata.users u  ON u.id = asc.actor_user_id
+        FROM metadata.alert_state_changes c
+        JOIN metadata.alerts a      ON a.id = c.alert_id
+        LEFT JOIN metadata.users u  ON u.id = c.actor_user_id
         LEFT JOIN metadata.alert_types at2  ON at2.id = a.alert_type_id
         LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
         LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
         LEFT JOIN metadata.greenhouses g ON g.id = sec.greenhouse_id
         WHERE a.tenant_id = ?
-          AND asc.at >= ?
-          AND asc.at < ?
+          AND c.at >= ?
+          AND c.at < ?
           $extraWhere
-        ORDER BY asc.at $orderDir
+        ORDER BY c.at $orderDir
         LIMIT $limit OFFSET $offset
     """.trimIndent()
 
     private fun countTransitionSql(whereClauses: String): String = """
         SELECT COUNT(*)
-          FROM metadata.alert_state_changes asc
-          JOIN metadata.alerts a      ON a.id = asc.alert_id
+          FROM metadata.alert_state_changes c
+          JOIN metadata.alerts a      ON a.id = c.alert_id
           LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
          WHERE a.tenant_id = ?
-           AND asc.at >= ?
-           AND asc.at < ?
+           AND c.at >= ?
+           AND c.at < ?
            $whereClauses
     """.trimIndent()
 
@@ -226,7 +225,7 @@ class AlertHistoryQueryAdapter(
         )
 
         if (query.sources.isNotEmpty()) {
-            clauses.append(" AND asc.source = ANY(?::VARCHAR[])")
+            clauses.append(" AND c.source = ANY(?::VARCHAR[])")
             params.add(query.sources.toTypedArray<String>().joinToPostgresArray())
         }
         if (query.severityIds.isNotEmpty()) {
@@ -250,12 +249,12 @@ class AlertHistoryQueryAdapter(
             params.add(query.codes.toTypedArray<String>().joinToPostgresArray())
         }
         if (query.actorUserIds.isNotEmpty()) {
-            clauses.append(" AND asc.actor_user_id = ANY(?::BIGINT[])")
+            clauses.append(" AND c.actor_user_id = ANY(?::BIGINT[])")
             params.add(query.actorUserIds.joinToString(",", "{", "}"))
         }
         when (query.transitionKind) {
-            TransitionKind.OPEN -> clauses.append(" AND asc.to_resolved = FALSE")
-            TransitionKind.CLOSE -> clauses.append(" AND asc.to_resolved = TRUE")
+            TransitionKind.OPEN -> clauses.append(" AND c.to_resolved = FALSE")
+            TransitionKind.CLOSE -> clauses.append(" AND c.to_resolved = TRUE")
             TransitionKind.ANY -> { /* no clause */ }
         }
 
@@ -276,12 +275,10 @@ class AlertHistoryQueryAdapter(
           open_asc.actor_user_id      AS trigger_actor_user_id,
           open_asc.actor_ref          AS trigger_actor_ref,
           open_u.username             AS trigger_username,
-          open_u.display_name         AS trigger_display_name,
           close_asc.actor_kind        AS resolve_actor_kind,
           close_asc.actor_user_id     AS resolve_actor_user_id,
           close_asc.actor_ref         AS resolve_actor_ref,
           close_u.username            AS resolve_username,
-          close_u.display_name        AS resolve_display_name,
           a.severity_id,
           sev.name                    AS severity_name,
           a.sector_id,
@@ -338,12 +335,15 @@ class AlertHistoryQueryAdapter(
         val actorUserId = rs.getLong("actor_user_id").takeIf { !rs.wasNull() }
         val actorRef = rs.getString("actor_ref")
         val username = rs.getString("username")
-        val displayName = rs.getString("display_name")
+        // displayName falls back to username — `metadata.users` does not store a separate
+        // display_name column; the read path mirrors what UserLookupAdapter already does
+        // for FCM rendering (see UserLookupAdapter.kt). Keeping the field non-null when
+        // possible lets clients show "resolved by <name>" without extra branching.
         val actor: AlertActor = when (actorKind) {
             "USER" -> AlertActor.User(
                 userId = actorUserId ?: 0L,
                 username = username,
-                displayName = displayName,
+                displayName = username,
             )
             "DEVICE" -> AlertActor.Device(deviceRef = actorRef)
             else -> AlertActor.System
@@ -394,21 +394,24 @@ class AlertHistoryQueryAdapter(
                 else -> AlertActor.System
             }
 
+        // displayName falls back to username — see comment in mapTransition.
+        val triggerUsername = rs.getString("trigger_username")
         val triggerActor = actorFrom(
             rs.getString("trigger_actor_kind"),
             rs.getLong("trigger_actor_user_id").takeIf { !rs.wasNull() },
             rs.getString("trigger_actor_ref"),
-            rs.getString("trigger_username"),
-            rs.getString("trigger_display_name"),
+            triggerUsername,
+            triggerUsername,
         )
         val resolveActorKind = rs.getString("resolve_actor_kind")
         val resolveActor: AlertActor? = if (resolveActorKind != null) {
+            val resolveUsername = rs.getString("resolve_username")
             actorFrom(
                 resolveActorKind,
                 rs.getLong("resolve_actor_user_id").takeIf { !rs.wasNull() },
                 rs.getString("resolve_actor_ref"),
-                rs.getString("resolve_username"),
-                rs.getString("resolve_display_name"),
+                resolveUsername,
+                resolveUsername,
             )
         } else null
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapter.kt
@@ -50,17 +50,17 @@ class AlertStatsQueryAdapter(
         val sql = """
             SELECT $groupByCol AS key, $labelCol AS label,
                    COUNT(*) AS cnt,
-                   MAX(asc.at) AS last_seen_at
-              FROM metadata.alert_state_changes asc
-              JOIN metadata.alerts a      ON a.id = asc.alert_id
+                   MAX(c.at) AS last_seen_at
+              FROM metadata.alert_state_changes c
+              JOIN metadata.alerts a      ON a.id = c.alert_id
               LEFT JOIN metadata.alert_types at2  ON at2.id = a.alert_type_id
               LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
               LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
               LEFT JOIN metadata.greenhouses g ON g.id = sec.greenhouse_id
              WHERE a.tenant_id = ?
-               AND asc.to_resolved = FALSE
-               AND asc.at >= ?
-               AND asc.at < ?
+               AND c.to_resolved = FALSE
+               AND c.at >= ?
+               AND c.at < ?
              GROUP BY key, label
              ORDER BY cnt DESC
              LIMIT ?
@@ -101,13 +101,13 @@ class AlertStatsQueryAdapter(
         val (groupByCol, labelCol) = mttrGroupByColumns(query.groupBy)
         val sql = """
             SELECT $groupByCol AS key, $labelCol AS label,
-                   AVG(EXTRACT(EPOCH FROM (cl.at - op.at)))             AS mttr_avg,
+                   AVG(EXTRACT(EPOCH FROM (cl.at - pairs.at)))             AS mttr_avg,
                    PERCENTILE_CONT(0.5) WITHIN GROUP
-                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - op.at)))     AS p50,
+                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - pairs.at)))     AS p50,
                    PERCENTILE_CONT(0.95) WITHIN GROUP
-                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - op.at)))     AS p95,
+                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - pairs.at)))     AS p95,
                    PERCENTILE_CONT(0.99) WITHIN GROUP
-                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - op.at)))     AS p99,
+                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - pairs.at)))     AS p99,
                    COUNT(*)                                              AS sample_size
               FROM (
                 SELECT op.alert_id,
@@ -170,17 +170,17 @@ class AlertStatsQueryAdapter(
         }
         val (groupByCol, _) = timeseriesGroupByColumns(query.groupBy)
         val sql = """
-            SELECT date_trunc('$truncUnit', asc.at AT TIME ZONE 'UTC') AS bucket_start,
-                   $groupByCol                                          AS key,
-                   COUNT(*) FILTER (WHERE asc.to_resolved = FALSE)     AS opened,
-                   COUNT(*) FILTER (WHERE asc.to_resolved = TRUE)      AS closed
-              FROM metadata.alert_state_changes asc
-              JOIN metadata.alerts a      ON a.id = asc.alert_id
+            SELECT date_trunc('$truncUnit', c.at AT TIME ZONE 'UTC') AS bucket_start,
+                   $groupByCol                                        AS key,
+                   COUNT(*) FILTER (WHERE c.to_resolved = FALSE)     AS opened,
+                   COUNT(*) FILTER (WHERE c.to_resolved = TRUE)      AS closed
+              FROM metadata.alert_state_changes c
+              JOIN metadata.alerts a      ON a.id = c.alert_id
               LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
               LEFT JOIN metadata.alert_types at2      ON at2.id = a.alert_type_id
              WHERE a.tenant_id = ?
-               AND asc.at >= ?
-               AND asc.at < ?
+               AND c.at >= ?
+               AND c.at < ?
              GROUP BY bucket_start, key
              ORDER BY bucket_start ASC, key ASC
         """.trimIndent()
@@ -216,7 +216,7 @@ class AlertStatsQueryAdapter(
         val (groupByCol, labelCol) = activeDurationGroupByColumns(query.groupBy)
         val sql = """
             SELECT $groupByCol AS key, $labelCol AS label,
-                   SUM(EXTRACT(EPOCH FROM (cl.at - op.at)))::BIGINT AS total_active_seconds
+                   SUM(EXTRACT(EPOCH FROM (cl.at - pairs.at)))::BIGINT AS total_active_seconds
               FROM (
                 SELECT op.alert_id,
                        op.at,
@@ -261,29 +261,31 @@ class AlertStatsQueryAdapter(
     @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun byActor(query: ByActorStatsQuery): List<ByActorBucket> {
         val toResolved = query.role == ActorStatsRole.RESOLVER
+        // displayName falls back to username — `metadata.users` does not store a separate
+        // display_name column. See AlertHistoryQueryAdapter.mapTransition for the same pattern.
         val sql = """
-            SELECT asc.actor_user_id,
+            SELECT c.actor_user_id,
                    u.username,
-                   u.display_name,
                    COUNT(*) AS cnt
-              FROM metadata.alert_state_changes asc
-              JOIN metadata.alerts a ON a.id = asc.alert_id
-              LEFT JOIN metadata.users u ON u.id = asc.actor_user_id
+              FROM metadata.alert_state_changes c
+              JOIN metadata.alerts a ON a.id = c.alert_id
+              LEFT JOIN metadata.users u ON u.id = c.actor_user_id
              WHERE a.tenant_id = ?
-               AND asc.actor_kind = 'USER'
-               AND asc.to_resolved = ?
-               AND asc.at >= ?
-               AND asc.at < ?
-             GROUP BY asc.actor_user_id, u.username, u.display_name
+               AND c.actor_kind = 'USER'
+               AND c.to_resolved = ?
+               AND c.at >= ?
+               AND c.at < ?
+             GROUP BY c.actor_user_id, u.username
              ORDER BY cnt DESC
         """.trimIndent()
 
         return jdbc.query(sql,
             { rs, _ ->
+                val username = rs.getString("username")
                 ByActorBucket(
                     actorUserId = rs.getLong("actor_user_id"),
-                    username = rs.getString("username"),
-                    displayName = rs.getString("display_name"),
+                    username = username,
+                    displayName = username,
                     count = rs.getLong("cnt"),
                 )
             },
@@ -317,25 +319,25 @@ class AlertStatsQueryAdapter(
         ) ?: 0L
 
         val openedToday = jdbc.queryForObject(
-            """SELECT COUNT(*) FROM metadata.alert_state_changes asc
-               JOIN metadata.alerts a ON a.id = asc.alert_id
-               WHERE a.tenant_id = ? AND asc.to_resolved = FALSE
-                 AND asc.at >= ? AND asc.at < ?""",
+            """SELECT COUNT(*) FROM metadata.alert_state_changes c
+               JOIN metadata.alerts a ON a.id = c.alert_id
+               WHERE a.tenant_id = ? AND c.to_resolved = FALSE
+                 AND c.at >= ? AND c.at < ?""",
             Long::class.java,
             tenantId.value, Timestamp.from(todayStart), Timestamp.from(todayEnd),
         ) ?: 0L
 
         val closedToday = jdbc.queryForObject(
-            """SELECT COUNT(*) FROM metadata.alert_state_changes asc
-               JOIN metadata.alerts a ON a.id = asc.alert_id
-               WHERE a.tenant_id = ? AND asc.to_resolved = TRUE
-                 AND asc.at >= ? AND asc.at < ?""",
+            """SELECT COUNT(*) FROM metadata.alert_state_changes c
+               JOIN metadata.alerts a ON a.id = c.alert_id
+               WHERE a.tenant_id = ? AND c.to_resolved = TRUE
+                 AND c.at >= ? AND c.at < ?""",
             Long::class.java,
             tenantId.value, Timestamp.from(todayStart), Timestamp.from(todayEnd),
         ) ?: 0L
 
         val mttrTodaySeconds = jdbc.queryForObject(
-            """SELECT AVG(EXTRACT(EPOCH FROM (cl.at - op.at)))
+            """SELECT AVG(EXTRACT(EPOCH FROM (cl.at - pairs.at)))
                FROM (
                  SELECT op.alert_id, op.at,
                         LEAD(op.id) OVER (PARTITION BY op.alert_id ORDER BY op.at) AS close_id
@@ -351,10 +353,10 @@ class AlertStatsQueryAdapter(
 
         val top3Codes = jdbc.query(
             """SELECT a.code, COUNT(*) AS cnt
-               FROM metadata.alert_state_changes asc
-               JOIN metadata.alerts a ON a.id = asc.alert_id
-               WHERE a.tenant_id = ? AND asc.to_resolved = FALSE
-                 AND asc.at >= ? AND asc.at < ?
+               FROM metadata.alert_state_changes c
+               JOIN metadata.alerts a ON a.id = c.alert_id
+               WHERE a.tenant_id = ? AND c.to_resolved = FALSE
+                 AND c.at >= ? AND c.at < ?
                GROUP BY a.code
                ORDER BY cnt DESC
                LIMIT 3""",

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapterIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapterIntegrationTest.kt
@@ -1,0 +1,136 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.domain.model.TransitionKind
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEpisodesQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEventsQuery
+import com.apptolast.invernaderos.features.shared.domain.model.SortOrder
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * SQL contract tests against the live DEV `metadata` Postgres.
+ *
+ * Goal: prove that every native SQL the adapter emits PARSES and EXECUTES
+ * against a real Postgres 16, exercising columns and aliases that JdbcTemplate
+ * unit-stubs would never catch. PR-1 (asc reserved-word alias + non-existent
+ * `users.display_name`) shipped to prod precisely because there was no test
+ * at this layer.
+ *
+ * We do NOT assert on row content — DEV DB is shared and rebuilt by Flyway,
+ * so seeding fixtures here would race with other tests. The contract these
+ * tests defend is "SQL is valid"; row content is covered by smoke curl
+ * post-deploy and unit tests on the use-case layer.
+ *
+ * Requires INVERNADEROS_TEST_DB_PASSWORD env var to be set (resolved in
+ * src/test/resources/application.yaml).
+ */
+@SpringBootTest
+class AlertHistoryQueryAdapterIntegrationTest {
+
+    @Autowired
+    private lateinit var adapter: AlertHistoryQueryAdapter
+
+    private val anyTenant = TenantId(1L)
+    private val anyAlertId = 1L
+
+    private fun defaultEventsQuery(): AlertEventsQuery = AlertEventsQuery(
+        tenantId = anyTenant,
+        from = Instant.now().minus(30, ChronoUnit.DAYS),
+        to = Instant.now(),
+        sources = emptyList(),
+        severityIds = emptyList(),
+        alertTypeIds = emptyList(),
+        sectorIds = emptyList(),
+        greenhouseIds = emptyList(),
+        codes = emptyList(),
+        actorUserIds = emptyList(),
+        transitionKind = TransitionKind.ANY,
+        page = 0,
+        size = 50,
+    )
+
+    private fun defaultEpisodesQuery(): AlertEpisodesQuery = AlertEpisodesQuery(
+        tenantId = anyTenant,
+        from = Instant.now().minus(30, ChronoUnit.DAYS),
+        to = Instant.now(),
+        severityIds = emptyList(),
+        sectorIds = emptyList(),
+        codes = emptyList(),
+        onlyClosed = false,
+        page = 0,
+        size = 50,
+    )
+
+    @Test
+    fun `findTransitionsByAlertId DESC parses and executes`() {
+        val rows = adapter.findTransitionsByAlertId(anyAlertId, anyTenant, SortOrder.DESC)
+        assertThat(rows).isNotNull
+    }
+
+    @Test
+    fun `findTransitionsByAlertId ASC parses and executes`() {
+        val rows = adapter.findTransitionsByAlertId(anyAlertId, anyTenant, SortOrder.ASC)
+        assertThat(rows).isNotNull
+    }
+
+    @Test
+    fun `findTransitions with no filters parses and executes`() {
+        val result = adapter.findTransitions(defaultEventsQuery())
+        assertThat(result).isNotNull
+        assertThat(result.size).isEqualTo(50)
+    }
+
+    @Test
+    fun `findTransitions with all filters parses and executes`() {
+        val q = defaultEventsQuery().copy(
+            sources = listOf("MQTT", "API", "SYSTEM"),
+            severityIds = listOf(1, 2, 3, 4),
+            alertTypeIds = listOf(1, 2),
+            sectorIds = listOf(1L, 2L),
+            greenhouseIds = listOf(1L),
+            codes = listOf("ALT-00001"),
+            actorUserIds = listOf(1L),
+            transitionKind = TransitionKind.OPEN,
+        )
+        val result = adapter.findTransitions(q)
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    fun `findTransitions with transitionKind CLOSE parses and executes`() {
+        val q = defaultEventsQuery().copy(transitionKind = TransitionKind.CLOSE)
+        val result = adapter.findTransitions(q)
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    fun `findEpisodes with no filters parses and executes`() {
+        val result = adapter.findEpisodes(defaultEpisodesQuery())
+        assertThat(result).isNotNull
+        assertThat(result.size).isEqualTo(50)
+    }
+
+    @Test
+    fun `findEpisodes with onlyClosed=true parses and executes`() {
+        val q = defaultEpisodesQuery().copy(onlyClosed = true)
+        val result = adapter.findEpisodes(q)
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    fun `findEpisodes with all filters parses and executes`() {
+        val q = defaultEpisodesQuery().copy(
+            severityIds = listOf(1, 2),
+            sectorIds = listOf(1L),
+            codes = listOf("ALT-00001"),
+            onlyClosed = true,
+        )
+        val result = adapter.findEpisodes(q)
+        assertThat(result).isNotNull
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapterIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapterIntegrationTest.kt
@@ -1,0 +1,94 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActorStatsRole
+import com.apptolast.invernaderos.features.alert.domain.model.query.ByActorStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesStatsQuery
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * SQL contract tests against the live DEV `metadata` Postgres for the
+ * statistics adapter. Same rationale as AlertHistoryQueryAdapterIntegrationTest:
+ * the goal is "SQL parses and runs against PG 16", not row content.
+ *
+ * Covers all 6 stat endpoints (recurrence / mttr / timeseries / activeDuration
+ * / byActor / summary) across every enum branch of their groupBy / role / bucket
+ * dimensions, so any future SQL drift (column rename, reserved-word alias,
+ * dialect mismatch) breaks at this test layer rather than at runtime in prod.
+ */
+@SpringBootTest
+class AlertStatsQueryAdapterIntegrationTest {
+
+    @Autowired
+    private lateinit var adapter: AlertStatsQueryAdapter
+
+    private val anyTenant = TenantId(1L)
+    private val from: Instant get() = Instant.now().minus(30, ChronoUnit.DAYS)
+    private val to: Instant get() = Instant.now()
+
+    @Test
+    fun `recurrence parses and executes for every groupBy`() {
+        for (gb in RecurrenceGroupBy.entries) {
+            val r = adapter.recurrence(RecurrenceStatsQuery(anyTenant, from, to, gb, limit = 10))
+            assertThat(r).isNotNull
+        }
+    }
+
+    @Test
+    fun `mttr parses and executes for every groupBy`() {
+        for (gb in MttrGroupBy.entries) {
+            val r = adapter.mttr(MttrStatsQuery(anyTenant, from, to, gb))
+            assertThat(r).isNotNull
+        }
+    }
+
+    @Test
+    fun `timeseries parses and executes for every bucket and groupBy`() {
+        for (b in TimeseriesBucket.entries) {
+            for (gb in TimeseriesGroupBy.entries) {
+                val r = adapter.timeseries(TimeseriesStatsQuery(anyTenant, from, to, b, gb))
+                assertThat(r).isNotNull
+            }
+        }
+    }
+
+    @Test
+    fun `activeDuration parses and executes for every groupBy`() {
+        for (gb in ActiveDurationGroupBy.entries) {
+            val r = adapter.activeDuration(ActiveDurationStatsQuery(anyTenant, from, to, gb))
+            assertThat(r).isNotNull
+        }
+    }
+
+    @Test
+    fun `byActor parses and executes for every role`() {
+        for (role in ActorStatsRole.entries) {
+            val r = adapter.byActor(ByActorStatsQuery(anyTenant, from, to, role))
+            assertThat(r).isNotNull
+        }
+    }
+
+    @Test
+    fun `summary parses and executes`() {
+        val r = adapter.summary(anyTenant, from, to)
+        assertThat(r).isNotNull
+        // sanity: all numeric counts must be non-negative
+        assertThat(r.totalActiveNow).isGreaterThanOrEqualTo(0L)
+        assertThat(r.openedToday).isGreaterThanOrEqualTo(0L)
+        assertThat(r.closedToday).isGreaterThanOrEqualTo(0L)
+        assertThat(r.top3RecurrentCodesThisWeek).isNotNull
+    }
+}


### PR DESCRIPTION
## Summary

The alert-history feature (PR #112) shipped with **three SQL bugs** that cause every history/stats endpoint to return **HTTP 500** in dev and prod. This PR repairs the drift and adds integration tests so the same class of bug cannot reach prod again.

## Bugs fixed

### 1. Alias `asc` is a PostgreSQL reserved word
Reproduced live with psql:
```
SELECT MAX(asc.at) FROM metadata.alert_state_changes asc
-> ERROR: syntax error at or near "asc"
```
Renamed to `c` (alert_state_changes context) in **11 native SQL sites**:
- `AlertHistoryQueryAdapter` — `transitionSql`, `countTransitionSql`, the `buildTransitionWhere` fragment.
- `AlertStatsQueryAdapter` — `recurrence`, `timeseries`, `byActor`, `summary`'s `openedToday`/`closedToday`/`top3Codes`.
- `AlertHistoryJpaRepository.countByAlertIdAndTenantId` — this `@Query` was **not** on the original audit list. The new integration test caught it.

### 2. `metadata.users` does not have a `display_name` column
Real schema: `id, tenant_id, username, email, password_hash, role, is_active, last_login, created_at, updated_at, reset_password_token, reset_password_token_expiry, code, locale`.

Removed the column from **3 SELECTs and 3 row mappers**. `AlertActor.User.displayName` now falls back to `username`, consistent with what `UserLookupAdapter.kt:40` already does for FCM rendering.

### 3. `op.at` referenced outside its subquery scope (BUG PRE-EXISTENTE)
`mttr` / `activeDuration` / `summary.mttrTodaySeconds` referenced `op.at` in the OUTER select, but `op` is only an alias inside a derived table aliased `pairs`. PostgreSQL error: `missing FROM-clause entry for table "op"`. Replaced with `pairs.at` everywhere outside the subquery scope.

This bug was hidden by bug #1 — when `asc` failed first, this never executed.

## Tests

Added **two SQL contract tests** under `features/alert/infrastructure/adapter/output`:

- `AlertHistoryQueryAdapterIntegrationTest` (8 cases) — every public method × every meaningful input combination.
- `AlertStatsQueryAdapterIntegrationTest` (6 cases) — every enum branch of every stat endpoint (`RecurrenceGroupBy.entries`, `MttrGroupBy.entries`, `TimeseriesBucket.entries × TimeseriesGroupBy.entries`, `ActiveDurationGroupBy.entries`, `ActorStatsRole.entries`, plus `summary`).

These tests caught **two bugs that the static audit had missed**: the JpaRepository `@Query` and the `op.at` reference.

## Pre-flight

```
./gradlew test --warning-mode=all
  -> 351 tests, 0 fails, 0 errors, 0 skipped, BUILD SUCCESSFUL in 2m 7s
```

`psql` repro of each fixed query against live DEV metadata DB now returns **0 rows but 0 errors** (vs. previous `syntax error` / `column does not exist` / `missing FROM-clause entry for table op`).

## Test plan post-deploy

- [x] CI test job passes (gating from PR #119/#120).
- [x] Smoke curl against `inverapi-dev.apptolast.com`:
  - `GET /api/v1/tenants/{t}/alert-events` -> 200
  - `GET /api/v1/tenants/{t}/alert-events/episodes` -> 200
  - `GET /api/v1/tenants/{t}/alerts/{id}/history` -> 200
  - `GET /api/v1/tenants/{t}/alerts/stats/{recurrence,mttr,timeseries,active-duration,by-actor,summary}` -> 200
- [x] No new exceptions in `kubectl logs` for 5 min after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)