### PR TITLE
merge: deploy alert SQL drift fix to prod (#123)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ test_output*.txt
 fix_imports.py
 fix_missing_imports.py
 fix_packages.py
+.claude/

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "3aa8eb2e-e9f7-46af-8580-a118da5da9cf",
+          "id": "7853e0e7-07b7-47e9-86fc-6ecdafc0f372",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "0a4b72bf-92ca-4927-80a7-4cd22c990840",
+              "id": "38fb0884-3b10-441e-854f-3509683a5962",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "89e104c8-767e-4ee5-8003-3ba31440de05",
+          "id": "25dbc75b-f0c3-4837-9ce1-cb6a5714a3f3",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "6ac82cd2-958e-4d4f-9d21-f266c99f7f5d",
+              "id": "0851392a-0d9b-4f50-920d-836c2b5f08e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "7c947c6f-191d-401f-b45a-d8c5413ea393",
+          "id": "9ad0bc52-b6e5-46e1-acd8-f3749a09a2dd",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "d124eccf-d590-48b5-babd-14732744bd41",
+              "id": "0885622e-30aa-4fa4-8110-10b1184618c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "5402a489-eb31-4c38-9327-288a6d5c69af",
+          "id": "0a3b42c2-4329-40a1-bad1-0f624cd16fd7",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "d0a77186-41f1-4ac9-b277-51cf94c48df9",
+              "id": "fcc2fad1-0982-4bf1-88c7-d5aad52ac939",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "9181418f-8e36-4268-9c87-636425bce98c",
+          "id": "2dfd4540-17f3-4757-af95-2da3b988f093",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "fbc5ae64-a2ea-43ef-9dbb-0aca7e790530",
+              "id": "f81ec099-21a7-43fc-941a-a177df563a4d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "770b44c8-ae50-4593-8ebb-434db7b90c1e",
+          "id": "10b698d9-a2ad-4930-8445-80b74a408407",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "3592da04-71df-4a78-9f6c-4a4bbedc9fee",
+              "id": "19ed3313-176d-439f-93d0-253a36a1f035",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "7ca628a6-8ed8-40ad-bc89-69377ce591e2",
+          "id": "7fb8de6d-34ba-49f4-b86b-eca727831dae",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "2f415e48-11de-4661-9b5f-32db2b32d5b6",
+              "id": "0d1d0d5d-3ee7-411d-80d0-0c61904e7a0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "abe8ac12-c98d-40d0-9cb8-e0f04b08e50f",
+          "id": "0206d8a8-9a9d-45f2-9731-9712414bfd71",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "69e7697d-7495-4375-b816-e7abd09bb53f",
+              "id": "db1c58a2-7fe7-4651-ae58-8f7fc1467881",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "d4e0bf0f-fa1d-4677-b63c-edda41508c21",
+          "id": "66c3b692-68cb-4e87-aa1d-d2c8c76a1ceb",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "bf54da93-1328-4f43-8cf5-3b3bcd1b586c",
+              "id": "b4ef846b-a6fc-4149-8a1d-e0fc46163fc8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "3af0a276-8cf8-45d9-aa9c-9f60be47730a",
+          "id": "8ae5521a-9566-4353-bf7a-63a6b3a8ef07",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "a0f9ce8a-0b5d-43e2-8045-50e18e54051c",
+              "id": "8fbff6cb-7a06-44c4-ae1f-327c5aba63f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "2226cf01-ae93-4411-85d4-6bf1b10d356f",
+          "id": "2171e504-d4fb-41c6-a67b-33d1b22be7b9",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "c7431c3f-185a-4ef5-8e56-d9d7e4d1383d",
+              "id": "60de6c9e-f07a-426d-9b58-4663f18e6b15",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "efc4d3f8-7579-4eb7-ba73-9a717975245c",
+          "id": "037774b8-8745-42bc-965a-0143393a1345",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "45e4bf94-31f2-4239-991d-d2ff241725fd",
+              "id": "2bd46fc6-e4cc-4e14-b17f-804132113e3d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "367f01be-7f8d-4ece-bb30-f51edf7a7053",
+          "id": "9aa66a97-85ea-43cb-8bc7-8eb696d03443",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "83f56fbb-5dfd-4918-a598-d86bde719d6d",
+              "id": "22a6265c-e4c8-4c74-9bc3-963bfba11f8e",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "f27116e9-e36b-4a2c-9d00-1fc90f413595",
+          "id": "c39f3a35-5907-42b9-b2aa-adbbc17a5a55",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "a5e4238b-c3dc-4919-b0ee-9b5bb0bd799c",
+              "id": "a0ed913b-2361-4296-86e5-3e90a5d5087d",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "7400a933-2eb9-41a3-a31f-25e49d4d00ce",
+          "id": "4dc903f1-e601-4003-b8d6-07ce77b92c5a",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "a4266ce0-6189-4dc4-bc88-5f0d5f00d103",
+              "id": "133c498c-6aa6-4cac-87c6-1eba80930531",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "4b87e78a-afc7-45b3-adf1-3e770a85d08a",
+          "id": "b6e35aa4-0761-4c48-80a2-e9f57d5a80b6",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "0d2799e6-d92e-479e-a4ff-aca28175fe4e",
+              "id": "e69f6951-3ade-43d7-98a0-89ae1e8a7761",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "7c3e01f4-e39b-4b7e-a85c-192dc64ca617",
+          "id": "f4f53a05-0a31-4e08-97b2-676985698730",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "2b0dbbae-c790-418a-be93-0b47f5227dd5",
+              "id": "2c3b8802-420e-4d2b-aea3-9cbd8d2212ee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "7ca0d650-1cfc-40e8-9200-6d11f27de177",
+          "id": "382d725a-4a7b-4162-8f70-34593f516317",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "d26c8862-4ce0-41bf-9fa8-74222a4bd36e",
+              "id": "c9aad4b6-492f-4a46-b562-2e76177f055e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "cee24244-fac7-44e0-8d07-74b94673dd52",
+          "id": "e989c9d6-e967-4fd3-99e9-c0f988a1e1f4",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "b7395c29-ae12-4721-9eff-a1a77fec563c",
+              "id": "ca6519d0-090f-4a45-979a-ffe77f45d759",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "6933bd3a-4504-42d9-a45d-697982852d1f",
+          "id": "99a8f039-7d32-4feb-8d29-4f03e1dceda6",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "4a36a78c-fa59-4a0f-a6cc-37d432938b46",
+              "id": "f45b680f-3b2b-400c-ade7-cb8d15894bec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "ca6feb60-b571-4bcb-9a15-7f8e808bc973",
+          "id": "0ee5ca04-3445-4653-8313-a761974256c0",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "3b28e37e-7cd2-4017-847a-466943934008",
+              "id": "97e350d9-310d-4d37-adf0-c91bfd6c980c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "1c6eb589-81a7-4e8a-8344-d47ce03a457c",
+          "id": "8f09fb46-905a-4b8b-a956-feb57f8857e3",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "9be3dfd3-49e8-448b-9cdf-97a873b4d14a",
+              "id": "56453aa9-4be2-4ba4-8cf3-91e4d96a45f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "2e38a545-ccb9-4426-be76-108ba4bd2003",
+          "id": "6c30fc05-04ed-404c-8a11-d7a7b7d8ba42",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "cf10be2d-e133-43b8-8779-cb9b980b8904",
+              "id": "394ac013-a307-4a91-859f-a5ee6a04a364",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "819adb92-5e1b-42ff-a29d-d1049d5c0ae9",
+          "id": "67f89657-e8f5-486a-a56c-963dfe4a9d70",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "3318941a-f23b-4e1e-8c50-9f78a7fa9740",
+              "id": "2f47f43a-510d-40d3-a99a-6af1ec0af4b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "47ae905c-36fd-4cc6-8ed6-8ff287577c93",
+          "id": "b1a0c8f4-d1b0-462b-91b8-5ebf8b8e9208",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "ff2283b8-bacf-464f-83e3-f331c421d6dc",
+              "id": "4b05163b-6186-4242-a42b-385e3e4e6f85",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "71e52d41-e739-466d-b083-3385b38a3788",
+          "id": "e904bf7d-934e-45d6-b9cf-b86725b57fd7",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "e4cfaf51-c430-45ef-b10a-3e2eb141b070",
+              "id": "ff58e70d-3c4c-4f72-9e54-0f04822836e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "91e03d0d-7729-4d09-9026-64ee67b11cd9",
+          "id": "c418cbf6-f3d4-4e0e-92bc-a2566d1fdd2e",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "579602a2-d1f6-4f1c-a403-fe7cdeb2eec2",
+              "id": "f0c84269-5231-4530-bb13-e780b0eda686",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "19e882b8-467b-4a15-b686-e09af91c3991",
+          "id": "d96af7fc-e4b8-4963-9a51-5376ae0ece98",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "95529a68-88a5-4c91-a3d5-89098c145ead",
+              "id": "92db1126-a2a0-455f-9460-3835ac90b591",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "1a94112d-caf8-4073-9bb9-0de9975fb200",
+          "id": "614d0944-d3d3-429c-a60d-480126688aef",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "830c0337-dc2f-438e-bce4-bcf90bcc4918",
+              "id": "0522ab5e-1056-4cc8-a17f-5ea188b27a24",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": 4218\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": 7410.856595184474,\n        \"key_2\": 6333.228787550451,\n        \"key_3\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 9528.972029295692,\n        \"key_1\": 10.07491792738291\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "3f3a242f-2844-4c5b-876e-7d1fb192b656",
+          "id": "e6a97f77-22c9-4e79-9523-1071b535f3f5",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "cc1a022f-67ed-43f3-acc7-9378ef45dbaa",
+              "id": "35b53c51-f5ee-4ccc-96f6-1ee3d0121559",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "702d3ba4-b100-4481-b514-7373cdaa1140",
+          "id": "45ecd374-aaac-4f42-b5d8-3e6fca753a03",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a57E67\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#f658dD\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "5eb9f6b6-e570-4a3e-a829-52b645cb5b6e",
+              "id": "185a47e5-d6c4-4b3f-8926-447edb9e26f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#a57E67\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#f658dD\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "7ae5d91f-eb27-4517-88f8-aef830389bfe",
+          "id": "2bd15ea6-dc23-4afd-9572-e9024f8ea833",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "c71c189e-5c4c-41a4-83d6-b79d2df09e11",
+              "id": "ecb426f3-bef6-4776-aec2-affc9e795cd4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "7a051efc-8193-44c3-93fa-d1f06fbefee3",
+          "id": "ef2801f8-6581-42bb-816f-6f284b6cd1c6",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "c11de4b2-a8fc-4459-93b7-76c4e2a4e9ce",
+              "id": "5808d432-d73a-413a-842e-5ac675b0e5cd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "279892b3-603e-4453-8b36-a1f16db9519f",
+          "id": "5ab1b749-b474-472f-876b-09acde0eb0bb",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1f5ffE\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d0c39b\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "a4486b53-ce49-4783-8aa4-676f2ce2d857",
+              "id": "af35a021-9960-4f54-9434-c349df717356",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1f5ffE\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d0c39b\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "7c79909b-53f9-4fb7-87c8-e5354b8f378a",
+          "id": "2fe783b6-478c-443c-862b-8a53b104d082",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "7dfd3933-283d-46e7-bb17-6fdd08a81aba",
+              "id": "c5134bf1-7a76-4019-bf1e-a254d5507c5e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "a6708c47-d5ae-4592-9946-3d6bcd56f800",
+          "id": "77134043-0ee5-4076-9981-f0adae49009d",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "3e45dab9-f1f7-4806-a7f3-12f201d4220c",
+              "id": "b312899c-d264-4389-a3e0-c0dd1b37cba0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "447140b1-1010-4af7-a29b-4adc1a0a78c6",
+          "id": "3132a26d-54f0-4853-8687-834961b865dc",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "4c68503b-6b5a-4c12-a8ad-c27d1422fe5d",
+              "id": "7197fb72-cedf-428e-99cd-2a9979b7063d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "e920a107-2605-46f3-ab7d-f817de7a0304",
+          "id": "d173904e-3189-4b41-ac46-e20db6b0b6ae",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "c2885289-b8f7-487d-bce6-0e5730cb3673",
+              "id": "115bb8cd-56c9-4377-9262-d0a1183ee534",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "9e744ce2-0b58-4350-ab9a-557a11c5141b",
+          "id": "17eb17b5-04e6-4800-8b91-b374aec61dc8",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "5dec0e8b-d537-4408-a06c-a2e74f4155ef",
+              "id": "fbc36368-abac-44f9-aa6b-c5c89119b0f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "47a369cf-15be-4eca-81f0-5d065096c265",
+          "id": "07e511e4-330e-4fb3-9d30-bc17119e6d8e",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "7a5867cd-b793-4d39-8300-73a762fc6201",
+              "id": "dd264152-806f-4ee3-88b2-33f076f05556",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "2fab968c-ef53-4347-acd1-840b292e4058",
+          "id": "65ba62a1-24fd-48e1-964f-4549ba66d730",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "edfe9dbd-19a7-45db-b66c-48387d329543",
+              "id": "35f85f3b-5e00-4ffd-be8a-11d619008d0c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "54059961-7c29-43f0-b15d-e42ab7a27153",
+          "id": "e09d2287-024a-4272-a9a8-2a3b1805be97",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "1e7558d2-f144-4ac2-a5d1-4e867bc11d54",
+              "id": "2ba04635-0bde-4911-9ef6-e2d9d02e0b46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "10588c9b-8ff1-4a12-8b3f-e71ac624a68a",
+          "id": "37e17ee1-95c3-4115-b708-ad25b14e6027",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "1e730628-78cf-4583-874b-bb8d86cd9ec1",
+              "id": "6e8501d3-3023-4929-9cc3-3452ddbf7cd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "9ec1b6a6-f881-46e2-971a-3c25f1e4f4f3",
+          "id": "262e070f-171a-46c4-8310-127c75e4f97f",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "e7671ac9-afca-4335-b5ff-5b958eb0cb76",
+              "id": "c899d8f1-e181-4ed4-b35a-37cc4eabcb7c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "75547756-b38b-4bbb-8db8-1c58d41f4e9b",
+          "id": "efa9764c-c3a5-42ed-8439-107e8d2c1ce1",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "34a08680-2375-4713-aea3-a45cd550923a",
+              "id": "c78ee417-32aa-4a0a-8952-71dfab1094c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "fd01d602-b85d-4522-bce6-7d5b87a52ec3",
+          "id": "95e5a2f2-2a1f-4e69-a7bd-133e1452cd48",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "8ac4be3b-4b02-4ab7-85b1-09bef438f234",
+              "id": "9d65f6be-dde1-4aed-bbd8-3346c0c894f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "53eb4969-4224-42be-adba-6414784654a4",
+          "id": "f3a9763c-4828-4be1-8a51-f736dbf94ef9",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "b277094d-f866-4f70-b5a2-a2979cfab0f6",
+              "id": "4cdb64c2-1b27-4c88-bf22-601c2b25356c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "2fd8b0e2-c390-4c8b-a31c-557fa44b6b12",
+          "id": "0ff7bc2a-d416-4fbf-afa7-5a1375cb48dc",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "d3b129ff-b566-47a2-b05e-1cb37cccfc33",
+              "id": "fa45861f-7eef-41c7-b8f4-28c1d61973a9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "7b291ff4-1d27-4a03-84ed-a08f1bec33e2",
+          "id": "1b22c0b7-6783-4fb0-b231-d1e8edfcdeb5",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "4313fdcd-327d-458a-95bf-d647aa906d4e",
+              "id": "cd4d4699-4e39-4d7c-bddf-86537db0a786",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "d5c9d910-cc25-4e88-bf9a-2dab4e541da8",
+          "id": "cd78a690-c035-412d-a2b2-04ec49a4c58e",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "afe80899-9c12-4677-a8a3-595ab76914d4",
+              "id": "31f314e3-e971-4dce-9a86-4a8a0cfc087d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "ece2a2ca-3ce5-4006-9c4e-ca5b72259e5a",
+          "id": "99aba962-a987-4cf3-bb5b-d42501210824",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "7a5718fc-caa4-47d4-891a-ecdcd83eaa86",
+              "id": "86cab62e-01b1-41f9-9675-a6bc68939e70",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "36a18e15-a304-4ed1-98c2-ff2aac2b33ca",
+          "id": "8bb3db70-6d3a-4058-9c13-61545eed2374",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "caff1b48-2cd2-4387-aced-3f4f9c7059ab",
+              "id": "33dd2baf-365f-44fb-9540-a40d30c31c96",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "4f90528f-847b-4739-a554-19bcccfbaceb",
+          "id": "8398f19f-bbfa-4cc3-87b5-6b227283064a",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "02a1be2c-0d9c-49b2-9744-bd8b6ed83d34",
+              "id": "b4fbfa84-c9e7-4ccf-b233-a72e06f1c279",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "f0121f6b-9f78-4c56-a3ec-19b6793416b8",
+          "id": "c90854ff-743b-4ce3-a50d-94e831af0327",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "3a1216b8-0577-4f19-ab7f-5d12d76bfc5c",
+              "id": "186473ae-edd0-4ce9-b66e-03224c8aff54",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "33a1f224-bf9c-4e2e-9c26-2132d0a8388a",
+          "id": "40ddc12c-7985-4e43-9092-c3054afa8625",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "30a91ea0-b086-473f-a67d-36da6d91c07d",
+              "id": "f42f79a7-ab76-48e4-b027-51b531ab5d4b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "d436d2e3-b6e9-485e-ac32-dd4176c21861",
+          "id": "96447a7b-628f-45cd-92ee-0df8990b818e",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "a1fc43d2-9834-449d-ae72-3d5ef3980707",
+              "id": "c281dc9f-f90f-4b2d-8bc8-0c9419992e57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "ea728afa-3f9e-4e85-a31a-4861e565aa82",
+          "id": "71d7f137-49d1-4499-9518-3838f7aefe68",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "b3d6c521-be19-4ada-b37e-2250ed120584",
+              "id": "3fbc8e29-0bf9-4f11-9c5c-010ab7b502bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "efe45393-0b15-4bd8-8192-b905b21bce0d",
+          "id": "02da2763-15c0-41bd-901d-6568a522bd18",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "9bd16905-4a45-4d43-acd7-a48639709fed",
+              "id": "db035c90-f3ed-405c-9b58-35f2f4d8b027",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "bb4d17b7-fc52-436d-8922-be7e4b884f6c",
+          "id": "efa9f079-5126-4ac8-aca7-675cf8aa4a36",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "2b3a64d3-bab6-4a44-bd4e-ff96dc066599",
+              "id": "2ede6388-f62b-470f-9bd9-9b90a4a14b80",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "6024de80-020f-4752-aad9-b49240f101f6",
+          "id": "2d69636f-6b2e-46e6-8259-7cf1704dab3c",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "128ac5ba-c117-4e28-9079-4173593b18bf",
+              "id": "d01c348e-e4ff-469a-8016-b3d58007c91f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "f3421903-2498-409c-a4ca-b983818fe8bb",
+          "id": "8353ce5f-3f8d-420c-9b88-165e415ff459",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "a99f9755-a1ab-4f7a-a04a-fdea830fac56",
+              "id": "1c4e90e0-8bb4-4bda-81fc-93c93ad45b8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "1a87df5b-757c-4e02-933b-ad8562d60736",
+          "id": "fe93b0cf-dd0e-48e7-a1a8-cb669c23b786",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "6beeedc4-d381-4e66-8e7c-6ea56214cd95",
+              "id": "c591fa6c-eb93-4bd8-bf08-021f3b1b7f81",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "bc47adb2-f54b-480e-aa4b-2a802c07e29a",
+          "id": "6849edc7-2079-49ae-964d-62fd7c7f7845",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7566,7 +7566,7 @@
           },
           "response": [
             {
-              "id": "12e7c09d-efc0-4e49-855c-7e3b0946b401",
+              "id": "40f1a7b6-e269-43ef-b586-7c98955568aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7655,7 +7655,7 @@
           }
         },
         {
-          "id": "1c126107-e4ae-423c-bfe1-ebb55d81fbdc",
+          "id": "79d5ec60-5e0c-4df7-ac0e-e17d2f946585",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7722,7 +7722,7 @@
           },
           "response": [
             {
-              "id": "3867bfab-3ee4-4b27-b2e7-084ac9a31212",
+              "id": "3b2aa231-e551-4a91-86bf-fca71b0edb4f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7817,7 +7817,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "e9ff3a04-472c-4736-bd1d-3424543f7aa6",
+          "id": "d69363c6-c3e2-46b0-b5ec-d5b563e038a7",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7870,7 +7870,7 @@
           },
           "response": [
             {
-              "id": "eb8a797b-23f3-4cc9-b6fb-f6d724629d43",
+              "id": "6391f71d-cb54-458d-a860-18524b71c0a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7945,7 +7945,7 @@
           }
         },
         {
-          "id": "5fefaee9-5049-41cc-98e6-7bffcdabbc74",
+          "id": "740f1f23-72ba-40d6-9015-39157ab3d144",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -8011,7 +8011,7 @@
           },
           "response": [
             {
-              "id": "d00bdfca-33ea-4654-9d20-be4f0a7a1e7e",
+              "id": "6d10f526-5a3c-46a0-a9a8-9a04cab93bd4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8099,7 +8099,7 @@
           }
         },
         {
-          "id": "4f6100ea-ca12-46ff-8547-0fd3c510e9e5",
+          "id": "3efac420-2187-4fa6-b656-00e68ad6238a",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8146,7 +8146,7 @@
           },
           "response": [
             {
-              "id": "f6cd40e2-4a0e-45e0-a1b1-5cef18220560",
+              "id": "2f41d6e5-a57e-4a14-ae09-d1ad7ef4d09f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8211,7 +8211,7 @@
           }
         },
         {
-          "id": "f81fbc5b-de35-4460-b4e2-53ac79ad0991",
+          "id": "d026b4b1-9267-4ebe-a049-7e4be1fde0fb",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8253,7 +8253,7 @@
           },
           "response": [
             {
-              "id": "12f42e16-3178-4c3a-86fc-150eee9b8b65",
+              "id": "3b6e298f-380c-4c9f-ab75-f37cec05899c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8317,7 +8317,7 @@
           }
         },
         {
-          "id": "4cfc8c21-33b5-44a6-b7d3-600ac559c4aa",
+          "id": "e8687a19-af5a-43af-9416-46c6e5132e21",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8372,7 +8372,7 @@
           },
           "response": [
             {
-              "id": "ca771faa-5807-496d-9668-49b66c748728",
+              "id": "e3aa396e-1f22-426f-b6f2-a3a713ec6c63",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8455,7 +8455,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "27be4916-173a-438d-b1d9-ecc2e5abe40b",
+          "id": "63945f44-0dc4-4a4e-9304-b90688014105",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8496,7 +8496,7 @@
           },
           "response": [
             {
-              "id": "72fa2559-1985-4bf8-be8b-34a0418e9c64",
+              "id": "0257a78c-66e7-40f3-b0fe-61a637b24254",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8559,7 +8559,7 @@
           }
         },
         {
-          "id": "e75ad076-1d77-4d7d-9718-5081897f5ca5",
+          "id": "f8a4fca6-2781-4215-b134-3bc70f2fd99f",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8613,7 +8613,7 @@
           },
           "response": [
             {
-              "id": "943656b6-a03a-4589-8eae-8a9b26740ce2",
+              "id": "633d9b91-27ba-43df-a11b-7979f00e7902",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8689,7 +8689,7 @@
           }
         },
         {
-          "id": "b1bf0f00-57ee-41e6-8df9-6ac0f1a3716f",
+          "id": "0d5b2bc3-3f67-44a3-a9d5-dd1f8c17193d",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8724,7 +8724,7 @@
           },
           "response": [
             {
-              "id": "82f4e4fb-2d14-4a4c-870b-fe8f15961cce",
+              "id": "0aa30852-6395-4dd5-8410-2257ec668f2d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8777,7 +8777,7 @@
           }
         },
         {
-          "id": "b44b3f81-7c74-4dc5-9b32-898eedb8c858",
+          "id": "0b4c3340-90f4-4f2b-83c5-aa610ea0b36d",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8834,7 +8834,7 @@
           },
           "response": [
             {
-              "id": "97fe35ef-84c2-45c8-8965-1a65ece77460",
+              "id": "497e4383-b233-41b9-8d89-63044a95ae41",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8913,7 +8913,7 @@
           }
         },
         {
-          "id": "6fc9b563-d687-4ba7-bf97-17b73270beef",
+          "id": "904126c0-fba5-42e5-bba5-dafd007d8a28",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8955,7 +8955,7 @@
           },
           "response": [
             {
-              "id": "380ddf0f-ab0f-47d5-8db5-f0c12e01bc39",
+              "id": "bc5f04fa-9372-43d3-b0e3-214149f0ece8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9025,7 +9025,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "dadbe54a-dd13-480d-846b-103bf40d67ab",
+          "id": "dbb53759-1bf6-490f-83e8-28a454830154",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9078,7 +9078,7 @@
           },
           "response": [
             {
-              "id": "8d166ee4-78d9-41db-96bc-0dd318a50882",
+              "id": "4bc0058b-59ff-4960-aeb1-fb4dfe0b89d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9153,7 +9153,7 @@
           }
         },
         {
-          "id": "b9714b11-0b46-480b-8c01-f69e4d052597",
+          "id": "db341ee9-5557-456c-98aa-48de71f58efb",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9219,7 +9219,7 @@
           },
           "response": [
             {
-              "id": "0f542e35-3e7c-4e2e-b7f1-117c81caf98b",
+              "id": "a35d2078-b5ff-43b0-b7c8-ffbdfcc9b745",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9307,7 +9307,7 @@
           }
         },
         {
-          "id": "4c943354-94fe-4f90-b86b-c0b4588d8347",
+          "id": "22fbc223-879b-4e58-bdb6-a5ded996fdfc",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9354,7 +9354,7 @@
           },
           "response": [
             {
-              "id": "bc98f053-1592-467b-86bf-f3048ee0be69",
+              "id": "99f5f76d-876a-4f8e-810c-89a36ecab689",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9419,7 +9419,7 @@
           }
         },
         {
-          "id": "1cf3821d-7f8a-4097-9c53-d0eb4e93519c",
+          "id": "6d285920-bee6-4de2-927b-68ad78cfce66",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9461,7 +9461,7 @@
           },
           "response": [
             {
-              "id": "f2018056-9532-4dd5-9de1-1969c9e84e43",
+              "id": "a3bb1412-9eb3-4976-9960-6fa610df71e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9525,7 +9525,7 @@
           }
         },
         {
-          "id": "239957d7-3fd4-42bb-ad96-e1c6767dc2a6",
+          "id": "6189b25f-8326-4d5e-93f9-9668b3154659",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9580,7 +9580,7 @@
           },
           "response": [
             {
-              "id": "6be6fe00-c1ab-46c1-866e-2fde18e86c3d",
+              "id": "72c2289a-dc9b-474c-b0e9-3d8f74e29ecd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9663,7 +9663,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "d403d36d-063d-4bc8-8b1f-f3e0c902f2c6",
+          "id": "c8af8a16-9f5c-4e05-b1b8-710f2e558b83",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9705,7 +9705,7 @@
           },
           "response": [
             {
-              "id": "92cedfae-cecb-4944-8489-3429835c2a04",
+              "id": "b266eced-b063-4bde-bb28-5176b965e256",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9769,7 +9769,7 @@
           }
         },
         {
-          "id": "a74ffd1e-0f56-42ae-a654-245e206c6e38",
+          "id": "b684b086-79e0-40ea-88eb-808840a45e2e",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9824,7 +9824,7 @@
           },
           "response": [
             {
-              "id": "b2c83eae-d21d-4cb5-8224-0c7a40209d46",
+              "id": "2e7a3126-2b89-4ba1-9002-38cbc84f81b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9901,7 +9901,7 @@
           }
         },
         {
-          "id": "ba7e6e07-6ac4-4252-a5ac-b9f88788e490",
+          "id": "e727cc1b-bfd5-468c-a0db-2c107b8acf6f",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9937,7 +9937,7 @@
           },
           "response": [
             {
-              "id": "8ec26c58-d248-4adf-acbf-22195495d27c",
+              "id": "98f26b4f-d249-4e7c-b21c-f82757d10eed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9991,7 +9991,7 @@
           }
         },
         {
-          "id": "a5d12a88-2cd4-4618-84b0-5f3ce7b22580",
+          "id": "3884059d-3a01-4bf0-a2d4-fd891a84606e",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -10021,7 +10021,7 @@
           },
           "response": [
             {
-              "id": "dad58e6b-15ed-4eb8-b845-039312fa2c8c",
+              "id": "969f780d-f8fc-45dc-951c-912f6d9a4623",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10073,7 +10073,7 @@
           }
         },
         {
-          "id": "bd11c458-1064-462f-9213-6d6263fea0fe",
+          "id": "4c7f7560-aa24-4094-985b-5bbe554246ab",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10116,7 +10116,7 @@
           },
           "response": [
             {
-              "id": "d8453933-a486-4935-ae16-d1dc61c67872",
+              "id": "4d25a340-26e8-40de-a25e-db7576bf43ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10187,7 +10187,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "af59e526-c3c8-4807-9158-843e81151fa2",
+          "id": "96563097-24a7-4169-81bc-c3d9648156b2",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10229,7 +10229,7 @@
           },
           "response": [
             {
-              "id": "cfd0dd9b-3f02-4584-8f8c-bd6ed0271882",
+              "id": "28bb29e9-7bc3-4a85-a9c1-85e5d4fab885",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10287,7 +10287,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "dae4f38b-eeb7-46c8-a7e0-a7d76a99e9b6",
+              "id": "38affcb8-3e3f-459d-a430-35ee32fe8829",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10351,7 +10351,7 @@
           }
         },
         {
-          "id": "d18bfd54-0e5d-49fb-90ed-8cfb58363704",
+          "id": "c7e65dee-c467-4616-a77b-67596d90fe33",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10406,7 +10406,7 @@
           },
           "response": [
             {
-              "id": "8b8403a4-082b-4e00-b54f-bd75028a1af4",
+              "id": "9326d533-c572-45d3-a571-818f7dbc4d08",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10477,7 +10477,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "95bed3a8-7009-43d4-b4c8-32cbf94002e3",
+              "id": "09125980-c21c-40d9-9a83-7832e5070eaf",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10548,7 +10548,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0661f363-1062-4c19-9a7a-ff08ad86ec91",
+              "id": "b32b82c9-b2b5-469b-939c-ca83bac6fec0",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10625,7 +10625,7 @@
           }
         },
         {
-          "id": "23f39b3b-7e29-4a24-be16-9ffe3f936d13",
+          "id": "a85a1496-dc6b-4c8c-8dc0-f6a1302765b5",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10661,7 +10661,7 @@
           },
           "response": [
             {
-              "id": "d5b12d6b-b0e7-4244-99e1-79a36d3350db",
+              "id": "03f63bd2-68a9-42ae-aaa3-7748e122d329",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10709,7 +10709,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6492ab23-fdf9-47cb-bc87-8c79cdc57a85",
+              "id": "647f4cef-4752-49bf-b4a5-8e8c908d7ac3",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10757,7 +10757,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8fc35e0a-3225-4c59-8688-1f211a50b59b",
+              "id": "d40a27fd-a607-4417-8e6f-76afdbada3e0",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
           }
         },
         {
-          "id": "3e291f16-f8dd-45cf-9a4b-83616d60ea3f",
+          "id": "e5d4ea12-ea07-4244-b846-8af0d88fbaea",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10841,7 +10841,7 @@
           },
           "response": [
             {
-              "id": "2c53bd93-6b15-4679-ab10-28d4f9d2fc1b",
+              "id": "b3281a16-8a22-4643-9b0d-ebd4fc6e1909",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10893,7 +10893,7 @@
           }
         },
         {
-          "id": "c93b9710-a900-4652-9e27-b753e41c6539",
+          "id": "ccee3497-341a-497b-b6e5-b829f05cb002",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10936,7 +10936,7 @@
           },
           "response": [
             {
-              "id": "fed7cb7f-5e98-4b26-9636-13f11250a5f7",
+              "id": "b8e4929c-6f66-4baa-8c92-e47f83d1c637",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10995,7 +10995,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6095f852-eebb-4c4d-a257-17f8b20e32ea",
+              "id": "7646a1a8-ce20-4940-af6c-a424dcae5e7f",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11066,7 +11066,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "33b05a56-e965-4814-a435-0763479ccdc3",
+          "id": "596661e9-46e6-492d-bdbd-4e1f73df3362",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11150,7 +11150,7 @@
           },
           "response": [
             {
-              "id": "4666bcc4-57c6-49eb-857d-f2d6953b891f",
+              "id": "4dd62c34-8644-4e69-badf-37204bd577c8",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11253,7 +11253,7 @@
           }
         },
         {
-          "id": "c0d1b7d3-3658-4c0b-88b3-4e8b277dddad",
+          "id": "76ba4654-b464-45cb-ae9a-3e3fa2c8daa7",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11319,7 +11319,7 @@
           },
           "response": [
             {
-              "id": "736823ad-2bf5-46ee-88ea-813155fd897c",
+              "id": "4a105ffa-a458-438b-be27-8f8e69463ab8",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11404,7 +11404,7 @@
           }
         },
         {
-          "id": "c4aab1b8-9564-4233-8f93-711c7352fb1f",
+          "id": "30740ea6-216c-4937-a457-b5a531c9e0da",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11488,7 +11488,7 @@
           },
           "response": [
             {
-              "id": "850c4bdf-9c6f-4d56-845a-dad4e2d2f175",
+              "id": "5f5b7d30-16fe-40b9-8d78-37bb6ebe4271",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11591,7 +11591,7 @@
           }
         },
         {
-          "id": "b3c0d375-ac97-4ef9-aba6-4cda52023c85",
+          "id": "97c5e54b-14ac-4eb3-9772-f9b54ac6e97b",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11666,7 +11666,7 @@
           },
           "response": [
             {
-              "id": "1998529f-deae-4550-863d-c23086db65ef",
+              "id": "b582a386-25b5-4ba7-b068-841a951cf95a",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11760,7 +11760,7 @@
           }
         },
         {
-          "id": "7e3d58b1-8862-42de-99d7-1a3370a4d74d",
+          "id": "51fd7358-cb85-4682-a6c3-c1441d0e61cd",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11835,7 +11835,7 @@
           },
           "response": [
             {
-              "id": "7fd41185-d905-49a8-b6d4-b1a6cb900a19",
+              "id": "6e3c3daf-d501-4ca3-9b4a-ffc14b3ef84b",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11929,7 +11929,7 @@
           }
         },
         {
-          "id": "cd970118-c70e-4669-95a6-1e52c843ed37",
+          "id": "bb64395b-92ca-42e4-9222-121ad2a88cfa",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -12004,7 +12004,7 @@
           },
           "response": [
             {
-              "id": "fa89a9c8-cd98-4ecd-b07d-37967f938b63",
+              "id": "30080d5d-e582-4ae5-82b9-312a145b71d9",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12104,7 +12104,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "073440bf-0787-4caf-a2f8-f2012575eeec",
+          "id": "27a8e176-b195-4e2d-9104-d4f032ece058",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12170,7 +12170,7 @@
           },
           "response": [
             {
-              "id": "0325e60b-fa3f-4f49-994d-7d669e82a802",
+              "id": "6b053a0a-10c1-4da3-b5b5-0f08cbdb7e20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12244,7 +12244,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12261,7 +12261,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "671c7e54-3530-4c12-8b34-d4b0cb956e56",
+          "id": "2d3fc2a7-2758-4acb-a141-91a07c98fd64",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12303,7 +12303,7 @@
           },
           "response": [
             {
-              "id": "616fc086-0e36-45b9-a0a0-f17955f3461a",
+              "id": "b366990e-0159-443c-b532-ead3fdfe25db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12373,7 +12373,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "2674c642-c629-417c-82ee-819fcc388e29",
+          "id": "028def05-c5c3-47df-8fcd-682b2d3a8cbf",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12412,7 +12412,7 @@
           },
           "response": [
             {
-              "id": "2e5b6116-97c6-4b27-940c-44e033b76399",
+              "id": "01b2d2ba-12ff-4419-b1bd-371cc5229dc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12465,7 +12465,7 @@
           }
         },
         {
-          "id": "4381e40b-68d6-488a-8149-44bf9ac1c44d",
+          "id": "2732c6b3-a181-45f3-99d1-749e0f1f9180",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12497,7 +12497,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"aj-YR\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"22:14\",\n  \"quietHoursEnd\": \"16:44\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ye-IE\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:40\",\n  \"quietHoursEnd\": \"03:10\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12517,7 +12517,7 @@
           },
           "response": [
             {
-              "id": "183aaf0b-d08c-4cee-9618-c1588edc3029",
+              "id": "7f3240e9-de7e-400f-a000-60f5ec59ab43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12555,7 +12555,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"aj-YR\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"22:14\",\n  \"quietHoursEnd\": \"16:44\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ye-IE\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:40\",\n  \"quietHoursEnd\": \"03:10\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12589,7 +12589,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "e01ab9bf-4eea-408d-a006-f33747b9683f",
+          "id": "15564b6d-0a00-417e-98cc-cb16a9b5c40e",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12631,7 +12631,7 @@
           },
           "response": [
             {
-              "id": "aec96e14-e881-4a6b-acc8-6c85e9e2111d",
+              "id": "3d85307b-f960-4b56-9f55-009230062cca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12695,7 +12695,7 @@
           }
         },
         {
-          "id": "22117922-f3a9-4b8f-be0c-93290b7b81a7",
+          "id": "3befa4b2-1f9a-4d59-801b-fbb120eca2ad",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12738,7 +12738,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#3C2c43\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#A47bed\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12750,7 +12750,7 @@
           },
           "response": [
             {
-              "id": "ba0d17da-63cf-48dc-9da1-19b67eab3070",
+              "id": "777dbb97-fef1-425e-9f8f-c85acb981e54",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12799,7 +12799,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#3C2c43\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#A47bed\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12827,7 +12827,7 @@
           }
         },
         {
-          "id": "679236de-f96a-4577-ad9a-5a5d162fc17e",
+          "id": "93dfcb47-fff0-451f-8f5e-4a4203d33774",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12863,7 +12863,7 @@
           },
           "response": [
             {
-              "id": "bba432f6-b9f9-4e55-b332-e95a44515edd",
+              "id": "bee43e9a-8871-4ecd-a23c-40f9fcc58544",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12917,7 +12917,7 @@
           }
         },
         {
-          "id": "1db211fc-f28d-4102-9301-3688d4a9b35c",
+          "id": "7d084e5b-fb58-49e7-a5fd-9751460e1500",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12947,7 +12947,7 @@
           },
           "response": [
             {
-              "id": "347225b3-8166-4c19-ac03-ed5848a8232f",
+              "id": "1924f9af-23c6-4c46-9a9b-84d4e412d16c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12999,7 +12999,7 @@
           }
         },
         {
-          "id": "bf0d994b-8c61-4fcb-ba59-3bd59b69aaba",
+          "id": "53330990-fe0a-420b-a085-e2f0935e63c6",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -13030,7 +13030,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#245acc\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d9de5c\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -13042,7 +13042,7 @@
           },
           "response": [
             {
-              "id": "5e3e98ae-8d2a-47e8-bda7-97522d43e74a",
+              "id": "c9452c15-fa3c-420d-86e2-543027bf95f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13079,7 +13079,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#245acc\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d9de5c\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13107,7 +13107,7 @@
           }
         },
         {
-          "id": "caa7c07a-12bf-4171-a722-e266c90c23c0",
+          "id": "0d4aea1e-d27d-4cfa-b45e-064d5b5c4af9",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13138,7 +13138,7 @@
           },
           "response": [
             {
-              "id": "7fde997a-aa9b-4495-9067-10e36bad4dbf",
+              "id": "53d5eef7-5009-4cbc-bb47-5b573690b6e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13197,7 +13197,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "5f5ffa58-d80b-4635-8dc4-ec190cf6d759",
+          "id": "a2d4298d-68e5-4a68-b59e-f65625d5d0ee",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13250,7 +13250,7 @@
           },
           "response": [
             {
-              "id": "5e9471f0-6c37-49f4-9c99-3454131c12eb",
+              "id": "46100447-a684-4e34-816e-ed200d73e431",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13325,7 +13325,7 @@
           }
         },
         {
-          "id": "b1e980bf-c8b0-4aef-a77d-019b0f2bae00",
+          "id": "2b2e25c3-af77-461b-8e21-01b5c3362513",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13391,7 +13391,7 @@
           },
           "response": [
             {
-              "id": "d5a49e65-5d95-495e-b932-204b59ed34b3",
+              "id": "32258e3a-cf01-4a1f-a6f3-f35dc4e89e0f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13479,7 +13479,7 @@
           }
         },
         {
-          "id": "bf7a3691-d131-431f-8044-137ffd400486",
+          "id": "e40d5597-6e13-442b-bfae-9518f227502a",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13526,7 +13526,7 @@
           },
           "response": [
             {
-              "id": "ea0d985b-5163-47af-a771-11dfa98e5d5b",
+              "id": "be82c4d7-d696-4e61-8d2b-1ed3779a5490",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13591,7 +13591,7 @@
           }
         },
         {
-          "id": "b6841365-5d27-407e-980a-61c9b6ef5340",
+          "id": "730c3bd0-709b-4d22-8ce6-8aaea9c9e74f",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13633,7 +13633,7 @@
           },
           "response": [
             {
-              "id": "362a85ef-58ec-438b-a0c7-5351cf3a9a75",
+              "id": "3b59a819-5394-437e-b057-3f66bd4175c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13697,7 +13697,7 @@
           }
         },
         {
-          "id": "bd360aac-3527-4a80-bc53-c279dad31321",
+          "id": "663ef278-7c9f-41c1-8128-a8bac8eade16",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13752,7 +13752,7 @@
           },
           "response": [
             {
-              "id": "f020808a-0b37-48e9-8c8b-b7d72b943967",
+              "id": "238b3fad-395d-4ee7-9965-8e9af9925410",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13829,7 +13829,7 @@
           }
         },
         {
-          "id": "5db744b2-5fdd-4bef-858c-7b7791ab1dc1",
+          "id": "dcd35340-13ea-455e-868d-fed14ee25138",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13883,7 +13883,7 @@
           },
           "response": [
             {
-              "id": "d1458b3f-d3f2-4376-94ec-e912ba157acf",
+              "id": "bc068302-34c9-4c19-95bb-b30115dc2578",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13959,7 +13959,7 @@
           }
         },
         {
-          "id": "b7901c28-fa2a-48ed-aa3a-abaa674f5167",
+          "id": "caad95fc-cfe0-428e-a41b-9c6323182261",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -14025,7 +14025,7 @@
           },
           "response": [
             {
-              "id": "f57ffeb7-4143-408f-8791-a108d0b9c0cc",
+              "id": "f533ad45-3803-4b64-89fd-ef24423b4078",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14113,7 +14113,7 @@
           }
         },
         {
-          "id": "087addf2-2736-401b-8ab9-d8d47626c2b8",
+          "id": "7e1e0c51-e13c-4ec4-84b1-7b4ec4c09cb0",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14191,7 +14191,7 @@
           },
           "response": [
             {
-              "id": "fada11aa-e484-4d90-9b2b-c0fa047acd04",
+              "id": "695e9b8a-257f-4592-b90f-55247052b328",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14291,7 +14291,7 @@
           }
         },
         {
-          "id": "3edae1e2-bdda-4f12-8cde-d503894da232",
+          "id": "1eb39cd9-4cc5-4831-a6e8-566c14125d1b",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14357,7 +14357,7 @@
           },
           "response": [
             {
-              "id": "0606aa4c-6adf-49d2-8d1f-8ba0e984ac15",
+              "id": "541d4775-be19-4a6c-9234-e75dbe02f8cb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14445,7 +14445,7 @@
           }
         },
         {
-          "id": "ba8e1bf4-3807-4c99-93ae-232ef46474c9",
+          "id": "11052081-b942-44a8-95b3-b6886a41e806",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14500,7 +14500,7 @@
           },
           "response": [
             {
-              "id": "3ecf3434-a0a7-460e-9cc5-c55d427b0652",
+              "id": "94d20fa5-300a-4dc2-b5ff-8a3387f8750a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14583,7 +14583,7 @@
       "description": "",
       "item": [
         {
-          "id": "8994c1e6-091a-4fbb-859d-8741f39cc9c7",
+          "id": "7df97f10-c626-4422-8e35-6ae07787cb50",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14624,7 +14624,7 @@
           },
           "response": [
             {
-              "id": "9097b361-55c5-4ad0-98d9-fc3dd8c9a1fc",
+              "id": "d91b8f08-aff9-40e5-91e0-44eff4ee0a0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14687,7 +14687,7 @@
           }
         },
         {
-          "id": "46a2f619-ea62-4655-9a55-e24a401de627",
+          "id": "4452ced2-69ff-41e2-9072-a3fd3b6e59f4",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14741,7 +14741,7 @@
           },
           "response": [
             {
-              "id": "3ea2f652-3a68-4c2b-945c-980439b579a5",
+              "id": "b710d030-10c3-4b55-8127-1f9ac65e2218",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14817,7 +14817,7 @@
           }
         },
         {
-          "id": "30960123-7001-4a99-9552-1bbc086e61b9",
+          "id": "3b1a2e66-10c3-472e-8f2c-2b447ff82778",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14852,7 +14852,7 @@
           },
           "response": [
             {
-              "id": "3fde248b-9e88-4a29-ba8e-f6c71d3ef251",
+              "id": "dfaf7ff5-636b-4e3a-914e-a5f67c399225",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14905,7 +14905,7 @@
           }
         },
         {
-          "id": "025ad0e1-3201-4b61-8b51-2d26e07e3972",
+          "id": "dd488fb4-ef92-46d2-98c1-8ad385450165",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14966,7 +14966,7 @@
           },
           "response": [
             {
-              "id": "50fa1d22-3dc4-4a5e-9dad-4c5fa800aad9",
+              "id": "85856842-c77b-4686-b455-6b0b26873c87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15049,7 +15049,7 @@
           }
         },
         {
-          "id": "9fbe8ede-f7a8-4bf4-85a8-87dcce35f82f",
+          "id": "1cb443de-bf7f-411a-ab44-a3acdd1d7365",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15091,7 +15091,7 @@
           },
           "response": [
             {
-              "id": "4513b89f-eca8-4f46-9e98-99112b3ec2e5",
+              "id": "075d99d8-0648-459c-a4db-b0295c3d99a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15155,7 +15155,7 @@
           }
         },
         {
-          "id": "69aee3f0-0b15-4df6-b8de-43dd288881b5",
+          "id": "460315fb-6d8e-43b0-be9f-613f23e5a58e",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15230,7 +15230,7 @@
           },
           "response": [
             {
-              "id": "73875328-38f1-4a2a-8361-d1632b6c7607",
+              "id": "39ef4bdf-4ba9-45ff-b3b7-008e2e4403fd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15327,7 +15327,7 @@
           }
         },
         {
-          "id": "aebce18b-d5d7-49e6-aae5-3a414820cf3a",
+          "id": "157280d6-70d9-4175-adc3-a8fc53fedd60",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15369,7 +15369,7 @@
           },
           "response": [
             {
-              "id": "a72f9d55-e6ae-442e-924f-c2eb7ec8a823",
+              "id": "93bb90ea-dd27-4469-a42a-a2a9da8b38c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15433,7 +15433,7 @@
           }
         },
         {
-          "id": "f25b301c-8cb8-4b26-9bca-c5ac4b816576",
+          "id": "2aca88d5-e609-4fc8-b8e7-aa33adf2a115",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15476,7 +15476,7 @@
           },
           "response": [
             {
-              "id": "3255ca8a-7d78-4e5c-a57b-32349ea2eca5",
+              "id": "de762741-7a1b-440c-9fe1-c88bb0f0ec1e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15541,7 +15541,7 @@
           }
         },
         {
-          "id": "e791c865-8dd7-4c58-937d-0abe4e404f06",
+          "id": "37c389ff-ef58-4cd4-99cd-32056b38c9d0",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15584,7 +15584,7 @@
           },
           "response": [
             {
-              "id": "38b02b45-04c2-4b7c-9eff-f65ab590938f",
+              "id": "c8277d56-7ca6-4d0e-ad3d-1f58a1a58467",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15649,7 +15649,7 @@
           }
         },
         {
-          "id": "912359ed-0622-4479-9686-2ef71b80e438",
+          "id": "8799ff31-c3cd-4078-911d-1d27c696ad60",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15701,7 +15701,7 @@
           },
           "response": [
             {
-              "id": "e9bbc42e-0d4a-4a72-94cb-c959b789b7c5",
+              "id": "03d958d4-5a4f-4d84-b9c6-93cf9624e9be",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15775,7 +15775,7 @@
           }
         },
         {
-          "id": "3d147643-ea96-407b-a1d0-2c783ef9ec58",
+          "id": "9d9b9901-e4c6-4e54-8b63-1404a7c96648",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15817,7 +15817,7 @@
           },
           "response": [
             {
-              "id": "64d86ac3-e361-4c6d-90c5-31a57f788170",
+              "id": "56273ea3-40b8-4148-9ceb-394ae5ad7285",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15881,7 +15881,7 @@
           }
         },
         {
-          "id": "17f405d8-4a18-4ae8-89c9-3d5891eab2f8",
+          "id": "38dca605-3c79-450d-be23-837ebd59c819",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15934,7 +15934,7 @@
           },
           "response": [
             {
-              "id": "36733095-a5a8-406a-b125-6f4cd7379ca3",
+              "id": "7acaf532-1497-43ac-9872-0ae8eacc089e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16009,7 +16009,7 @@
           }
         },
         {
-          "id": "4e7bd156-2cb7-49f5-a816-a15c5645458b",
+          "id": "256aeb37-ea6e-483c-9b44-8cb5ce04ff77",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -16062,7 +16062,7 @@
           },
           "response": [
             {
-              "id": "0d391120-f088-4a8c-b3a6-a35dd33df3cd",
+              "id": "78d7150c-e814-46c7-81b5-ce4bb68621d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16137,7 +16137,7 @@
           }
         },
         {
-          "id": "e640a3c1-c405-42cc-bf7f-3b72868fd81d",
+          "id": "b84b47de-1bc2-4855-ab5d-9a9938e25614",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16181,7 +16181,7 @@
           },
           "response": [
             {
-              "id": "bea7a166-34ae-455c-9833-a70e99c839b0",
+              "id": "1e4f0d91-0344-4083-adaf-6837aa617caa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16247,7 +16247,7 @@
           }
         },
         {
-          "id": "b1a423d3-7c25-4d9b-a34c-1d62c146b652",
+          "id": "17c291d0-d67e-47dc-b654-293ab28cee31",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16291,7 +16291,7 @@
           },
           "response": [
             {
-              "id": "6e3c63af-db30-4590-91d5-f3ff0982b6fe",
+              "id": "d3589deb-a11d-48a9-bf36-dca06d17ca1b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16363,7 +16363,7 @@
       "description": "",
       "item": [
         {
-          "id": "20e0e040-5ebb-4e00-a7c2-e36f202cabdb",
+          "id": "c58a25af-a8a0-4e44-b9eb-e3fbae047c6c",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16405,7 +16405,7 @@
           },
           "response": [
             {
-              "id": "b960a591-45d2-4a21-9d33-2614f93176d3",
+              "id": "fa6bb830-18c4-4112-9a34-56680b9f5704",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16454,7 +16454,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4dfa31cc-0e0c-4bf2-82d3-705dae16cd3b",
+              "id": "f87e2928-6363-4b13-8604-69635ca3bdda",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16509,7 +16509,7 @@
           }
         },
         {
-          "id": "28f4667f-6a8f-4fa2-b886-7149ecb8b099",
+          "id": "b7265d08-dd65-421c-804d-c2774ac50996",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16555,7 +16555,7 @@
           },
           "response": [
             {
-              "id": "9bf03bee-8225-4801-8bc0-8898175a76bd",
+              "id": "b363117b-cd95-49a7-9b5a-5b301430e842",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16614,7 +16614,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ff0e6b9b-c350-42f4-9851-972ca8d66d55",
+              "id": "92cabdab-7c41-4580-8f6b-106ed58f50e0",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16679,7 +16679,7 @@
           }
         },
         {
-          "id": "4ece3f2a-3051-4be4-9fb4-69249864681e",
+          "id": "cacde3a2-e864-435e-b0cb-16c013b1246d",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16725,7 +16725,7 @@
           },
           "response": [
             {
-              "id": "80c45c8e-e778-4c34-907e-2307a4d8d528",
+              "id": "e6b5b4f4-d5f7-485f-8ef8-2be446fbe8eb",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16784,7 +16784,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "50fa6cc9-1945-48b5-b3cd-c1e9b0750b4d",
+              "id": "e0e45dd9-eaea-47a9-a1a9-73351a59c179",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16843,7 +16843,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "bc9d99a8-a207-46fe-b81b-27d5ebe061c5",
+              "id": "5382c3ea-1eb6-4b5f-837b-4e7553003265",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16902,7 +16902,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "da5d36d5-7898-46e2-9d37-e79548249df6",
+              "id": "a29870f6-4450-4529-9561-8e5adfd885b3",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16967,7 +16967,7 @@
           }
         },
         {
-          "id": "5bc40566-3812-44c9-b7fe-18a4d9ecca3b",
+          "id": "b3b67fc0-1a0f-48f6-b0dd-03e0c41e1688",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -17013,7 +17013,7 @@
           },
           "response": [
             {
-              "id": "a2f8f5d4-1911-4671-97be-411cc5f569f4",
+              "id": "7c268af3-a245-4b0f-9009-438668bce8ac",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -17072,7 +17072,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a63d7398-aa48-4a1b-9e0c-6d78bdcdcf32",
+              "id": "4da15659-db0d-40e5-85a3-9e3ac04bf052",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17137,7 +17137,7 @@
           }
         },
         {
-          "id": "baaa4aee-7020-49d0-b454-842f1c22b728",
+          "id": "662a85b3-2c50-46b0-9de3-5a8a03e497a4",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17179,7 +17179,7 @@
           },
           "response": [
             {
-              "id": "23d8e13b-7d45-4b3e-826d-d40fc6b43b0c",
+              "id": "502ce310-3213-44c4-a6e9-7ab0daea7816",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17240,7 +17240,7 @@
       "description": "",
       "item": [
         {
-          "id": "cb30cb04-987d-4b35-93fb-09c54ab02ea7",
+          "id": "dfcee392-0a9d-4c92-bb92-1e3c7d43ad0f",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17289,7 +17289,7 @@
           },
           "response": [
             {
-              "id": "809e0ec4-1e29-44fc-ab72-4ebdf71621c5",
+              "id": "8af89467-8826-4a9e-8730-95828888f216",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17349,7 +17349,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17360,7 +17360,7 @@
           }
         },
         {
-          "id": "bb8d7349-0088-45e4-8d86-b1f57e1718ae",
+          "id": "d862cdd5-d4a4-40ce-aef5-02fd867a14e1",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17409,7 +17409,7 @@
           },
           "response": [
             {
-              "id": "da6c619d-d0e7-4056-96a1-8c7570912d9a",
+              "id": "25008b5f-472d-44cf-b865-dcb57f7d48ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17480,7 +17480,7 @@
           }
         },
         {
-          "id": "dc1bf625-0534-4108-8e47-bf8dd0e14064",
+          "id": "3ae10608-d876-4d9d-b10c-d5631876f11c",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17529,7 +17529,7 @@
           },
           "response": [
             {
-              "id": "35afcbc5-cd25-4465-aabb-1fdb38e5c7a7",
+              "id": "b40d7b8a-2ad7-445f-ab06-d20dde00e4d2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17600,7 +17600,7 @@
           }
         },
         {
-          "id": "0b4b122f-be0a-4389-b3cf-38edef8f2a22",
+          "id": "6637206a-f205-4d01-818d-869f7a098798",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17649,7 +17649,7 @@
           },
           "response": [
             {
-              "id": "036d70e3-5bd4-47d5-bef9-b2144de25f3d",
+              "id": "d2bd2b0e-d489-42ca-ab4b-c0e95d1c9d09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17726,7 +17726,7 @@
       "description": "",
       "item": [
         {
-          "id": "9842eb89-ad88-493e-b7e6-601f494e5903",
+          "id": "4c96c278-05fe-4623-8690-4b31f58567d6",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17766,7 +17766,7 @@
           },
           "response": [
             {
-              "id": "95fcfacc-d825-482c-8dd3-26cebccf7f50",
+              "id": "ca49cbec-195e-4566-8456-3d118acebebe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17828,7 +17828,7 @@
           }
         },
         {
-          "id": "52f46ad7-71b1-451a-b2b5-2ee9bf259340",
+          "id": "a543e622-dbe5-441c-a053-a63b88e86a26",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17858,7 +17858,7 @@
           },
           "response": [
             {
-              "id": "801c97ce-aca9-4d84-b92e-8032cd98b511",
+              "id": "e0cfad5a-8c95-4437-bb48-6bb13e3d676e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17899,7 +17899,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17910,7 +17910,7 @@
           }
         },
         {
-          "id": "adb50c8d-9810-4811-ab6b-27dcb5bfc233",
+          "id": "8f03b62c-2cd5-420c-a832-4bbf2744d275",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17962,7 +17962,7 @@
           },
           "response": [
             {
-              "id": "ee0b800d-57a9-40fb-8bc1-9287dd65e581",
+              "id": "9b19b212-d221-42a0-b4f7-58278a1688b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18042,7 +18042,7 @@
       "description": "",
       "item": [
         {
-          "id": "bfac743f-946a-4e35-a1a5-dcda29ac0724",
+          "id": "799182be-ca6c-4036-8f74-74128bf08a6c",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -18071,7 +18071,7 @@
           },
           "response": [
             {
-              "id": "2529227d-3806-4abd-b153-42a088471679",
+              "id": "31d23fd8-f4d5-451f-8de2-9fc1ade5421f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18122,7 +18122,7 @@
           }
         },
         {
-          "id": "39db10cd-b105-4417-8f1f-292aac6d2855",
+          "id": "01b3286b-78ed-4262-b742-e7b8aea11b77",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18163,7 +18163,7 @@
           },
           "response": [
             {
-              "id": "4e7a5b4b-3090-47b7-9481-e1fc8a7859f0",
+              "id": "422f3fc2-3f9a-498a-bef4-6a7afea6b4a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18232,7 +18232,7 @@
       "description": "",
       "item": [
         {
-          "id": "2b03801b-d039-463b-a4ed-73f27cda634e",
+          "id": "a5f3815d-ca42-4eb6-8156-a37b3141520d",
           "name": "health",
           "request": {
             "name": "health",
@@ -18261,7 +18261,7 @@
           },
           "response": [
             {
-              "id": "f6a70970-57a2-4699-9975-1cd72a579934",
+              "id": "06763d98-9307-4020-b9cb-1d993068f890",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18301,7 +18301,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true\n}",
+              "body": "{\n  \"key_0\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18318,7 +18318,7 @@
       "description": "",
       "item": [
         {
-          "id": "921f0f11-ead3-4dc8-909c-ac28d22b5fc8",
+          "id": "496d4361-24be-456e-bf70-7d36bda701e9",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18370,7 +18370,7 @@
           },
           "response": [
             {
-              "id": "d5d9d1fb-0aff-4731-8f70-0fe3ef5781f2",
+              "id": "b6e5d5bc-ce19-4aa8-bc1f-3ee81e9ed68c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18444,7 +18444,7 @@
           }
         },
         {
-          "id": "466cce72-b43e-409a-abc4-5e0c39d2a2cd",
+          "id": "d98df4d3-5cfa-4868-85dd-fa9669b46788",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18485,7 +18485,7 @@
           },
           "response": [
             {
-              "id": "2f421da0-084b-4393-8a4f-373d1e98adf3",
+              "id": "629411ec-4280-4924-9913-daa5f7ef1a2c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18537,7 +18537,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18548,7 +18548,7 @@
           }
         },
         {
-          "id": "ff8ec9d7-a1e5-445b-94d5-7ac0caeb8cab",
+          "id": "52d1d618-976e-4d07-b635-6a58c7d32a9c",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18578,7 +18578,7 @@
           },
           "response": [
             {
-              "id": "6cf293be-3689-4b13-9bba-fb76ef9edf26",
+              "id": "53612fc0-5add-4050-8191-81b944adff5a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18650,9 +18650,9 @@
     }
   ],
   "info": {
-    "_postman_id": "9836aac1-c2c6-44d3-8b68-5e1fef83eba9",
+    "_postman_id": "ed4e6421-a7dc-40e7-955d-7efe4d504e8e",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-03 23:12 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 00:30 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "7853e0e7-07b7-47e9-86fc-6ecdafc0f372",
+          "id": "a2395872-1f59-40df-99b2-6d395d677ca2",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "38fb0884-3b10-441e-854f-3509683a5962",
+              "id": "19557de2-1f96-49be-9f74-b39afe963139",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "25dbc75b-f0c3-4837-9ce1-cb6a5714a3f3",
+          "id": "0aa20e44-e840-4bdd-8b67-33f8783caaa8",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "0851392a-0d9b-4f50-920d-836c2b5f08e3",
+              "id": "b47dc58b-0987-4fe4-8552-0890e00160cd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "9ad0bc52-b6e5-46e1-acd8-f3749a09a2dd",
+          "id": "3baed847-6615-4579-9980-31f987528131",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "0885622e-30aa-4fa4-8110-10b1184618c1",
+              "id": "378cd42f-c9e6-4103-a1d3-48a78fc8b978",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "0a3b42c2-4329-40a1-bad1-0f624cd16fd7",
+          "id": "1069c200-b8e0-4ebd-8595-c1ae5f14e9d6",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "fcc2fad1-0982-4bf1-88c7-d5aad52ac939",
+              "id": "e3568a20-3455-4df6-8ec2-da79f52d61da",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "2dfd4540-17f3-4757-af95-2da3b988f093",
+          "id": "0361de88-c662-4531-9a8e-c69e10699ba1",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "f81ec099-21a7-43fc-941a-a177df563a4d",
+              "id": "a43b07a8-cbab-4d55-baad-38d6d5e7fe64",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "10b698d9-a2ad-4930-8445-80b74a408407",
+          "id": "5784cdd4-fb9d-4502-b306-7d75ed42f35d",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "19ed3313-176d-439f-93d0-253a36a1f035",
+              "id": "33de9150-d3ed-4395-b20e-0107dd04c932",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "7fb8de6d-34ba-49f4-b86b-eca727831dae",
+          "id": "c4f0ca82-6dc7-4b6c-93c8-0adf30e57478",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "0d1d0d5d-3ee7-411d-80d0-0c61904e7a0e",
+              "id": "81b71999-dfac-4075-90d9-64fbc78a2680",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "0206d8a8-9a9d-45f2-9731-9712414bfd71",
+          "id": "211c8871-d434-4231-956f-d44a86e32009",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "db1c58a2-7fe7-4651-ae58-8f7fc1467881",
+              "id": "1592229a-b5b6-4b66-acc1-dcdc22d51f11",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "66c3b692-68cb-4e87-aa1d-d2c8c76a1ceb",
+          "id": "0c471d48-b483-4b20-b112-c9539bf41470",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "b4ef846b-a6fc-4149-8a1d-e0fc46163fc8",
+              "id": "fddf3140-3816-424b-b360-78b2bafc4957",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "8ae5521a-9566-4353-bf7a-63a6b3a8ef07",
+          "id": "016f38a8-4d25-418e-8989-32c264838dba",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "8fbff6cb-7a06-44c4-ae1f-327c5aba63f9",
+              "id": "88fae696-400d-4d73-a98e-9b36026fe031",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "2171e504-d4fb-41c6-a67b-33d1b22be7b9",
+          "id": "aa1a8287-8ace-4d20-be5d-30e8aaac4461",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "60de6c9e-f07a-426d-9b58-4663f18e6b15",
+              "id": "1216aa34-f71d-44bf-9429-1b4525d01152",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "037774b8-8745-42bc-965a-0143393a1345",
+          "id": "52789d01-a424-4abe-bf1f-4b6f452bcc51",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "2bd46fc6-e4cc-4e14-b17f-804132113e3d",
+              "id": "1673bf64-5fee-4757-b800-e0374ae61298",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "9aa66a97-85ea-43cb-8bc7-8eb696d03443",
+          "id": "2fc9c257-4a49-478a-8dc5-806923263272",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "22a6265c-e4c8-4c74-9bc3-963bfba11f8e",
+              "id": "f5c179f2-5c32-4343-b127-b65d20a6ce74",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "c39f3a35-5907-42b9-b2aa-adbbc17a5a55",
+          "id": "8173c000-dc8d-4c97-a965-e88f50d3c1cd",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "a0ed913b-2361-4296-86e5-3e90a5d5087d",
+              "id": "1629b39c-f25e-4003-975a-996b69c14c47",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "4dc903f1-e601-4003-b8d6-07ce77b92c5a",
+          "id": "34f4131b-f52f-46de-9134-da5bd3aa8b36",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "133c498c-6aa6-4cac-87c6-1eba80930531",
+              "id": "8e1809f6-3e44-43a8-bd07-5f4d64be751c",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "b6e35aa4-0761-4c48-80a2-e9f57d5a80b6",
+          "id": "e2761a81-2972-44ae-b5ca-945685a59930",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "e69f6951-3ade-43d7-98a0-89ae1e8a7761",
+              "id": "70822453-d433-47d7-a1fb-6b262722d5a1",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "f4f53a05-0a31-4e08-97b2-676985698730",
+          "id": "cf2cd7d0-a35e-4352-be74-56d9c4edc6df",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "2c3b8802-420e-4d2b-aea3-9cbd8d2212ee",
+              "id": "5dc1e101-c856-44d0-8a48-b1aac0e4b2fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "382d725a-4a7b-4162-8f70-34593f516317",
+          "id": "5c4cbb2b-d7bb-4ce1-9960-60c0cbb399c0",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "c9aad4b6-492f-4a46-b562-2e76177f055e",
+              "id": "d8424f26-6d9c-451b-a410-b3a2bf5a00bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "e989c9d6-e967-4fd3-99e9-c0f988a1e1f4",
+          "id": "f9e386f3-62f5-4c6f-ae0a-7bf26c0ffd4e",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "ca6519d0-090f-4a45-979a-ffe77f45d759",
+              "id": "7f6e4534-9d2e-4a35-98da-ccbc6b6c3589",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "99a8f039-7d32-4feb-8d29-4f03e1dceda6",
+          "id": "4c230d6b-a2bb-4f04-a23e-42f8d5bfb484",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "f45b680f-3b2b-400c-ade7-cb8d15894bec",
+              "id": "a1c7267b-f6de-483f-96b1-a9f336061155",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "0ee5ca04-3445-4653-8313-a761974256c0",
+          "id": "c2dc5c64-cf14-499e-a3d7-b58faabba4c1",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "97e350d9-310d-4d37-adf0-c91bfd6c980c",
+              "id": "2aa1dfb0-1653-4621-9160-06bc353a7102",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "8f09fb46-905a-4b8b-a956-feb57f8857e3",
+          "id": "bfdff723-f668-441b-a3bd-e2928b34366d",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "56453aa9-4be2-4ba4-8cf3-91e4d96a45f0",
+              "id": "d2047b1e-95f2-4113-812a-f37e157eb0d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "6c30fc05-04ed-404c-8a11-d7a7b7d8ba42",
+          "id": "e303b2cc-c252-4b74-a719-769f3e58edfe",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "394ac013-a307-4a91-859f-a5ee6a04a364",
+              "id": "0f4fb4cc-b7a1-4000-8fb1-46f2329a7fbb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "67f89657-e8f5-486a-a56c-963dfe4a9d70",
+          "id": "fc560549-a405-4f17-bf29-7e91c5c15abd",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "2f47f43a-510d-40d3-a99a-6af1ec0af4b7",
+              "id": "2978cdc7-5a9d-4269-8bb2-25569a4a7573",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "b1a0c8f4-d1b0-462b-91b8-5ebf8b8e9208",
+          "id": "39cd2d52-bdd6-4710-b59e-41fd47f32420",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "4b05163b-6186-4242-a42b-385e3e4e6f85",
+              "id": "db4085e5-e706-446e-bd3b-3f2f94146dd3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "e904bf7d-934e-45d6-b9cf-b86725b57fd7",
+          "id": "4e13d092-5804-412d-9ca9-40ee75a0b689",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "ff58e70d-3c4c-4f72-9e54-0f04822836e3",
+              "id": "0fe0e104-1609-42a1-9940-3e458d27172b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "c418cbf6-f3d4-4e0e-92bc-a2566d1fdd2e",
+          "id": "5d6ed2c6-d720-41b9-b3be-555280ff751a",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "f0c84269-5231-4530-bb13-e780b0eda686",
+              "id": "6f6fcd9d-1ce1-4c38-a2ff-d32625c2e679",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "d96af7fc-e4b8-4963-9a51-5376ae0ece98",
+          "id": "233b58c9-0be7-4436-9c72-3df5f5529510",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "92db1126-a2a0-455f-9460-3835ac90b591",
+              "id": "6efb0a70-2e9a-4224-9f10-48d38e6e4a52",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "614d0944-d3d3-429c-a60d-480126688aef",
+          "id": "d486c736-d964-4f8a-9e91-7fd5857c72f0",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "0522ab5e-1056-4cc8-a17f-5ea188b27a24",
+              "id": "4ec990f5-d457-4931-a57b-a9a1af3b6668",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 9528.972029295692,\n        \"key_1\": 10.07491792738291\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 2103.8812929301143,\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 5602.632432226357,\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "e6a97f77-22c9-4e79-9523-1071b535f3f5",
+          "id": "2a7547c1-3d2f-4561-8b31-77d467ba9de2",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "35b53c51-f5ee-4ccc-96f6-1ee3d0121559",
+              "id": "ca3bb585-9de5-4e77-921d-b67c184a9bcc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "45ecd374-aaac-4f42-b5d8-3e6fca753a03",
+          "id": "018fa34b-71bb-4682-83ec-f7d084a21640",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#f658dD\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#b6212B\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "185a47e5-d6c4-4b3f-8926-447edb9e26f0",
+              "id": "4c2b4102-b5a5-422b-89f8-ede9d1634ca3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#f658dD\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#b6212B\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "2bd15ea6-dc23-4afd-9572-e9024f8ea833",
+          "id": "dbd31011-7d94-409b-9bf0-8505d1711f74",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "ecb426f3-bef6-4776-aec2-affc9e795cd4",
+              "id": "836acdd6-0192-4b1d-80c6-8a00e695aa72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "ef2801f8-6581-42bb-816f-6f284b6cd1c6",
+          "id": "56320fc6-aa62-4a83-95fa-98f783e213f7",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "5808d432-d73a-413a-842e-5ac675b0e5cd",
+              "id": "aeea2497-6a6c-4a1d-b9f3-808020e3f640",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "5ab1b749-b474-472f-876b-09acde0eb0bb",
+          "id": "271f665e-0a96-4474-b996-cdc6ff474ab3",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d0c39b\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F6D5Ef\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "af35a021-9960-4f54-9434-c349df717356",
+              "id": "fbfc2b91-dbc4-462b-bef1-e7f7fb50cec5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d0c39b\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F6D5Ef\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "2fe783b6-478c-443c-862b-8a53b104d082",
+          "id": "183b544f-0a17-48a0-8442-7e2423ab68e6",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "c5134bf1-7a76-4019-bf1e-a254d5507c5e",
+              "id": "f803aaf2-4211-4992-8003-b10dd22a6603",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "77134043-0ee5-4076-9981-f0adae49009d",
+          "id": "53fc110a-a4bb-4bad-88cd-f4839599501b",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "b312899c-d264-4389-a3e0-c0dd1b37cba0",
+              "id": "09be9b2d-6438-4a05-9db2-728be14161b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "3132a26d-54f0-4853-8687-834961b865dc",
+          "id": "9796e06c-33c6-4328-80fb-43210113c1b4",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "7197fb72-cedf-428e-99cd-2a9979b7063d",
+              "id": "4647b9e1-ac83-4c44-9422-16b8d1a5775d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "d173904e-3189-4b41-ac46-e20db6b0b6ae",
+          "id": "07fe5bb3-963a-4133-86cd-1500b1b16b9f",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "115bb8cd-56c9-4377-9262-d0a1183ee534",
+              "id": "c9806010-9d94-4d41-809b-73c396f47cc3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "17eb17b5-04e6-4800-8b91-b374aec61dc8",
+          "id": "21f4d260-f6ca-4802-8b05-a566e6fc9310",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "fbc36368-abac-44f9-aa6b-c5c89119b0f0",
+              "id": "db6ecb31-5f5a-4179-a5b1-93c922a96435",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "07e511e4-330e-4fb3-9d30-bc17119e6d8e",
+          "id": "c91d94f2-22e6-480c-85ab-35e6076ffd2d",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "dd264152-806f-4ee3-88b2-33f076f05556",
+              "id": "f7af8152-e1b4-44fd-9186-b28eb915cc46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "65ba62a1-24fd-48e1-964f-4549ba66d730",
+          "id": "544fc772-c98a-425a-b1ef-fff9ec08dc07",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "35f85f3b-5e00-4ffd-be8a-11d619008d0c",
+              "id": "af133ee0-80ba-4a3d-9859-d686a8d4b156",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 7273.618143753877,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "e09d2287-024a-4272-a9a8-2a3b1805be97",
+          "id": "aad1ef01-372e-4072-bbf4-a81b4d2a09de",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "2ba04635-0bde-4911-9ef6-e2d9d02e0b46",
+              "id": "29f32fa6-087d-43d5-b36a-f0f20eacf2d6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "37e17ee1-95c3-4115-b708-ad25b14e6027",
+          "id": "739b2d5e-db56-44dc-9e60-94fcdd79ab74",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "6e8501d3-3023-4929-9cc3-3452ddbf7cd8",
+              "id": "09576269-2e17-4af7-afea-5bcf03990bab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "262e070f-171a-46c4-8310-127c75e4f97f",
+          "id": "c03de258-63d6-43b9-b33c-ad0f372d4954",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "c899d8f1-e181-4ed4-b35a-37cc4eabcb7c",
+              "id": "1e992db7-dd5b-45a2-b8a1-2d1dcfc69d9b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "efa9764c-c3a5-42ed-8439-107e8d2c1ce1",
+          "id": "2edae6b5-17b8-4b8f-9aa7-628fd435d352",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "c78ee417-32aa-4a0a-8952-71dfab1094c1",
+              "id": "2d262e99-0f91-4535-bb0c-7b63493f3415",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "95e5a2f2-2a1f-4e69-a7bd-133e1452cd48",
+          "id": "18051fe7-b324-417e-bf0e-cf10db782766",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "9d65f6be-dde1-4aed-bbd8-3346c0c894f3",
+              "id": "efa81b6f-5b6a-424e-8ccc-5017f272ac8d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "f3a9763c-4828-4be1-8a51-f736dbf94ef9",
+          "id": "e8f7f902-a396-4bb6-9941-ed35723f30fe",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "4cdb64c2-1b27-4c88-bf22-601c2b25356c",
+              "id": "ab00824e-462f-45d2-857c-d0500050bc82",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "0ff7bc2a-d416-4fbf-afa7-5a1375cb48dc",
+          "id": "bcfccdf4-db1c-4ca1-a92c-cab7e98fde90",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "fa45861f-7eef-41c7-b8f4-28c1d61973a9",
+              "id": "c4544d8e-6899-4075-a2f5-b1998ac6fa01",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "1b22c0b7-6783-4fb0-b231-d1e8edfcdeb5",
+          "id": "f09014a7-ab37-4d6c-a170-b4efdf88aae7",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "cd4d4699-4e39-4d7c-bddf-86537db0a786",
+              "id": "3084acab-2c9e-4380-856b-0ef3f11ec490",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "cd78a690-c035-412d-a2b2-04ec49a4c58e",
+          "id": "c7d5cf03-a5bb-48d6-9b71-5c4c01f6bc4e",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "31f314e3-e971-4dce-9a86-4a8a0cfc087d",
+              "id": "a3bf746f-5f25-4a62-b54b-fc9331752db1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "99aba962-a987-4cf3-bb5b-d42501210824",
+          "id": "1e4885eb-1808-4614-b9cf-22249929bb26",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "86cab62e-01b1-41f9-9675-a6bc68939e70",
+              "id": "a7c45cff-f39e-4c30-9684-5f0c5cf7b467",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "8bb3db70-6d3a-4058-9c13-61545eed2374",
+          "id": "25ad8726-4924-4efc-bab0-1055e1de51cf",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "33dd2baf-365f-44fb-9540-a40d30c31c96",
+              "id": "5564d213-689d-4224-ab01-a4fe4dd781e5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "8398f19f-bbfa-4cc3-87b5-6b227283064a",
+          "id": "ff1bc132-5cf3-41fe-94d0-04b42fdf3e17",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "b4fbfa84-c9e7-4ccf-b233-a72e06f1c279",
+              "id": "28e96838-0e57-4c9a-922f-3655353560ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "c90854ff-743b-4ce3-a50d-94e831af0327",
+          "id": "677bd4ac-3a2d-4e17-b0be-88af2c971ad4",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "186473ae-edd0-4ce9-b66e-03224c8aff54",
+              "id": "e33ed5d2-ea35-4cad-b58a-b391501dc0b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "40ddc12c-7985-4e43-9092-c3054afa8625",
+          "id": "bc18f274-e9e4-45b5-83c8-9b6639688f63",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "f42f79a7-ab76-48e4-b027-51b531ab5d4b",
+              "id": "60541a89-486c-4f85-ae9b-62a054272121",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "96447a7b-628f-45cd-92ee-0df8990b818e",
+          "id": "33d51fd1-213f-442b-931a-bcaf652851db",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "c281dc9f-f90f-4b2d-8bc8-0c9419992e57",
+              "id": "dc8aa8cd-1e73-40a1-8239-1c3d525ee59c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "71d7f137-49d1-4499-9518-3838f7aefe68",
+          "id": "d921076c-dec3-4f8c-a20e-25ab466e784a",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "3fbc8e29-0bf9-4f11-9c5c-010ab7b502bf",
+              "id": "012766cd-0424-4be9-acc7-6bb8f1d6f3ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "02da2763-15c0-41bd-901d-6568a522bd18",
+          "id": "9c9d9122-e31a-47be-b358-f8b1b54606e8",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "db035c90-f3ed-405c-9b58-35f2f4d8b027",
+              "id": "3f7ea7ad-58b0-4e10-a409-aa732346ae13",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "efa9f079-5126-4ac8-aca7-675cf8aa4a36",
+          "id": "bfa3cbf2-b86d-41c4-9537-465de07a6ed5",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "2ede6388-f62b-470f-9bd9-9b90a4a14b80",
+              "id": "8c281cfb-811a-47df-9c60-3a22d64379aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "2d69636f-6b2e-46e6-8259-7cf1704dab3c",
+          "id": "95aa776a-309c-4e06-9865-777a44cc492c",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "d01c348e-e4ff-469a-8016-b3d58007c91f",
+              "id": "d2537e05-35ce-42f1-a7f2-029f4bacba47",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "8353ce5f-3f8d-420c-9b88-165e415ff459",
+          "id": "c00c71e9-68c3-499b-9942-de59bc355ece",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "1c4e90e0-8bb4-4bda-81fc-93c93ad45b8c",
+              "id": "0d1e09c4-6a28-42f6-a765-6e76a407de92",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "fe93b0cf-dd0e-48e7-a1a8-cb669c23b786",
+          "id": "104a7bca-543a-4edc-8d84-458dcd8b749f",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "c591fa6c-eb93-4bd8-bf08-021f3b1b7f81",
+              "id": "e285ff2e-99a6-43d8-adc4-989297265a1f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "6849edc7-2079-49ae-964d-62fd7c7f7845",
+          "id": "38b4cb28-ede4-43d5-b597-3f103d78a7e1",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7566,7 +7566,7 @@
           },
           "response": [
             {
-              "id": "40f1a7b6-e269-43ef-b586-7c98955568aa",
+              "id": "a14a9a1e-b47a-4aa4-93bf-13f82052a067",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7655,7 +7655,7 @@
           }
         },
         {
-          "id": "79d5ec60-5e0c-4df7-ac0e-e17d2f946585",
+          "id": "957901b6-79aa-4305-a821-934b95429261",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7722,7 +7722,7 @@
           },
           "response": [
             {
-              "id": "3b2aa231-e551-4a91-86bf-fca71b0edb4f",
+              "id": "1b8465e7-3581-4d3c-a08f-e84313236e49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7817,7 +7817,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "d69363c6-c3e2-46b0-b5ec-d5b563e038a7",
+          "id": "7e28c746-58a4-4fb4-80c5-71b8945cf7bc",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7870,7 +7870,7 @@
           },
           "response": [
             {
-              "id": "6391f71d-cb54-458d-a860-18524b71c0a3",
+              "id": "3177d9b1-7af9-47ee-83c5-1ea5616ccbc6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7945,7 +7945,7 @@
           }
         },
         {
-          "id": "740f1f23-72ba-40d6-9015-39157ab3d144",
+          "id": "7084f00b-0554-45ec-8524-edf658390194",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -8011,7 +8011,7 @@
           },
           "response": [
             {
-              "id": "6d10f526-5a3c-46a0-a9a8-9a04cab93bd4",
+              "id": "333c0f49-dc6f-43b2-a5f0-5149f240d7ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8099,7 +8099,7 @@
           }
         },
         {
-          "id": "3efac420-2187-4fa6-b656-00e68ad6238a",
+          "id": "47d9afe6-4da8-4e10-8d3d-371890471974",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8146,7 +8146,7 @@
           },
           "response": [
             {
-              "id": "2f41d6e5-a57e-4a14-ae09-d1ad7ef4d09f",
+              "id": "f2e16ff3-6fab-4cdf-ae9b-9903e2ab7bec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8211,7 +8211,7 @@
           }
         },
         {
-          "id": "d026b4b1-9267-4ebe-a049-7e4be1fde0fb",
+          "id": "fdbdee87-b23e-4592-b462-8babb1916ca0",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8253,7 +8253,7 @@
           },
           "response": [
             {
-              "id": "3b6e298f-380c-4c9f-ab75-f37cec05899c",
+              "id": "1d7e9187-8037-4a15-a802-5806022d56f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8317,7 +8317,7 @@
           }
         },
         {
-          "id": "e8687a19-af5a-43af-9416-46c6e5132e21",
+          "id": "d42cf437-0002-4cc0-9f67-01e7051ec46a",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8372,7 +8372,7 @@
           },
           "response": [
             {
-              "id": "e3aa396e-1f22-426f-b6f2-a3a713ec6c63",
+              "id": "9ace949c-cbe7-4c44-8a67-2b33acf27139",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8455,7 +8455,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "63945f44-0dc4-4a4e-9304-b90688014105",
+          "id": "96cc1ccd-b093-4d1f-bf41-ec5bd00ec91f",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8496,7 +8496,7 @@
           },
           "response": [
             {
-              "id": "0257a78c-66e7-40f3-b0fe-61a637b24254",
+              "id": "f0176206-2159-4667-b160-8e73eca3250c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8559,7 +8559,7 @@
           }
         },
         {
-          "id": "f8a4fca6-2781-4215-b134-3bc70f2fd99f",
+          "id": "7cb6a1af-9246-4801-8745-003fff09c638",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8613,7 +8613,7 @@
           },
           "response": [
             {
-              "id": "633d9b91-27ba-43df-a11b-7979f00e7902",
+              "id": "4356ca79-b1b2-4279-9be9-1ff6646b2979",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8689,7 +8689,7 @@
           }
         },
         {
-          "id": "0d5b2bc3-3f67-44a3-a9d5-dd1f8c17193d",
+          "id": "c5d07cf1-4226-4217-849f-df9daf3279b4",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8724,7 +8724,7 @@
           },
           "response": [
             {
-              "id": "0aa30852-6395-4dd5-8410-2257ec668f2d",
+              "id": "295ae0c5-0efa-4171-be7f-f498e70b8490",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8777,7 +8777,7 @@
           }
         },
         {
-          "id": "0b4c3340-90f4-4f2b-83c5-aa610ea0b36d",
+          "id": "27ec0787-0b97-40ea-8a34-4d1df115f8a0",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8834,7 +8834,7 @@
           },
           "response": [
             {
-              "id": "497e4383-b233-41b9-8d89-63044a95ae41",
+              "id": "0fd4b23a-e56f-4ff7-931e-dd3e7335d037",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8913,7 +8913,7 @@
           }
         },
         {
-          "id": "904126c0-fba5-42e5-bba5-dafd007d8a28",
+          "id": "d0f0bdb3-cfb2-4687-a5e4-4efb8b7f7d19",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8955,7 +8955,7 @@
           },
           "response": [
             {
-              "id": "bc5f04fa-9372-43d3-b0e3-214149f0ece8",
+              "id": "e7740d5d-0699-4ce4-b2cc-2d52612c63e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9025,7 +9025,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "dbb53759-1bf6-490f-83e8-28a454830154",
+          "id": "bbd04764-e783-40c1-a17b-7840c5f66fca",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9078,7 +9078,7 @@
           },
           "response": [
             {
-              "id": "4bc0058b-59ff-4960-aeb1-fb4dfe0b89d8",
+              "id": "5804c8b4-b90a-4ce9-b742-339b3d23f5af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9153,7 +9153,7 @@
           }
         },
         {
-          "id": "db341ee9-5557-456c-98aa-48de71f58efb",
+          "id": "a57d6fba-a206-48d2-b532-ce57aa1954f2",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9219,7 +9219,7 @@
           },
           "response": [
             {
-              "id": "a35d2078-b5ff-43b0-b7c8-ffbdfcc9b745",
+              "id": "b2ca0161-a077-484f-bf00-dc27ed6fa6e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9307,7 +9307,7 @@
           }
         },
         {
-          "id": "22fbc223-879b-4e58-bdb6-a5ded996fdfc",
+          "id": "98d07c9b-112c-491d-ac79-2c31de5631cc",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9354,7 +9354,7 @@
           },
           "response": [
             {
-              "id": "99f5f76d-876a-4f8e-810c-89a36ecab689",
+              "id": "615f20f6-48e4-4332-8aa2-92f6ae332fff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9419,7 +9419,7 @@
           }
         },
         {
-          "id": "6d285920-bee6-4de2-927b-68ad78cfce66",
+          "id": "2c84358d-a4c9-4540-bb2c-eab3b17e5dcc",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9461,7 +9461,7 @@
           },
           "response": [
             {
-              "id": "a3bb1412-9eb3-4976-9960-6fa610df71e3",
+              "id": "90c42db3-233f-482f-8c5c-c0a186530a29",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9525,7 +9525,7 @@
           }
         },
         {
-          "id": "6189b25f-8326-4d5e-93f9-9668b3154659",
+          "id": "9da2645f-3e77-408a-800b-1c4406e56afa",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9580,7 +9580,7 @@
           },
           "response": [
             {
-              "id": "72c2289a-dc9b-474c-b0e9-3d8f74e29ecd",
+              "id": "60ef7fd7-0f22-4a6b-abbf-7be882a19094",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9663,7 +9663,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "c8af8a16-9f5c-4e05-b1b8-710f2e558b83",
+          "id": "a17b1c0b-b2f1-4d4a-aa96-a760cd428ebc",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9705,7 +9705,7 @@
           },
           "response": [
             {
-              "id": "b266eced-b063-4bde-bb28-5176b965e256",
+              "id": "cdcb09aa-3349-4011-9236-bd7b2e997b07",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9769,7 +9769,7 @@
           }
         },
         {
-          "id": "b684b086-79e0-40ea-88eb-808840a45e2e",
+          "id": "d0398417-e7a1-4354-8175-a311bedd093c",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9824,7 +9824,7 @@
           },
           "response": [
             {
-              "id": "2e7a3126-2b89-4ba1-9002-38cbc84f81b0",
+              "id": "a0e176ba-4eea-4d18-8406-43f1201e8fa0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9901,7 +9901,7 @@
           }
         },
         {
-          "id": "e727cc1b-bfd5-468c-a0db-2c107b8acf6f",
+          "id": "a6c4abb7-99a9-47bc-b9d9-4f1612251c0f",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9937,7 +9937,7 @@
           },
           "response": [
             {
-              "id": "98f26b4f-d249-4e7c-b21c-f82757d10eed",
+              "id": "cfa7d286-8d2b-4ba1-a45a-342f6a7f91cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9991,7 +9991,7 @@
           }
         },
         {
-          "id": "3884059d-3a01-4bf0-a2d4-fd891a84606e",
+          "id": "07bc289c-1639-4896-8fb9-5357b47dbc20",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -10021,7 +10021,7 @@
           },
           "response": [
             {
-              "id": "969f780d-f8fc-45dc-951c-912f6d9a4623",
+              "id": "16963e78-c686-4d48-8d80-99bbb419f52e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10073,7 +10073,7 @@
           }
         },
         {
-          "id": "4c7f7560-aa24-4094-985b-5bbe554246ab",
+          "id": "f5515c3e-7d6f-4bcf-b49a-f077f117d6ae",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10116,7 +10116,7 @@
           },
           "response": [
             {
-              "id": "4d25a340-26e8-40de-a25e-db7576bf43ac",
+              "id": "7350d682-169c-485c-a250-fdf08277fe26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10187,7 +10187,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "96563097-24a7-4169-81bc-c3d9648156b2",
+          "id": "ec6c6ba5-de34-4305-b711-2a75c0976ada",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10229,7 +10229,7 @@
           },
           "response": [
             {
-              "id": "28bb29e9-7bc3-4a85-a9c1-85e5d4fab885",
+              "id": "9bf8d786-456e-43c4-b18e-993d1a7ff31d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10287,7 +10287,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "38affcb8-3e3f-459d-a430-35ee32fe8829",
+              "id": "e5702c9b-53ff-40c2-9d25-273271a0624d",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10351,7 +10351,7 @@
           }
         },
         {
-          "id": "c7e65dee-c467-4616-a77b-67596d90fe33",
+          "id": "aa7d252c-416c-4dd2-ba65-e2ebaa48a546",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10406,7 +10406,7 @@
           },
           "response": [
             {
-              "id": "9326d533-c572-45d3-a571-818f7dbc4d08",
+              "id": "615722c9-fd51-4e1f-b872-25f984e49e82",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10477,7 +10477,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "09125980-c21c-40d9-9a83-7832e5070eaf",
+              "id": "55290937-498e-45ca-9170-17d587628f66",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10548,7 +10548,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b32b82c9-b2b5-469b-939c-ca83bac6fec0",
+              "id": "d2878f1d-ae8c-4755-8672-d21bfb3bedde",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10625,7 +10625,7 @@
           }
         },
         {
-          "id": "a85a1496-dc6b-4c8c-8dc0-f6a1302765b5",
+          "id": "ffd4d8a4-ccb8-418c-aad9-f257e7024d26",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10661,7 +10661,7 @@
           },
           "response": [
             {
-              "id": "03f63bd2-68a9-42ae-aaa3-7748e122d329",
+              "id": "69bf1d99-89e8-4bf2-a22e-2c9d7b221a45",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10709,7 +10709,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "647f4cef-4752-49bf-b4a5-8e8c908d7ac3",
+              "id": "b508632d-5f3d-4db9-9f09-5e0b4b5324ab",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10757,7 +10757,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d40a27fd-a607-4417-8e6f-76afdbada3e0",
+              "id": "308d81ac-e984-4f7d-ba05-cc645cbfcc36",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
           }
         },
         {
-          "id": "e5d4ea12-ea07-4244-b846-8af0d88fbaea",
+          "id": "f930f339-3968-48d3-a51a-6281541f08d4",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10841,7 +10841,7 @@
           },
           "response": [
             {
-              "id": "b3281a16-8a22-4643-9b0d-ebd4fc6e1909",
+              "id": "4199df84-c9bf-4d1c-a722-d80cd80999ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10893,7 +10893,7 @@
           }
         },
         {
-          "id": "ccee3497-341a-497b-b6e5-b829f05cb002",
+          "id": "8d05a9d3-5b7f-447e-8d44-479b261c0ea1",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10936,7 +10936,7 @@
           },
           "response": [
             {
-              "id": "b8e4929c-6f66-4baa-8c92-e47f83d1c637",
+              "id": "9db1dbaf-6fd2-4482-afe0-7656f4f2145b",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10995,7 +10995,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "7646a1a8-ce20-4940-af6c-a424dcae5e7f",
+              "id": "15bf1039-8e56-42bc-8e4d-eaf3688c7a2e",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11066,7 +11066,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "596661e9-46e6-492d-bdbd-4e1f73df3362",
+          "id": "9ac010c9-b2a4-45f5-a66b-19415746d17f",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11150,7 +11150,7 @@
           },
           "response": [
             {
-              "id": "4dd62c34-8644-4e69-badf-37204bd577c8",
+              "id": "5930b118-8696-479e-aa51-dabbdd2c2275",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11253,7 +11253,7 @@
           }
         },
         {
-          "id": "76ba4654-b464-45cb-ae9a-3e3fa2c8daa7",
+          "id": "f0292fb4-ac01-462a-ab17-ba2b57a1d4ea",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11319,7 +11319,7 @@
           },
           "response": [
             {
-              "id": "4a105ffa-a458-438b-be27-8f8e69463ab8",
+              "id": "e6cdaa89-7304-4187-8cb8-8fdc5888e5ce",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11404,7 +11404,7 @@
           }
         },
         {
-          "id": "30740ea6-216c-4937-a457-b5a531c9e0da",
+          "id": "078af20b-9ebd-45e6-b25e-bbe3b2040f1e",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11488,7 +11488,7 @@
           },
           "response": [
             {
-              "id": "5f5b7d30-16fe-40b9-8d78-37bb6ebe4271",
+              "id": "bc4155ab-5b7e-4770-a1ee-074771b44733",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11591,7 +11591,7 @@
           }
         },
         {
-          "id": "97c5e54b-14ac-4eb3-9772-f9b54ac6e97b",
+          "id": "28bd5ddd-9740-43cb-9b51-85fc430b01c8",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11666,7 +11666,7 @@
           },
           "response": [
             {
-              "id": "b582a386-25b5-4ba7-b068-841a951cf95a",
+              "id": "f33d2c5b-71f8-4848-a534-403b09274adf",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11760,7 +11760,7 @@
           }
         },
         {
-          "id": "51fd7358-cb85-4682-a6c3-c1441d0e61cd",
+          "id": "22b081d9-723e-4e75-a0da-5b7dd5c174d9",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11835,7 +11835,7 @@
           },
           "response": [
             {
-              "id": "6e3c3daf-d501-4ca3-9b4a-ffc14b3ef84b",
+              "id": "91875e3f-28d8-4cb7-adec-dd57a9567f44",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11929,7 +11929,7 @@
           }
         },
         {
-          "id": "bb64395b-92ca-42e4-9222-121ad2a88cfa",
+          "id": "74e1419d-50ef-4940-b05a-f3aaec50a589",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -12004,7 +12004,7 @@
           },
           "response": [
             {
-              "id": "30080d5d-e582-4ae5-82b9-312a145b71d9",
+              "id": "3dd0b94a-8177-48ef-bbfa-47ae0a2b4c7f",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12104,7 +12104,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "27a8e176-b195-4e2d-9104-d4f032ece058",
+          "id": "ff4fb090-fbb5-4b68-b9ae-cb1439363b04",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12170,7 +12170,7 @@
           },
           "response": [
             {
-              "id": "6b053a0a-10c1-4da3-b5b5-0f08cbdb7e20",
+              "id": "a8bd86d0-9cf3-4692-af75-0b1b6ae06e7c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12244,7 +12244,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 7273.618143753877,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12261,7 +12261,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "2d3fc2a7-2758-4acb-a141-91a07c98fd64",
+          "id": "54d38855-e155-41d7-bf25-660bc44c04e4",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12303,7 +12303,7 @@
           },
           "response": [
             {
-              "id": "b366990e-0159-443c-b532-ead3fdfe25db",
+              "id": "10186c8d-2d02-4730-9aaf-50bf9e8b50f8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12373,7 +12373,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "028def05-c5c3-47df-8fcd-682b2d3a8cbf",
+          "id": "91ccffad-1244-4ce3-94fc-88348bba9a4f",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12412,7 +12412,7 @@
           },
           "response": [
             {
-              "id": "01b2d2ba-12ff-4419-b1bd-371cc5229dc4",
+              "id": "a1038db6-7152-4aa1-a875-09122140c9ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12465,7 +12465,7 @@
           }
         },
         {
-          "id": "2732c6b3-a181-45f3-99d1-749e0f1f9180",
+          "id": "04664213-bdf4-48d2-b519-857bd8a1310c",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12497,7 +12497,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ye-IE\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:40\",\n  \"quietHoursEnd\": \"03:10\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ie-FR\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"13:50\",\n  \"quietHoursEnd\": \"22:00\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12517,7 +12517,7 @@
           },
           "response": [
             {
-              "id": "7f3240e9-de7e-400f-a000-60f5ec59ab43",
+              "id": "1975477e-6f11-4f6c-ab58-790ae757623b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12555,7 +12555,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ye-IE\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:40\",\n  \"quietHoursEnd\": \"03:10\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ie-FR\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"13:50\",\n  \"quietHoursEnd\": \"22:00\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12589,7 +12589,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "15564b6d-0a00-417e-98cc-cb16a9b5c40e",
+          "id": "9cf524d8-dde2-4c38-9efc-49784bb7ff23",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12631,7 +12631,7 @@
           },
           "response": [
             {
-              "id": "3d85307b-f960-4b56-9f55-009230062cca",
+              "id": "4529d8fa-8afc-42a0-8c7e-6ace3532abd2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12695,7 +12695,7 @@
           }
         },
         {
-          "id": "3befa4b2-1f9a-4d59-801b-fbb120eca2ad",
+          "id": "4f3bd9cd-ed86-46ab-be5f-730981306159",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12738,7 +12738,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#A47bed\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2EeDE0\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12750,7 +12750,7 @@
           },
           "response": [
             {
-              "id": "777dbb97-fef1-425e-9f8f-c85acb981e54",
+              "id": "7f857468-d8d1-4bee-a6a1-7a78f1d5699c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12799,7 +12799,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#A47bed\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#2EeDE0\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12827,7 +12827,7 @@
           }
         },
         {
-          "id": "93dfcb47-fff0-451f-8f5e-4a4203d33774",
+          "id": "066c574a-0336-4236-ad08-bf44fbb9f04d",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12863,7 +12863,7 @@
           },
           "response": [
             {
-              "id": "bee43e9a-8871-4ecd-a23c-40f9fcc58544",
+              "id": "bd012999-6643-46f0-b955-cab71cf287af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12917,7 +12917,7 @@
           }
         },
         {
-          "id": "7d084e5b-fb58-49e7-a5fd-9751460e1500",
+          "id": "fdd78d1a-8fa0-49a3-aa81-2228fe1aa50d",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12947,7 +12947,7 @@
           },
           "response": [
             {
-              "id": "1924f9af-23c6-4c46-9a9b-84d4e412d16c",
+              "id": "eaa13b45-f835-486e-a400-e6d2afc611c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12999,7 +12999,7 @@
           }
         },
         {
-          "id": "53330990-fe0a-420b-a085-e2f0935e63c6",
+          "id": "eefb1ef8-3f8b-4fd2-af67-cbd355ccd647",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -13030,7 +13030,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d9de5c\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2070e1\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -13042,7 +13042,7 @@
           },
           "response": [
             {
-              "id": "c9452c15-fa3c-420d-86e2-543027bf95f9",
+              "id": "9e5d0861-f254-4d55-9e1b-edeea4f8050d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13079,7 +13079,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#d9de5c\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2070e1\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13107,7 +13107,7 @@
           }
         },
         {
-          "id": "0d4aea1e-d27d-4cfa-b45e-064d5b5c4af9",
+          "id": "e3e08dcd-f6c0-4461-8233-42c6e044514e",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13138,7 +13138,7 @@
           },
           "response": [
             {
-              "id": "53d5eef7-5009-4cbc-bb47-5b573690b6e3",
+              "id": "8f07efd2-c0f7-4f90-8268-9e3222363502",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13197,7 +13197,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "a2d4298d-68e5-4a68-b59e-f65625d5d0ee",
+          "id": "53eb4dec-7979-46ba-a440-ef8cd984b556",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13250,7 +13250,7 @@
           },
           "response": [
             {
-              "id": "46100447-a684-4e34-816e-ed200d73e431",
+              "id": "f658b2d6-aa6d-461c-934f-969a2f757ae2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13325,7 +13325,7 @@
           }
         },
         {
-          "id": "2b2e25c3-af77-461b-8e21-01b5c3362513",
+          "id": "413b0164-7240-49c6-80e5-7e0b403261c6",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13391,7 +13391,7 @@
           },
           "response": [
             {
-              "id": "32258e3a-cf01-4a1f-a6f3-f35dc4e89e0f",
+              "id": "811070ef-b40d-4ab7-bcad-be3b30f35201",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13479,7 +13479,7 @@
           }
         },
         {
-          "id": "e40d5597-6e13-442b-bfae-9518f227502a",
+          "id": "86ca0cb1-a5f3-4f85-a276-4c7448a14428",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13526,7 +13526,7 @@
           },
           "response": [
             {
-              "id": "be82c4d7-d696-4e61-8d2b-1ed3779a5490",
+              "id": "462cf705-5fc3-4d04-a27f-5eb45b14553b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13591,7 +13591,7 @@
           }
         },
         {
-          "id": "730c3bd0-709b-4d22-8ce6-8aaea9c9e74f",
+          "id": "a738fb1b-f886-4bb5-b723-72c14099d9b8",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13633,7 +13633,7 @@
           },
           "response": [
             {
-              "id": "3b59a819-5394-437e-b057-3f66bd4175c6",
+              "id": "e9e61cf0-c6d4-481a-aaaa-34070fe6cd60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13697,7 +13697,7 @@
           }
         },
         {
-          "id": "663ef278-7c9f-41c1-8128-a8bac8eade16",
+          "id": "bf67cb07-d17d-4f86-81f8-0e391c5488a4",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13752,7 +13752,7 @@
           },
           "response": [
             {
-              "id": "238b3fad-395d-4ee7-9965-8e9af9925410",
+              "id": "eeb82bb5-2da5-4276-8ddc-330cc05f3b6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13829,7 +13829,7 @@
           }
         },
         {
-          "id": "dcd35340-13ea-455e-868d-fed14ee25138",
+          "id": "8bcda56b-32d1-420a-9916-db3a40f15271",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13883,7 +13883,7 @@
           },
           "response": [
             {
-              "id": "bc068302-34c9-4c19-95bb-b30115dc2578",
+              "id": "3f4faa47-732c-40c2-86d1-c1ae9793797d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13959,7 +13959,7 @@
           }
         },
         {
-          "id": "caad95fc-cfe0-428e-a41b-9c6323182261",
+          "id": "2229ddbf-bdf4-4ee8-81a7-4e0fb525f751",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -14025,7 +14025,7 @@
           },
           "response": [
             {
-              "id": "f533ad45-3803-4b64-89fd-ef24423b4078",
+              "id": "8deead08-f774-4b56-83fa-0c7b7df4334a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14113,7 +14113,7 @@
           }
         },
         {
-          "id": "7e1e0c51-e13c-4ec4-84b1-7b4ec4c09cb0",
+          "id": "c4a59ab7-5baf-41c7-836a-4a1b137be607",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14191,7 +14191,7 @@
           },
           "response": [
             {
-              "id": "695e9b8a-257f-4592-b90f-55247052b328",
+              "id": "85fa03be-54cd-4256-918d-9788e8681ea0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14291,7 +14291,7 @@
           }
         },
         {
-          "id": "1eb39cd9-4cc5-4831-a6e8-566c14125d1b",
+          "id": "2ef14164-7836-4aa0-b5f2-b36ef847e15e",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14357,7 +14357,7 @@
           },
           "response": [
             {
-              "id": "541d4775-be19-4a6c-9234-e75dbe02f8cb",
+              "id": "866065fb-9734-42d4-96f6-5297a93d125f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14445,7 +14445,7 @@
           }
         },
         {
-          "id": "11052081-b942-44a8-95b3-b6886a41e806",
+          "id": "7d5a103c-49a4-485c-bae6-c208249160b8",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14500,7 +14500,7 @@
           },
           "response": [
             {
-              "id": "94d20fa5-300a-4dc2-b5ff-8a3387f8750a",
+              "id": "8756d532-cf03-4ecd-a092-23a0b8ed6146",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14583,7 +14583,7 @@
       "description": "",
       "item": [
         {
-          "id": "7df97f10-c626-4422-8e35-6ae07787cb50",
+          "id": "f6a225a1-b915-4461-8d40-9efa0fa85c04",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14624,7 +14624,7 @@
           },
           "response": [
             {
-              "id": "d91b8f08-aff9-40e5-91e0-44eff4ee0a0e",
+              "id": "31e4ea07-3f2b-48b8-9eab-9746312a2273",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14687,7 +14687,7 @@
           }
         },
         {
-          "id": "4452ced2-69ff-41e2-9072-a3fd3b6e59f4",
+          "id": "7e947965-fc19-4265-b939-e90ae6ca32a3",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14741,7 +14741,7 @@
           },
           "response": [
             {
-              "id": "b710d030-10c3-4b55-8127-1f9ac65e2218",
+              "id": "3215cf38-39b1-4e64-adc8-5853f489d860",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14817,7 +14817,7 @@
           }
         },
         {
-          "id": "3b1a2e66-10c3-472e-8f2c-2b447ff82778",
+          "id": "b5c5c555-5bf6-4976-a4bd-a0b90736d8dd",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14852,7 +14852,7 @@
           },
           "response": [
             {
-              "id": "dfaf7ff5-636b-4e3a-914e-a5f67c399225",
+              "id": "cc151217-e871-43be-80eb-920c1c90520c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14905,7 +14905,7 @@
           }
         },
         {
-          "id": "dd488fb4-ef92-46d2-98c1-8ad385450165",
+          "id": "19942507-1bc1-420b-b34a-db84bee3739b",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14966,7 +14966,7 @@
           },
           "response": [
             {
-              "id": "85856842-c77b-4686-b455-6b0b26873c87",
+              "id": "28865f3c-a4e2-4409-a346-2675552100e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15049,7 +15049,7 @@
           }
         },
         {
-          "id": "1cb443de-bf7f-411a-ab44-a3acdd1d7365",
+          "id": "662947ca-9956-4eb3-aaea-f5123e8b89aa",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15091,7 +15091,7 @@
           },
           "response": [
             {
-              "id": "075d99d8-0648-459c-a4db-b0295c3d99a7",
+              "id": "43ee4098-d073-4dad-92e2-a43468baffe5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15155,7 +15155,7 @@
           }
         },
         {
-          "id": "460315fb-6d8e-43b0-be9f-613f23e5a58e",
+          "id": "fdb97e31-f50b-4d9c-9ce2-9e8ac8fe3561",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15230,7 +15230,7 @@
           },
           "response": [
             {
-              "id": "39ef4bdf-4ba9-45ff-b3b7-008e2e4403fd",
+              "id": "d1b7fb22-ec5a-401b-bbcd-14ca5f309ce2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15327,7 +15327,7 @@
           }
         },
         {
-          "id": "157280d6-70d9-4175-adc3-a8fc53fedd60",
+          "id": "fa0bed6b-70f9-4550-960e-c0d6e613c4a3",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15369,7 +15369,7 @@
           },
           "response": [
             {
-              "id": "93bb90ea-dd27-4469-a42a-a2a9da8b38c9",
+              "id": "0d5fd0cf-14f4-465f-8b7b-69368e46a0f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15433,7 +15433,7 @@
           }
         },
         {
-          "id": "2aca88d5-e609-4fc8-b8e7-aa33adf2a115",
+          "id": "bb2951e2-cc34-4b93-9939-6a3169a7a7cf",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15476,7 +15476,7 @@
           },
           "response": [
             {
-              "id": "de762741-7a1b-440c-9fe1-c88bb0f0ec1e",
+              "id": "a4e5ae59-6656-4482-aaf1-79af23554e65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15541,7 +15541,7 @@
           }
         },
         {
-          "id": "37c389ff-ef58-4cd4-99cd-32056b38c9d0",
+          "id": "e7603188-17e4-49cd-9f6f-c11817b00316",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15584,7 +15584,7 @@
           },
           "response": [
             {
-              "id": "c8277d56-7ca6-4d0e-ad3d-1f58a1a58467",
+              "id": "0d87d576-3c88-4f24-893a-981e62cdbd03",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15649,7 +15649,7 @@
           }
         },
         {
-          "id": "8799ff31-c3cd-4078-911d-1d27c696ad60",
+          "id": "64a9bc4a-8e10-4634-a479-481d3b792d72",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15701,7 +15701,7 @@
           },
           "response": [
             {
-              "id": "03d958d4-5a4f-4d84-b9c6-93cf9624e9be",
+              "id": "3d1fb4bf-2d2b-4585-947d-d9f7d5ff359d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15775,7 +15775,7 @@
           }
         },
         {
-          "id": "9d9b9901-e4c6-4e54-8b63-1404a7c96648",
+          "id": "04bf6cad-1d14-4396-ab3f-057fbd86056e",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15817,7 +15817,7 @@
           },
           "response": [
             {
-              "id": "56273ea3-40b8-4148-9ceb-394ae5ad7285",
+              "id": "0ab7dc0b-8c58-4046-b384-ce07566d5a91",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15881,7 +15881,7 @@
           }
         },
         {
-          "id": "38dca605-3c79-450d-be23-837ebd59c819",
+          "id": "901e9ea2-55dc-4892-979f-fb554b436d2f",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15934,7 +15934,7 @@
           },
           "response": [
             {
-              "id": "7acaf532-1497-43ac-9872-0ae8eacc089e",
+              "id": "6babce23-3bf7-4ff9-9a71-eafbd1ad718a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16009,7 +16009,7 @@
           }
         },
         {
-          "id": "256aeb37-ea6e-483c-9b44-8cb5ce04ff77",
+          "id": "ccfe8d16-51dd-4457-b0c8-cc2c8937fa4e",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -16062,7 +16062,7 @@
           },
           "response": [
             {
-              "id": "78d7150c-e814-46c7-81b5-ce4bb68621d5",
+              "id": "a2ca7908-e319-4f9c-b1ca-71759490142b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16137,7 +16137,7 @@
           }
         },
         {
-          "id": "b84b47de-1bc2-4855-ab5d-9a9938e25614",
+          "id": "ec003f9e-bd9d-4b62-9213-932a8e3165e7",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16181,7 +16181,7 @@
           },
           "response": [
             {
-              "id": "1e4f0d91-0344-4083-adaf-6837aa617caa",
+              "id": "ca05bae2-e278-4081-b367-3e273480f2a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16247,7 +16247,7 @@
           }
         },
         {
-          "id": "17c291d0-d67e-47dc-b654-293ab28cee31",
+          "id": "a29d1e66-7226-4e45-bc1d-520d309269ca",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16291,7 +16291,7 @@
           },
           "response": [
             {
-              "id": "d3589deb-a11d-48a9-bf36-dca06d17ca1b",
+              "id": "0e37f5d2-7798-40d1-9ea2-fb98a8da23b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16363,7 +16363,7 @@
       "description": "",
       "item": [
         {
-          "id": "c58a25af-a8a0-4e44-b9eb-e3fbae047c6c",
+          "id": "ad032349-ce2a-4e81-ba9e-56ea9544de68",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16405,7 +16405,7 @@
           },
           "response": [
             {
-              "id": "fa6bb830-18c4-4112-9a34-56680b9f5704",
+              "id": "a210dbe5-fc83-488e-bda9-c039e2cfb6f6",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16454,7 +16454,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f87e2928-6363-4b13-8604-69635ca3bdda",
+              "id": "3fc9a059-0faa-474d-8c88-97206d3104e6",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16509,7 +16509,7 @@
           }
         },
         {
-          "id": "b7265d08-dd65-421c-804d-c2774ac50996",
+          "id": "d2b35f94-7199-4e0f-8a0c-f3ed7474ae2f",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16555,7 +16555,7 @@
           },
           "response": [
             {
-              "id": "b363117b-cd95-49a7-9b5a-5b301430e842",
+              "id": "ed785efd-0ca1-4f55-b15a-c8971b5c44a9",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16614,7 +16614,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "92cabdab-7c41-4580-8f6b-106ed58f50e0",
+              "id": "68dfcab1-0f71-43c0-b1e9-7659ec07b16c",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16679,7 +16679,7 @@
           }
         },
         {
-          "id": "cacde3a2-e864-435e-b0cb-16c013b1246d",
+          "id": "d4595e2f-b218-484d-8d7a-bb605e48ad0c",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16725,7 +16725,7 @@
           },
           "response": [
             {
-              "id": "e6b5b4f4-d5f7-485f-8ef8-2be446fbe8eb",
+              "id": "6cba3e9d-2d31-4984-ab6c-4feed1db1ab2",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16784,7 +16784,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e0e45dd9-eaea-47a9-a1a9-73351a59c179",
+              "id": "088f0f12-ce51-483e-9f3c-d7ce8c2aad74",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16843,7 +16843,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "5382c3ea-1eb6-4b5f-837b-4e7553003265",
+              "id": "7d968b91-11ba-4003-8872-e20d16ae4b4a",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16902,7 +16902,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a29870f6-4450-4529-9561-8e5adfd885b3",
+              "id": "df588a32-fd68-4bf0-982a-3c29a2fd018d",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16967,7 +16967,7 @@
           }
         },
         {
-          "id": "b3b67fc0-1a0f-48f6-b0dd-03e0c41e1688",
+          "id": "d82306cc-e6af-4e1a-9204-8f280d9dfe10",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -17013,7 +17013,7 @@
           },
           "response": [
             {
-              "id": "7c268af3-a245-4b0f-9009-438668bce8ac",
+              "id": "f5359e43-13f7-4b83-9dc5-cfb665c69a5d",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -17072,7 +17072,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4da15659-db0d-40e5-85a3-9e3ac04bf052",
+              "id": "36ccb2e8-06b7-4710-91b3-2374dc76a663",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17137,7 +17137,7 @@
           }
         },
         {
-          "id": "662a85b3-2c50-46b0-9de3-5a8a03e497a4",
+          "id": "876549c2-63cd-46e0-b56b-7fc8634e82c5",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17179,7 +17179,7 @@
           },
           "response": [
             {
-              "id": "502ce310-3213-44c4-a6e9-7ab0daea7816",
+              "id": "c90a9dd3-5b11-4d4a-ba7a-8832a9a65da3",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17240,7 +17240,7 @@
       "description": "",
       "item": [
         {
-          "id": "dfcee392-0a9d-4c92-bb92-1e3c7d43ad0f",
+          "id": "ab42eccf-4054-4c31-b1c6-8867c72be116",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17289,7 +17289,7 @@
           },
           "response": [
             {
-              "id": "8af89467-8826-4a9e-8730-95828888f216",
+              "id": "1563c544-d4af-447a-bb78-436d47165b0f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17349,7 +17349,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 7273.618143753877,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17360,7 +17360,7 @@
           }
         },
         {
-          "id": "d862cdd5-d4a4-40ce-aef5-02fd867a14e1",
+          "id": "e6c33d33-92b2-4e82-aee5-5a12b41c6247",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17409,7 +17409,7 @@
           },
           "response": [
             {
-              "id": "25008b5f-472d-44cf-b865-dcb57f7d48ed",
+              "id": "fd92c98d-0188-4652-91bf-49b11f32f252",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17480,7 +17480,7 @@
           }
         },
         {
-          "id": "3ae10608-d876-4d9d-b10c-d5631876f11c",
+          "id": "307eb728-e4e4-4184-aa5c-a4a8f5d1bb45",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17529,7 +17529,7 @@
           },
           "response": [
             {
-              "id": "b40d7b8a-2ad7-445f-ab06-d20dde00e4d2",
+              "id": "7364c175-0ad9-4eb6-99ba-9d8254a46bb8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17600,7 +17600,7 @@
           }
         },
         {
-          "id": "6637206a-f205-4d01-818d-869f7a098798",
+          "id": "65577c20-43ec-4469-b7d4-b9b8ac257afd",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17649,7 +17649,7 @@
           },
           "response": [
             {
-              "id": "d2bd2b0e-d489-42ca-ab4b-c0e95d1c9d09",
+              "id": "a5af0da5-c722-4ef6-a33f-c30a9c5add3c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17726,7 +17726,7 @@
       "description": "",
       "item": [
         {
-          "id": "4c96c278-05fe-4623-8690-4b31f58567d6",
+          "id": "2e9cdeda-1f15-4ae9-a7f5-1ee8aaefbb4f",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17766,7 +17766,7 @@
           },
           "response": [
             {
-              "id": "ca49cbec-195e-4566-8456-3d118acebebe",
+              "id": "58037bb4-09eb-4ba5-be45-d51f96ccf33b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17828,7 +17828,7 @@
           }
         },
         {
-          "id": "a543e622-dbe5-441c-a053-a63b88e86a26",
+          "id": "053376c3-16b5-4e6d-adb6-85405ec046ba",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17858,7 +17858,7 @@
           },
           "response": [
             {
-              "id": "e0cfad5a-8c95-4437-bb48-6bb13e3d676e",
+              "id": "45ffd99f-e115-4026-93e6-1a20a2d944a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17899,7 +17899,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 7273.618143753877,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17910,7 +17910,7 @@
           }
         },
         {
-          "id": "8f03b62c-2cd5-420c-a832-4bbf2744d275",
+          "id": "9c94319b-9e08-49fd-828b-faab76a870f1",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17962,7 +17962,7 @@
           },
           "response": [
             {
-              "id": "9b19b212-d221-42a0-b4f7-58278a1688b8",
+              "id": "5bbe12af-49cf-4d06-af36-43e41b54616b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18042,7 +18042,7 @@
       "description": "",
       "item": [
         {
-          "id": "799182be-ca6c-4036-8f74-74128bf08a6c",
+          "id": "00aadf8d-1bfd-4434-bf78-34b4190fc10a",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -18071,7 +18071,7 @@
           },
           "response": [
             {
-              "id": "31d23fd8-f4d5-451f-8de2-9fc1ade5421f",
+              "id": "797f099c-a85c-4556-ab02-79eeacb37582",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18122,7 +18122,7 @@
           }
         },
         {
-          "id": "01b3286b-78ed-4262-b742-e7b8aea11b77",
+          "id": "3883cf10-704b-4c3e-9bb2-ead76147004c",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18163,7 +18163,7 @@
           },
           "response": [
             {
-              "id": "422f3fc2-3f9a-498a-bef4-6a7afea6b4a2",
+              "id": "2479f9e5-ae0c-4e1c-b148-dbf0911e8a99",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18232,7 +18232,7 @@
       "description": "",
       "item": [
         {
-          "id": "a5f3815d-ca42-4eb6-8156-a37b3141520d",
+          "id": "abb0b60a-2651-4a08-b621-3dcfd17c6e3b",
           "name": "health",
           "request": {
             "name": "health",
@@ -18261,7 +18261,7 @@
           },
           "response": [
             {
-              "id": "06763d98-9307-4020-b9cb-1d993068f890",
+              "id": "e8982054-cb47-4f31-902c-aba7ba21d605",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18301,7 +18301,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\"\n}",
+              "body": "{\n  \"key_0\": 7273.618143753877,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18318,7 +18318,7 @@
       "description": "",
       "item": [
         {
-          "id": "496d4361-24be-456e-bf70-7d36bda701e9",
+          "id": "13be2532-4ce5-4ad9-b094-45521b9f3bc0",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18370,7 +18370,7 @@
           },
           "response": [
             {
-              "id": "b6e5d5bc-ce19-4aa8-bc1f-3ee81e9ed68c",
+              "id": "c1d04619-6bae-4677-bd7e-969b62e497f5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18444,7 +18444,7 @@
           }
         },
         {
-          "id": "d98df4d3-5cfa-4868-85dd-fa9669b46788",
+          "id": "db01507e-d94d-4436-8b42-1d75484a95e1",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18485,7 +18485,7 @@
           },
           "response": [
             {
-              "id": "629411ec-4280-4924-9913-daa5f7ef1a2c",
+              "id": "405fd880-fae2-43d2-aca3-daa09f91bbf8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18537,7 +18537,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_3\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18548,7 +18548,7 @@
           }
         },
         {
-          "id": "52d1d618-976e-4d07-b635-6a58c7d32a9c",
+          "id": "cf66f427-16d6-4efe-9c1c-cb96c3bec7f8",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18578,7 +18578,7 @@
           },
           "response": [
             {
-              "id": "53612fc0-5add-4050-8191-81b944adff5a",
+              "id": "e889eee8-57f3-4baf-a4b0-46ba29f8f38f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18619,7 +18619,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18650,9 +18650,9 @@
     }
   ],
   "info": {
-    "_postman_id": "ed4e6421-a7dc-40e7-955d-7efe4d504e8e",
+    "_postman_id": "60802c77-f7e3-49f7-b33a-a2dd10e69cbb",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 00:30 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 01:00 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryJpaRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryJpaRepository.kt
@@ -24,9 +24,9 @@ interface AlertHistoryJpaRepository : JpaRepository<AlertStateChange, Long> {
     @Query(
         value = """
             SELECT COUNT(*)
-              FROM metadata.alert_state_changes asc
-              JOIN metadata.alerts a ON a.id = asc.alert_id
-             WHERE asc.alert_id = :alertId
+              FROM metadata.alert_state_changes c
+              JOIN metadata.alerts a ON a.id = c.alert_id
+             WHERE c.alert_id = :alertId
                AND a.tenant_id = :tenantId
         """,
         nativeQuery = true

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapter.kt
@@ -57,7 +57,7 @@ class AlertHistoryQueryAdapter(
 
         val orderDir = if (order == SortOrder.ASC) "ASC" else "DESC"
         val sql = transitionSql(
-            extraWhere = "AND asc.alert_id = ?",
+            extraWhere = "AND c.alert_id = ?",
             orderDir = orderDir,
             limit = "ALL",
             offset = "0",
@@ -142,17 +142,16 @@ class AlertHistoryQueryAdapter(
         offset: String,
     ): String = """
         SELECT
-          asc.id                         AS transition_id,
-          asc.at,
-          asc.from_resolved,
-          asc.to_resolved,
-          asc.source,
-          asc.raw_value,
-          asc.actor_kind,
-          asc.actor_user_id,
-          asc.actor_ref,
+          c.id                           AS transition_id,
+          c.at,
+          c.from_resolved,
+          c.to_resolved,
+          c.source,
+          c.raw_value,
+          c.actor_kind,
+          c.actor_user_id,
+          c.actor_ref,
           u.username,
-          u.display_name,
           a.id                           AS alert_id,
           a.code                         AS alert_code,
           a.message                      AS alert_message,
@@ -167,48 +166,48 @@ class AlertHistoryQueryAdapter(
           sec.code                       AS sector_code,
           sec.greenhouse_id,
           g.name                         AS greenhouse_name,
-          LAG(asc.at)
-            OVER (PARTITION BY asc.alert_id ORDER BY asc.at)
+          LAG(c.at)
+            OVER (PARTITION BY c.alert_id ORDER BY c.at)
                                          AS previous_transition_at,
           -- PG16 does not support LAST_VALUE(... IGNORE NULLS); use MAX over CASE
           -- which naturally ignores NULLs and returns the most recent OPEN before this row.
-          CASE WHEN asc.to_resolved = TRUE THEN
-            MAX(CASE WHEN asc.to_resolved = FALSE THEN asc.at END)
-              OVER (PARTITION BY asc.alert_id ORDER BY asc.at
+          CASE WHEN c.to_resolved = TRUE THEN
+            MAX(CASE WHEN c.to_resolved = FALSE THEN c.at END)
+              OVER (PARTITION BY c.alert_id ORDER BY c.at
                     ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
           END                            AS episode_started_at,
           NULLIF(
-            COUNT(*) FILTER (WHERE asc.to_resolved = FALSE)
-              OVER (PARTITION BY asc.alert_id ORDER BY asc.at
+            COUNT(*) FILTER (WHERE c.to_resolved = FALSE)
+              OVER (PARTITION BY c.alert_id ORDER BY c.at
                     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
             0
           )                              AS occurrence_number,
           ROW_NUMBER()
-            OVER (PARTITION BY asc.alert_id ORDER BY asc.at)
+            OVER (PARTITION BY c.alert_id ORDER BY c.at)
                                          AS total_transitions_so_far
-        FROM metadata.alert_state_changes asc
-        JOIN metadata.alerts a      ON a.id = asc.alert_id
-        LEFT JOIN metadata.users u  ON u.id = asc.actor_user_id
+        FROM metadata.alert_state_changes c
+        JOIN metadata.alerts a      ON a.id = c.alert_id
+        LEFT JOIN metadata.users u  ON u.id = c.actor_user_id
         LEFT JOIN metadata.alert_types at2  ON at2.id = a.alert_type_id
         LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
         LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
         LEFT JOIN metadata.greenhouses g ON g.id = sec.greenhouse_id
         WHERE a.tenant_id = ?
-          AND asc.at >= ?
-          AND asc.at < ?
+          AND c.at >= ?
+          AND c.at < ?
           $extraWhere
-        ORDER BY asc.at $orderDir
+        ORDER BY c.at $orderDir
         LIMIT $limit OFFSET $offset
     """.trimIndent()
 
     private fun countTransitionSql(whereClauses: String): String = """
         SELECT COUNT(*)
-          FROM metadata.alert_state_changes asc
-          JOIN metadata.alerts a      ON a.id = asc.alert_id
+          FROM metadata.alert_state_changes c
+          JOIN metadata.alerts a      ON a.id = c.alert_id
           LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
          WHERE a.tenant_id = ?
-           AND asc.at >= ?
-           AND asc.at < ?
+           AND c.at >= ?
+           AND c.at < ?
            $whereClauses
     """.trimIndent()
 
@@ -226,7 +225,7 @@ class AlertHistoryQueryAdapter(
         )
 
         if (query.sources.isNotEmpty()) {
-            clauses.append(" AND asc.source = ANY(?::VARCHAR[])")
+            clauses.append(" AND c.source = ANY(?::VARCHAR[])")
             params.add(query.sources.toTypedArray<String>().joinToPostgresArray())
         }
         if (query.severityIds.isNotEmpty()) {
@@ -250,12 +249,12 @@ class AlertHistoryQueryAdapter(
             params.add(query.codes.toTypedArray<String>().joinToPostgresArray())
         }
         if (query.actorUserIds.isNotEmpty()) {
-            clauses.append(" AND asc.actor_user_id = ANY(?::BIGINT[])")
+            clauses.append(" AND c.actor_user_id = ANY(?::BIGINT[])")
             params.add(query.actorUserIds.joinToString(",", "{", "}"))
         }
         when (query.transitionKind) {
-            TransitionKind.OPEN -> clauses.append(" AND asc.to_resolved = FALSE")
-            TransitionKind.CLOSE -> clauses.append(" AND asc.to_resolved = TRUE")
+            TransitionKind.OPEN -> clauses.append(" AND c.to_resolved = FALSE")
+            TransitionKind.CLOSE -> clauses.append(" AND c.to_resolved = TRUE")
             TransitionKind.ANY -> { /* no clause */ }
         }
 
@@ -276,12 +275,10 @@ class AlertHistoryQueryAdapter(
           open_asc.actor_user_id      AS trigger_actor_user_id,
           open_asc.actor_ref          AS trigger_actor_ref,
           open_u.username             AS trigger_username,
-          open_u.display_name         AS trigger_display_name,
           close_asc.actor_kind        AS resolve_actor_kind,
           close_asc.actor_user_id     AS resolve_actor_user_id,
           close_asc.actor_ref         AS resolve_actor_ref,
           close_u.username            AS resolve_username,
-          close_u.display_name        AS resolve_display_name,
           a.severity_id,
           sev.name                    AS severity_name,
           a.sector_id,
@@ -338,12 +335,15 @@ class AlertHistoryQueryAdapter(
         val actorUserId = rs.getLong("actor_user_id").takeIf { !rs.wasNull() }
         val actorRef = rs.getString("actor_ref")
         val username = rs.getString("username")
-        val displayName = rs.getString("display_name")
+        // displayName falls back to username — `metadata.users` does not store a separate
+        // display_name column; the read path mirrors what UserLookupAdapter already does
+        // for FCM rendering (see UserLookupAdapter.kt). Keeping the field non-null when
+        // possible lets clients show "resolved by <name>" without extra branching.
         val actor: AlertActor = when (actorKind) {
             "USER" -> AlertActor.User(
                 userId = actorUserId ?: 0L,
                 username = username,
-                displayName = displayName,
+                displayName = username,
             )
             "DEVICE" -> AlertActor.Device(deviceRef = actorRef)
             else -> AlertActor.System
@@ -394,21 +394,24 @@ class AlertHistoryQueryAdapter(
                 else -> AlertActor.System
             }
 
+        // displayName falls back to username — see comment in mapTransition.
+        val triggerUsername = rs.getString("trigger_username")
         val triggerActor = actorFrom(
             rs.getString("trigger_actor_kind"),
             rs.getLong("trigger_actor_user_id").takeIf { !rs.wasNull() },
             rs.getString("trigger_actor_ref"),
-            rs.getString("trigger_username"),
-            rs.getString("trigger_display_name"),
+            triggerUsername,
+            triggerUsername,
         )
         val resolveActorKind = rs.getString("resolve_actor_kind")
         val resolveActor: AlertActor? = if (resolveActorKind != null) {
+            val resolveUsername = rs.getString("resolve_username")
             actorFrom(
                 resolveActorKind,
                 rs.getLong("resolve_actor_user_id").takeIf { !rs.wasNull() },
                 rs.getString("resolve_actor_ref"),
-                rs.getString("resolve_username"),
-                rs.getString("resolve_display_name"),
+                resolveUsername,
+                resolveUsername,
             )
         } else null
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapter.kt
@@ -50,17 +50,17 @@ class AlertStatsQueryAdapter(
         val sql = """
             SELECT $groupByCol AS key, $labelCol AS label,
                    COUNT(*) AS cnt,
-                   MAX(asc.at) AS last_seen_at
-              FROM metadata.alert_state_changes asc
-              JOIN metadata.alerts a      ON a.id = asc.alert_id
+                   MAX(c.at) AS last_seen_at
+              FROM metadata.alert_state_changes c
+              JOIN metadata.alerts a      ON a.id = c.alert_id
               LEFT JOIN metadata.alert_types at2  ON at2.id = a.alert_type_id
               LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
               LEFT JOIN metadata.sectors sec ON sec.id = a.sector_id
               LEFT JOIN metadata.greenhouses g ON g.id = sec.greenhouse_id
              WHERE a.tenant_id = ?
-               AND asc.to_resolved = FALSE
-               AND asc.at >= ?
-               AND asc.at < ?
+               AND c.to_resolved = FALSE
+               AND c.at >= ?
+               AND c.at < ?
              GROUP BY key, label
              ORDER BY cnt DESC
              LIMIT ?
@@ -101,13 +101,13 @@ class AlertStatsQueryAdapter(
         val (groupByCol, labelCol) = mttrGroupByColumns(query.groupBy)
         val sql = """
             SELECT $groupByCol AS key, $labelCol AS label,
-                   AVG(EXTRACT(EPOCH FROM (cl.at - op.at)))             AS mttr_avg,
+                   AVG(EXTRACT(EPOCH FROM (cl.at - pairs.at)))             AS mttr_avg,
                    PERCENTILE_CONT(0.5) WITHIN GROUP
-                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - op.at)))     AS p50,
+                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - pairs.at)))     AS p50,
                    PERCENTILE_CONT(0.95) WITHIN GROUP
-                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - op.at)))     AS p95,
+                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - pairs.at)))     AS p95,
                    PERCENTILE_CONT(0.99) WITHIN GROUP
-                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - op.at)))     AS p99,
+                     (ORDER BY EXTRACT(EPOCH FROM (cl.at - pairs.at)))     AS p99,
                    COUNT(*)                                              AS sample_size
               FROM (
                 SELECT op.alert_id,
@@ -170,17 +170,17 @@ class AlertStatsQueryAdapter(
         }
         val (groupByCol, _) = timeseriesGroupByColumns(query.groupBy)
         val sql = """
-            SELECT date_trunc('$truncUnit', asc.at AT TIME ZONE 'UTC') AS bucket_start,
-                   $groupByCol                                          AS key,
-                   COUNT(*) FILTER (WHERE asc.to_resolved = FALSE)     AS opened,
-                   COUNT(*) FILTER (WHERE asc.to_resolved = TRUE)      AS closed
-              FROM metadata.alert_state_changes asc
-              JOIN metadata.alerts a      ON a.id = asc.alert_id
+            SELECT date_trunc('$truncUnit', c.at AT TIME ZONE 'UTC') AS bucket_start,
+                   $groupByCol                                        AS key,
+                   COUNT(*) FILTER (WHERE c.to_resolved = FALSE)     AS opened,
+                   COUNT(*) FILTER (WHERE c.to_resolved = TRUE)      AS closed
+              FROM metadata.alert_state_changes c
+              JOIN metadata.alerts a      ON a.id = c.alert_id
               LEFT JOIN metadata.alert_severities sev ON sev.id = a.severity_id
               LEFT JOIN metadata.alert_types at2      ON at2.id = a.alert_type_id
              WHERE a.tenant_id = ?
-               AND asc.at >= ?
-               AND asc.at < ?
+               AND c.at >= ?
+               AND c.at < ?
              GROUP BY bucket_start, key
              ORDER BY bucket_start ASC, key ASC
         """.trimIndent()
@@ -216,7 +216,7 @@ class AlertStatsQueryAdapter(
         val (groupByCol, labelCol) = activeDurationGroupByColumns(query.groupBy)
         val sql = """
             SELECT $groupByCol AS key, $labelCol AS label,
-                   SUM(EXTRACT(EPOCH FROM (cl.at - op.at)))::BIGINT AS total_active_seconds
+                   SUM(EXTRACT(EPOCH FROM (cl.at - pairs.at)))::BIGINT AS total_active_seconds
               FROM (
                 SELECT op.alert_id,
                        op.at,
@@ -261,29 +261,31 @@ class AlertStatsQueryAdapter(
     @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
     override fun byActor(query: ByActorStatsQuery): List<ByActorBucket> {
         val toResolved = query.role == ActorStatsRole.RESOLVER
+        // displayName falls back to username — `metadata.users` does not store a separate
+        // display_name column. See AlertHistoryQueryAdapter.mapTransition for the same pattern.
         val sql = """
-            SELECT asc.actor_user_id,
+            SELECT c.actor_user_id,
                    u.username,
-                   u.display_name,
                    COUNT(*) AS cnt
-              FROM metadata.alert_state_changes asc
-              JOIN metadata.alerts a ON a.id = asc.alert_id
-              LEFT JOIN metadata.users u ON u.id = asc.actor_user_id
+              FROM metadata.alert_state_changes c
+              JOIN metadata.alerts a ON a.id = c.alert_id
+              LEFT JOIN metadata.users u ON u.id = c.actor_user_id
              WHERE a.tenant_id = ?
-               AND asc.actor_kind = 'USER'
-               AND asc.to_resolved = ?
-               AND asc.at >= ?
-               AND asc.at < ?
-             GROUP BY asc.actor_user_id, u.username, u.display_name
+               AND c.actor_kind = 'USER'
+               AND c.to_resolved = ?
+               AND c.at >= ?
+               AND c.at < ?
+             GROUP BY c.actor_user_id, u.username
              ORDER BY cnt DESC
         """.trimIndent()
 
         return jdbc.query(sql,
             { rs, _ ->
+                val username = rs.getString("username")
                 ByActorBucket(
                     actorUserId = rs.getLong("actor_user_id"),
-                    username = rs.getString("username"),
-                    displayName = rs.getString("display_name"),
+                    username = username,
+                    displayName = username,
                     count = rs.getLong("cnt"),
                 )
             },
@@ -317,25 +319,25 @@ class AlertStatsQueryAdapter(
         ) ?: 0L
 
         val openedToday = jdbc.queryForObject(
-            """SELECT COUNT(*) FROM metadata.alert_state_changes asc
-               JOIN metadata.alerts a ON a.id = asc.alert_id
-               WHERE a.tenant_id = ? AND asc.to_resolved = FALSE
-                 AND asc.at >= ? AND asc.at < ?""",
+            """SELECT COUNT(*) FROM metadata.alert_state_changes c
+               JOIN metadata.alerts a ON a.id = c.alert_id
+               WHERE a.tenant_id = ? AND c.to_resolved = FALSE
+                 AND c.at >= ? AND c.at < ?""",
             Long::class.java,
             tenantId.value, Timestamp.from(todayStart), Timestamp.from(todayEnd),
         ) ?: 0L
 
         val closedToday = jdbc.queryForObject(
-            """SELECT COUNT(*) FROM metadata.alert_state_changes asc
-               JOIN metadata.alerts a ON a.id = asc.alert_id
-               WHERE a.tenant_id = ? AND asc.to_resolved = TRUE
-                 AND asc.at >= ? AND asc.at < ?""",
+            """SELECT COUNT(*) FROM metadata.alert_state_changes c
+               JOIN metadata.alerts a ON a.id = c.alert_id
+               WHERE a.tenant_id = ? AND c.to_resolved = TRUE
+                 AND c.at >= ? AND c.at < ?""",
             Long::class.java,
             tenantId.value, Timestamp.from(todayStart), Timestamp.from(todayEnd),
         ) ?: 0L
 
         val mttrTodaySeconds = jdbc.queryForObject(
-            """SELECT AVG(EXTRACT(EPOCH FROM (cl.at - op.at)))
+            """SELECT AVG(EXTRACT(EPOCH FROM (cl.at - pairs.at)))
                FROM (
                  SELECT op.alert_id, op.at,
                         LEAD(op.id) OVER (PARTITION BY op.alert_id ORDER BY op.at) AS close_id
@@ -351,10 +353,10 @@ class AlertStatsQueryAdapter(
 
         val top3Codes = jdbc.query(
             """SELECT a.code, COUNT(*) AS cnt
-               FROM metadata.alert_state_changes asc
-               JOIN metadata.alerts a ON a.id = asc.alert_id
-               WHERE a.tenant_id = ? AND asc.to_resolved = FALSE
-                 AND asc.at >= ? AND asc.at < ?
+               FROM metadata.alert_state_changes c
+               JOIN metadata.alerts a ON a.id = c.alert_id
+               WHERE a.tenant_id = ? AND c.to_resolved = FALSE
+                 AND c.at >= ? AND c.at < ?
                GROUP BY a.code
                ORDER BY cnt DESC
                LIMIT 3""",

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapterIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertHistoryQueryAdapterIntegrationTest.kt
@@ -1,0 +1,136 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.domain.model.TransitionKind
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEpisodesQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.AlertEventsQuery
+import com.apptolast.invernaderos.features.shared.domain.model.SortOrder
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * SQL contract tests against the live DEV `metadata` Postgres.
+ *
+ * Goal: prove that every native SQL the adapter emits PARSES and EXECUTES
+ * against a real Postgres 16, exercising columns and aliases that JdbcTemplate
+ * unit-stubs would never catch. PR-1 (asc reserved-word alias + non-existent
+ * `users.display_name`) shipped to prod precisely because there was no test
+ * at this layer.
+ *
+ * We do NOT assert on row content — DEV DB is shared and rebuilt by Flyway,
+ * so seeding fixtures here would race with other tests. The contract these
+ * tests defend is "SQL is valid"; row content is covered by smoke curl
+ * post-deploy and unit tests on the use-case layer.
+ *
+ * Requires INVERNADEROS_TEST_DB_PASSWORD env var to be set (resolved in
+ * src/test/resources/application.yaml).
+ */
+@SpringBootTest
+class AlertHistoryQueryAdapterIntegrationTest {
+
+    @Autowired
+    private lateinit var adapter: AlertHistoryQueryAdapter
+
+    private val anyTenant = TenantId(1L)
+    private val anyAlertId = 1L
+
+    private fun defaultEventsQuery(): AlertEventsQuery = AlertEventsQuery(
+        tenantId = anyTenant,
+        from = Instant.now().minus(30, ChronoUnit.DAYS),
+        to = Instant.now(),
+        sources = emptyList(),
+        severityIds = emptyList(),
+        alertTypeIds = emptyList(),
+        sectorIds = emptyList(),
+        greenhouseIds = emptyList(),
+        codes = emptyList(),
+        actorUserIds = emptyList(),
+        transitionKind = TransitionKind.ANY,
+        page = 0,
+        size = 50,
+    )
+
+    private fun defaultEpisodesQuery(): AlertEpisodesQuery = AlertEpisodesQuery(
+        tenantId = anyTenant,
+        from = Instant.now().minus(30, ChronoUnit.DAYS),
+        to = Instant.now(),
+        severityIds = emptyList(),
+        sectorIds = emptyList(),
+        codes = emptyList(),
+        onlyClosed = false,
+        page = 0,
+        size = 50,
+    )
+
+    @Test
+    fun `findTransitionsByAlertId DESC parses and executes`() {
+        val rows = adapter.findTransitionsByAlertId(anyAlertId, anyTenant, SortOrder.DESC)
+        assertThat(rows).isNotNull
+    }
+
+    @Test
+    fun `findTransitionsByAlertId ASC parses and executes`() {
+        val rows = adapter.findTransitionsByAlertId(anyAlertId, anyTenant, SortOrder.ASC)
+        assertThat(rows).isNotNull
+    }
+
+    @Test
+    fun `findTransitions with no filters parses and executes`() {
+        val result = adapter.findTransitions(defaultEventsQuery())
+        assertThat(result).isNotNull
+        assertThat(result.size).isEqualTo(50)
+    }
+
+    @Test
+    fun `findTransitions with all filters parses and executes`() {
+        val q = defaultEventsQuery().copy(
+            sources = listOf("MQTT", "API", "SYSTEM"),
+            severityIds = listOf(1, 2, 3, 4),
+            alertTypeIds = listOf(1, 2),
+            sectorIds = listOf(1L, 2L),
+            greenhouseIds = listOf(1L),
+            codes = listOf("ALT-00001"),
+            actorUserIds = listOf(1L),
+            transitionKind = TransitionKind.OPEN,
+        )
+        val result = adapter.findTransitions(q)
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    fun `findTransitions with transitionKind CLOSE parses and executes`() {
+        val q = defaultEventsQuery().copy(transitionKind = TransitionKind.CLOSE)
+        val result = adapter.findTransitions(q)
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    fun `findEpisodes with no filters parses and executes`() {
+        val result = adapter.findEpisodes(defaultEpisodesQuery())
+        assertThat(result).isNotNull
+        assertThat(result.size).isEqualTo(50)
+    }
+
+    @Test
+    fun `findEpisodes with onlyClosed=true parses and executes`() {
+        val q = defaultEpisodesQuery().copy(onlyClosed = true)
+        val result = adapter.findEpisodes(q)
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    fun `findEpisodes with all filters parses and executes`() {
+        val q = defaultEpisodesQuery().copy(
+            severityIds = listOf(1, 2),
+            sectorIds = listOf(1L),
+            codes = listOf("ALT-00001"),
+            onlyClosed = true,
+        )
+        val result = adapter.findEpisodes(q)
+        assertThat(result).isNotNull
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapterIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertStatsQueryAdapterIntegrationTest.kt
@@ -1,0 +1,94 @@
+package com.apptolast.invernaderos.features.alert.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActiveDurationStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.ActorStatsRole
+import com.apptolast.invernaderos.features.alert.domain.model.query.ByActorStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.MttrStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.RecurrenceStatsQuery
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesBucket
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesGroupBy
+import com.apptolast.invernaderos.features.alert.domain.model.query.TimeseriesStatsQuery
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * SQL contract tests against the live DEV `metadata` Postgres for the
+ * statistics adapter. Same rationale as AlertHistoryQueryAdapterIntegrationTest:
+ * the goal is "SQL parses and runs against PG 16", not row content.
+ *
+ * Covers all 6 stat endpoints (recurrence / mttr / timeseries / activeDuration
+ * / byActor / summary) across every enum branch of their groupBy / role / bucket
+ * dimensions, so any future SQL drift (column rename, reserved-word alias,
+ * dialect mismatch) breaks at this test layer rather than at runtime in prod.
+ */
+@SpringBootTest
+class AlertStatsQueryAdapterIntegrationTest {
+
+    @Autowired
+    private lateinit var adapter: AlertStatsQueryAdapter
+
+    private val anyTenant = TenantId(1L)
+    private val from: Instant get() = Instant.now().minus(30, ChronoUnit.DAYS)
+    private val to: Instant get() = Instant.now()
+
+    @Test
+    fun `recurrence parses and executes for every groupBy`() {
+        for (gb in RecurrenceGroupBy.entries) {
+            val r = adapter.recurrence(RecurrenceStatsQuery(anyTenant, from, to, gb, limit = 10))
+            assertThat(r).isNotNull
+        }
+    }
+
+    @Test
+    fun `mttr parses and executes for every groupBy`() {
+        for (gb in MttrGroupBy.entries) {
+            val r = adapter.mttr(MttrStatsQuery(anyTenant, from, to, gb))
+            assertThat(r).isNotNull
+        }
+    }
+
+    @Test
+    fun `timeseries parses and executes for every bucket and groupBy`() {
+        for (b in TimeseriesBucket.entries) {
+            for (gb in TimeseriesGroupBy.entries) {
+                val r = adapter.timeseries(TimeseriesStatsQuery(anyTenant, from, to, b, gb))
+                assertThat(r).isNotNull
+            }
+        }
+    }
+
+    @Test
+    fun `activeDuration parses and executes for every groupBy`() {
+        for (gb in ActiveDurationGroupBy.entries) {
+            val r = adapter.activeDuration(ActiveDurationStatsQuery(anyTenant, from, to, gb))
+            assertThat(r).isNotNull
+        }
+    }
+
+    @Test
+    fun `byActor parses and executes for every role`() {
+        for (role in ActorStatsRole.entries) {
+            val r = adapter.byActor(ByActorStatsQuery(anyTenant, from, to, role))
+            assertThat(r).isNotNull
+        }
+    }
+
+    @Test
+    fun `summary parses and executes`() {
+        val r = adapter.summary(anyTenant, from, to)
+        assertThat(r).isNotNull
+        // sanity: all numeric counts must be non-negative
+        assertThat(r.totalActiveNow).isGreaterThanOrEqualTo(0L)
+        assertThat(r.openedToday).isGreaterThanOrEqualTo(0L)
+        assertThat(r.closedToday).isGreaterThanOrEqualTo(0L)
+        assertThat(r.top3RecurrentCodesThisWeek).isNotNull
+    }
+}


### PR DESCRIPTION
## Summary

Promotes PR #123 (`fix(alert): repair SQL drift breaking history+stats endpoints`) from `develop` to `main`. Fixes 3 SQL bugs that cause every alert history+stats endpoint to return HTTP 500 in prod right now.

## What gets deployed

- 9 endpoints currently returning HTTP 500 in prod become 200:
  - `GET /api/v1/tenants/{t}/alert-events`
  - `GET /api/v1/tenants/{t}/alert-events/episodes`
  - `GET /api/v1/tenants/{t}/alerts/{id}/history`
  - `GET /api/v1/tenants/{t}/alerts/stats/{recurrence,mttr,timeseries,active-duration,by-actor,summary}`

## Verification on dev

- `./gradlew test --warning-mode=all` -> 351 tests, 0 fails, 0 errors, 0 skipped.
- Rolling restart in `apptolast-invernadero-api-dev` ok, new pod ready.
- Smoke curl with authenticated JWT against `inverapi-dev.apptolast.com`: all 9 endpoints return 200 (vs. 500 before).
- 5 min of `kubectl logs` after smoke: no new exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)