### PR TITLE
fix(alert): derive resolve actor from JWT

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
@@ -383,9 +383,8 @@ class AlertController(
      * Resuelve una alerta. Delegated to hexagonal use case so that an audit row is written
      * to alert_state_changes and the AlertStateChangedEvent is published.
      *
-     * Query params:
-     * - userId: ID del usuario que resuelve (opcional)
-     * - userName: Nombre del usuario (ignorado, kept for backward compat)
+     * Actor is derived from the authenticated JWT. Legacy userId/userName query
+     * parameters are ignored when present.
      *
      * Response: Alert resuelto
      *
@@ -393,9 +392,7 @@ class AlertController(
      */
     @PutMapping("/{id}/resolve")
     fun resolveAlert(
-        @PathVariable id: Long,
-        @RequestParam(required = false) userId: Long?,
-        @RequestParam(required = false) userName: String?
+        @PathVariable id: Long
     ): ResponseEntity<AlertResponse> {
         logger.debug("PUT /api/alerts/$id/resolve - Resolving alert (legacy)")
 
@@ -405,7 +402,7 @@ class AlertController(
         }
         val tenantId = TenantId(alert.tenantId)
 
-        return restInboundAdapter.resolve(id, tenantId, userId).fold(
+        return restInboundAdapter.resolve(id, tenantId, tenantContext.currentUserId()).fold(
             onLeft = { error ->
                 when (error) {
                     is AlertError.NotFound -> ResponseEntity.notFound().build()
@@ -444,7 +441,7 @@ class AlertController(
         }
         val tenantId = TenantId(alert.tenantId)
 
-        return restInboundAdapter.reopen(id, tenantId, actorUserId = null).fold(
+        return restInboundAdapter.reopen(id, tenantId, actorUserId = tenantContext.currentUserId()).fold(
             onLeft = { error ->
                 when (error) {
                     is AlertError.NotFound -> ResponseEntity.notFound().build()

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertReopenRequest.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertReopenRequest.kt
@@ -1,9 +1,0 @@
-package com.apptolast.invernaderos.features.alert.dto.request
-
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "Request body for reopening a resolved alert")
-data class AlertReopenRequest(
-    @Schema(description = "ID of the user who is reopening the alert. Null = system actor.", example = "42")
-    val actorUserId: Long? = null,
-)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertResolveRequest.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertResolveRequest.kt
@@ -1,9 +1,0 @@
-package com.apptolast.invernaderos.features.alert.dto.request
-
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "Solicitud para resolver una Alerta")
-data class AlertResolveRequest(
-    @Schema(description = "ID del usuario que resuelve la alerta")
-    val resolvedByUserId: Long? = null
-)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
@@ -24,8 +24,8 @@ class AlertRestInboundAdapter(
 ) {
 
     @Transactional("metadataTransactionManager")
-    fun resolve(id: Long, tenantId: TenantId, resolvedByUserId: Long?): Either<AlertError, Alert> =
-        resolveUseCase.resolve(id, tenantId, resolvedByUserId)
+    fun resolve(id: Long, tenantId: TenantId, actorUserId: Long?): Either<AlertError, Alert> =
+        resolveUseCase.resolve(id, tenantId, actorUserId)
 
     @Transactional("metadataTransactionManager")
     fun reopen(id: Long, tenantId: TenantId, actorUserId: Long? = null): Either<AlertError, Alert> =

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
@@ -8,12 +8,11 @@ import com.apptolast.invernaderos.features.alert.domain.port.input.UpdateAlertUs
 import com.apptolast.invernaderos.features.alert.dto.mapper.toCommand
 import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
 import com.apptolast.invernaderos.features.alert.dto.request.AlertCreateRequest
-import com.apptolast.invernaderos.features.alert.dto.request.AlertReopenRequest
-import com.apptolast.invernaderos.features.alert.dto.request.AlertResolveRequest
 import com.apptolast.invernaderos.features.alert.dto.request.AlertUpdateRequest
 import com.apptolast.invernaderos.features.alert.dto.response.AlertResponse
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import com.apptolast.invernaderos.features.shared.security.RequiresTenantOwnership
+import com.apptolast.invernaderos.features.shared.security.TenantContext
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -35,7 +34,8 @@ class TenantAlertController(
     private val findUseCase: FindAlertUseCase,
     private val updateUseCase: UpdateAlertUseCase,
     private val deleteUseCase: DeleteAlertUseCase,
-    private val restInboundAdapter: AlertRestInboundAdapter
+    private val restInboundAdapter: AlertRestInboundAdapter,
+    private val tenantContext: TenantContext
 ) {
 
     @GetMapping
@@ -132,10 +132,9 @@ class TenantAlertController(
     @RequiresTenantOwnership
     fun resolve(
         @PathVariable tenantId: Long,
-        @PathVariable alertId: Long,
-        @RequestBody(required = false) request: AlertResolveRequest?
+        @PathVariable alertId: Long
     ): ResponseEntity<Any> {
-        return restInboundAdapter.resolve(alertId, TenantId(tenantId), request?.resolvedByUserId).fold(
+        return restInboundAdapter.resolve(alertId, TenantId(tenantId), tenantContext.currentUserId()).fold(
             onLeft = { error ->
                 // resolve() can only emit NotFound, AlreadyResolved or SectorNotOwnedByTenant.
                 // NotResolved is reachable only from reopen() — handled in /reopen below.
@@ -161,10 +160,9 @@ class TenantAlertController(
     @RequiresTenantOwnership
     fun reopen(
         @PathVariable tenantId: Long,
-        @PathVariable alertId: Long,
-        @RequestBody(required = false) request: AlertReopenRequest?
+        @PathVariable alertId: Long
     ): ResponseEntity<Any> {
-        return restInboundAdapter.reopen(alertId, TenantId(tenantId), request?.actorUserId).fold(
+        return restInboundAdapter.reopen(alertId, TenantId(tenantId), tenantContext.currentUserId()).fold(
             onLeft = { error ->
                 // reopen() can only emit NotFound or NotResolved.
                 // AlreadyResolved is reachable only from resolve() — handled in /resolve above.

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/LegacyAlertControllerActorTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/LegacyAlertControllerActorTest.kt
@@ -1,0 +1,91 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.Alert
+import com.apptolast.invernaderos.features.alert.AlertController
+import com.apptolast.invernaderos.features.alert.AlertService
+import com.apptolast.invernaderos.features.alert.domain.model.Alert as DomainAlert
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertRestInboundAdapter
+import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.shared.security.TenantContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import java.time.Instant
+
+class LegacyAlertControllerActorTest {
+
+    private val alertService = mockk<AlertService>()
+    private val restInboundAdapter = mockk<AlertRestInboundAdapter>()
+    private val tenantContext = mockk<TenantContext>()
+    private val controller = AlertController(alertService, restInboundAdapter, tenantContext)
+
+    @Test
+    fun `legacy resolve derives actor user id from authenticated context`() {
+        val legacyAlert = sampleLegacyAlert(isResolved = false, resolvedByUserId = null)
+        every { alertService.getById(1L) } returns legacyAlert
+        every { tenantContext.currentTenantId() } returns 10L
+        every { tenantContext.currentUserId() } returns 77L
+        every { restInboundAdapter.resolve(1L, TenantId(10L), 77L) } returns
+            Either.Right(sampleDomainAlert(isResolved = true, resolvedByUserId = 77L))
+
+        val response = controller.resolveAlert(1L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        verify(exactly = 1) { restInboundAdapter.resolve(1L, TenantId(10L), 77L) }
+    }
+
+    @Test
+    fun `legacy reopen derives actor user id from authenticated context`() {
+        val legacyAlert = sampleLegacyAlert(isResolved = true, resolvedByUserId = 77L)
+        every { alertService.getById(1L) } returns legacyAlert
+        every { tenantContext.currentTenantId() } returns 10L
+        every { tenantContext.currentUserId() } returns 77L
+        every { restInboundAdapter.reopen(1L, TenantId(10L), 77L) } returns
+            Either.Right(sampleDomainAlert(isResolved = false, resolvedByUserId = null))
+
+        val response = controller.reopenAlert(1L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        verify(exactly = 1) { restInboundAdapter.reopen(1L, TenantId(10L), 77L) }
+    }
+
+    private fun sampleLegacyAlert(isResolved: Boolean, resolvedByUserId: Long?) = Alert(
+        id = 1L,
+        code = "ALT-00001",
+        sectorId = 20L,
+        tenantId = 10L,
+        message = "Alert",
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.parse("2026-01-01T00:00:00Z") else null,
+        resolvedByUserId = resolvedByUserId,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    private fun sampleDomainAlert(isResolved: Boolean, resolvedByUserId: Long?) = DomainAlert(
+        id = 1L,
+        code = "ALT-00001",
+        tenantId = TenantId(10L),
+        sectorId = SectorId(20L),
+        sectorCode = null,
+        alertTypeId = null,
+        alertTypeName = null,
+        severityId = null,
+        severityName = null,
+        severityLevel = null,
+        message = "Alert",
+        description = null,
+        clientName = null,
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.parse("2026-01-01T00:00:00Z") else null,
+        resolvedByUserId = resolvedByUserId,
+        resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/TenantAlertControllerActorTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/TenantAlertControllerActorTest.kt
@@ -1,0 +1,80 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.port.input.CreateAlertUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.DeleteAlertUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.UpdateAlertUseCase
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertRestInboundAdapter
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.TenantAlertController
+import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.shared.security.TenantContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import java.time.Instant
+
+class TenantAlertControllerActorTest {
+
+    private val restInboundAdapter = mockk<AlertRestInboundAdapter>()
+    private val tenantContext = mockk<TenantContext>()
+    private val controller = TenantAlertController(
+        createUseCase = mockk<CreateAlertUseCase>(),
+        findUseCase = mockk<FindAlertUseCase>(),
+        updateUseCase = mockk<UpdateAlertUseCase>(),
+        deleteUseCase = mockk<DeleteAlertUseCase>(),
+        restInboundAdapter = restInboundAdapter,
+        tenantContext = tenantContext,
+    )
+
+    @Test
+    fun `resolve derives actor user id from authenticated context`() {
+        every { tenantContext.currentUserId() } returns 77L
+        every { restInboundAdapter.resolve(1L, TenantId(10L), 77L) } returns
+            Either.Right(sampleAlert(isResolved = true, resolvedByUserId = 77L))
+
+        val response = controller.resolve(10L, 1L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        verify(exactly = 1) { restInboundAdapter.resolve(1L, TenantId(10L), 77L) }
+    }
+
+    @Test
+    fun `reopen derives actor user id from authenticated context`() {
+        every { tenantContext.currentUserId() } returns 77L
+        every { restInboundAdapter.reopen(1L, TenantId(10L), 77L) } returns
+            Either.Right(sampleAlert(isResolved = false, resolvedByUserId = null))
+
+        val response = controller.reopen(10L, 1L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        verify(exactly = 1) { restInboundAdapter.reopen(1L, TenantId(10L), 77L) }
+    }
+
+    private fun sampleAlert(isResolved: Boolean, resolvedByUserId: Long?) = Alert(
+        id = 1L,
+        code = "ALT-00001",
+        tenantId = TenantId(10L),
+        sectorId = SectorId(20L),
+        sectorCode = null,
+        alertTypeId = null,
+        alertTypeName = null,
+        severityId = null,
+        severityName = null,
+        severityLevel = null,
+        message = "Alert",
+        description = null,
+        clientName = null,
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.parse("2026-01-01T00:00:00Z") else null,
+        resolvedByUserId = resolvedByUserId,
+        resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+}


### PR DESCRIPTION
PR-3 for #121.\n\nChanges:\n- Resolve/reopen endpoints derive actor user id from authenticated TenantContext/JWT.\n- Remove client-controlled resolvedByUserId and actorUserId request DTOs from tenant alert resolve/reopen.\n- Legacy resolve/reopen ignore userId/userName query params and use the authenticated user id.\n- Add controller regression tests for tenant and legacy resolve/reopen actor derivation.\n\nLocal validation:\n- INVERNADEROS_TEST_DB_PASSWORD=<dev secret> ./gradlew compileKotlin compileTestKotlin test --warning-mode=all\n- Grep for ERROR/WARN/FAILED/warning/MqttException/AccessDeniedException: no matches