### PR TITLE
fix(alert): run tenant write use cases in transaction

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -62,6 +63,7 @@ class TenantAlertController(
     @PostMapping
     @Operation(summary = "Crear una nueva alerta para un cliente")
     @RequiresTenantOwnership
+    @Transactional("metadataTransactionManager")
     fun create(
         @PathVariable tenantId: Long,
         @RequestBody request: AlertCreateRequest
@@ -89,6 +91,7 @@ class TenantAlertController(
     @PutMapping("/{alertId}")
     @Operation(summary = "Actualizar una alerta existente de un cliente")
     @RequiresTenantOwnership
+    @Transactional("metadataTransactionManager")
     fun update(
         @PathVariable tenantId: Long,
         @PathVariable alertId: Long,
@@ -117,6 +120,7 @@ class TenantAlertController(
     @DeleteMapping("/{alertId}")
     @Operation(summary = "Eliminar una alerta de un cliente")
     @RequiresTenantOwnership
+    @Transactional("metadataTransactionManager")
     fun delete(
         @PathVariable tenantId: Long,
         @PathVariable alertId: Long

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/TenantAlertControllerTransactionTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/TenantAlertControllerTransactionTest.kt
@@ -1,0 +1,37 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.TenantAlertController
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.annotation.Transactional
+
+class TenantAlertControllerTransactionTest {
+
+    @Test
+    fun `tenant alert write endpoints use metadata transaction manager`() {
+        listOf(
+            TenantAlertController::class.java.getMethod(
+                "create",
+                Long::class.javaPrimitiveType,
+                Class.forName("com.apptolast.invernaderos.features.alert.dto.request.AlertCreateRequest"),
+            ),
+            TenantAlertController::class.java.getMethod(
+                "update",
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Class.forName("com.apptolast.invernaderos.features.alert.dto.request.AlertUpdateRequest"),
+            ),
+            TenantAlertController::class.java.getMethod(
+                "delete",
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+            ),
+        ).forEach { method ->
+            val transactional = method.getAnnotation(Transactional::class.java)
+            assertThat(transactional)
+                .describedAs("${method.name} must run in metadataTransactionManager")
+                .isNotNull
+            assertThat(transactional.value).isEqualTo("metadataTransactionManager")
+        }
+    }
+}


### PR DESCRIPTION
Follow-up required for PR-3 dev verification.\n\nProblem found during live dev smoke:\n- POST /api/v1/tenants/{tenantId}/alerts returned 500 because CreateAlertUseCase reached AlertRepositoryAdapter.save(), which calls EntityManager.flush(), without an active metadata transaction.\n\nChanges:\n- Add metadataTransactionManager transactions to TenantAlertController create/update/delete write endpoints.\n- Add regression test asserting tenant write endpoints keep the metadata transaction manager.\n\nLocal validation:\n- INVERNADEROS_TEST_DB_PASSWORD=<dev secret> ./gradlew compileKotlin compileTestKotlin test --warning-mode=all\n- Grep for ERROR/WARN/FAILED/warning/MqttException/AccessDeniedException: no matches