### PR TITLE
fix(alert): avoid merging read-only associations

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/Alert.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/Alert.kt
@@ -69,45 +69,45 @@ data class Alert(
 
     @field:NotNull(message = "Sector ID is required")
     @Column(name = "sector_id", nullable = false)
-    val sectorId: Long,
+    var sectorId: Long,
 
     @field:NotNull(message = "Tenant ID is required")
     @Column(name = "tenant_id", nullable = false)
-    val tenantId: Long,
+    var tenantId: Long,
 
     /**
      * FK al tipo de alerta (alert_types).
      * Nullable para compatibilidad con datos legacy.
      */
     @Column(name = "alert_type_id")
-    val alertTypeId: Short? = null,
+    var alertTypeId: Short? = null,
 
     /**
      * FK a la severidad (alert_severities).
      * Nullable para compatibilidad con datos legacy.
      */
     @Column(name = "severity_id")
-    val severityId: Short? = null,
+    var severityId: Short? = null,
 
     /**
      * Mensaje descriptivo de la alerta.
      * Nullable para permitir alertas sin mensaje inicial.
      */
     @Column(name = "message", columnDefinition = "TEXT")
-    val message: String? = null,
+    var message: String? = null,
 
     /**
      * Descripcion detallada de la alerta.
      * Separado de message para permitir titulo corto y descripcion larga.
      */
     @Column(name = "description", columnDefinition = "TEXT")
-    val description: String? = null,
+    var description: String? = null,
 
     /**
      * Indica si la alerta fue resuelta.
      */
     @Column(name = "client_name")
-    val clientName: String? = null,
+    var clientName: String? = null,
 
     @Column(name = "is_resolved", nullable = false)
     var isResolved: Boolean = false,

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapter.kt
@@ -28,8 +28,15 @@ class AlertRepositoryAdapter(
     }
 
     override fun save(alert: Alert): Alert {
-        val entity = alert.toEntity()
-        val saved = jpaRepository.save(entity)
+        val saved = if (alert.id == null) {
+            jpaRepository.save(alert.toEntity())
+        } else {
+            val managed = jpaRepository.findById(alert.id).orElseThrow {
+                IllegalStateException("Alert with ID ${alert.id} cannot be found before update")
+            }
+            managed.applyScalarValuesFrom(alert)
+            managed
+        }
         // Force a fresh load with @EntityGraph("Alert.context"): without flush+detach,
         // findById returns the cached managed entity whose LAZY relations (severity,
         // sector, alertType) remain uninitialized. Downstream notification dispatch
@@ -38,6 +45,21 @@ class AlertRepositoryAdapter(
         entityManager.flush()
         entityManager.detach(saved)
         return jpaRepository.findById(savedId).orElseThrow().toDomain()
+    }
+
+    private fun com.apptolast.invernaderos.features.alert.Alert.applyScalarValuesFrom(alert: Alert) {
+        code = alert.code
+        tenantId = alert.tenantId.value
+        sectorId = alert.sectorId.value
+        alertTypeId = alert.alertTypeId
+        severityId = alert.severityId
+        message = alert.message
+        description = alert.description
+        clientName = alert.clientName
+        isResolved = alert.isResolved
+        resolvedAt = alert.resolvedAt
+        resolvedByUserId = alert.resolvedByUserId
+        updatedAt = alert.updatedAt
     }
 
     override fun delete(id: Long, tenantId: TenantId): Boolean {

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapterTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapterTest.kt
@@ -4,8 +4,11 @@ import com.apptolast.invernaderos.features.alert.Alert as AlertEntity
 import com.apptolast.invernaderos.features.alert.AlertRepository
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
 import com.apptolast.invernaderos.features.catalog.AlertSeverity
+import com.apptolast.invernaderos.features.sector.Sector
 import com.apptolast.invernaderos.features.shared.domain.model.SectorId
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.tenant.Tenant
+import com.apptolast.invernaderos.features.user.User
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -125,5 +128,104 @@ class AlertRepositoryAdapterTest {
         }
         verify(exactly = 1) { entityManager.flush() }
         verify(exactly = 1) { entityManager.detach(rawSavedEntity) }
+    }
+
+    @Test
+    fun `save updates managed entity scalars without merging detached read-only associations`() {
+        val now = Instant.parse("2026-05-03T22:00:00Z")
+        val updatedAt = Instant.parse("2026-05-03T23:00:00Z")
+        val tenant = Tenant(id = 10L, code = "TNT-10", name = "Tenant", email = "tenant@example.com")
+        val sector = Sector(id = 20L, code = "SEC-20", tenantId = 10L, greenhouseId = 30L, name = "Sector")
+        val resolvedByUser = User(
+            id = 42L,
+            code = "USR-42",
+            tenantId = 10L,
+            username = "resolver",
+            email = "resolver@example.com",
+            passwordHash = "hash",
+            role = "USER",
+        )
+        val managedEntity = AlertEntity(
+            id = 99L,
+            code = "ALT-99",
+            tenantId = 10L,
+            sectorId = 20L,
+            alertTypeId = null,
+            severityId = null,
+            message = "Old message",
+            description = null,
+            clientName = null,
+            isResolved = false,
+            resolvedAt = null,
+            resolvedByUserId = null,
+            createdAt = now,
+            updatedAt = now
+        ).apply {
+            this.tenant = tenant
+            this.sector = sector
+        }
+        val reloadedEntity = AlertEntity(
+            id = 99L,
+            code = "ALT-99",
+            tenantId = 10L,
+            sectorId = 20L,
+            alertTypeId = null,
+            severityId = null,
+            message = "Resolved by API",
+            description = "Updated",
+            clientName = "client",
+            isResolved = true,
+            resolvedAt = updatedAt,
+            resolvedByUserId = 42L,
+            createdAt = now,
+            updatedAt = updatedAt
+        ).apply {
+            this.tenant = tenant
+            this.sector = sector
+            this.resolvedByUser = resolvedByUser
+        }
+        val domainInput = Alert(
+            id = 99L,
+            code = "ALT-99",
+            tenantId = TenantId(10L),
+            sectorId = SectorId(20L),
+            sectorCode = "SEC-20",
+            alertTypeId = null,
+            alertTypeName = null,
+            severityId = null,
+            severityName = null,
+            severityLevel = null,
+            message = "Resolved by API",
+            description = "Updated",
+            clientName = "client",
+            isResolved = true,
+            resolvedAt = updatedAt,
+            resolvedByUserId = 42L,
+            resolvedByUserName = "resolver",
+            createdAt = now,
+            updatedAt = updatedAt,
+        )
+
+        every { jpaRepository.findById(99L) } returnsMany listOf(Optional.of(managedEntity), Optional.of(reloadedEntity))
+        justRun { entityManager.flush() }
+        justRun { entityManager.detach(managedEntity) }
+
+        val result = adapter.save(domainInput)
+
+        assertThat(result.isResolved).isTrue()
+        assertThat(result.resolvedByUserId).isEqualTo(42L)
+        assertThat(result.resolvedByUserName).isEqualTo("resolver")
+        assertThat(managedEntity.message).isEqualTo("Resolved by API")
+        assertThat(managedEntity.resolvedByUserId).isEqualTo(42L)
+        assertThat(managedEntity.tenant).isSameAs(tenant)
+        assertThat(managedEntity.sector).isSameAs(sector)
+        assertThat(managedEntity.resolvedByUser).isNull()
+        verify(exactly = 0) { jpaRepository.save(any()) }
+        verifyOrder {
+            jpaRepository.findById(99L)
+            entityManager.flush()
+            entityManager.detach(managedEntity)
+            jpaRepository.findById(99L)
+        }
     }
 }


### PR DESCRIPTION
Follow-up from PR-3 dev smoke log verification.\n\nProblem found during live smoke:\n- Resolve/reopen succeeded but Hibernate emitted HHH000502 WARN lines because existing alerts were saved by merging detached entities with null read-only associations (tenant/sector/resolvedByUser).\n\nChanges:\n- AlertRepositoryAdapter.save() now persists new alerts normally but updates existing managed entities by copying only scalar columns.\n- Alert scalar columns that are legitimately updated are mutable JPA properties.\n- Add regression coverage that existing alert saves do not call repository.save()/merge detached associations and still reload via EntityGraph.\n\nLocal validation:\n- INVERNADEROS_TEST_DB_PASSWORD=<dev secret> ./gradlew compileKotlin compileTestKotlin test --warning-mode=all\n- Grep for ERROR/WARN/FAILED/warning/MqttException/AccessDeniedException: no matches