### PR TITLE
merge: deploy alert actor JWT fix to prod (#127)

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "95c57e5e-1ad0-4645-9527-4ea68ee23973",
+          "id": "7ca2eb4f-356a-4a78-badd-b30ef1867308",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "6672a845-0a90-49a9-9362-bb266e6b9cfd",
+              "id": "d7b38744-1660-4f28-8242-b0bb0b2f3242",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "36e90cff-d47a-4cf3-92fb-9242714c6b5d",
+          "id": "cada5d2a-4a61-4e4f-ac5e-0d8e894396aa",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "cde52dcf-bc53-4112-9ac3-c7c5162209c3",
+              "id": "88afe4e0-4d21-40df-bd8f-804d74693430",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "1ddbb107-d1a4-4f64-91c9-28a758e8e84b",
+          "id": "b19919f4-ddcb-47b1-930f-ba08402d5c78",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "15688c75-3585-490d-bdcf-0c434192823d",
+              "id": "92f002b3-6f70-44f8-a0ab-a7dc2f8bf48f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "94bd1bb7-7bc0-46b6-92ba-6223b398bfb1",
+          "id": "94891cd5-e64f-4908-9f31-20e46cc5162f",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "5abdc54c-5134-46de-97bd-73e1130db6fe",
+              "id": "c298628f-5ae8-4b78-a431-3c5f86e39ddb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "b5163fd1-e6c7-43bf-a324-3b13d0593356",
+          "id": "235224cc-d2c9-42ff-89ba-ccca167da9f1",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "58ae4c08-5e1c-427d-91b5-8e1848c55a03",
+              "id": "ab76e5e3-df31-4145-88ce-6b098b66439d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "bebf1217-b6e3-4c92-b564-29f19ea659ad",
+          "id": "a932dabc-f540-48d4-8bd8-1270b07b1a2f",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "c120ae64-685d-48ff-a4c3-eaee30b6efbb",
+              "id": "499d47a7-d51e-4ce9-9870-743f1b2bce59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "c4aea9f2-4bfc-4594-baca-d8db67d13edc",
+          "id": "418bf036-f1fc-49e6-a907-5a2fbb623af4",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "e47e15ce-4ea8-45f9-9e07-3e2e8d3f381a",
+              "id": "f63850d8-1ea7-40af-b05e-af96d3244f9e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "ec9ce03d-faae-4803-8020-70321f7310b5",
+          "id": "0f3ffb1e-f157-438b-bad2-647678a1ae3d",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "6599ded5-7e09-474c-882d-c2071ca99160",
+              "id": "5988a1bd-fc7f-4f2e-878e-97e8816d98b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "ae75c924-4f77-4b9c-aa4d-fe9de0a1c6aa",
+          "id": "2b8eb40f-5f4e-4ece-8c19-09ab9cb07d2c",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "81197dd8-b26f-4113-82b9-0f95a7570159",
+              "id": "85c722f5-f63a-4b20-adff-b83e38fe00c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "a1964422-e1f2-4fde-9c5c-65f29e707a46",
+          "id": "a8c1c7fe-dad9-4c6f-acc8-3c138b84f034",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "000dfacf-d3a3-4503-8880-5ad6b1dda6b8",
+              "id": "b6f9c7bd-e732-4f78-8a26-83db8cc07e42",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "71d4dbae-0a65-4d50-90b3-c4f595b56678",
+          "id": "50c16e65-f446-44b8-84d7-0fc277254400",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "7de3d900-43fc-475c-8055-6c31308f9edc",
+              "id": "feb74291-c978-42e9-8447-1676d730b092",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "c6b8c275-1eee-40ce-b008-58ad28a8b0ec",
+          "id": "5f1fd886-8902-4eee-b8b4-45f3cc333210",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "6a079683-3d5a-49f0-b271-200be904f206",
+              "id": "7b4da647-31e8-49d4-b23c-c595674b7edb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "0a2f8e31-1105-4c34-b1bb-9e39c5c050fa",
+          "id": "36f5d280-7e80-4efc-8972-22ad4b9a8779",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "f5beefff-fbc3-4e37-8b78-127ae5b195ef",
+              "id": "f6105133-b7ca-433c-9b6d-23b3f863682c",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "e8ee31c9-1a4e-470e-bf92-2ae73071ffec",
+          "id": "3c74e26f-e5e1-4fd1-a10d-9e997c6e0e9b",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "071ec31c-65e0-4303-81cf-1d179d09e30c",
+              "id": "610bfc79-adfc-4648-90f2-bf60920867bc",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "ab054a04-08ea-418d-8763-eaeb342173d7",
+          "id": "e476629d-a45b-43e6-8f2a-b06b654cb042",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "d76169b0-3ca5-4e74-ad83-3ec12c6f108b",
+              "id": "003d783a-4285-444b-a4cc-e0329885a738",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "a254fb16-2a41-4644-a0ab-87addbad8091",
+          "id": "e61d54f9-f11a-4716-9db9-8b69d998f320",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "cf92c697-84a8-41b3-9324-b818697a7067",
+              "id": "1239e23e-ec43-4b4a-a2aa-c339c7cad150",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "88fd3981-56a4-4a94-9e24-fe09eaf06248",
+          "id": "02d80bb7-65c5-43e3-982d-aed3913f6df2",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "26250d69-fe98-4edd-8723-f43bb39b79ed",
+              "id": "3658c982-64e8-49e5-af2f-e1ca7bfee428",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "100b54df-55fb-4358-a67b-21272d3f84f1",
+          "id": "127d0479-4611-4012-9711-a46b6722cc4b",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "3b7bb043-e730-4160-8c7f-363c1af71676",
+              "id": "21c0c3be-f9f3-4ca1-bd6c-eea15c4501b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "fab8f6fe-952b-4d3e-aaa9-926ddeaf0c21",
+          "id": "2e22f1e5-5574-4912-a949-13f1a8e1b761",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "d8bfafa8-88b0-48bf-b5e8-47c718d118d5",
+              "id": "fe1b2998-48b9-4340-b4c8-c97a9f41eeee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "5acadb90-4071-4e5e-94dc-f3d089ffb372",
+          "id": "c1a904ca-cde7-48ad-8dcf-e76a8ba86693",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "da098987-233b-4d44-b885-8d6f105a4ca3",
+              "id": "4fa997f6-75c4-46f9-abb2-bc29f7692b68",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "13cfb758-6b8f-4d28-8ac6-8e4b8ebb8b14",
+          "id": "28b3ff2c-9b78-4686-8332-99d4a733c8d8",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "a035aa18-b53f-4207-a61d-fed94917f9e8",
+              "id": "99552841-efff-46fe-8a98-5fdbbf36a2aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "616db2ac-7ae5-4aa4-97dc-a35aa521eb84",
+          "id": "abb434ad-08d5-4dbd-9764-21bab2b4132f",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "c7cf0e20-cf8e-414e-afd6-27a1a9fd1e53",
+              "id": "99d29c14-589b-4704-8053-eaaedb5d7e5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "964856ab-a666-4ad8-8bf3-3884b654ced0",
+          "id": "d26018ce-f65a-4718-9678-328b29ee05ae",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "08a698cf-e300-42b8-a5a9-9fc1fa4051c2",
+              "id": "f0c144d9-c2af-42f2-9489-cd9ddb558e20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "b7971f39-5a8c-4805-84fb-e145007c3e68",
+          "id": "893ced84-0d59-49ca-9e5e-2dd01d2b0f7f",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "9c40fcfc-324f-46d9-9b96-0a46ecaed141",
+              "id": "ed88ff1c-dbda-4255-88b8-0d75de29d686",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "1060a54a-e8bd-406a-bc26-0a6bae1a7a5d",
+          "id": "37b881bc-0a0e-449c-886f-c01db548eeab",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "f884fdf7-927f-4eef-b859-fe4a13328bcc",
+              "id": "7a7979a1-b4c0-4cb9-a286-d6629f27c673",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "38ef3dd7-e91e-4fcb-b0da-ccbbd82b9de3",
+          "id": "cb08b4c9-241f-47ea-96c2-7b299914dddd",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "f207a882-ddbe-4fb2-b208-fc6e8d8a37ce",
+              "id": "f15ed184-2230-4a06-a55b-603886e1201e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "2da42989-391e-4402-b298-92c29fed42b8",
+          "id": "b3a07dff-4bfa-4564-9f26-6f6521d548d7",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "39d16efd-d312-428d-a0d8-0939a8d3c633",
+              "id": "5c6da229-7dd6-4362-8cfa-5f51b0081eb6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "2b78c81f-d1ed-4324-ab4b-5e7b06caeba8",
+          "id": "a8b4670b-ab61-4e7f-9a7d-cb70aba12e12",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "3300a723-9824-4366-8809-7aaa84bfb050",
+              "id": "0093620d-167d-463f-9dc0-f602b6c34948",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "aacccf90-b83e-4694-8df8-988a9afcf0c6",
+          "id": "94cc69f3-a26b-43e2-9584-ff9f54b1d37c",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "5d645272-cfa0-4270-ba43-7563987b2285",
+              "id": "b69ecc3a-7cf7-44c6-8ae2-88a16096b7bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\",\n        \"key_1\": false,\n        \"key_2\": 7551.880248308298\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": 4458,\n        \"key_2\": 9324,\n        \"key_3\": 9402\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 4823,\n        \"key_1\": 1680.5687131679204,\n        \"key_2\": 3712.8053371106694\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 5189.958799435959\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "b293a5c4-1779-43de-bb2d-ec9c5a728f50",
+          "id": "4ecc9c68-2fc7-4bb7-ba05-46867a11946c",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "92dd089f-7818-4c8b-b3c0-6b25d25f2fd3",
+              "id": "39775df5-cc53-4dc5-a774-29e8bd287029",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "60befdeb-74ec-4adb-a21c-2208ee800611",
+          "id": "be05364f-e8e1-420a-9237-26c055c47b9d",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2A604e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e1EcDE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "be2dcbf3-c30b-4b4b-a59f-59057321169c",
+              "id": "50b46bb7-cc66-4d27-b75c-a480e3bc959d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2A604e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e1EcDE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "377502d5-c1e4-4415-81f1-82187bb0fbd2",
+          "id": "fd7ab3e5-15b6-4131-9ec7-8ecdd8ac2608",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "cb4ab310-beb6-4575-878b-a011654fe399",
+              "id": "cd9e313a-563d-4530-ba28-1a3d81740d98",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "1f559f9a-303c-42cd-ba1d-a14d0620638f",
+          "id": "02f283e2-78c2-4c57-ba02-c3ba6b49e475",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "fdf0de77-9734-4efd-989d-deb0c1f495b4",
+              "id": "59074f05-ef59-4baf-a1bc-6376cbf24fae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "fde70bec-384c-472f-b2f9-170ae1162917",
+          "id": "b3f8a923-b063-41f7-a5f2-2d07a13056cb",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A48e54\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1A8afa\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "f2df95b9-a228-4d06-9112-fe7cbe660491",
+              "id": "15c6b985-bf87-45a3-9388-beea8b1116b9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#A48e54\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1A8afa\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "8f1d4468-cb41-4a44-8fe3-dbf5659db345",
+          "id": "5a026d00-3154-47e1-950f-4e4e05b8cd18",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "a5f27e42-c075-4e20-aa94-37e4de02324a",
+              "id": "952047a7-2b85-418e-824a-93f2860b418f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "60fec447-d21b-4e0d-8bfa-383d4ee7e11c",
+          "id": "543932fb-01a4-4613-90ca-532f0e8a2438",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "438ffa17-bca4-4312-b653-98b9afa660a0",
+              "id": "edf1591b-0ce9-4d60-8f4d-a15fd5c8f79e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "92aee402-2267-431d-88b3-fc026474f8e5",
+          "id": "428c36a4-ffbe-427d-87f8-ebd5d9b36f45",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "e288ca51-e4de-4fbe-bd94-7057d6fb2402",
+              "id": "6f0137a5-cc3f-4c3c-83c3-f76740676526",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "73edb203-9768-4d60-b8b3-5cbd90fe5303",
+          "id": "d05baa68-98f3-4a29-89a4-af6abac7ba3a",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "a52fff5f-f8cf-4b99-aeea-25181793a271",
+              "id": "1738daa7-7875-43f0-b6fd-d1282eb8ae6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "48cf8bd6-2ca2-435e-bb06-a0859919dd82",
+          "id": "12e112fe-7d3f-4c0d-a524-3f2f8501ea0f",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "e719e3e1-ee13-4492-877f-4e8d2648e10d",
+              "id": "56c8e4fc-3395-4c90-8e9a-ee8b3a75c37d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "e6f5203c-26a0-4d0e-918b-989a14c91c3c",
+          "id": "4ec4a1bf-bcaf-40be-b06a-4e264c9285e7",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "9c4e9113-cdf6-4e5b-adc0-f35bb4f39de6",
+              "id": "98ccc83a-b6db-4f3b-afac-ba801db41ba7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "cb01802a-456e-43bf-af28-1ecf0a0aa5e4",
+          "id": "020b8c17-269a-4491-a181-54ad6892e5e6",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "93008a00-912e-4c0f-b0b6-1c1e122d95e4",
+              "id": "d29becc9-41cf-49c1-b6fd-c8e7cc282b25",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": true,\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "9f04057c-f3cb-4e33-8fba-a73e687de26a",
+          "id": "e95f39cd-3bdb-4b4d-b647-f7a599a074b6",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "986e294b-094d-4b80-94f3-bc920189363a",
+              "id": "7d1755c9-011d-4ba6-b3c4-59598e56eeb0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "b1026c08-f21c-49ac-b097-9c0a561f7876",
+          "id": "c7a001a0-ffae-4143-a920-ded68b97a1bf",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "4bff590a-5d65-4cef-9cc4-7b1feec7e5e7",
+              "id": "6a3812b2-1354-4fac-b345-40468fc9e98f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "026eb968-9c8f-4216-8a7d-2a33bd4d3597",
+          "id": "f8b46481-bc63-4150-a878-4703224e5eb8",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "d4513d66-af79-420e-9d42-f81bff698541",
+              "id": "9eda8ee7-cd25-4dd5-b00a-36f833c91d0f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "f5489ef6-bbbb-42b6-a051-a85207f91691",
+          "id": "89da002d-0d53-4003-8ad0-fcd026372ab3",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "7c314e72-4c16-4afd-81a1-c2791cdd4711",
+              "id": "7d37c555-a9ad-482e-8b78-f3bdd479af35",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "f08f4820-0e07-4bc0-a6a6-d72a54fe6ba3",
+          "id": "150b6c13-e7f0-4d47-8c96-d9d474ad1d02",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "e96a9241-760e-49a0-b6a3-5719154d3120",
+              "id": "f148fa8c-2177-459f-b6bf-ea413cf0db26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "382e265f-1c63-47db-98af-0148c5e895bb",
+          "id": "e6e3039a-9587-4060-99ab-4280c3697e3b",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "d037d711-f10a-4ba1-80c0-85859fe44f1e",
+              "id": "d5c4c498-412f-46a1-abfc-ce7e5a53bf7b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "20af1295-111d-44d8-825d-99069fb3e491",
+          "id": "2c92e953-1697-40a4-8471-faef954c0c99",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "960ca902-e220-48b5-9928-08bee5a9db96",
+              "id": "d063c046-c3f7-46cd-a8e7-cb0015cdd8b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "d99b4477-df60-41e2-99df-3b484415fc27",
+          "id": "46d62ae4-e70b-4260-abd4-62ea09f41b91",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "cac40a93-4c78-4cdf-ade1-2b7e82f07c77",
+              "id": "cf12b471-eded-4d43-b3bf-a4700dfb000a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "2c95f07a-d8d8-4726-a33d-11831918e7de",
+          "id": "52ff80aa-2c0d-4bbc-82ad-2fe5c96e185e",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "b2b09632-4f4e-438e-a9b6-e4e9bb58fd16",
+              "id": "5b494b26-d460-4e72-8f78-55f03de1a9b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "a1548d36-b902-489e-a5e4-92f37a2a053a",
+          "id": "64c4e66d-0ed0-4403-8378-f8784692603d",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "deedbf84-4d8b-4b01-acea-a0c912b0ed3c",
+              "id": "48597055-978c-4176-babf-b8db5efa8932",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "435313d4-8a72-4177-b0a6-3045dd87df92",
+          "id": "fc720048-3d8e-4b48-8dc6-54484e455914",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "03be1d6b-ba92-4199-883c-1b548c2900b6",
+              "id": "a49fa763-5d71-4f30-b8fd-41907f8c7c46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "10b0afcd-8b27-4ea7-8a72-0e556f263b9f",
+          "id": "eb7ca9d4-f1a1-463c-bd8c-302b98f4359a",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "d601e974-4c19-4343-81ac-4279dcdcdad5",
+              "id": "4ecbfdac-6207-4a3b-97f0-bc4c6d778e92",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "1f69a1d7-dc4a-44ff-9b64-e5162890fdb8",
+          "id": "35a9f437-e472-41da-9172-7602b3eb1d65",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "d80cd624-66ce-4385-a3d7-6b3dfc702365",
+              "id": "1a6c7bf6-1b14-4612-b805-c9239babb194",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "607f4dc4-39db-431e-907a-d0146e02d0c9",
+          "id": "1e2b0967-ab19-4497-be8c-a5596f520544",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "c18fe61b-f028-498c-bf1c-db20fdb21b74",
+              "id": "d0358125-f65b-4090-a992-60f977fd9161",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "30bff743-56db-458b-a960-062705afe75f",
+          "id": "1a4494e7-a448-4c71-981f-a08ba7fb9c2d",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "243c78c8-be7b-4e3a-a953-f458f9e2ecdd",
+              "id": "f6cc975a-1e72-41f2-b27c-52e3a6917d87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "4e148887-c8f1-4825-809e-06b15b4779aa",
+          "id": "11db3396-c51f-4dc4-8f6d-f74ad9b651e0",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "93c3c345-1b25-4988-bee2-c5b404ffa723",
+              "id": "7337e6fb-60b9-4964-83ec-bfab4ef96de8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "368c63fa-09a7-4af7-aad1-914c804f41ec",
+          "id": "bc5d341a-f60b-4787-920f-5453e93a025d",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "d1fc9ecb-96e5-460c-938a-ce6c76d02b6e",
+              "id": "83911944-a63b-44a1-b9c9-fccfbb1faf3c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "b33af2a8-7048-4cbe-901e-0c0bd1bd1057",
+          "id": "97d6d9c2-712a-4cf9-8335-e76eadcfbc3a",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "640bfefd-e071-4e3a-949b-aa0ff1e5bee2",
+              "id": "79fdc72f-be52-4c64-a43e-c8d62ce4d70c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "b65cdf3c-96ad-4b18-af84-dc45f3559cb0",
+          "id": "afa6e30f-4f06-40aa-89d8-46d94f832f96",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "1b44ee67-1106-4cfe-a818-dd0a67598328",
+              "id": "93794633-40c8-45f3-a852-f800e17a6d84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "4347bb08-a5e6-4c9a-acf2-0752d5e7b65e",
+          "id": "62eb64c2-7306-47e9-a852-0ab78aa022c1",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "9f3735a2-1679-4aab-a2ab-a12ec178d0ca",
+              "id": "998f6eb6-0d07-4785-b399-6c1da58371c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "06ab4497-adf9-45b1-bf09-955290d2a050",
+          "id": "0750a3ce-65c2-4563-aa90-d005a54aa804",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "db62b4d2-8eb5-4b4d-a272-d79c7e2710e0",
+              "id": "0cbdcfb7-59c7-4fbe-8c40-57929c912b75",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "e2f38eab-ca80-446e-bf05-3c91fed091ef",
+          "id": "d969cb39-0db9-4398-8628-c795002fdce5",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7566,7 +7566,7 @@
           },
           "response": [
             {
-              "id": "e770d236-00d3-4a47-8429-7573cf2ac8bc",
+              "id": "9dc9d0e0-e340-4382-8bf5-89df8c766164",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7655,7 +7655,7 @@
           }
         },
         {
-          "id": "35a38f27-b915-419c-9c20-fe6f0ed1c0f2",
+          "id": "728622f2-17a8-4a67-890f-63a2ec42aab4",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7722,7 +7722,7 @@
           },
           "response": [
             {
-              "id": "f39bc9ae-26fc-4df7-9c3f-b120e42133e1",
+              "id": "899cd404-7552-4ec4-9dd3-01f65911906a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7817,7 +7817,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "1c675ade-46f5-427a-9efc-add047bbb7cb",
+          "id": "b8d4aeca-6fd8-4166-aab1-7d6c3faaf1d8",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7870,7 +7870,7 @@
           },
           "response": [
             {
-              "id": "90123ba6-9621-48ec-a947-7890cc4d484a",
+              "id": "64c33aee-aa5d-48df-8f50-970a8f8472e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7945,7 +7945,7 @@
           }
         },
         {
-          "id": "3d5eb277-bd7f-4976-bead-3d943d58b61c",
+          "id": "0865bcb7-3359-43a3-8c83-6dae9adbc669",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -8011,7 +8011,7 @@
           },
           "response": [
             {
-              "id": "361de6a9-f2aa-40ec-9a7e-4171300f4a62",
+              "id": "8f71b92d-3a25-4f3c-95e4-e3f8e7f57b88",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8099,7 +8099,7 @@
           }
         },
         {
-          "id": "a02db606-cbd1-4a26-a8a9-8a2b3143073e",
+          "id": "d97353a9-32fc-4fbf-a8e7-e63570e39fed",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8146,7 +8146,7 @@
           },
           "response": [
             {
-              "id": "27ca63c5-a5a2-4f66-8d07-a94b67ef5318",
+              "id": "a7f41d9a-50c9-4dc8-a1f2-8d077fddd660",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8211,7 +8211,7 @@
           }
         },
         {
-          "id": "269d8ca9-bdc0-48c0-8583-bf9095c9fb4b",
+          "id": "6337ecb4-777b-4412-ac08-311fee94b70d",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8253,7 +8253,7 @@
           },
           "response": [
             {
-              "id": "6b4a1204-d755-4b35-90a5-c38afb0f5695",
+              "id": "21113850-e70b-400d-9323-3bca6ed483cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8317,7 +8317,7 @@
           }
         },
         {
-          "id": "67978f45-0a8e-4605-bfa2-33a34410dd0e",
+          "id": "80187089-cc2d-48db-b12c-cb2b3c800c09",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8372,7 +8372,7 @@
           },
           "response": [
             {
-              "id": "9cf00031-4177-43a4-93ca-39529568e016",
+              "id": "ef578fc6-abf6-4e74-a277-747fec26e4ad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8455,7 +8455,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "5251984e-c433-479d-a068-3a129b6d51cb",
+          "id": "be9f483d-f422-46b5-9251-eb2f982a44eb",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8496,7 +8496,7 @@
           },
           "response": [
             {
-              "id": "70f74a0a-46cc-4dcc-82c4-b11ab62db018",
+              "id": "c9654005-11c7-4808-a8fc-ae94b93df11a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8559,7 +8559,7 @@
           }
         },
         {
-          "id": "6a524938-c3f8-4d8f-bbff-2900a52d7644",
+          "id": "f6a7235b-5121-4ffc-9474-86b85f0ce85d",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8613,7 +8613,7 @@
           },
           "response": [
             {
-              "id": "46e293cf-fc02-4e5d-ae84-8e092eb757e2",
+              "id": "0f267034-ff5a-40b3-9353-2d9e93452f6c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8689,7 +8689,7 @@
           }
         },
         {
-          "id": "9608b1e3-924d-49c6-bb2e-71556845f88e",
+          "id": "4be21270-99f3-43a5-a0bf-c79da396e157",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8724,7 +8724,7 @@
           },
           "response": [
             {
-              "id": "5335faa5-2545-46d8-a0fc-18338cb00ea6",
+              "id": "d47eb321-a87a-4902-a955-cf011b6bab87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8777,7 +8777,7 @@
           }
         },
         {
-          "id": "3d96cdba-2dd4-48f3-b72a-a33e1cabe9b4",
+          "id": "27a77cd9-7c15-4afa-9a01-52ddec9fd31c",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8834,7 +8834,7 @@
           },
           "response": [
             {
-              "id": "10b3c593-b555-4101-9529-5c5fc265f846",
+              "id": "2f2358c4-4e52-45a6-8e5b-48bffe26561a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8913,7 +8913,7 @@
           }
         },
         {
-          "id": "47f04a65-9ae9-43c9-8880-ca337439c9da",
+          "id": "76219055-78ab-4472-8f19-a2d995b29567",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8955,7 +8955,7 @@
           },
           "response": [
             {
-              "id": "410e8de0-f812-42c7-8701-ef627eceedc5",
+              "id": "e882a5cc-dc7b-466d-9b07-cc9df58a84a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9025,7 +9025,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "dbd4f2d5-8bcc-46f4-bd5b-bb039d59a26a",
+          "id": "c0fca345-9097-4779-81d7-4ecb721520f1",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9078,7 +9078,7 @@
           },
           "response": [
             {
-              "id": "34845f89-2172-4782-8215-f4f2d0c937b1",
+              "id": "b1afdf55-6343-4622-afa3-1732897009d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9153,7 +9153,7 @@
           }
         },
         {
-          "id": "b3a1efac-c0e9-4569-b61f-195c3eb62727",
+          "id": "e4578a5c-4d42-4dbd-a344-87e49b3744ce",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9219,7 +9219,7 @@
           },
           "response": [
             {
-              "id": "da54354c-bf51-49eb-b4fe-2ec8e7254c42",
+              "id": "64ed2b49-ed2e-415e-b2d4-0bcf373610b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9307,7 +9307,7 @@
           }
         },
         {
-          "id": "30ad60d8-79ca-4d88-b485-729916a3b230",
+          "id": "c8867d48-4fcc-4830-83fd-eb4af6954e31",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9354,7 +9354,7 @@
           },
           "response": [
             {
-              "id": "ecd927ee-3fe4-4596-9042-917a1ba5f2d0",
+              "id": "69538ee3-7aa1-4bca-8ae8-b487fdfdf3ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9419,7 +9419,7 @@
           }
         },
         {
-          "id": "bf7761e6-7074-49b5-8078-4e746cca99e5",
+          "id": "97dfea09-f8b3-40a3-8534-5173e415654b",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9461,7 +9461,7 @@
           },
           "response": [
             {
-              "id": "294f2449-f120-456d-b0d7-12e82d61ee98",
+              "id": "b48f02bd-0a7d-4c50-b890-87d4d06a07e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9525,7 +9525,7 @@
           }
         },
         {
-          "id": "defbfc55-516b-44f5-b5ff-1ef4d10f1fd3",
+          "id": "ccb7e650-1b3d-4ace-af21-3c2bee9efa1b",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9580,7 +9580,7 @@
           },
           "response": [
             {
-              "id": "2983844a-3d9e-4e1d-8880-104f4279f086",
+              "id": "4c690d2d-51d0-4709-9131-b483b2be278e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9663,7 +9663,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "1de38b89-2605-4918-99f7-c989ae3f8655",
+          "id": "be105009-3ed9-4a40-9133-5518fa7b05db",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9705,7 +9705,7 @@
           },
           "response": [
             {
-              "id": "2597e02d-32fb-4a1e-a442-7cd89efbaf82",
+              "id": "7cfef96f-92c6-4e43-9149-350e94bf6a4c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9769,7 +9769,7 @@
           }
         },
         {
-          "id": "9be30e0e-c313-4427-b34e-8431738d271c",
+          "id": "2de80635-7f14-4a39-a074-7f37c2e78605",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9824,7 +9824,7 @@
           },
           "response": [
             {
-              "id": "b92e8d17-9280-48f3-83e0-ed08bba9009f",
+              "id": "18cb0e8d-9e5c-4809-bc88-223a4624155c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9901,7 +9901,7 @@
           }
         },
         {
-          "id": "f8a649d6-32e3-4239-8ca6-d8b657639d0d",
+          "id": "88fe8bf7-1031-4458-ae6d-baa9a49d6e12",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9937,7 +9937,7 @@
           },
           "response": [
             {
-              "id": "4260f2e0-ad17-48c2-847a-54a4a12b5625",
+              "id": "209e9d7f-eabb-4779-838e-9ad1f7fe37dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9991,7 +9991,7 @@
           }
         },
         {
-          "id": "1f1f7e17-9f12-4f23-9ed6-c17801ae4315",
+          "id": "978cce54-6b6c-4219-ab4a-b5191a98cb37",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -10021,7 +10021,7 @@
           },
           "response": [
             {
-              "id": "3693a374-f6f4-47bf-a248-33ae22324923",
+              "id": "64c63485-0b31-4ca2-a3fc-57593f4e720a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10073,7 +10073,7 @@
           }
         },
         {
-          "id": "ba50116d-ab25-40dd-86cf-66adc6174501",
+          "id": "d16ddd10-e5a0-40e8-b214-8e1b5b52ef0c",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10116,7 +10116,7 @@
           },
           "response": [
             {
-              "id": "4b618cc2-141b-4b1f-b851-f64db1d01f60",
+              "id": "3d21263c-0362-4179-bd3b-44a7d75e0918",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10187,7 +10187,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "53fc347f-0231-4e57-9faf-99e73ccd2ac0",
+          "id": "128ad577-8f9a-4826-942b-eef36b6d09c0",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10229,7 +10229,7 @@
           },
           "response": [
             {
-              "id": "0781252f-4dfe-40fd-8f64-e3db24402437",
+              "id": "41d79778-a644-4cca-9ce4-ade357065d40",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10287,7 +10287,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ef9b7c84-44c1-4cb7-a48a-72c6230dff57",
+              "id": "0d94985b-00ec-4239-bcf2-eff254cc97f2",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10351,7 +10351,7 @@
           }
         },
         {
-          "id": "fac92884-fb35-4c88-ba9a-00e63fcfe30e",
+          "id": "b877cb5d-bce0-44c7-aab0-69f552b14140",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10406,7 +10406,7 @@
           },
           "response": [
             {
-              "id": "8412ee08-b8d4-4d89-98b9-6cc9f1e90895",
+              "id": "2794fecb-24a3-4c34-88fd-83e2aa2083f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10477,7 +10477,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a83db8ed-5836-4fdd-a284-548ad495fd81",
+              "id": "45987773-fa75-4be6-8d2c-5da7aa14d987",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10548,7 +10548,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "9f100ccf-d3a3-4b35-bd91-b26062cbfaff",
+              "id": "3fc03cca-6c40-481d-86ce-4d6002e05214",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10625,7 +10625,7 @@
           }
         },
         {
-          "id": "17223c03-7a01-4279-b46a-61dced347b20",
+          "id": "8323d747-6ef4-428c-b275-01f483627b46",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10661,7 +10661,7 @@
           },
           "response": [
             {
-              "id": "fe96493e-d74e-4f4b-a9c7-7986cf133a35",
+              "id": "f04aeb7f-9800-4a6d-9952-b7b5f40e6895",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10709,7 +10709,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8df05731-eeec-4fe0-9962-5a7553ba7722",
+              "id": "d5b161b6-1ca2-4246-8cb2-3521cf085017",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10757,7 +10757,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "bfeed5dc-f11b-4c16-86a2-bb7cd64c5d12",
+              "id": "8139d3c2-e246-4326-9c99-6f5edb46559f",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
           }
         },
         {
-          "id": "8abf909d-44be-4ea6-a61a-fa69f4a75c50",
+          "id": "85f7403c-5e0d-4d30-86d3-d953254ff03d",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10841,7 +10841,7 @@
           },
           "response": [
             {
-              "id": "a8c164bf-5edd-49a0-b628-e4d865e0afc6",
+              "id": "180d817c-da43-4bb5-b11a-c44b31d32607",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10893,7 +10893,7 @@
           }
         },
         {
-          "id": "74867e9d-44fb-43d0-aa19-3e8d98bbda4d",
+          "id": "75269c4b-f92a-442e-89d8-2590b2c27032",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10936,7 +10936,7 @@
           },
           "response": [
             {
-              "id": "4e35c4b5-e309-477d-a2a4-13847eea3c5b",
+              "id": "19e5ab9c-549d-44ee-9699-d937aa40b1a1",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10995,7 +10995,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "368f173b-f20f-42a1-93ba-8aa178d09df3",
+              "id": "6cbc04e2-c3be-4fd3-af41-3a34e95cfa87",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11066,7 +11066,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "2d5115a4-8982-4910-9ff2-6e2bf139094f",
+          "id": "a4b1b334-18aa-40ec-9404-383af303c23e",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11150,7 +11150,7 @@
           },
           "response": [
             {
-              "id": "61e1c121-1e5e-4061-a5a8-681e4a265a2a",
+              "id": "e234a775-280d-466d-80f1-ccf0800969b9",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11253,7 +11253,7 @@
           }
         },
         {
-          "id": "29ac9dbe-bcd3-40dc-9ee0-ea4c85cc9486",
+          "id": "506ad094-84f6-4c53-b8b2-8b68ea2eb9ff",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11319,7 +11319,7 @@
           },
           "response": [
             {
-              "id": "631c82a1-6e85-43fd-8d70-2b16a301167f",
+              "id": "84a560ec-7ed2-4e33-97c8-1dc2b8939835",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11404,7 +11404,7 @@
           }
         },
         {
-          "id": "9bd2507d-abca-4f9b-90fd-c100b1345f8d",
+          "id": "6e6d9049-3588-446f-bb60-20d00f9788b4",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11488,7 +11488,7 @@
           },
           "response": [
             {
-              "id": "5c6e3db2-08a8-4dee-8329-66a6eba92084",
+              "id": "bf2826f3-11bd-4f00-b9bc-b47a920e1961",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11591,7 +11591,7 @@
           }
         },
         {
-          "id": "fb885a9b-c182-40b6-9c8f-9bfaa520d8e4",
+          "id": "3782ea87-6dcc-4c38-aa23-d16aa4245868",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11666,7 +11666,7 @@
           },
           "response": [
             {
-              "id": "694532d4-3e65-4f35-8f12-70965447999e",
+              "id": "f2a11ee2-00b5-4481-bb52-62261c87c949",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11760,7 +11760,7 @@
           }
         },
         {
-          "id": "e85e7e99-8b71-44af-9574-d13c2ba8d5ba",
+          "id": "7b3825fb-ff2d-4232-bc8b-600bd8950941",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11835,7 +11835,7 @@
           },
           "response": [
             {
-              "id": "0e9af50d-c824-4a87-af0a-20fc5971343c",
+              "id": "03930305-43cd-4f96-87b8-b8aba46af630",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11929,7 +11929,7 @@
           }
         },
         {
-          "id": "c5b5798f-ceb0-474e-988a-b10e81197651",
+          "id": "b6243f02-2be7-4429-93e5-579f1a401123",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -12004,7 +12004,7 @@
           },
           "response": [
             {
-              "id": "7c52b605-e924-4322-b14c-d98f11ca8da7",
+              "id": "c0795a25-5f87-4d30-ac63-f011496b56f6",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12104,7 +12104,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "d8a32979-2065-40c7-a466-4ca295982111",
+          "id": "5695f9e5-c44b-419c-b664-676185937851",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12170,7 +12170,7 @@
           },
           "response": [
             {
-              "id": "2b15fce6-ea9e-46fd-a041-b9a3a5ce8af1",
+              "id": "df5747fe-fe9d-4b63-823b-63aa7ee8ba1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12244,7 +12244,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": true,\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12261,7 +12261,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "8d7ea6f1-7196-4de6-8217-4dbdcb04507f",
+          "id": "b7ac056d-333d-4a18-a1d9-da8a4a2dc4f1",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12303,7 +12303,7 @@
           },
           "response": [
             {
-              "id": "2943fee8-df11-4b8b-a1b8-4c00a2313553",
+              "id": "33e05e48-31eb-4793-88a9-ea5b63a25966",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12373,7 +12373,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "c39f8b30-47cc-470f-9d01-faa6465513a6",
+          "id": "58a22972-3597-472a-9c66-1b37cc58f967",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12412,7 +12412,7 @@
           },
           "response": [
             {
-              "id": "8a49ea3c-318c-45bc-8f96-9d250d0e0028",
+              "id": "d3ecf677-4f8a-43a7-a750-95e8329a9cd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12465,7 +12465,7 @@
           }
         },
         {
-          "id": "31a6eafa-59f8-426e-b9f3-c9f838df162d",
+          "id": "e4d3abbe-8bd7-40c5-b0eb-0b96ef54dc1a",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12497,7 +12497,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"rc-DK\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"22:59\",\n  \"quietHoursEnd\": \"21:05\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"uy-ZF\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:13\",\n  \"quietHoursEnd\": \"00:51\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12517,7 +12517,7 @@
           },
           "response": [
             {
-              "id": "0888b5de-fc8b-4f87-8822-c9929e749fc3",
+              "id": "5e627f84-bef0-4643-9d95-d255c3bf1f7d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12555,7 +12555,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"rc-DK\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"22:59\",\n  \"quietHoursEnd\": \"21:05\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"uy-ZF\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:13\",\n  \"quietHoursEnd\": \"00:51\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12589,7 +12589,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "ae977a72-b4b8-4fa2-931f-48946ae2303d",
+          "id": "03615bec-139c-49fa-8eb4-c4162cdda212",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12631,7 +12631,7 @@
           },
           "response": [
             {
-              "id": "d56bf4a9-b695-4c74-91d6-d3b51b6b6e2c",
+              "id": "05d889e4-702d-4206-b54d-a1eacfe836d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12695,7 +12695,7 @@
           }
         },
         {
-          "id": "090510f4-d308-4fe6-925d-4e13cf383190",
+          "id": "4580f517-2597-4fdc-9284-5c26c593fc41",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12738,7 +12738,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#1Fba37\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#6bBFFE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12750,7 +12750,7 @@
           },
           "response": [
             {
-              "id": "99c992be-cc22-4f7e-8749-e8d458a1b671",
+              "id": "78674a7c-b2be-4cc6-9e34-aa7f350da5cb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12799,7 +12799,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#1Fba37\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#6bBFFE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12827,7 +12827,7 @@
           }
         },
         {
-          "id": "fdd4f158-9e8e-4e1a-a839-2178a949c324",
+          "id": "a5397f8a-f781-43c6-abf7-70a4bac572d6",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12863,7 +12863,7 @@
           },
           "response": [
             {
-              "id": "7745cb46-b385-4699-a48c-c1915fc49893",
+              "id": "e5776fa3-b5df-4973-af13-2f39293c3be8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12917,7 +12917,7 @@
           }
         },
         {
-          "id": "598c8c9a-ba16-44aa-82f1-5ad51d80534f",
+          "id": "4e15eb2e-75c1-47ca-8e17-73f6ae83f793",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12947,7 +12947,7 @@
           },
           "response": [
             {
-              "id": "72d188dd-0a6f-4ae2-a46d-0b157e7a686d",
+              "id": "1f1e82dd-7a4d-47ca-a597-40c6a97f5066",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12999,7 +12999,7 @@
           }
         },
         {
-          "id": "f16bfdfe-a974-4a3f-8f0d-9b62231d9a2b",
+          "id": "4e34b352-4c6e-4960-a03a-a2d42d471334",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -13030,7 +13030,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#733c9F\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3cb11a\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -13042,7 +13042,7 @@
           },
           "response": [
             {
-              "id": "baf43b1b-9cfd-45d6-9e93-f3d0800a23b4",
+              "id": "512bf707-90be-44fe-85ce-985870d864be",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13079,7 +13079,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#733c9F\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3cb11a\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13107,7 +13107,7 @@
           }
         },
         {
-          "id": "18f5c777-3788-4198-804c-e7d8f1cf942e",
+          "id": "1ce8a2b3-9da4-496e-ba76-874b5cbb60b4",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13138,7 +13138,7 @@
           },
           "response": [
             {
-              "id": "b5fa6710-6dad-4f4e-bbc6-87dc1104d8e9",
+              "id": "a3d5425a-e903-48b7-9f78-803714aa7f6f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13197,7 +13197,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "b8fa467f-c274-495a-9f3e-ef4c05b86821",
+          "id": "176ecf8a-ef03-4199-bdd9-fc6d8f8d60db",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13250,7 +13250,7 @@
           },
           "response": [
             {
-              "id": "16ee2858-0829-41b2-acf1-f58343930db4",
+              "id": "b4166aa9-509b-4b1b-a23a-1de11e824dff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13325,7 +13325,7 @@
           }
         },
         {
-          "id": "e2f0642b-0f9e-41fb-8fe5-70ff099bc2bf",
+          "id": "140b193b-fe8b-4af1-80a8-cecc7bb7e691",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13391,7 +13391,7 @@
           },
           "response": [
             {
-              "id": "f7e912ec-303e-472b-87e7-eb173473c5c6",
+              "id": "016027e4-ac3d-4072-804c-1f7902d39baa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13479,7 +13479,7 @@
           }
         },
         {
-          "id": "3bc3408f-a332-47c7-b6cf-c552a2d5b337",
+          "id": "a1f192a0-3815-4dd9-88bb-1f81e6fb6269",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13526,7 +13526,7 @@
           },
           "response": [
             {
-              "id": "a0bcb92d-5137-4204-9e27-693dd211e882",
+              "id": "32acdc92-8ef3-4933-9b10-ed33fb95a37e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13591,7 +13591,7 @@
           }
         },
         {
-          "id": "b6c8ab59-a13c-45c8-a1c4-333b6d1646a9",
+          "id": "4c59ee2b-4d60-4e50-a4e3-566f23ac23fd",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13633,7 +13633,7 @@
           },
           "response": [
             {
-              "id": "b5aaae9a-55a9-4a98-83bd-c1fe8654fdd4",
+              "id": "3363f355-802c-4677-9c36-ad045848da3b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13697,7 +13697,7 @@
           }
         },
         {
-          "id": "df48ba26-ff53-4d50-8992-8d54993451cb",
+          "id": "3e418062-6521-4673-ba45-c735717ee0d3",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13752,7 +13752,7 @@
           },
           "response": [
             {
-              "id": "e7408dce-f864-4a58-a8d3-dfa4448e0b92",
+              "id": "1367710e-fb05-4729-94b2-f7ace54bd1ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13829,7 +13829,7 @@
           }
         },
         {
-          "id": "96a084f0-2c57-4648-ade4-65b83d97eced",
+          "id": "5157b72f-d627-4359-91de-17e15e8b0685",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13883,7 +13883,7 @@
           },
           "response": [
             {
-              "id": "1984e567-5def-4ac4-a4b0-c4029555d631",
+              "id": "63ec2e8d-0059-42d2-b537-989dc5860ac7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13959,7 +13959,7 @@
           }
         },
         {
-          "id": "7cb7aff5-99c3-4044-a7f2-5f9bed643bfb",
+          "id": "8ce73e15-058d-457c-bf56-e4f71fa254ca",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -14025,7 +14025,7 @@
           },
           "response": [
             {
-              "id": "66ac8876-8407-4b39-a69d-eef7bdae04d7",
+              "id": "8cee3bf9-4483-4c9c-97a4-1772ffd9c2e0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14113,7 +14113,7 @@
           }
         },
         {
-          "id": "0425e617-cb67-47b9-923b-48b6dfd47aae",
+          "id": "01ff8d9a-bbbb-48b9-a6ea-55f789e1319f",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14191,7 +14191,7 @@
           },
           "response": [
             {
-              "id": "170773b6-cee0-4c7c-a87f-96650f19bb45",
+              "id": "c0d4fd55-c5aa-4665-bf8a-593d9d465ad0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14291,7 +14291,7 @@
           }
         },
         {
-          "id": "c5a3b25d-3d5d-4454-9e18-2bf236790506",
+          "id": "48ff34f7-1853-4f56-a7df-00da1d8ce081",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14357,7 +14357,7 @@
           },
           "response": [
             {
-              "id": "e2ee909b-277f-4fb4-9ac2-ec823bebdb56",
+              "id": "cc9bb7e7-81b6-4208-8966-2f4a221d1bcb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14445,7 +14445,7 @@
           }
         },
         {
-          "id": "c93d4e9c-b0da-498e-b85b-034ee1d84b6d",
+          "id": "d7909b11-9b8b-4ed8-8558-bcb0cdce6f4e",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14500,7 +14500,7 @@
           },
           "response": [
             {
-              "id": "235750d7-2477-4e23-9842-66ebea7f185b",
+              "id": "3b3a2d82-6979-4aba-af7f-102f9fd9ef69",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14583,7 +14583,7 @@
       "description": "",
       "item": [
         {
-          "id": "3bbb19e6-32f2-44e4-94bb-adfd8c3b9b39",
+          "id": "18e931bb-9480-45b5-a57f-b299a204a7d4",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14624,7 +14624,7 @@
           },
           "response": [
             {
-              "id": "31bc6450-8abc-42a3-a596-db3b3baee0c5",
+              "id": "d95dc9ee-986e-4dba-82d3-974f1cca5227",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14687,7 +14687,7 @@
           }
         },
         {
-          "id": "dab2b631-043f-440f-afa8-4269b659b206",
+          "id": "812dc2ef-00c1-45a3-8055-641eb2f66d69",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14741,7 +14741,7 @@
           },
           "response": [
             {
-              "id": "c6707001-2156-4b49-8387-7d088be7e694",
+              "id": "355fd814-e195-47a2-a43a-457fae023a2e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14817,7 +14817,7 @@
           }
         },
         {
-          "id": "c0ecf4da-f17b-45b5-841a-f6dd7125ad35",
+          "id": "a7ef06bf-2d3c-4fdf-88d4-d8d495391396",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14852,7 +14852,7 @@
           },
           "response": [
             {
-              "id": "6850b40c-f9d8-4a8e-bec2-4beeafe6b951",
+              "id": "057f4fc7-cb88-42a0-9edc-1b1d8c711792",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14905,7 +14905,7 @@
           }
         },
         {
-          "id": "d82e0961-75e0-4307-a9a0-a62c841458e1",
+          "id": "eba72ffa-ccfa-4015-a0b9-8e4021338345",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14966,7 +14966,7 @@
           },
           "response": [
             {
-              "id": "cc1ac7bf-33aa-4595-8a3d-078d13dd090c",
+              "id": "bcd2efa3-1fc5-4979-9cd9-1771bfa45dd2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15049,7 +15049,7 @@
           }
         },
         {
-          "id": "c925a192-bb42-41b0-a75b-13cfd7d3af53",
+          "id": "3e9b672f-4fd6-4585-a0be-b7729191c55f",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15091,7 +15091,7 @@
           },
           "response": [
             {
-              "id": "787e9bc2-da18-44f8-aee2-cd41c2db6264",
+              "id": "1841af83-ff42-4631-bf23-2b77a9bb13d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15155,7 +15155,7 @@
           }
         },
         {
-          "id": "a90069a6-88fb-4ffc-a0b4-3957b499db19",
+          "id": "3a60b75b-5e08-46bc-b748-788bb8600a02",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15230,7 +15230,7 @@
           },
           "response": [
             {
-              "id": "c6096e18-18f4-4ba9-aea9-1c182f4a45c3",
+              "id": "a03f8378-a6b0-45a6-a8e1-1d499211ccff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15327,7 +15327,7 @@
           }
         },
         {
-          "id": "9a253cdf-6df9-4247-9b0d-a476a3b21311",
+          "id": "1ce15f3a-3532-49fb-9dd5-a7314e0c745a",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15369,7 +15369,7 @@
           },
           "response": [
             {
-              "id": "646779b1-9164-49f1-9929-85c05810c493",
+              "id": "50b3ad66-f46e-4fb5-b45a-da44ceb23e51",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15433,7 +15433,7 @@
           }
         },
         {
-          "id": "132ee7f3-f15e-4eb6-8bf5-f437067f86bc",
+          "id": "e8ea2391-7ff4-4d9f-9e28-407d584303c3",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15476,7 +15476,7 @@
           },
           "response": [
             {
-              "id": "46fa4d65-5b51-41de-850f-e2d9644b3e80",
+              "id": "cc4e6afa-a045-439f-abc6-0e4cc90350cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15541,7 +15541,7 @@
           }
         },
         {
-          "id": "0c9e7a68-8bdf-4857-9c45-d5ff1181f946",
+          "id": "431ddff6-bca1-4a96-99a6-f1396ac95aec",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15584,7 +15584,7 @@
           },
           "response": [
             {
-              "id": "3f59fc96-3a71-45ea-8dbf-96ea8303f6f2",
+              "id": "0b1cb4fb-02e6-4aa7-b5d9-6a91022ad4e2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15649,7 +15649,7 @@
           }
         },
         {
-          "id": "77d137ac-6ebe-4764-a578-0cdff8150b3a",
+          "id": "54e90397-f7b1-49be-aadb-1840f024098f",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15701,7 +15701,7 @@
           },
           "response": [
             {
-              "id": "9388a99e-e683-4383-a4d1-fb5e4fb94883",
+              "id": "c35db232-1785-45ab-9fe8-1c4e2e76e56d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15775,7 +15775,7 @@
           }
         },
         {
-          "id": "ed50af77-bdc8-4c08-b17e-0f92fc500da1",
+          "id": "17492645-ec1f-45c4-8643-bd43899c56f8",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15817,7 +15817,7 @@
           },
           "response": [
             {
-              "id": "d32d6a80-11e3-4d18-94f6-81cea90a8bc6",
+              "id": "c98e48ff-890e-4b06-b3c6-9228ac4fff16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15881,7 +15881,7 @@
           }
         },
         {
-          "id": "ef952677-2cc6-4e86-86a0-83194a7195fc",
+          "id": "7a61caa7-f7a6-4cd2-87d9-aaef98334922",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15934,7 +15934,7 @@
           },
           "response": [
             {
-              "id": "90820ad7-1e35-4abd-90e4-bd6821f6f542",
+              "id": "534b58cb-f548-4474-af82-08b265eb987f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16009,7 +16009,7 @@
           }
         },
         {
-          "id": "52a17106-47f2-42df-9f4a-52a0929690f0",
+          "id": "3a9e4449-5b19-47ff-b930-ba8fc45ceef3",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -16062,7 +16062,7 @@
           },
           "response": [
             {
-              "id": "22cf53c5-125a-46b1-936d-bc3ca2a38523",
+              "id": "138adac1-eb32-4962-8923-389cc1f55650",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16137,7 +16137,7 @@
           }
         },
         {
-          "id": "2d12436f-01c0-4274-a5fc-36829f8cf4c0",
+          "id": "0d6d9a54-9201-4ace-bda4-c297348f0051",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16181,7 +16181,7 @@
           },
           "response": [
             {
-              "id": "b91174d7-c6d1-4f6a-a3af-55b4b1627fff",
+              "id": "3a446730-a73c-487d-bd1d-480b78aa5ed3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16236,7 +16236,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16247,7 +16247,7 @@
           }
         },
         {
-          "id": "d9946d8e-c4c6-4d5f-8c40-5363fc21ad9d",
+          "id": "74879335-9a98-48a5-8316-af54ed461100",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16291,7 +16291,7 @@
           },
           "response": [
             {
-              "id": "30af3e4d-a2f9-4c5c-810e-0847cb9e9129",
+              "id": "09eb9cd8-562f-43c2-857e-7f315940db78",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16346,7 +16346,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16363,7 +16363,7 @@
       "description": "",
       "item": [
         {
-          "id": "019b2a88-3c2a-4d7c-8bb4-0a6c42809167",
+          "id": "1792ce18-3f5d-4274-9a0b-223c4ad6d22c",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16405,7 +16405,7 @@
           },
           "response": [
             {
-              "id": "59ec8469-a07b-41a6-8a03-08367e53f0e4",
+              "id": "ae595cc7-c51d-4940-80cf-338fde59c29f",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16454,7 +16454,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d13a9795-82a9-4ef7-9cc2-066859165c22",
+              "id": "4778704c-77ba-4914-a970-5f7522eb5a9f",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16509,7 +16509,7 @@
           }
         },
         {
-          "id": "c89b597b-f2f6-4e22-9058-c9fcbb902e00",
+          "id": "fe5e20b6-596a-464f-a67c-4d87a2b780b2",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16555,7 +16555,7 @@
           },
           "response": [
             {
-              "id": "dff66189-20ee-406e-af4f-577b25539721",
+              "id": "1cac2260-33e0-4ec0-bf5f-bd4adeb38831",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16614,7 +16614,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4f95a31b-d82b-4c63-af7b-e176252b3bdb",
+              "id": "a55f71d1-60ef-451a-b9bd-78623f903e81",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16679,7 +16679,7 @@
           }
         },
         {
-          "id": "242a739b-7b2e-4a7d-a82b-ebd7f0c24917",
+          "id": "4bbab457-ceab-4c0d-9f4e-bab383003d4f",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16725,7 +16725,7 @@
           },
           "response": [
             {
-              "id": "a67702a6-0a1c-47fa-b83a-cbb5ca5c07e4",
+              "id": "9c08ceef-7147-42a3-8fdc-8b88a737a1b5",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16784,7 +16784,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "be6349fe-9640-4c5e-8f86-ce8200bcf872",
+              "id": "c90c8817-80b1-4d43-a6fd-6631114e7811",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16843,7 +16843,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "745ad192-e2da-424b-a0c1-43c96d268729",
+              "id": "cf9b60a9-6cd4-4e01-bf7d-d7a0e6d272a4",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16902,7 +16902,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "5a9f6a69-ffa0-4778-b948-4132b376e7f7",
+              "id": "184cf50e-b314-4ee9-a8d1-fe3af51c6ef9",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16967,7 +16967,7 @@
           }
         },
         {
-          "id": "a05da92a-c52b-4235-b276-375545c4648e",
+          "id": "dab6ef55-1f3c-4fbd-b472-3945311c55e1",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -17013,7 +17013,7 @@
           },
           "response": [
             {
-              "id": "219ce53b-2b4a-4374-bf58-8d3d7a104829",
+              "id": "a85ab219-65da-41a3-9462-f7d22e14cf8d",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -17072,7 +17072,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d8dd7890-493a-4e9d-a09f-8f83ed1fa1f1",
+              "id": "8c19701a-7392-4bf6-9bb2-9fbe391d8911",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17137,7 +17137,7 @@
           }
         },
         {
-          "id": "c51a6387-c089-41d8-85bf-a1f57ab96ffd",
+          "id": "78c2fe90-f698-4883-ac52-d0946dd3358a",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17179,7 +17179,7 @@
           },
           "response": [
             {
-              "id": "ce9e7d97-eecb-4f9f-9385-ed1320209a44",
+              "id": "205aad45-68b0-4204-ac5b-0f2170614854",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17240,7 +17240,7 @@
       "description": "",
       "item": [
         {
-          "id": "c0856708-9119-48e2-80e7-a3e8a693a48a",
+          "id": "6ab38588-46e2-4c59-9fa9-5e923fb11cd4",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17289,7 +17289,7 @@
           },
           "response": [
             {
-              "id": "06af38fc-7688-4414-8281-7824a94a56f4",
+              "id": "5c3b4cf2-1d33-4be6-8752-00c7d6b514d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17349,7 +17349,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": true,\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17360,7 +17360,7 @@
           }
         },
         {
-          "id": "f7a202b1-e705-4d02-a3f3-862a320d188d",
+          "id": "12d0aa32-aabf-412f-ad17-17a1bcb452d0",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17409,7 +17409,7 @@
           },
           "response": [
             {
-              "id": "2ac8336f-8b1e-4278-abfa-0d9c4e9fa301",
+              "id": "eb01e795-6dad-49bf-bf93-71f3259e42c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17480,7 +17480,7 @@
           }
         },
         {
-          "id": "5a55654b-8df3-4d07-9c99-4c6f7dcc484b",
+          "id": "c839ec71-e7ad-4106-9fdd-78e2ab1049c9",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17529,7 +17529,7 @@
           },
           "response": [
             {
-              "id": "288d3f5f-c01a-4f4c-a489-757a1d845856",
+              "id": "8ac7894d-5a86-453e-82dd-d7507a7fb2ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17600,7 +17600,7 @@
           }
         },
         {
-          "id": "36724250-cf53-47a0-8af5-9ee851cd02c7",
+          "id": "ea36c9ab-0530-48a4-95a0-aed2dcc648bc",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17649,7 +17649,7 @@
           },
           "response": [
             {
-              "id": "e1fad904-d4a8-4c15-ba89-88934d0df492",
+              "id": "21328801-8111-4f36-b8b9-0d772b8aac20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17726,7 +17726,7 @@
       "description": "",
       "item": [
         {
-          "id": "7a930544-b4cf-4548-afba-031053199f5e",
+          "id": "21ab08d9-b604-41c3-9102-ebcea9db3b84",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17766,7 +17766,7 @@
           },
           "response": [
             {
-              "id": "f1d1a065-f62c-47f4-820c-74368baf887b",
+              "id": "f93aa73f-143a-402a-88a0-fc38fbee69dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17828,7 +17828,7 @@
           }
         },
         {
-          "id": "da6a0282-b2ca-4c31-8556-843716a1b426",
+          "id": "ad332121-da0e-4662-97f9-d1fcdb0ea117",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17858,7 +17858,7 @@
           },
           "response": [
             {
-              "id": "0bba2777-4db4-482c-825f-c4693bc13a27",
+              "id": "5d0beee9-56b3-4c1c-af27-26ba5615a954",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17899,7 +17899,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": true,\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17910,7 +17910,7 @@
           }
         },
         {
-          "id": "c6427d07-c06d-4545-8d86-17c775fa8811",
+          "id": "7606774c-c559-4f70-8811-d8f5a374e727",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17962,7 +17962,7 @@
           },
           "response": [
             {
-              "id": "b9dd677a-4ef2-4ae1-8257-e49ba9121979",
+              "id": "77db0aee-2181-40a7-bfa4-17677c6390e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18042,7 +18042,7 @@
       "description": "",
       "item": [
         {
-          "id": "2a4652b0-7340-4fcf-991d-57b5186776e2",
+          "id": "ac015591-e416-44a6-9a28-d8602b602a3a",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -18071,7 +18071,7 @@
           },
           "response": [
             {
-              "id": "c781cb41-5ecf-46e2-b3c7-6831206c7e30",
+              "id": "a64f6d4c-0660-47ca-9ab1-d0a9765c52a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18122,7 +18122,7 @@
           }
         },
         {
-          "id": "00195c2a-62f9-4466-b980-f593244c5ba4",
+          "id": "c16feeba-2119-4cbf-87ae-69a6e6eb3789",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18163,7 +18163,7 @@
           },
           "response": [
             {
-              "id": "83ed347e-5081-4bb6-982b-2a6f5bddb8f4",
+              "id": "ff6e0d50-ca4d-4de4-acc1-f4f557626665",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18232,7 +18232,7 @@
       "description": "",
       "item": [
         {
-          "id": "9fed3b89-562a-4556-a796-e79fb3594363",
+          "id": "1450781b-c582-41f4-bd61-0178cd8a89a9",
           "name": "health",
           "request": {
             "name": "health",
@@ -18261,7 +18261,7 @@
           },
           "response": [
             {
-              "id": "97733b4c-c511-43ea-b7f7-cec7ed1f99f3",
+              "id": "67e90720-2231-45de-80c8-7989b26fc268",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18301,7 +18301,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": true,\n  \"key_2\": \"string\"\n}",
+              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18318,7 +18318,7 @@
       "description": "",
       "item": [
         {
-          "id": "9d922f41-876d-498c-bd05-b5156ecef603",
+          "id": "939d026a-8d0d-43d1-97f6-a8eca2a265c7",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18370,7 +18370,7 @@
           },
           "response": [
             {
-              "id": "0208d2d0-d77e-4300-99b3-3abed58af6b2",
+              "id": "c8fe69f4-5621-4c33-98ea-1f4357d8d9f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18444,7 +18444,7 @@
           }
         },
         {
-          "id": "676067ca-edfb-48d4-b405-0fa5aa24393a",
+          "id": "b9e0ac8c-4b97-40f4-8754-a470f510ab63",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18485,7 +18485,7 @@
           },
           "response": [
             {
-              "id": "b6c027e8-9681-4a0b-8813-d745bd607e9b",
+              "id": "477cd3a0-03dd-4ae3-a748-48590fff4699",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18537,7 +18537,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18548,7 +18548,7 @@
           }
         },
         {
-          "id": "2940a96f-15b0-4af9-8189-02e15e0ab6e7",
+          "id": "a8c18ba9-31cf-486d-a4a0-d7f847e611ff",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18578,7 +18578,7 @@
           },
           "response": [
             {
-              "id": "d0860488-0209-4cc2-bf14-7bb822b6eb73",
+              "id": "a9f8f37c-d19e-4583-af00-0a7f68ae279a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18619,7 +18619,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18650,9 +18650,9 @@
     }
   ],
   "info": {
-    "_postman_id": "349c2047-a718-49c5-a222-436c98830e42",
+    "_postman_id": "a6fa00cd-fce7-411a-ae50-f793c47e530d",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 01:16 UTC\nRama: main\nEntorno: prod\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 02:17 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "7ca2eb4f-356a-4a78-badd-b30ef1867308",
+          "id": "2052ddb1-f5e0-4f54-948b-242739d00f92",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "d7b38744-1660-4f28-8242-b0bb0b2f3242",
+              "id": "46609128-4de4-4a35-951e-114231fbeecb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "cada5d2a-4a61-4e4f-ac5e-0d8e894396aa",
+          "id": "a22b9461-1954-4912-b80d-9024e14f3473",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "88afe4e0-4d21-40df-bd8f-804d74693430",
+              "id": "b3785cf9-a62f-4249-95b2-ef12804c4aa7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "b19919f4-ddcb-47b1-930f-ba08402d5c78",
+          "id": "20022f81-8604-48b4-b0b7-94891bc62ea9",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "92f002b3-6f70-44f8-a0ab-a7dc2f8bf48f",
+              "id": "4cabaffd-923a-49b4-9223-d4aa1920421b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "94891cd5-e64f-4908-9f31-20e46cc5162f",
+          "id": "6e605711-8479-457b-83b5-65ffc68dedcb",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "c298628f-5ae8-4b78-a431-3c5f86e39ddb",
+              "id": "275f253e-7946-455c-acae-2f1a691ecfdf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "235224cc-d2c9-42ff-89ba-ccca167da9f1",
+          "id": "3b1a28ce-d1ab-44c3-9c5f-3bd55bdcaff9",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "ab76e5e3-df31-4145-88ce-6b098b66439d",
+              "id": "fee07ccc-52e6-4006-8e46-15c33e214f9c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "a932dabc-f540-48d4-8bd8-1270b07b1a2f",
+          "id": "902bc4b6-1307-41fe-aebc-34fd9024ae88",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "499d47a7-d51e-4ce9-9870-743f1b2bce59",
+              "id": "0bccd02b-b738-4a48-9639-58889e8aac10",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "418bf036-f1fc-49e6-a907-5a2fbb623af4",
+          "id": "722dc98f-b42a-443d-9894-78fe3ca39e29",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "f63850d8-1ea7-40af-b05e-af96d3244f9e",
+              "id": "23273576-0078-457d-8e82-1cd10010103a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "0f3ffb1e-f157-438b-bad2-647678a1ae3d",
+          "id": "ab8a56e4-e775-41f1-84b5-9d3a72987752",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "5988a1bd-fc7f-4f2e-878e-97e8816d98b0",
+              "id": "ce398121-3e7a-4b24-adf0-c5af569b945f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "2b8eb40f-5f4e-4ece-8c19-09ab9cb07d2c",
+          "id": "ebfc202a-e62b-4f3a-9531-733f16f15755",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "85c722f5-f63a-4b20-adff-b83e38fe00c5",
+              "id": "84d32b82-3506-48e0-ba55-6ee09ab6968d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "a8c1c7fe-dad9-4c6f-acc8-3c138b84f034",
+          "id": "58bc16a0-8c0e-43ad-a938-a0187a89b4c4",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "b6f9c7bd-e732-4f78-8a26-83db8cc07e42",
+              "id": "afd58684-2a8f-40a2-8f91-147846704c67",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "50c16e65-f446-44b8-84d7-0fc277254400",
+          "id": "59bfa7b7-ea0f-499f-a33c-ee71315f90dc",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "feb74291-c978-42e9-8447-1676d730b092",
+              "id": "9e253b12-80cb-42da-acc8-8d51f55a4566",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "5f1fd886-8902-4eee-b8b4-45f3cc333210",
+          "id": "d5f0ebb7-7898-4dd3-a87d-403686102ac9",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "7b4da647-31e8-49d4-b23c-c595674b7edb",
+              "id": "d32e8ba7-0fe3-4e9c-b1c1-463528e620c0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "36f5d280-7e80-4efc-8972-22ad4b9a8779",
+          "id": "b61f3958-bd37-4ebb-9312-5c7e01efa81c",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "f6105133-b7ca-433c-9b6d-23b3f863682c",
+              "id": "edf762ce-b174-4555-ae2d-3409b94756c4",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "3c74e26f-e5e1-4fd1-a10d-9e997c6e0e9b",
+          "id": "4a587d07-c763-4a5b-9639-25648df36d22",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "610bfc79-adfc-4648-90f2-bf60920867bc",
+              "id": "3a367828-0d05-4216-adc0-bcb454d37726",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "e476629d-a45b-43e6-8f2a-b06b654cb042",
+          "id": "addcd4b5-030c-4d68-9da2-0920b8daf91a",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "003d783a-4285-444b-a4cc-e0329885a738",
+              "id": "04d70884-8d8a-451f-ba65-242aa34f341b",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "e61d54f9-f11a-4716-9db9-8b69d998f320",
+          "id": "4787f31c-0766-457b-8202-720e9a479520",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "1239e23e-ec43-4b4a-a2aa-c339c7cad150",
+              "id": "f60eae5c-c4bb-4721-b695-36c5ad9eb5d5",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "02d80bb7-65c5-43e3-982d-aed3913f6df2",
+          "id": "26b52b4f-5af3-452c-8a0e-3ddd9dc4d505",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "3658c982-64e8-49e5-af2f-e1ca7bfee428",
+              "id": "356d2e6e-b600-4172-b3cb-38f716b462d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "127d0479-4611-4012-9711-a46b6722cc4b",
+          "id": "09144f2b-b860-4ffb-baea-adede27679b3",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "21c0c3be-f9f3-4ca1-bd6c-eea15c4501b0",
+              "id": "0a963c00-ae55-4ed0-a35f-f90e94c75308",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "2e22f1e5-5574-4912-a949-13f1a8e1b761",
+          "id": "33d8d39c-5ffe-4184-be86-ef48c48b3353",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "fe1b2998-48b9-4340-b4c8-c97a9f41eeee",
+              "id": "03ccdff0-ade9-4870-8cc1-96165f3d1360",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "c1a904ca-cde7-48ad-8dcf-e76a8ba86693",
+          "id": "27e3c899-ed11-4daa-9821-57bdcbc6bf6a",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "4fa997f6-75c4-46f9-abb2-bc29f7692b68",
+              "id": "79b14531-f57e-45cb-a87f-c4fbd7980096",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "28b3ff2c-9b78-4686-8332-99d4a733c8d8",
+          "id": "b3cc7324-8168-4b27-8a7a-e296f54aaa5d",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "99552841-efff-46fe-8a98-5fdbbf36a2aa",
+              "id": "0ae13a04-0860-4848-8ffb-bde945dd64c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "abb434ad-08d5-4dbd-9764-21bab2b4132f",
+          "id": "8724c0eb-d6b6-44ec-bf8f-2707175fc306",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "99d29c14-589b-4704-8053-eaaedb5d7e5f",
+              "id": "9020bfd3-2aa5-456c-aa6e-028e677f57c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "d26018ce-f65a-4718-9678-328b29ee05ae",
+          "id": "0378dc67-7ab5-413f-be1c-93c898f06211",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "f0c144d9-c2af-42f2-9489-cd9ddb558e20",
+              "id": "9abb8806-ad72-4012-8afd-81efd020de29",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "893ced84-0d59-49ca-9e5e-2dd01d2b0f7f",
+          "id": "67b10216-d170-4086-9f32-503cda322b74",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "ed88ff1c-dbda-4255-88b8-0d75de29d686",
+              "id": "14362250-ea92-4b42-8240-940ab6d6a76d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "37b881bc-0a0e-449c-886f-c01db548eeab",
+          "id": "0dee0b5a-0c3a-4fc2-9c74-ab9a512a44df",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "7a7979a1-b4c0-4cb9-a286-d6629f27c673",
+              "id": "741a5820-5e87-4be8-89c2-21db768d70e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "cb08b4c9-241f-47ea-96c2-7b299914dddd",
+          "id": "c7e0c3a4-7cc4-4272-8e11-e3ebe6a29e24",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "f15ed184-2230-4a06-a55b-603886e1201e",
+              "id": "d721f48c-39c6-4fbd-92fe-2ac0d7cbed61",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "b3a07dff-4bfa-4564-9f26-6f6521d548d7",
+          "id": "fbe6e120-a4c6-4a2a-a663-5b9d745c4e75",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "5c6da229-7dd6-4362-8cfa-5f51b0081eb6",
+              "id": "b9769460-76f0-4147-833a-9253a3c1583f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "a8b4670b-ab61-4e7f-9a7d-cb70aba12e12",
+          "id": "b7faee9c-a411-41f2-8aa8-3bff08164a68",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "0093620d-167d-463f-9dc0-f602b6c34948",
+              "id": "a0dbadbf-7be1-4ac4-aba1-2e3a999fbd34",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "94cc69f3-a26b-43e2-9584-ff9f54b1d37c",
+          "id": "c633264a-3191-49f3-ab6b-6801013f4849",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "b69ecc3a-7cf7-44c6-8ae2-88a16096b7bc",
+              "id": "15ad28e4-942a-42dc-9e90-acde4f57ce11",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 4823,\n        \"key_1\": 1680.5687131679204,\n        \"key_2\": 3712.8053371106694\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 5189.958799435959\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": true,\n        \"key_1\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 2289.6296474284304,\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "4ecc9c68-2fc7-4bb7-ba05-46867a11946c",
+          "id": "c3417342-881f-4035-a1a9-609d26aaec44",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "39775df5-cc53-4dc5-a774-29e8bd287029",
+              "id": "ec3ca9a3-e34e-4195-bd3c-2d78f1da941a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "be05364f-e8e1-420a-9237-26c055c47b9d",
+          "id": "4e971ba6-48d1-4864-940e-5397d86fc386",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e1EcDE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#0BaC96\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "50b46bb7-cc66-4d27-b75c-a480e3bc959d",
+              "id": "b2e3cb0f-2cb1-4672-9acd-c7a52e2510fd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e1EcDE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#0BaC96\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "fd7ab3e5-15b6-4131-9ec7-8ecdd8ac2608",
+          "id": "23a9c525-4c73-4dd8-bec8-d5fd396e531f",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "cd9e313a-563d-4530-ba28-1a3d81740d98",
+              "id": "1939dcdf-91b3-4825-ba8f-b49c7de480d6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "02f283e2-78c2-4c57-ba02-c3ba6b49e475",
+          "id": "22cfa59e-dea3-4aec-a73e-124a57d0a1fb",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "59074f05-ef59-4baf-a1bc-6376cbf24fae",
+              "id": "de33fe38-be60-4d71-82a1-8c003f72cb29",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "b3f8a923-b063-41f7-a5f2-2d07a13056cb",
+          "id": "268f7577-b0ec-4c1f-8704-6c843422c333",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1A8afa\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#DE468e\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "15c6b985-bf87-45a3-9388-beea8b1116b9",
+              "id": "26ee6dc2-b918-4225-975d-1822e854894e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#1A8afa\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#DE468e\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "5a026d00-3154-47e1-950f-4e4e05b8cd18",
+          "id": "b2110ea2-46cc-4c54-bb00-57d83e34ee6a",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "952047a7-2b85-418e-824a-93f2860b418f",
+              "id": "96e3b601-c27a-49b9-9948-c149fc3aadb7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "543932fb-01a4-4613-90ca-532f0e8a2438",
+          "id": "c17caa50-6c2f-4ef4-bf08-50e4298929d6",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "edf1591b-0ce9-4d60-8f4d-a15fd5c8f79e",
+              "id": "57ef68e0-e985-49ce-87d0-e34901bc4d32",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "428c36a4-ffbe-427d-87f8-ebd5d9b36f45",
+          "id": "abb2511b-84b6-468e-a4de-6b46b932dff7",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "6f0137a5-cc3f-4c3c-83c3-f76740676526",
+              "id": "9d544781-feef-4776-b491-f07db2468f59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "d05baa68-98f3-4a29-89a4-af6abac7ba3a",
+          "id": "f5cda752-63ba-4091-9315-db8ed3a05e02",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "1738daa7-7875-43f0-b6fd-d1282eb8ae6e",
+              "id": "55a212f9-0234-4743-a122-5b53d93c7c7a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "12e112fe-7d3f-4c0d-a524-3f2f8501ea0f",
+          "id": "d56a7593-219d-4fc8-b7a2-a96898001612",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "56c8e4fc-3395-4c90-8e9a-ee8b3a75c37d",
+              "id": "9c4e2289-7d69-4082-b718-40d9972e4336",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "4ec4a1bf-bcaf-40be-b06a-4e264c9285e7",
+          "id": "1e9fc591-162c-463a-bd47-cc4d9aa0b367",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "98ccc83a-b6db-4f3b-afac-ba801db41ba7",
+              "id": "343d504a-9c8e-4868-ad5b-e5feeebf64c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "020b8c17-269a-4491-a181-54ad6892e5e6",
+          "id": "e4b3ca0f-78e1-4610-b5a8-90b0d42808d2",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "d29becc9-41cf-49c1-b6fd-c8e7cc282b25",
+              "id": "74a77a9f-f924-45fb-9c5f-6c97cef1ee47",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
+              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "e95f39cd-3bdb-4b4d-b647-f7a599a074b6",
+          "id": "7779cf2e-5545-4b0b-9d39-7fdd3e662410",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "7d1755c9-011d-4ba6-b3c4-59598e56eeb0",
+              "id": "f39e5c89-f3c7-4476-8492-a3799490223d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "c7a001a0-ffae-4143-a920-ded68b97a1bf",
+          "id": "43937ccb-5c41-48b8-b335-1a88f8c5dfbc",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "6a3812b2-1354-4fac-b345-40468fc9e98f",
+              "id": "0323adf8-cb87-4561-a17b-2216263fe51c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "f8b46481-bc63-4150-a878-4703224e5eb8",
+          "id": "b9f6b1af-21ab-481e-851f-77e3024df57b",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "9eda8ee7-cd25-4dd5-b00a-36f833c91d0f",
+              "id": "03378909-1155-4b28-bc3c-cc6cb2ba6a6a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "89da002d-0d53-4003-8ad0-fcd026372ab3",
+          "id": "569dd1d4-d1b5-4eae-890a-99a181b881ad",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "7d37c555-a9ad-482e-8b78-f3bdd479af35",
+              "id": "de932eda-91e2-422e-91dc-46c9e1c585aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "150b6c13-e7f0-4d47-8c96-d9d474ad1d02",
+          "id": "7719d415-9113-44a3-b34c-a1d42ddb3c25",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "f148fa8c-2177-459f-b6bf-ea413cf0db26",
+              "id": "2f360c7b-31d7-4204-b608-a14e9b0ad300",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "e6e3039a-9587-4060-99ab-4280c3697e3b",
+          "id": "55752572-7701-47dc-9220-38853ecd308d",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "d5c4c498-412f-46a1-abfc-ce7e5a53bf7b",
+              "id": "0f68f8dd-df00-4fea-b81b-91cb2fe2b2f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "2c92e953-1697-40a4-8471-faef954c0c99",
+          "id": "840af979-31a8-4e4d-aa27-79767e176599",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "d063c046-c3f7-46cd-a8e7-cb0015cdd8b2",
+              "id": "0eb886c2-9220-4bd6-a53d-dab05bdb4b5b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "46d62ae4-e70b-4260-abd4-62ea09f41b91",
+          "id": "7561b6e4-b85c-4e34-8738-33470e74a9ea",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "cf12b471-eded-4d43-b3bf-a4700dfb000a",
+              "id": "85ce0db3-c24e-46ae-a24a-895ac86a8cd5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "52ff80aa-2c0d-4bbc-82ad-2fe5c96e185e",
+          "id": "dc6193d5-19d4-4912-8983-8d4ba2e1ef19",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "5b494b26-d460-4e72-8f78-55f03de1a9b3",
+              "id": "a4b4873b-8e05-4a0d-8902-6b4f0b0546cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "64c4e66d-0ed0-4403-8378-f8784692603d",
+          "id": "cf13f4d2-2409-45ee-84df-11b9758a5ef1",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "48597055-978c-4176-babf-b8db5efa8932",
+              "id": "efb09a6f-898d-4205-b00a-e08436dfffb5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "fc720048-3d8e-4b48-8dc6-54484e455914",
+          "id": "dc207984-3efb-426d-91f4-cdad3cdd8278",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "a49fa763-5d71-4f30-b8fd-41907f8c7c46",
+              "id": "cc9909cd-7c9b-40fb-b80e-85929f9fb270",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "eb7ca9d4-f1a1-463c-bd8c-302b98f4359a",
+          "id": "ede2c096-d1ac-491d-b070-8aad9c3293de",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "4ecbfdac-6207-4a3b-97f0-bc4c6d778e92",
+              "id": "840412b1-381c-4576-b0a3-ab5883729842",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "35a9f437-e472-41da-9172-7602b3eb1d65",
+          "id": "910e4972-d55f-4f0b-b040-8adaa0da774b",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "1a6c7bf6-1b14-4612-b805-c9239babb194",
+              "id": "9ad86b96-e93d-4618-909b-dc8beb6e6687",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "1e2b0967-ab19-4497-be8c-a5596f520544",
+          "id": "1763f422-da6f-4784-a458-eab7cd280491",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "d0358125-f65b-4090-a992-60f977fd9161",
+              "id": "64bda7fe-40f6-44d3-b0a9-473f017d302e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "1a4494e7-a448-4c71-981f-a08ba7fb9c2d",
+          "id": "67b840bc-db1a-472d-b72a-b3dcb9ef957f",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "f6cc975a-1e72-41f2-b27c-52e3a6917d87",
+              "id": "f7a22d46-3d3c-42d5-b837-c981fff64496",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "11db3396-c51f-4dc4-8f6d-f74ad9b651e0",
+          "id": "484595ac-5b3e-4740-b4e7-183f28ca8ce8",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "7337e6fb-60b9-4964-83ec-bfab4ef96de8",
+              "id": "3faecb94-e7a2-44c0-b75f-7384f160ca64",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "bc5d341a-f60b-4787-920f-5453e93a025d",
+          "id": "f2827f7b-4ede-4161-b855-9fae2928994b",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "83911944-a63b-44a1-b9c9-fccfbb1faf3c",
+              "id": "a342a238-984b-443a-8c40-fe8f43c01c42",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "97d6d9c2-712a-4cf9-8335-e76eadcfbc3a",
+          "id": "fd225bc0-7bd8-44cf-9453-62ffaba77491",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "79fdc72f-be52-4c64-a43e-c8d62ce4d70c",
+              "id": "dcfdf3be-b723-4a40-8c5d-47e9de639b65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "afa6e30f-4f06-40aa-89d8-46d94f832f96",
+          "id": "a8cfad2b-1aa1-49a6-a93d-181ef155298f",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "93794633-40c8-45f3-a852-f800e17a6d84",
+              "id": "06138bf6-787f-4fd1-9b7e-6b5764c07ca2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "62eb64c2-7306-47e9-a852-0ab78aa022c1",
+          "id": "ccdb69bf-81d8-4b57-a000-5acdbb6cac87",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "998f6eb6-0d07-4785-b399-6c1da58371c9",
+              "id": "535b4c14-c81a-4186-be9e-17daf5b563b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "0750a3ce-65c2-4563-aa90-d005a54aa804",
+          "id": "e6e1d653-3e22-482b-b902-513156c9f086",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "0cbdcfb7-59c7-4fbe-8c40-57929c912b75",
+              "id": "ed54724f-faf7-4af9-a8f0-27c9038f1018",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "d969cb39-0db9-4398-8628-c795002fdce5",
+          "id": "70a16b2d-63eb-430b-91c7-845c38e862f7",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7566,7 +7566,7 @@
           },
           "response": [
             {
-              "id": "9dc9d0e0-e340-4382-8bf5-89df8c766164",
+              "id": "64103517-d6ec-4c46-ad58-f57bdd24170b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7655,7 +7655,7 @@
           }
         },
         {
-          "id": "728622f2-17a8-4a67-890f-63a2ec42aab4",
+          "id": "7fa3564f-e18b-4b07-a71d-864771920ac9",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7722,7 +7722,7 @@
           },
           "response": [
             {
-              "id": "899cd404-7552-4ec4-9dd3-01f65911906a",
+              "id": "9fced464-7115-4b0c-8706-a94f67c5b154",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7817,7 +7817,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "b8d4aeca-6fd8-4166-aab1-7d6c3faaf1d8",
+          "id": "54d85628-56a8-44b7-9ffd-243b3574f77d",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7870,7 +7870,7 @@
           },
           "response": [
             {
-              "id": "64c33aee-aa5d-48df-8f50-970a8f8472e3",
+              "id": "670c5d24-08d6-460d-a173-24da3193533e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7945,7 +7945,7 @@
           }
         },
         {
-          "id": "0865bcb7-3359-43a3-8c83-6dae9adbc669",
+          "id": "53460fbb-f123-4a36-ba5a-919474f0d268",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -8011,7 +8011,7 @@
           },
           "response": [
             {
-              "id": "8f71b92d-3a25-4f3c-95e4-e3f8e7f57b88",
+              "id": "b1eb6f1c-71fd-47e9-bd9d-600e64474423",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8099,7 +8099,7 @@
           }
         },
         {
-          "id": "d97353a9-32fc-4fbf-a8e7-e63570e39fed",
+          "id": "494bbed8-17db-46ba-bf70-3b59c1560237",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8146,7 +8146,7 @@
           },
           "response": [
             {
-              "id": "a7f41d9a-50c9-4dc8-a1f2-8d077fddd660",
+              "id": "ab7a57ac-37f4-4fe0-a2f0-30daefe8f100",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8211,7 +8211,7 @@
           }
         },
         {
-          "id": "6337ecb4-777b-4412-ac08-311fee94b70d",
+          "id": "6e39b899-c935-448e-ab13-1cf2fdb8b7bd",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8253,7 +8253,7 @@
           },
           "response": [
             {
-              "id": "21113850-e70b-400d-9323-3bca6ed483cf",
+              "id": "7c2c04d8-c3cb-4e1e-bf81-c43290897132",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8317,7 +8317,7 @@
           }
         },
         {
-          "id": "80187089-cc2d-48db-b12c-cb2b3c800c09",
+          "id": "88d2bf2c-0c81-4cd1-8191-6b05f1141566",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8372,7 +8372,7 @@
           },
           "response": [
             {
-              "id": "ef578fc6-abf6-4e74-a277-747fec26e4ad",
+              "id": "d63ef747-f498-44ac-86ca-4fd82144bf19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8455,7 +8455,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "be9f483d-f422-46b5-9251-eb2f982a44eb",
+          "id": "24b2114b-796f-4aaa-94d5-0e8ed1f9872f",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8496,7 +8496,7 @@
           },
           "response": [
             {
-              "id": "c9654005-11c7-4808-a8fc-ae94b93df11a",
+              "id": "1184d9c7-1d3f-4593-8629-b17dfa6d98cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8559,7 +8559,7 @@
           }
         },
         {
-          "id": "f6a7235b-5121-4ffc-9474-86b85f0ce85d",
+          "id": "45b01f0e-f6b3-4194-8c52-c81e1337ec41",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8613,7 +8613,7 @@
           },
           "response": [
             {
-              "id": "0f267034-ff5a-40b3-9353-2d9e93452f6c",
+              "id": "b7d9aaa4-2612-4cec-a24c-50fc7559a1fd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8689,7 +8689,7 @@
           }
         },
         {
-          "id": "4be21270-99f3-43a5-a0bf-c79da396e157",
+          "id": "6a3ada1f-257c-4600-89e6-b5e9ccead033",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8724,7 +8724,7 @@
           },
           "response": [
             {
-              "id": "d47eb321-a87a-4902-a955-cf011b6bab87",
+              "id": "7aaf5533-c923-44f6-94ff-39b6b805a587",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8777,7 +8777,7 @@
           }
         },
         {
-          "id": "27a77cd9-7c15-4afa-9a01-52ddec9fd31c",
+          "id": "a72f9431-bcf9-4cf4-9a6a-aba886970206",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8834,7 +8834,7 @@
           },
           "response": [
             {
-              "id": "2f2358c4-4e52-45a6-8e5b-48bffe26561a",
+              "id": "1d581a89-d5f5-427b-97be-eeb95de6af2f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8913,7 +8913,7 @@
           }
         },
         {
-          "id": "76219055-78ab-4472-8f19-a2d995b29567",
+          "id": "fb6d963f-42bd-4fe6-95ff-c8c06bb042a8",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8955,7 +8955,7 @@
           },
           "response": [
             {
-              "id": "e882a5cc-dc7b-466d-9b07-cc9df58a84a4",
+              "id": "058f51e2-a562-42a4-8fae-6456c5d23d78",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9025,7 +9025,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "c0fca345-9097-4779-81d7-4ecb721520f1",
+          "id": "73d96e7b-e9f4-439b-8319-0926a9936313",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9078,7 +9078,7 @@
           },
           "response": [
             {
-              "id": "b1afdf55-6343-4622-afa3-1732897009d0",
+              "id": "a4ae8dda-582f-4c3f-93fd-2b894190dfd1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9153,7 +9153,7 @@
           }
         },
         {
-          "id": "e4578a5c-4d42-4dbd-a344-87e49b3744ce",
+          "id": "d1c19b50-f438-4cb2-93ae-273e50ff7cab",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9219,7 +9219,7 @@
           },
           "response": [
             {
-              "id": "64ed2b49-ed2e-415e-b2d4-0bcf373610b3",
+              "id": "d74b89a3-433b-460d-80a0-b9b864f1c479",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9307,7 +9307,7 @@
           }
         },
         {
-          "id": "c8867d48-4fcc-4830-83fd-eb4af6954e31",
+          "id": "9530afa7-35fb-4fba-b306-762938fb52c2",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9354,7 +9354,7 @@
           },
           "response": [
             {
-              "id": "69538ee3-7aa1-4bca-8ae8-b487fdfdf3ac",
+              "id": "2edec7dd-98cd-4fbe-8c9f-6c129949d1ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9419,7 +9419,7 @@
           }
         },
         {
-          "id": "97dfea09-f8b3-40a3-8534-5173e415654b",
+          "id": "3e8408e9-09d7-4d26-af5e-547a3756e663",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9461,7 +9461,7 @@
           },
           "response": [
             {
-              "id": "b48f02bd-0a7d-4c50-b890-87d4d06a07e6",
+              "id": "503406bd-2519-4f5c-9a20-b3a2db57a4d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9525,7 +9525,7 @@
           }
         },
         {
-          "id": "ccb7e650-1b3d-4ace-af21-3c2bee9efa1b",
+          "id": "b1814fe2-6411-4a23-9530-bb9f39c08fa0",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9580,7 +9580,7 @@
           },
           "response": [
             {
-              "id": "4c690d2d-51d0-4709-9131-b483b2be278e",
+              "id": "364eee0f-4dc3-4d88-8643-599d2eb89cda",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9663,7 +9663,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "be105009-3ed9-4a40-9133-5518fa7b05db",
+          "id": "8de1d8db-3c80-4c86-9bda-e54c8bf44669",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9705,7 +9705,7 @@
           },
           "response": [
             {
-              "id": "7cfef96f-92c6-4e43-9149-350e94bf6a4c",
+              "id": "e88b9c7a-8845-4bc9-add1-395cbd8df643",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9769,7 +9769,7 @@
           }
         },
         {
-          "id": "2de80635-7f14-4a39-a074-7f37c2e78605",
+          "id": "15033aaa-59f8-420e-ba1c-0e985a369c7f",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9824,7 +9824,7 @@
           },
           "response": [
             {
-              "id": "18cb0e8d-9e5c-4809-bc88-223a4624155c",
+              "id": "0115d104-708c-4152-91b8-dd258c206683",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9901,7 +9901,7 @@
           }
         },
         {
-          "id": "88fe8bf7-1031-4458-ae6d-baa9a49d6e12",
+          "id": "b3c06354-4f6e-433c-8a35-f90c2576532e",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9937,7 +9937,7 @@
           },
           "response": [
             {
-              "id": "209e9d7f-eabb-4779-838e-9ad1f7fe37dc",
+              "id": "a5d6fdb7-3bfb-46ab-a841-ddc5dd76de2d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9991,7 +9991,7 @@
           }
         },
         {
-          "id": "978cce54-6b6c-4219-ab4a-b5191a98cb37",
+          "id": "f0641871-b6c9-40eb-bda4-e1f459accfd6",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -10021,7 +10021,7 @@
           },
           "response": [
             {
-              "id": "64c63485-0b31-4ca2-a3fc-57593f4e720a",
+              "id": "f4040587-77d5-4ab9-8e36-985b8d9c5adf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10073,7 +10073,7 @@
           }
         },
         {
-          "id": "d16ddd10-e5a0-40e8-b214-8e1b5b52ef0c",
+          "id": "761697f1-4dee-41e8-bfaf-cbe05811e4b9",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10116,7 +10116,7 @@
           },
           "response": [
             {
-              "id": "3d21263c-0362-4179-bd3b-44a7d75e0918",
+              "id": "dabfff8a-9fec-4e53-8f90-7c2e96ecb1f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10187,7 +10187,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "128ad577-8f9a-4826-942b-eef36b6d09c0",
+          "id": "c565ee75-0fe9-495f-9a54-ad769276188a",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10229,7 +10229,7 @@
           },
           "response": [
             {
-              "id": "41d79778-a644-4cca-9ce4-ade357065d40",
+              "id": "f31241bc-5fed-49e0-a784-755c36e04b23",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10287,7 +10287,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0d94985b-00ec-4239-bcf2-eff254cc97f2",
+              "id": "6842a856-83c9-47e7-8785-f33c5806eb1f",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10351,7 +10351,7 @@
           }
         },
         {
-          "id": "b877cb5d-bce0-44c7-aab0-69f552b14140",
+          "id": "05a9782f-b01d-48e3-aeb2-b33cafa23d19",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10406,7 +10406,7 @@
           },
           "response": [
             {
-              "id": "2794fecb-24a3-4c34-88fd-83e2aa2083f1",
+              "id": "ffbfe837-48ff-40fa-ba38-793a5748054b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10477,7 +10477,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "45987773-fa75-4be6-8d2c-5da7aa14d987",
+              "id": "495a52d3-97c2-43c6-9521-86581fec8f30",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10548,7 +10548,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3fc03cca-6c40-481d-86ce-4d6002e05214",
+              "id": "d4b7d867-59ec-4c90-a001-0bfce41c98ea",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10625,7 +10625,7 @@
           }
         },
         {
-          "id": "8323d747-6ef4-428c-b275-01f483627b46",
+          "id": "589d07a3-97aa-436f-82d8-c85d4830fa8a",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10661,7 +10661,7 @@
           },
           "response": [
             {
-              "id": "f04aeb7f-9800-4a6d-9952-b7b5f40e6895",
+              "id": "0408c67b-991e-41f9-8f3e-2f3d24ccce2e",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10709,7 +10709,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d5b161b6-1ca2-4246-8cb2-3521cf085017",
+              "id": "cc77c50c-28fe-49ee-a05c-b0c7086de7e6",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10757,7 +10757,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8139d3c2-e246-4326-9c99-6f5edb46559f",
+              "id": "18607ec5-3566-4ada-ad25-6f6ccbd20fa4",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10811,7 @@
           }
         },
         {
-          "id": "85f7403c-5e0d-4d30-86d3-d953254ff03d",
+          "id": "a005ec04-fcd1-4104-8608-4c663c8d7ad8",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10841,7 +10841,7 @@
           },
           "response": [
             {
-              "id": "180d817c-da43-4bb5-b11a-c44b31d32607",
+              "id": "f6da3bd5-df9f-42ae-b0e2-8bf32f12826b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10893,7 +10893,7 @@
           }
         },
         {
-          "id": "75269c4b-f92a-442e-89d8-2590b2c27032",
+          "id": "b0877685-6ac7-431f-a48f-350c84ee79da",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10936,7 +10936,7 @@
           },
           "response": [
             {
-              "id": "19e5ab9c-549d-44ee-9699-d937aa40b1a1",
+              "id": "9394d250-238a-475c-8c70-8dd3b4ab627d",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10995,7 +10995,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6cbc04e2-c3be-4fd3-af41-3a34e95cfa87",
+              "id": "51fbcddb-6485-43d6-a637-d7418459cb32",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11066,7 +11066,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "a4b1b334-18aa-40ec-9404-383af303c23e",
+          "id": "97dd0923-9f14-4bbe-adb6-47a469f51887",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11150,7 +11150,7 @@
           },
           "response": [
             {
-              "id": "e234a775-280d-466d-80f1-ccf0800969b9",
+              "id": "1adc09a3-40e5-43ea-aa95-02218187cad6",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11253,7 +11253,7 @@
           }
         },
         {
-          "id": "506ad094-84f6-4c53-b8b2-8b68ea2eb9ff",
+          "id": "78a194fd-b815-4839-8f1f-48d43855cff8",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11319,7 +11319,7 @@
           },
           "response": [
             {
-              "id": "84a560ec-7ed2-4e33-97c8-1dc2b8939835",
+              "id": "8bbc1528-e31f-4c95-8dd7-f53c248f5b23",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11404,7 +11404,7 @@
           }
         },
         {
-          "id": "6e6d9049-3588-446f-bb60-20d00f9788b4",
+          "id": "c262a908-12aa-4995-b419-93aa0d998229",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11488,7 +11488,7 @@
           },
           "response": [
             {
-              "id": "bf2826f3-11bd-4f00-b9bc-b47a920e1961",
+              "id": "3bd66a15-fbfc-4671-87ab-ea4b65488ca0",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11591,7 +11591,7 @@
           }
         },
         {
-          "id": "3782ea87-6dcc-4c38-aa23-d16aa4245868",
+          "id": "e4c60f56-de13-49ce-abb0-cb7b24c72d10",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11666,7 +11666,7 @@
           },
           "response": [
             {
-              "id": "f2a11ee2-00b5-4481-bb52-62261c87c949",
+              "id": "9f22d542-a3a4-45fe-bfdc-a8dbecb25f8c",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11760,7 +11760,7 @@
           }
         },
         {
-          "id": "7b3825fb-ff2d-4232-bc8b-600bd8950941",
+          "id": "55895d5f-6999-47a9-9cb3-1790939cde14",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11835,7 +11835,7 @@
           },
           "response": [
             {
-              "id": "03930305-43cd-4f96-87b8-b8aba46af630",
+              "id": "723e71ad-e36d-44fb-b964-582f53c033c9",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11929,7 +11929,7 @@
           }
         },
         {
-          "id": "b6243f02-2be7-4429-93e5-579f1a401123",
+          "id": "3bdb09e3-2f65-4828-8934-965a310c0a8f",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -12004,7 +12004,7 @@
           },
           "response": [
             {
-              "id": "c0795a25-5f87-4d30-ac63-f011496b56f6",
+              "id": "880c8cd3-c674-4eaa-b14c-0dd85ef8feb5",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12104,7 +12104,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "5695f9e5-c44b-419c-b664-676185937851",
+          "id": "5d3dddd0-4598-4371-b54e-3857f2260df7",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12170,7 +12170,7 @@
           },
           "response": [
             {
-              "id": "df5747fe-fe9d-4b63-823b-63aa7ee8ba1c",
+              "id": "47382948-7db5-44fd-bf66-5f2d70693b88",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12244,7 +12244,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
+              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12261,7 +12261,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "b7ac056d-333d-4a18-a1d9-da8a4a2dc4f1",
+          "id": "d1e19a12-7a36-4722-ac23-69830b882230",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12303,7 +12303,7 @@
           },
           "response": [
             {
-              "id": "33e05e48-31eb-4793-88a9-ea5b63a25966",
+              "id": "483c2431-159e-4906-b5df-c8e439c8c9d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12373,7 +12373,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "58a22972-3597-472a-9c66-1b37cc58f967",
+          "id": "687d7ba0-4aa0-4ff4-9a4d-1cc163f0fe96",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12412,7 +12412,7 @@
           },
           "response": [
             {
-              "id": "d3ecf677-4f8a-43a7-a750-95e8329a9cd8",
+              "id": "4eacaf70-16a9-44c6-b8ff-11198f26a34e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12465,7 +12465,7 @@
           }
         },
         {
-          "id": "e4d3abbe-8bd7-40c5-b0eb-0b96ef54dc1a",
+          "id": "62be5b47-a7d9-48ec-80e9-b2ad5576aceb",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12497,7 +12497,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"uy-ZF\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:13\",\n  \"quietHoursEnd\": \"00:51\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"oi-HD\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"02:46\",\n  \"quietHoursEnd\": \"08:04\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12517,7 +12517,7 @@
           },
           "response": [
             {
-              "id": "5e627f84-bef0-4643-9d95-d255c3bf1f7d",
+              "id": "462ed8ed-83c8-4b8b-b7a1-95d14ca5a049",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12555,7 +12555,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"uy-ZF\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:13\",\n  \"quietHoursEnd\": \"00:51\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"oi-HD\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"02:46\",\n  \"quietHoursEnd\": \"08:04\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12589,7 +12589,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "03615bec-139c-49fa-8eb4-c4162cdda212",
+          "id": "b523f129-e32c-4b1b-9816-08689c8f1acb",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12631,7 +12631,7 @@
           },
           "response": [
             {
-              "id": "05d889e4-702d-4206-b54d-a1eacfe836d4",
+              "id": "218537bf-f784-4a12-8f20-bdd61ca94d86",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12695,7 +12695,7 @@
           }
         },
         {
-          "id": "4580f517-2597-4fdc-9284-5c26c593fc41",
+          "id": "d308da9e-c1d6-4def-8fd1-f54ca3a09a1e",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12738,7 +12738,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#6bBFFE\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#Cfd579\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12750,7 +12750,7 @@
           },
           "response": [
             {
-              "id": "78674a7c-b2be-4cc6-9e34-aa7f350da5cb",
+              "id": "1728d726-7eff-403c-a12f-30b3fe1b5b4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12799,7 +12799,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#6bBFFE\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#Cfd579\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12827,7 +12827,7 @@
           }
         },
         {
-          "id": "a5397f8a-f781-43c6-abf7-70a4bac572d6",
+          "id": "57e99320-6d2f-4e47-9b38-db6df9a89c54",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12863,7 +12863,7 @@
           },
           "response": [
             {
-              "id": "e5776fa3-b5df-4973-af13-2f39293c3be8",
+              "id": "c7193646-b553-4e2a-a8c7-06ce69ecb203",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12917,7 +12917,7 @@
           }
         },
         {
-          "id": "4e15eb2e-75c1-47ca-8e17-73f6ae83f793",
+          "id": "78e7f30a-abc0-438d-b32c-6f2384d371a0",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12947,7 +12947,7 @@
           },
           "response": [
             {
-              "id": "1f1e82dd-7a4d-47ca-a597-40c6a97f5066",
+              "id": "2af2175e-d5e7-4cba-ab4b-504c9e778130",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12999,7 +12999,7 @@
           }
         },
         {
-          "id": "4e34b352-4c6e-4960-a03a-a2d42d471334",
+          "id": "07aec017-6b2b-4a5c-a24e-9fa44fb68ac5",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -13030,7 +13030,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3cb11a\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6F5Ef5\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -13042,7 +13042,7 @@
           },
           "response": [
             {
-              "id": "512bf707-90be-44fe-85ce-985870d864be",
+              "id": "dbd0f5ed-16c3-4925-9474-b943f1a733f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13079,7 +13079,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3cb11a\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6F5Ef5\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13107,7 +13107,7 @@
           }
         },
         {
-          "id": "1ce8a2b3-9da4-496e-ba76-874b5cbb60b4",
+          "id": "fc7f5bf7-770a-4c20-ab69-030d31cffe01",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13138,7 +13138,7 @@
           },
           "response": [
             {
-              "id": "a3d5425a-e903-48b7-9f78-803714aa7f6f",
+              "id": "30394cee-9f8b-4333-8b15-1e89181abcdb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13197,7 +13197,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "176ecf8a-ef03-4199-bdd9-fc6d8f8d60db",
+          "id": "1d995b37-148b-4d6d-9de8-04fe6fc3c93d",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13250,7 +13250,7 @@
           },
           "response": [
             {
-              "id": "b4166aa9-509b-4b1b-a23a-1de11e824dff",
+              "id": "f4524b9f-2eeb-4c76-a7da-14f55af2b288",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13325,7 +13325,7 @@
           }
         },
         {
-          "id": "140b193b-fe8b-4af1-80a8-cecc7bb7e691",
+          "id": "e291641c-6264-46c3-8850-702c022d2bae",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13391,7 +13391,7 @@
           },
           "response": [
             {
-              "id": "016027e4-ac3d-4072-804c-1f7902d39baa",
+              "id": "b1179871-1a06-4885-85be-80fc5988fca0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13479,7 +13479,7 @@
           }
         },
         {
-          "id": "a1f192a0-3815-4dd9-88bb-1f81e6fb6269",
+          "id": "d8faa6bc-45cd-47cb-b7ac-3b0c3ac0b83a",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13526,7 +13526,7 @@
           },
           "response": [
             {
-              "id": "32acdc92-8ef3-4933-9b10-ed33fb95a37e",
+              "id": "c35f67e5-6792-43bc-8f95-6fe4a1c293c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13591,7 +13591,7 @@
           }
         },
         {
-          "id": "4c59ee2b-4d60-4e50-a4e3-566f23ac23fd",
+          "id": "5b29cff3-1379-440d-98ab-0e3550caf939",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13633,7 +13633,7 @@
           },
           "response": [
             {
-              "id": "3363f355-802c-4677-9c36-ad045848da3b",
+              "id": "2bbf3142-4da6-48be-a31d-ca715f455fc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13697,7 +13697,7 @@
           }
         },
         {
-          "id": "3e418062-6521-4673-ba45-c735717ee0d3",
+          "id": "c19981a8-119f-4cd6-8e01-b9a22338f270",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13752,7 +13752,7 @@
           },
           "response": [
             {
-              "id": "1367710e-fb05-4729-94b2-f7ace54bd1ab",
+              "id": "4046b5e9-2a86-4871-a9bc-7d705112d1fd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13829,7 +13829,7 @@
           }
         },
         {
-          "id": "5157b72f-d627-4359-91de-17e15e8b0685",
+          "id": "ba0dee55-21d1-42e7-821f-079e3426a5ce",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13883,7 +13883,7 @@
           },
           "response": [
             {
-              "id": "63ec2e8d-0059-42d2-b537-989dc5860ac7",
+              "id": "591adbd2-4ff1-41a6-842e-764aa459b78b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13959,7 +13959,7 @@
           }
         },
         {
-          "id": "8ce73e15-058d-457c-bf56-e4f71fa254ca",
+          "id": "803dc81e-0a67-4ade-a4dd-9e9796684e53",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -14025,7 +14025,7 @@
           },
           "response": [
             {
-              "id": "8cee3bf9-4483-4c9c-97a4-1772ffd9c2e0",
+              "id": "554361e9-694a-412e-a3fc-04b189d3907b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14113,7 +14113,7 @@
           }
         },
         {
-          "id": "01ff8d9a-bbbb-48b9-a6ea-55f789e1319f",
+          "id": "dee39843-b1c4-46cc-9fb2-a6d7570b9e86",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14191,7 +14191,7 @@
           },
           "response": [
             {
-              "id": "c0d4fd55-c5aa-4665-bf8a-593d9d465ad0",
+              "id": "6b28927c-7784-4e30-9386-7798f641783e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14291,7 +14291,7 @@
           }
         },
         {
-          "id": "48ff34f7-1853-4f56-a7df-00da1d8ce081",
+          "id": "26c3ebf7-227f-4951-9da8-ec5eba257b90",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14357,7 +14357,7 @@
           },
           "response": [
             {
-              "id": "cc9bb7e7-81b6-4208-8966-2f4a221d1bcb",
+              "id": "3caa0348-0d32-4ce4-9403-f3de0a3d566f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14445,7 +14445,7 @@
           }
         },
         {
-          "id": "d7909b11-9b8b-4ed8-8558-bcb0cdce6f4e",
+          "id": "0456fe51-f32b-41c5-932d-b9b6ca54120a",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14500,7 +14500,7 @@
           },
           "response": [
             {
-              "id": "3b3a2d82-6979-4aba-af7f-102f9fd9ef69",
+              "id": "bb4ed5b4-7fec-4a6f-9ab9-050d59d218c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14583,7 +14583,7 @@
       "description": "",
       "item": [
         {
-          "id": "18e931bb-9480-45b5-a57f-b299a204a7d4",
+          "id": "9d502408-4192-4319-91be-6ca74982d38d",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14624,7 +14624,7 @@
           },
           "response": [
             {
-              "id": "d95dc9ee-986e-4dba-82d3-974f1cca5227",
+              "id": "8b14724f-d8ca-4329-9d7d-a05be7866ee4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14687,7 +14687,7 @@
           }
         },
         {
-          "id": "812dc2ef-00c1-45a3-8055-641eb2f66d69",
+          "id": "954005c6-45db-4fa3-a268-b4a13e632d58",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14741,7 +14741,7 @@
           },
           "response": [
             {
-              "id": "355fd814-e195-47a2-a43a-457fae023a2e",
+              "id": "bee13e4f-7b4d-48ed-8496-7969fe2796be",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14817,7 +14817,7 @@
           }
         },
         {
-          "id": "a7ef06bf-2d3c-4fdf-88d4-d8d495391396",
+          "id": "b3af97f4-9322-4cbd-8ba9-42dd74a31e7a",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14852,7 +14852,7 @@
           },
           "response": [
             {
-              "id": "057f4fc7-cb88-42a0-9edc-1b1d8c711792",
+              "id": "15766437-3208-4212-a470-db860dbffc9b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14905,7 +14905,7 @@
           }
         },
         {
-          "id": "eba72ffa-ccfa-4015-a0b9-8e4021338345",
+          "id": "eff32a09-74dc-4395-a88e-0d54a0fdc762",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14966,7 +14966,7 @@
           },
           "response": [
             {
-              "id": "bcd2efa3-1fc5-4979-9cd9-1771bfa45dd2",
+              "id": "57198c54-8362-4c03-8660-0326cce6ed4a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15049,7 +15049,7 @@
           }
         },
         {
-          "id": "3e9b672f-4fd6-4585-a0be-b7729191c55f",
+          "id": "c3b8deaa-5614-4acd-80e9-6b5f02067d38",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15091,7 +15091,7 @@
           },
           "response": [
             {
-              "id": "1841af83-ff42-4631-bf23-2b77a9bb13d5",
+              "id": "513eaff2-e605-45de-97f5-dbf6d73d6187",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15155,7 +15155,7 @@
           }
         },
         {
-          "id": "3a60b75b-5e08-46bc-b748-788bb8600a02",
+          "id": "ae626943-27b7-4277-a15c-0a0fe723f859",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15230,7 +15230,7 @@
           },
           "response": [
             {
-              "id": "a03f8378-a6b0-45a6-a8e1-1d499211ccff",
+              "id": "360fdafb-07de-4bc8-aee0-01a3931dc9f5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15327,7 +15327,7 @@
           }
         },
         {
-          "id": "1ce15f3a-3532-49fb-9dd5-a7314e0c745a",
+          "id": "2ec08564-3b9d-461f-aa4a-619282948154",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15369,7 +15369,7 @@
           },
           "response": [
             {
-              "id": "50b3ad66-f46e-4fb5-b45a-da44ceb23e51",
+              "id": "4eae6225-8e63-4299-a959-2b1a541d2276",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15433,7 +15433,7 @@
           }
         },
         {
-          "id": "e8ea2391-7ff4-4d9f-9e28-407d584303c3",
+          "id": "3cc38262-8665-4b75-8a4d-e6ad586b3737",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15476,7 +15476,7 @@
           },
           "response": [
             {
-              "id": "cc4e6afa-a045-439f-abc6-0e4cc90350cc",
+              "id": "628feedd-6f25-463f-9219-d4edd5659e59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15541,7 +15541,7 @@
           }
         },
         {
-          "id": "431ddff6-bca1-4a96-99a6-f1396ac95aec",
+          "id": "6950fbb1-fdec-4cd7-ac34-2fe3f642bdca",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15584,7 +15584,7 @@
           },
           "response": [
             {
-              "id": "0b1cb4fb-02e6-4aa7-b5d9-6a91022ad4e2",
+              "id": "6bfa2263-0cff-44fe-a63c-76acbb8b0d65",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15649,7 +15649,7 @@
           }
         },
         {
-          "id": "54e90397-f7b1-49be-aadb-1840f024098f",
+          "id": "e51fef7f-213b-472d-aa3b-a19075069c02",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15701,7 +15701,7 @@
           },
           "response": [
             {
-              "id": "c35db232-1785-45ab-9fe8-1c4e2e76e56d",
+              "id": "a671ed0f-b369-4b3e-8c23-071616aa6f71",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15775,7 +15775,7 @@
           }
         },
         {
-          "id": "17492645-ec1f-45c4-8643-bd43899c56f8",
+          "id": "49364b9b-c07c-4de0-ba8d-e8d17578b3ef",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15817,7 +15817,7 @@
           },
           "response": [
             {
-              "id": "c98e48ff-890e-4b06-b3c6-9228ac4fff16",
+              "id": "a12afea1-68c1-4b02-b8f4-80e316876e9c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15881,7 +15881,7 @@
           }
         },
         {
-          "id": "7a61caa7-f7a6-4cd2-87d9-aaef98334922",
+          "id": "ee81d431-56b9-4bd4-8420-bd8b9932ff7b",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15934,7 +15934,7 @@
           },
           "response": [
             {
-              "id": "534b58cb-f548-4474-af82-08b265eb987f",
+              "id": "bea92c5e-3ef0-446a-a3be-64add60b3d3c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16009,7 +16009,7 @@
           }
         },
         {
-          "id": "3a9e4449-5b19-47ff-b930-ba8fc45ceef3",
+          "id": "f0490731-475a-499b-928f-4cdd6438f3d3",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -16062,7 +16062,7 @@
           },
           "response": [
             {
-              "id": "138adac1-eb32-4962-8923-389cc1f55650",
+              "id": "fb920ad2-24e2-4208-92ea-ddfffb650bba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16137,7 +16137,7 @@
           }
         },
         {
-          "id": "0d6d9a54-9201-4ace-bda4-c297348f0051",
+          "id": "e5f16eec-72b5-4cbe-a327-3fcb9459e75b",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16181,7 +16181,7 @@
           },
           "response": [
             {
-              "id": "3a446730-a73c-487d-bd1d-480b78aa5ed3",
+              "id": "9d83bf74-42b7-4211-84f7-223ef45e4386",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16236,7 +16236,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16247,7 +16247,7 @@
           }
         },
         {
-          "id": "74879335-9a98-48a5-8316-af54ed461100",
+          "id": "fa785c36-2d31-4a50-aa20-a4627c5b7624",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16291,7 +16291,7 @@
           },
           "response": [
             {
-              "id": "09eb9cd8-562f-43c2-857e-7f315940db78",
+              "id": "03f0b7d0-0c7b-453b-be39-a55f7fb023c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16346,7 +16346,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16363,7 +16363,7 @@
       "description": "",
       "item": [
         {
-          "id": "1792ce18-3f5d-4274-9a0b-223c4ad6d22c",
+          "id": "ce0daf4d-2ae8-4d9a-a18d-ef3b632bc055",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16405,7 +16405,7 @@
           },
           "response": [
             {
-              "id": "ae595cc7-c51d-4940-80cf-338fde59c29f",
+              "id": "39199821-15db-401c-885c-8a3fd45b107f",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16454,7 +16454,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4778704c-77ba-4914-a970-5f7522eb5a9f",
+              "id": "8c3402f3-2b9f-4884-b664-56d2e4d39945",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16509,7 +16509,7 @@
           }
         },
         {
-          "id": "fe5e20b6-596a-464f-a67c-4d87a2b780b2",
+          "id": "66082912-3e94-4a01-9602-a6dcb7f93c1a",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16555,7 +16555,7 @@
           },
           "response": [
             {
-              "id": "1cac2260-33e0-4ec0-bf5f-bd4adeb38831",
+              "id": "15d1c563-0ec5-4e96-856d-5966b0f8309d",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16614,7 +16614,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a55f71d1-60ef-451a-b9bd-78623f903e81",
+              "id": "d22eccd6-3aef-46df-bb8c-7965cd19177c",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16679,7 +16679,7 @@
           }
         },
         {
-          "id": "4bbab457-ceab-4c0d-9f4e-bab383003d4f",
+          "id": "ea3e4693-6684-4577-b597-74b8d798ef7a",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16725,7 +16725,7 @@
           },
           "response": [
             {
-              "id": "9c08ceef-7147-42a3-8fdc-8b88a737a1b5",
+              "id": "32fbb120-f7d0-445a-94d7-c9d9a50d8a3f",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16784,7 +16784,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c90c8817-80b1-4d43-a6fd-6631114e7811",
+              "id": "27c75918-fe16-416d-a7a2-a491c1ffe21a",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16843,7 +16843,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "cf9b60a9-6cd4-4e01-bf7d-d7a0e6d272a4",
+              "id": "0d0c3017-d214-42ae-a57f-67d88ffe6017",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16902,7 +16902,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "184cf50e-b314-4ee9-a8d1-fe3af51c6ef9",
+              "id": "75b3ef7a-d318-45fd-9330-39daa620f765",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16967,7 +16967,7 @@
           }
         },
         {
-          "id": "dab6ef55-1f3c-4fbd-b472-3945311c55e1",
+          "id": "4b3e7c28-52e1-4f60-acfd-bfa9d1044879",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -17013,7 +17013,7 @@
           },
           "response": [
             {
-              "id": "a85ab219-65da-41a3-9462-f7d22e14cf8d",
+              "id": "3e5bae3c-7df6-4224-808f-3f542cd52075",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -17072,7 +17072,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8c19701a-7392-4bf6-9bb2-9fbe391d8911",
+              "id": "9fa22a07-efe4-4aaf-91ed-3cde198e4b6e",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17137,7 +17137,7 @@
           }
         },
         {
-          "id": "78c2fe90-f698-4883-ac52-d0946dd3358a",
+          "id": "b85ce413-f23a-4748-8a62-4b6a3040f0cf",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17179,7 +17179,7 @@
           },
           "response": [
             {
-              "id": "205aad45-68b0-4204-ac5b-0f2170614854",
+              "id": "35cd2e38-a371-4830-87e8-34327ebfcb91",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17240,7 +17240,7 @@
       "description": "",
       "item": [
         {
-          "id": "6ab38588-46e2-4c59-9fa9-5e923fb11cd4",
+          "id": "759411bc-a095-4069-9cdd-c3bd7068471f",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17289,7 +17289,7 @@
           },
           "response": [
             {
-              "id": "5c3b4cf2-1d33-4be6-8752-00c7d6b514d1",
+              "id": "fd23f4ab-df4f-440a-acb3-e763ac8c4e16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17349,7 +17349,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
+              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17360,7 +17360,7 @@
           }
         },
         {
-          "id": "12d0aa32-aabf-412f-ad17-17a1bcb452d0",
+          "id": "6df53d15-80b6-43a6-9362-f25c833b57c5",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17409,7 +17409,7 @@
           },
           "response": [
             {
-              "id": "eb01e795-6dad-49bf-bf93-71f3259e42c3",
+              "id": "92e7ac17-e208-435d-a5aa-9f1093ccdd1e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17480,7 +17480,7 @@
           }
         },
         {
-          "id": "c839ec71-e7ad-4106-9fdd-78e2ab1049c9",
+          "id": "0ef41a35-9e31-4665-8f30-b2826de25941",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17529,7 +17529,7 @@
           },
           "response": [
             {
-              "id": "8ac7894d-5a86-453e-82dd-d7507a7fb2ca",
+              "id": "c489b113-e625-49a5-817e-15b59fa44803",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17600,7 +17600,7 @@
           }
         },
         {
-          "id": "ea36c9ab-0530-48a4-95a0-aed2dcc648bc",
+          "id": "286dcf7c-87cf-438f-ace3-1e2bd89606fb",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17649,7 +17649,7 @@
           },
           "response": [
             {
-              "id": "21328801-8111-4f36-b8b9-0d772b8aac20",
+              "id": "8dc0392d-3e18-47b5-94ad-c6dacd036e24",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17726,7 +17726,7 @@
       "description": "",
       "item": [
         {
-          "id": "21ab08d9-b604-41c3-9102-ebcea9db3b84",
+          "id": "430ef6a3-6f9f-4e96-8571-9cfca8cdcf73",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17766,7 +17766,7 @@
           },
           "response": [
             {
-              "id": "f93aa73f-143a-402a-88a0-fc38fbee69dc",
+              "id": "e23f2e86-be31-4032-8f66-fa3ebe60d0d0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17828,7 +17828,7 @@
           }
         },
         {
-          "id": "ad332121-da0e-4662-97f9-d1fcdb0ea117",
+          "id": "e66c3ce9-eabc-4b25-98ac-5d67655f6ec8",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17858,7 +17858,7 @@
           },
           "response": [
             {
-              "id": "5d0beee9-56b3-4c1c-af27-26ba5615a954",
+              "id": "743ffdb6-f37e-49fa-8222-ca006b8926ec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17899,7 +17899,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
+              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17910,7 +17910,7 @@
           }
         },
         {
-          "id": "7606774c-c559-4f70-8811-d8f5a374e727",
+          "id": "82ddb46f-9b61-4807-8350-93690369831f",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17962,7 +17962,7 @@
           },
           "response": [
             {
-              "id": "77db0aee-2181-40a7-bfa4-17677c6390e6",
+              "id": "854c5dcd-db77-45fe-8535-2ac097e26b0b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18042,7 +18042,7 @@
       "description": "",
       "item": [
         {
-          "id": "ac015591-e416-44a6-9a28-d8602b602a3a",
+          "id": "9e6361a1-06a4-471b-a6ba-7c4b87128b7e",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -18071,7 +18071,7 @@
           },
           "response": [
             {
-              "id": "a64f6d4c-0660-47ca-9ab1-d0a9765c52a4",
+              "id": "8548b159-6f01-41c7-b0cc-68c3bbd9458f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18122,7 +18122,7 @@
           }
         },
         {
-          "id": "c16feeba-2119-4cbf-87ae-69a6e6eb3789",
+          "id": "0f99597f-c493-477f-8e53-eba1939e8d0f",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18163,7 +18163,7 @@
           },
           "response": [
             {
-              "id": "ff6e0d50-ca4d-4de4-acc1-f4f557626665",
+              "id": "d819eede-c097-45e1-ac17-e3116dc83dd5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18232,7 +18232,7 @@
       "description": "",
       "item": [
         {
-          "id": "1450781b-c582-41f4-bd61-0178cd8a89a9",
+          "id": "0c5f6b28-e90e-4e4e-978b-408fcd4791d0",
           "name": "health",
           "request": {
             "name": "health",
@@ -18261,7 +18261,7 @@
           },
           "response": [
             {
-              "id": "67e90720-2231-45de-80c8-7989b26fc268",
+              "id": "6dc72b2d-8233-4e26-9ad9-6fa9dce3c0be",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18301,7 +18301,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": true,\n  \"key_1\": 2158.509716634607\n}",
+              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18318,7 +18318,7 @@
       "description": "",
       "item": [
         {
-          "id": "939d026a-8d0d-43d1-97f6-a8eca2a265c7",
+          "id": "a9f3f142-c167-46ac-a3d2-64f52641bd73",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18370,7 +18370,7 @@
           },
           "response": [
             {
-              "id": "c8fe69f4-5621-4c33-98ea-1f4357d8d9f6",
+              "id": "7c932ac5-06d6-4fff-8144-76f2f0e2046f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18444,7 +18444,7 @@
           }
         },
         {
-          "id": "b9e0ac8c-4b97-40f4-8754-a470f510ab63",
+          "id": "a69db21e-bca3-488e-8d00-de8366b30eff",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18485,7 +18485,7 @@
           },
           "response": [
             {
-              "id": "477cd3a0-03dd-4ae3-a748-48590fff4699",
+              "id": "0b51f9ee-ee5e-404f-b6b2-5e42b8fcff4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18548,7 +18548,7 @@
           }
         },
         {
-          "id": "a8c18ba9-31cf-486d-a4a0-d7f847e611ff",
+          "id": "bd90c6c0-c029-4682-b04b-699f335812fd",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18578,7 +18578,7 @@
           },
           "response": [
             {
-              "id": "a9f8f37c-d19e-4583-af00-0a7f68ae279a",
+              "id": "b37e3006-0fdb-475d-9670-0dcd2796d0ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18619,7 +18619,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18650,9 +18650,9 @@
     }
   ],
   "info": {
-    "_postman_id": "a6fa00cd-fce7-411a-ae50-f793c47e530d",
+    "_postman_id": "547c1b38-06ca-4903-8989-e62e76eda9ef",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 02:17 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 02:39 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "2052ddb1-f5e0-4f54-948b-242739d00f92",
+          "id": "6c79124c-7962-434e-b41e-506717c34784",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "46609128-4de4-4a35-951e-114231fbeecb",
+              "id": "0c852f6b-a08e-4458-97bc-0768d199af84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "a22b9461-1954-4912-b80d-9024e14f3473",
+          "id": "f6c9f20b-7a3c-411c-ad1b-cebd7d4def57",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "b3785cf9-a62f-4249-95b2-ef12804c4aa7",
+              "id": "036a1958-163a-4c9a-ba01-1e89a4fb4f9d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "20022f81-8604-48b4-b0b7-94891bc62ea9",
+          "id": "8e518385-4121-4907-9a80-5823ae016669",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "4cabaffd-923a-49b4-9223-d4aa1920421b",
+              "id": "a7969386-3a38-415b-9d7b-325f1f75991f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "6e605711-8479-457b-83b5-65ffc68dedcb",
+          "id": "3c40691c-12f1-4f56-8376-9b8f767ab238",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "275f253e-7946-455c-acae-2f1a691ecfdf",
+              "id": "a30b10d3-cda9-468d-b995-2ea0b351599f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "3b1a28ce-d1ab-44c3-9c5f-3bd55bdcaff9",
+          "id": "7d6bf824-f609-43b2-8f14-ddbb66afe3a3",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "fee07ccc-52e6-4006-8e46-15c33e214f9c",
+              "id": "03964a43-7f98-4c06-b2e8-50bee49b37f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "902bc4b6-1307-41fe-aebc-34fd9024ae88",
+          "id": "bbf7fc61-6929-4ff0-81a5-52989a59b59a",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "0bccd02b-b738-4a48-9639-58889e8aac10",
+              "id": "f00a06b0-82d7-44cb-b5cc-99de3fdcec89",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "722dc98f-b42a-443d-9894-78fe3ca39e29",
+          "id": "d4da6db4-a0e8-4d52-9455-f7969e024371",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "23273576-0078-457d-8e82-1cd10010103a",
+              "id": "cd5e6700-7dc2-4ad3-a5b4-d31db2f448f8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "ab8a56e4-e775-41f1-84b5-9d3a72987752",
+          "id": "b0b308a4-7c03-44c0-8f64-dce92ac45ad1",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "ce398121-3e7a-4b24-adf0-c5af569b945f",
+              "id": "7fd050b9-9f5e-40b5-9503-715acf962661",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "ebfc202a-e62b-4f3a-9531-733f16f15755",
+          "id": "3464b3c9-d4f0-496e-bf59-298e21737765",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "84d32b82-3506-48e0-ba55-6ee09ab6968d",
+              "id": "bfaa5faf-0dbe-4ea4-b2c6-c674a88992ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "58bc16a0-8c0e-43ad-a938-a0187a89b4c4",
+          "id": "51f858c8-4d69-4a54-af67-875aa0c67de5",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "afd58684-2a8f-40a2-8f91-147846704c67",
+              "id": "cc5ebab7-f768-404e-9635-3bc5bb76ac2f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "59bfa7b7-ea0f-499f-a33c-ee71315f90dc",
+          "id": "8df6bdc0-2188-4465-aeb9-5ea431790a8f",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "9e253b12-80cb-42da-acc8-8d51f55a4566",
+              "id": "ab343b75-a0bb-43b3-b166-b93e1b380c0c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "d5f0ebb7-7898-4dd3-a87d-403686102ac9",
+          "id": "81d33514-8cb9-4630-8fce-1dc99060f070",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "d32e8ba7-0fe3-4e9c-b1c1-463528e620c0",
+              "id": "f51ca3a3-514a-4bb2-9dc4-b79f38cba9c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "b61f3958-bd37-4ebb-9312-5c7e01efa81c",
+          "id": "a9cf3cc3-8fce-46a7-ac03-9b4312f20db5",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "edf762ce-b174-4555-ae2d-3409b94756c4",
+              "id": "3a419be0-848b-4fa6-afd5-e0a5e2f5170e",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "4a587d07-c763-4a5b-9639-25648df36d22",
+          "id": "a76511ad-2a46-4eb0-88c4-19676cbd95d1",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "3a367828-0d05-4216-adc0-bcb454d37726",
+              "id": "fc434830-7c94-485c-bff9-158afa09d013",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "addcd4b5-030c-4d68-9da2-0920b8daf91a",
+          "id": "3c1df1cb-86de-473b-953c-1d6a28da199e",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "04d70884-8d8a-451f-ba65-242aa34f341b",
+              "id": "cb589d67-e526-4d30-b7a0-bc5996200a13",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "4787f31c-0766-457b-8202-720e9a479520",
+          "id": "b69a4517-ae99-46bd-8eb6-7ae1ab41b137",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "f60eae5c-c4bb-4721-b695-36c5ad9eb5d5",
+              "id": "2070c328-6a3b-44ab-9c3b-2ce7dac2077a",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "26b52b4f-5af3-452c-8a0e-3ddd9dc4d505",
+          "id": "ef0c471a-091c-46b3-8023-926da27b4f6e",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "356d2e6e-b600-4172-b3cb-38f716b462d0",
+              "id": "e9191eac-9229-4639-96ec-fbc5a0cb6b60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "09144f2b-b860-4ffb-baea-adede27679b3",
+          "id": "4fa08236-96ce-47c1-8cb2-321d6c736f91",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "0a963c00-ae55-4ed0-a35f-f90e94c75308",
+              "id": "97c1322b-2f22-4aad-af7f-47d77189a97f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "33d8d39c-5ffe-4184-be86-ef48c48b3353",
+          "id": "d7cd8681-8ede-4cc6-bf42-268a6f9136d2",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "03ccdff0-ade9-4870-8cc1-96165f3d1360",
+              "id": "c5f7ca94-3f74-4f94-8f3f-64ce3ce9c528",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "27e3c899-ed11-4daa-9821-57bdcbc6bf6a",
+          "id": "67c2ecde-3a27-4f59-8f82-dacb1bee3fc8",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "79b14531-f57e-45cb-a87f-c4fbd7980096",
+              "id": "90205a4b-1bbc-4a61-bf52-01f7ca89bb9e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "b3cc7324-8168-4b27-8a7a-e296f54aaa5d",
+          "id": "90eb9691-27d6-412b-9c2f-26f3363d9911",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "0ae13a04-0860-4848-8ffb-bde945dd64c4",
+              "id": "5cc1c645-c0bb-413c-b946-b15439ada0bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "8724c0eb-d6b6-44ec-bf8f-2707175fc306",
+          "id": "686d9dbb-316e-404c-8482-203e9e8e30a3",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "9020bfd3-2aa5-456c-aa6e-028e677f57c6",
+              "id": "9b52a8b4-fd03-450a-a855-bc7650b0f55c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "0378dc67-7ab5-413f-be1c-93c898f06211",
+          "id": "237914fc-2e68-4e98-8658-1a15423ba2d3",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "9abb8806-ad72-4012-8afd-81efd020de29",
+              "id": "5e423021-9d30-4bff-86be-b78787088a0b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "67b10216-d170-4086-9f32-503cda322b74",
+          "id": "f18920c6-6480-4b38-ad96-46ef5abca639",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "14362250-ea92-4b42-8240-940ab6d6a76d",
+              "id": "bb60c55d-d133-4568-a6d1-d3576da41eb3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "0dee0b5a-0c3a-4fc2-9c74-ab9a512a44df",
+          "id": "b853fbe8-2c77-424e-8283-35d6056c6510",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "741a5820-5e87-4be8-89c2-21db768d70e3",
+              "id": "24e234b0-b47c-406d-b0a2-41f043581bab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "c7e0c3a4-7cc4-4272-8e11-e3ebe6a29e24",
+          "id": "9e19bd52-f402-42dd-9283-0853dca48907",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "d721f48c-39c6-4fbd-92fe-2ac0d7cbed61",
+              "id": "03507850-082a-4af1-87a1-c18e36c1e392",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "fbe6e120-a4c6-4a2a-a663-5b9d745c4e75",
+          "id": "2aadc98b-a2c5-4913-b3c0-f1ce7c8108db",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "b9769460-76f0-4147-833a-9253a3c1583f",
+              "id": "ecc9306b-a234-4e4b-b33d-05caa74a6bf9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "b7faee9c-a411-41f2-8aa8-3bff08164a68",
+          "id": "bbf2b577-7d6f-43ef-a794-74e2efa415a2",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "a0dbadbf-7be1-4ac4-aba1-2e3a999fbd34",
+              "id": "cb5352ba-96b8-4a7d-a089-1beff194d026",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "c633264a-3191-49f3-ab6b-6801013f4849",
+          "id": "4bc45856-cb27-4074-bdcf-056f5bdef3cd",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "15ad28e4-942a-42dc-9e90-acde4f57ce11",
+              "id": "5f806dd8-b79e-478f-8765-12496c0d9e48",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": true,\n        \"key_1\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 2289.6296474284304,\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 8982.275582944161\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "c3417342-881f-4035-a1a9-609d26aaec44",
+          "id": "51f36ec8-64de-4bb4-8e1b-df44aeb09837",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "ec3ca9a3-e34e-4195-bd3c-2d78f1da941a",
+              "id": "02da0cb2-0e8e-4237-ab6a-7a55c554dd59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "4e971ba6-48d1-4864-940e-5397d86fc386",
+          "id": "49441d58-6be2-4b80-a6fd-664b4e2ca5d5",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#0BaC96\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#58da43\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "b2e3cb0f-2cb1-4672-9acd-c7a52e2510fd",
+              "id": "1c19135c-d589-4ef4-8968-4ff69efc1ad0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#0BaC96\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#58da43\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "23a9c525-4c73-4dd8-bec8-d5fd396e531f",
+          "id": "3fa6156c-5c13-4efe-8e22-6c2f448d8403",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "1939dcdf-91b3-4825-ba8f-b49c7de480d6",
+              "id": "edf27e19-3cdb-4005-8deb-53af292b71d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "22cfa59e-dea3-4aec-a73e-124a57d0a1fb",
+          "id": "7ba4dfb0-7997-4a01-bfc8-111487464b06",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "de33fe38-be60-4d71-82a1-8c003f72cb29",
+              "id": "d07cb96c-7453-43dc-9204-9fcd66147c00",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "268f7577-b0ec-4c1f-8704-6c843422c333",
+          "id": "12780d08-200e-4a7c-9079-f2c2288048b1",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#DE468e\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2c5117\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "26ee6dc2-b918-4225-975d-1822e854894e",
+              "id": "c9b69f97-0ff4-4ccf-85ce-b3961fb1cecd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#DE468e\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2c5117\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "b2110ea2-46cc-4c54-bb00-57d83e34ee6a",
+          "id": "261508cb-69c0-4c57-8bae-54859d83843f",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "96e3b601-c27a-49b9-9948-c149fc3aadb7",
+              "id": "23f10f49-6637-4974-9c34-0861f5dfe5a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "c17caa50-6c2f-4ef4-bf08-50e4298929d6",
+          "id": "a496f178-f5b5-40b6-bc30-ab770e49b47a",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "57ef68e0-e985-49ce-87d0-e34901bc4d32",
+              "id": "6c484872-b5c4-44fb-ae8d-7308aa3ffe8d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "abb2511b-84b6-468e-a4de-6b46b932dff7",
+          "id": "8538ff50-3ff5-4abf-b34b-295fbc1fdbd3",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "9d544781-feef-4776-b491-f07db2468f59",
+              "id": "e1db996c-124f-4b53-b7b7-6c586b35fa4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "f5cda752-63ba-4091-9315-db8ed3a05e02",
+          "id": "93fc5d4d-19a0-4164-b45c-3be02ac20f9d",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "55a212f9-0234-4743-a122-5b53d93c7c7a",
+              "id": "0468cad5-45ed-464e-aa97-99b47b7e8e89",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "d56a7593-219d-4fc8-b7a2-a96898001612",
+          "id": "f0f76a1e-0257-47e2-91ff-36ec2c4f23ca",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "9c4e2289-7d69-4082-b718-40d9972e4336",
+              "id": "7c3cdf3c-4e77-4c21-a323-41c336190668",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "1e9fc591-162c-463a-bd47-cc4d9aa0b367",
+          "id": "92a06a0d-34c5-4d5e-bc41-f3a54c4c6857",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "343d504a-9c8e-4868-ad5b-e5feeebf64c5",
+              "id": "2dba7571-b7fe-4c49-a4cb-d5a91640e9a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "e4b3ca0f-78e1-4610-b5a8-90b0d42808d2",
+          "id": "f81b378c-1c11-4dde-85cb-399ca911d2c7",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "74a77a9f-f924-45fb-9c5f-6c97cef1ee47",
+              "id": "fee20ba2-5e92-4d9b-b85c-317e0ed59dab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "7779cf2e-5545-4b0b-9d39-7fdd3e662410",
+          "id": "bcd6d8fb-6844-4a72-9a49-72a6dc02c8ed",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "f39e5c89-f3c7-4476-8492-a3799490223d",
+              "id": "e37ebbbd-ea95-4379-8c9a-f90958ba5612",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "43937ccb-5c41-48b8-b335-1a88f8c5dfbc",
+          "id": "60e7259d-2ff0-4ab0-bb15-caca73b91ff5",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "0323adf8-cb87-4561-a17b-2216263fe51c",
+              "id": "1f13b459-9ff0-4d8f-bc6f-ff38a65e8136",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "b9f6b1af-21ab-481e-851f-77e3024df57b",
+          "id": "2b12538c-d035-4389-9205-c559f97056f7",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "03378909-1155-4b28-bc3c-cc6cb2ba6a6a",
+              "id": "9083edfb-46a3-48df-a348-80c92f1d0a92",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "569dd1d4-d1b5-4eae-890a-99a181b881ad",
+          "id": "cfdd456e-bfc3-43a8-9ac8-cfeff06740ec",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "de932eda-91e2-422e-91dc-46c9e1c585aa",
+              "id": "1101ce74-0ce6-40f2-ad09-d64d504082f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "7719d415-9113-44a3-b34c-a1d42ddb3c25",
+          "id": "6b94e6f1-8b20-4b2c-915a-a99aaec9847c",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "2f360c7b-31d7-4204-b608-a14e9b0ad300",
+              "id": "1efe698b-f5af-4702-99b2-5140ccfa99a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "55752572-7701-47dc-9220-38853ecd308d",
+          "id": "92628b19-28f0-45a9-b637-8abfc9369116",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "0f68f8dd-df00-4fea-b81b-91cb2fe2b2f3",
+              "id": "68da8ff9-369f-45e7-99c4-8f99b86f1780",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "840af979-31a8-4e4d-aa27-79767e176599",
+          "id": "4ddc7746-8b89-444c-b9a3-8d102458817e",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "0eb886c2-9220-4bd6-a53d-dab05bdb4b5b",
+              "id": "dd10004b-47b1-40c9-972e-eb731f413327",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "7561b6e4-b85c-4e34-8738-33470e74a9ea",
+          "id": "99268abe-ee60-4e45-ad98-66a53143435e",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "85ce0db3-c24e-46ae-a24a-895ac86a8cd5",
+              "id": "7ac57fe6-09f6-4d0b-b16a-8584b31a6653",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "dc6193d5-19d4-4912-8983-8d4ba2e1ef19",
+          "id": "f7c3711b-b9cb-42bf-a60a-1aaf4b42585f",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "a4b4873b-8e05-4a0d-8902-6b4f0b0546cf",
+              "id": "2772a808-3c8b-4d95-a72a-b00d022f8da3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "cf13f4d2-2409-45ee-84df-11b9758a5ef1",
+          "id": "27aa5b63-c9f4-444f-8b8e-0a85883215f3",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "efb09a6f-898d-4205-b00a-e08436dfffb5",
+              "id": "4dba9148-af09-47fa-a5af-7f347ec0d4b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "dc207984-3efb-426d-91f4-cdad3cdd8278",
+          "id": "2ad3ebde-c9a8-4a09-90e2-11eb65f3c7b5",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "cc9909cd-7c9b-40fb-b80e-85929f9fb270",
+              "id": "e2891435-f77f-4417-af67-3f5c92f0ebb6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "ede2c096-d1ac-491d-b070-8aad9c3293de",
+          "id": "f4cfd623-fc53-4366-aca7-b3e87b866dc7",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "840412b1-381c-4576-b0a3-ab5883729842",
+              "id": "4c42b38a-9072-46f4-978b-0b0ae41514da",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "910e4972-d55f-4f0b-b040-8adaa0da774b",
+          "id": "cc525664-6d2f-4eff-963a-779a1ba530c9",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "9ad86b96-e93d-4618-909b-dc8beb6e6687",
+              "id": "614ae574-7ffb-43a0-a367-5702ff275ca2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "1763f422-da6f-4784-a458-eab7cd280491",
+          "id": "ab4e00f6-010d-4292-b90b-b61dcb01333b",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "64bda7fe-40f6-44d3-b0a9-473f017d302e",
+              "id": "a7c6ae63-e75e-47da-a00b-847acc84eab3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "67b840bc-db1a-472d-b72a-b3dcb9ef957f",
+          "id": "58bb6dcb-7c01-4b09-bae8-dc478d486802",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "f7a22d46-3d3c-42d5-b837-c981fff64496",
+              "id": "55d00833-3a45-4292-82e1-57bb0c7d0d5b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "484595ac-5b3e-4740-b4e7-183f28ca8ce8",
+          "id": "d131a215-6fbe-484b-b3de-6ec5bf15e2b5",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "3faecb94-e7a2-44c0-b75f-7384f160ca64",
+              "id": "ebe97a2a-e880-467b-b8c4-08117bf21f13",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "f2827f7b-4ede-4161-b855-9fae2928994b",
+          "id": "80eab7f3-2dc0-45ab-849c-803090fffdd9",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "a342a238-984b-443a-8c40-fe8f43c01c42",
+              "id": "f0bdbccb-31ca-4a30-9c9c-f6e51d3b6d4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "fd225bc0-7bd8-44cf-9453-62ffaba77491",
+          "id": "c23b89f5-55b5-4f9b-9fb9-cd8d8c9a17dd",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "dcfdf3be-b723-4a40-8c5d-47e9de639b65",
+              "id": "f84d2cc3-5a7b-4a90-b363-9dc6719b8bbb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "a8cfad2b-1aa1-49a6-a93d-181ef155298f",
+          "id": "adb065c2-9b71-477f-b6a9-b70bb6fa614f",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "06138bf6-787f-4fd1-9b7e-6b5764c07ca2",
+              "id": "ca765984-3153-4e22-91fd-c6a271bd33b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "ccdb69bf-81d8-4b57-a000-5acdbb6cac87",
+          "id": "cdef7bd5-b459-4e8e-b2e3-ed92411ba111",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "535b4c14-c81a-4186-be9e-17daf5b563b3",
+              "id": "cfbccf08-745c-4794-86ab-c847873d8b8d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "e6e1d653-3e22-482b-b902-513156c9f086",
+          "id": "b0b5be7d-54f3-4efe-a3d6-0617100c17ba",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "ed54724f-faf7-4af9-a8f0-27c9038f1018",
+              "id": "7ff678c3-222e-424b-b84a-130aec204d79",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "70a16b2d-63eb-430b-91c7-845c38e862f7",
+          "id": "bcf92867-8199-4ab4-9988-c11fed96b19a",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7543,30 +7543,17 @@
             },
             "header": [
               {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
                 "key": "Accept",
                 "value": "*/*"
               }
             ],
             "method": "POST",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"resolvedByUserId\": \"<long>\"\n}",
-              "options": {
-                "raw": {
-                  "headerFamily": "json",
-                  "language": "json"
-                }
-              }
-            },
+            "body": {},
             "auth": null
           },
           "response": [
             {
-              "id": "64103517-d6ec-4c46-ad58-f57bdd24170b",
+              "id": "5fd98490-1334-4b8d-9d89-a05faae6df87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7608,10 +7595,6 @@
                 },
                 "header": [
                   {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
                     "key": "Accept",
                     "value": "*/*"
                   },
@@ -7625,16 +7608,7 @@
                   }
                 ],
                 "method": "POST",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"resolvedByUserId\": \"<long>\"\n}",
-                  "options": {
-                    "raw": {
-                      "headerFamily": "json",
-                      "language": "json"
-                    }
-                  }
-                }
+                "body": {}
               },
               "status": "OK",
               "code": 200,
@@ -7655,7 +7629,7 @@
           }
         },
         {
-          "id": "7fa3564f-e18b-4b07-a71d-864771920ac9",
+          "id": "5a9e4f95-610e-4b1d-90f5-85fd0dc2fd44",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7699,30 +7673,17 @@
             },
             "header": [
               {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
                 "key": "Accept",
                 "value": "*/*"
               }
             ],
             "method": "POST",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"actorUserId\": \"<long>\"\n}",
-              "options": {
-                "raw": {
-                  "headerFamily": "json",
-                  "language": "json"
-                }
-              }
-            },
+            "body": {},
             "auth": null
           },
           "response": [
             {
-              "id": "9fced464-7115-4b0c-8706-a94f67c5b154",
+              "id": "1f73b4d3-11bc-4c81-92f5-af6c970326ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7764,10 +7725,6 @@
                 },
                 "header": [
                   {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
                     "key": "Accept",
                     "value": "*/*"
                   },
@@ -7781,16 +7738,7 @@
                   }
                 ],
                 "method": "POST",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"actorUserId\": \"<long>\"\n}",
-                  "options": {
-                    "raw": {
-                      "headerFamily": "json",
-                      "language": "json"
-                    }
-                  }
-                }
+                "body": {}
               },
               "status": "OK",
               "code": 200,
@@ -7817,7 +7765,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "54d85628-56a8-44b7-9ffd-243b3574f77d",
+          "id": "f40a9f8f-87fd-4521-bf25-e30d00555335",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7870,7 +7818,7 @@
           },
           "response": [
             {
-              "id": "670c5d24-08d6-460d-a173-24da3193533e",
+              "id": "bc1ac55d-c567-4411-b9f8-5100d8d85b4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7945,7 +7893,7 @@
           }
         },
         {
-          "id": "53460fbb-f123-4a36-ba5a-919474f0d268",
+          "id": "effdea10-2638-4236-a265-be282173bab7",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -8011,7 +7959,7 @@
           },
           "response": [
             {
-              "id": "b1eb6f1c-71fd-47e9-bd9d-600e64474423",
+              "id": "660b1321-9d09-4ab4-937b-7126186300ee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8099,7 +8047,7 @@
           }
         },
         {
-          "id": "494bbed8-17db-46ba-bf70-3b59c1560237",
+          "id": "7c50ebd6-a9b3-42f2-9f4a-de1a6dc632ee",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8146,7 +8094,7 @@
           },
           "response": [
             {
-              "id": "ab7a57ac-37f4-4fe0-a2f0-30daefe8f100",
+              "id": "20a85623-2ad0-44ba-80f2-4332db4cacb7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8211,7 +8159,7 @@
           }
         },
         {
-          "id": "6e39b899-c935-448e-ab13-1cf2fdb8b7bd",
+          "id": "a96e7443-399c-487d-8b73-347847ee3141",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8253,7 +8201,7 @@
           },
           "response": [
             {
-              "id": "7c2c04d8-c3cb-4e1e-bf81-c43290897132",
+              "id": "cfa417e5-1886-4e03-8579-c07406d73087",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8317,7 +8265,7 @@
           }
         },
         {
-          "id": "88d2bf2c-0c81-4cd1-8191-6b05f1141566",
+          "id": "c5772145-9afb-4c6f-8627-27c41dcdff35",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8372,7 +8320,7 @@
           },
           "response": [
             {
-              "id": "d63ef747-f498-44ac-86ca-4fd82144bf19",
+              "id": "117950fa-0451-4368-a8f7-3ace16c3c662",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8455,7 +8403,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "24b2114b-796f-4aaa-94d5-0e8ed1f9872f",
+          "id": "678781ea-9d4e-4b02-80e8-64d8f99e6798",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8496,7 +8444,7 @@
           },
           "response": [
             {
-              "id": "1184d9c7-1d3f-4593-8629-b17dfa6d98cf",
+              "id": "1045ee25-2d26-400a-97ac-f06ba2d68845",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8559,7 +8507,7 @@
           }
         },
         {
-          "id": "45b01f0e-f6b3-4194-8c52-c81e1337ec41",
+          "id": "02986ea1-31d8-451f-8455-400f9f54469c",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8613,7 +8561,7 @@
           },
           "response": [
             {
-              "id": "b7d9aaa4-2612-4cec-a24c-50fc7559a1fd",
+              "id": "acf716f7-bf45-4402-b019-5e62b25733c8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8689,7 +8637,7 @@
           }
         },
         {
-          "id": "6a3ada1f-257c-4600-89e6-b5e9ccead033",
+          "id": "6fa1349e-3483-42ee-8cd5-41865c9c191a",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8724,7 +8672,7 @@
           },
           "response": [
             {
-              "id": "7aaf5533-c923-44f6-94ff-39b6b805a587",
+              "id": "1cdd27b6-394c-4b72-a424-7c1f530309a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8777,7 +8725,7 @@
           }
         },
         {
-          "id": "a72f9431-bcf9-4cf4-9a6a-aba886970206",
+          "id": "b72caf41-fc82-4e14-b530-7e57f301397b",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8834,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "1d581a89-d5f5-427b-97be-eeb95de6af2f",
+              "id": "7cf7d144-c035-4a57-84de-8607ae4a1ab9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8913,7 +8861,7 @@
           }
         },
         {
-          "id": "fb6d963f-42bd-4fe6-95ff-c8c06bb042a8",
+          "id": "8b42759a-1bb2-4e85-8620-798dbb0dae37",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8955,7 +8903,7 @@
           },
           "response": [
             {
-              "id": "058f51e2-a562-42a4-8fae-6456c5d23d78",
+              "id": "8498c494-30ef-4453-9524-4cfaacbf8c6a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9025,7 +8973,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "73d96e7b-e9f4-439b-8319-0926a9936313",
+          "id": "efda19a1-740c-445e-8055-3fc3028866ee",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9078,7 +9026,7 @@
           },
           "response": [
             {
-              "id": "a4ae8dda-582f-4c3f-93fd-2b894190dfd1",
+              "id": "767a7167-8edb-42cc-9ddd-8bfe4270f496",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9153,7 +9101,7 @@
           }
         },
         {
-          "id": "d1c19b50-f438-4cb2-93ae-273e50ff7cab",
+          "id": "3f74f486-164b-443e-9517-7c04cac9d713",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9219,7 +9167,7 @@
           },
           "response": [
             {
-              "id": "d74b89a3-433b-460d-80a0-b9b864f1c479",
+              "id": "1555fd55-934b-4acf-9e09-b2b8e279e1eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9307,7 +9255,7 @@
           }
         },
         {
-          "id": "9530afa7-35fb-4fba-b306-762938fb52c2",
+          "id": "8f8e451f-af28-484c-9c5f-88ddbb976403",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9354,7 +9302,7 @@
           },
           "response": [
             {
-              "id": "2edec7dd-98cd-4fbe-8c9f-6c129949d1ab",
+              "id": "a26223df-30eb-4c31-8d6f-baea417ab5f7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9419,7 +9367,7 @@
           }
         },
         {
-          "id": "3e8408e9-09d7-4d26-af5e-547a3756e663",
+          "id": "af0361a5-4732-49fa-87f4-a768bc9090e5",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9461,7 +9409,7 @@
           },
           "response": [
             {
-              "id": "503406bd-2519-4f5c-9a20-b3a2db57a4d1",
+              "id": "09691f10-8fae-4571-be8f-a35ca385b301",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9525,7 +9473,7 @@
           }
         },
         {
-          "id": "b1814fe2-6411-4a23-9530-bb9f39c08fa0",
+          "id": "f8dd2bb9-8667-425f-b960-43c50ee917ef",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9580,7 +9528,7 @@
           },
           "response": [
             {
-              "id": "364eee0f-4dc3-4d88-8643-599d2eb89cda",
+              "id": "6c746e36-0d9d-4180-8502-147a8d0dfccb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9663,7 +9611,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "8de1d8db-3c80-4c86-9bda-e54c8bf44669",
+          "id": "bd4d8723-8fee-453e-a86e-772f615db5cc",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9705,7 +9653,7 @@
           },
           "response": [
             {
-              "id": "e88b9c7a-8845-4bc9-add1-395cbd8df643",
+              "id": "92d5bb7c-9cf9-44bd-815d-74f6213e5a8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9769,7 +9717,7 @@
           }
         },
         {
-          "id": "15033aaa-59f8-420e-ba1c-0e985a369c7f",
+          "id": "8b6e490e-1149-4b6c-92fa-a53835ed72f4",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9824,7 +9772,7 @@
           },
           "response": [
             {
-              "id": "0115d104-708c-4152-91b8-dd258c206683",
+              "id": "e128a3fd-0d39-4e1e-92f2-aa8e35e27142",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9901,7 +9849,7 @@
           }
         },
         {
-          "id": "b3c06354-4f6e-433c-8a35-f90c2576532e",
+          "id": "54b3598c-011f-42e9-a8c8-41669a6894a8",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9937,7 +9885,7 @@
           },
           "response": [
             {
-              "id": "a5d6fdb7-3bfb-46ab-a841-ddc5dd76de2d",
+              "id": "d39fcd31-5b36-4815-8b0d-6919ed8f949e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9991,7 +9939,7 @@
           }
         },
         {
-          "id": "f0641871-b6c9-40eb-bda4-e1f459accfd6",
+          "id": "df0bc9f1-491b-49e8-9b51-07e8512e8f4a",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -10021,7 +9969,7 @@
           },
           "response": [
             {
-              "id": "f4040587-77d5-4ab9-8e36-985b8d9c5adf",
+              "id": "81b39f6a-e6e0-46ed-98e4-5e69241d0267",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10073,7 +10021,7 @@
           }
         },
         {
-          "id": "761697f1-4dee-41e8-bfaf-cbe05811e4b9",
+          "id": "e886a15d-b641-4d21-a33c-2ae73812a385",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10116,7 +10064,7 @@
           },
           "response": [
             {
-              "id": "dabfff8a-9fec-4e53-8f90-7c2e96ecb1f1",
+              "id": "21670304-310e-4f49-aa46-91c7b668516d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10187,7 +10135,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "c565ee75-0fe9-495f-9a54-ad769276188a",
+          "id": "d045e475-1d8d-4b62-83c8-4391c036d94a",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10229,7 +10177,7 @@
           },
           "response": [
             {
-              "id": "f31241bc-5fed-49e0-a784-755c36e04b23",
+              "id": "fbbda877-091a-4e8c-aad1-c4e9f317bdc1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10287,7 +10235,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6842a856-83c9-47e7-8785-f33c5806eb1f",
+              "id": "01d8674b-b53e-4fe1-88a5-7feb0e58859e",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10351,7 +10299,7 @@
           }
         },
         {
-          "id": "05a9782f-b01d-48e3-aeb2-b33cafa23d19",
+          "id": "0e427400-fc46-4524-ac69-157c3c15de21",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10406,7 +10354,7 @@
           },
           "response": [
             {
-              "id": "ffbfe837-48ff-40fa-ba38-793a5748054b",
+              "id": "7995aeed-ffc4-476e-8d3b-107f6da6fe23",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10477,7 +10425,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "495a52d3-97c2-43c6-9521-86581fec8f30",
+              "id": "f44d816d-3646-45a9-b1e8-a8ae7f1d7701",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10548,7 +10496,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d4b7d867-59ec-4c90-a001-0bfce41c98ea",
+              "id": "94e2da3b-fd85-4965-b76f-678679b52eee",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10625,7 +10573,7 @@
           }
         },
         {
-          "id": "589d07a3-97aa-436f-82d8-c85d4830fa8a",
+          "id": "c3ee7a73-d310-408c-ae4a-54dc5ea444af",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10661,7 +10609,7 @@
           },
           "response": [
             {
-              "id": "0408c67b-991e-41f9-8f3e-2f3d24ccce2e",
+              "id": "6664cfe0-d1f1-490c-8414-65e5e1144ecc",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10709,7 +10657,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "cc77c50c-28fe-49ee-a05c-b0c7086de7e6",
+              "id": "0b0b5856-366c-4f38-8341-a9ab15c24b69",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10757,7 +10705,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "18607ec5-3566-4ada-ad25-6f6ccbd20fa4",
+              "id": "4bdbaaef-3657-469e-a076-89361df1cebf",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10759,7 @@
           }
         },
         {
-          "id": "a005ec04-fcd1-4104-8608-4c663c8d7ad8",
+          "id": "5e232531-f643-4a9a-9864-dc31fdb9d078",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10841,7 +10789,7 @@
           },
           "response": [
             {
-              "id": "f6da3bd5-df9f-42ae-b0e2-8bf32f12826b",
+              "id": "139ce310-c063-4b10-b4ce-1f7b7d4edd89",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10893,7 +10841,7 @@
           }
         },
         {
-          "id": "b0877685-6ac7-431f-a48f-350c84ee79da",
+          "id": "109146d4-5515-49ce-a431-1f98bf74e745",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10936,7 +10884,7 @@
           },
           "response": [
             {
-              "id": "9394d250-238a-475c-8c70-8dd3b4ab627d",
+              "id": "80c94279-3233-4004-ae87-7acff424ad23",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10995,7 +10943,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "51fbcddb-6485-43d6-a637-d7418459cb32",
+              "id": "2a694b64-9bba-42d1-aef0-0c3fd9ab0781",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11066,7 +11014,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "97dd0923-9f14-4bbe-adb6-47a469f51887",
+          "id": "2848db16-b129-4d29-a9cb-418a5e42b38b",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11150,7 +11098,7 @@
           },
           "response": [
             {
-              "id": "1adc09a3-40e5-43ea-aa95-02218187cad6",
+              "id": "6a6fb576-e8f5-4624-b7c2-d46f4c65048b",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11253,7 +11201,7 @@
           }
         },
         {
-          "id": "78a194fd-b815-4839-8f1f-48d43855cff8",
+          "id": "c58084c1-bddb-429f-bc04-7fe0c5b92391",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11319,7 +11267,7 @@
           },
           "response": [
             {
-              "id": "8bbc1528-e31f-4c95-8dd7-f53c248f5b23",
+              "id": "d43e5b60-85c5-4ddf-9ccb-ec79221d43aa",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11404,7 +11352,7 @@
           }
         },
         {
-          "id": "c262a908-12aa-4995-b419-93aa0d998229",
+          "id": "a479f68c-8c3e-456f-ac7d-48835c1fd5c4",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11488,7 +11436,7 @@
           },
           "response": [
             {
-              "id": "3bd66a15-fbfc-4671-87ab-ea4b65488ca0",
+              "id": "3a061eb0-8e21-4d76-80e4-b872911282e1",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11591,7 +11539,7 @@
           }
         },
         {
-          "id": "e4c60f56-de13-49ce-abb0-cb7b24c72d10",
+          "id": "0931b878-9edb-43a0-81d7-439eb6b7e331",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11666,7 +11614,7 @@
           },
           "response": [
             {
-              "id": "9f22d542-a3a4-45fe-bfdc-a8dbecb25f8c",
+              "id": "6a03375e-e475-4973-a1df-c15d2dd6f91f",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11760,7 +11708,7 @@
           }
         },
         {
-          "id": "55895d5f-6999-47a9-9cb3-1790939cde14",
+          "id": "e965f508-f641-4a96-b7c5-1be6f526dc0e",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11835,7 +11783,7 @@
           },
           "response": [
             {
-              "id": "723e71ad-e36d-44fb-b964-582f53c033c9",
+              "id": "af186919-78f8-4baa-927a-3f66a4881853",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11929,7 +11877,7 @@
           }
         },
         {
-          "id": "3bdb09e3-2f65-4828-8934-965a310c0a8f",
+          "id": "27d945c7-cb95-4c01-bfcb-d355a61aff02",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -12004,7 +11952,7 @@
           },
           "response": [
             {
-              "id": "880c8cd3-c674-4eaa-b14c-0dd85ef8feb5",
+              "id": "91c13f1b-7007-4461-b196-8a70a987e64e",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12104,7 +12052,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "5d3dddd0-4598-4371-b54e-3857f2260df7",
+          "id": "3f5a4c7e-7a1e-4d6e-9dff-9f0cf83c2e8a",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12170,7 +12118,7 @@
           },
           "response": [
             {
-              "id": "47382948-7db5-44fd-bf66-5f2d70693b88",
+              "id": "b714e058-a1ce-4e7a-843e-eafab4db6eb3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12244,7 +12192,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12261,7 +12209,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "d1e19a12-7a36-4722-ac23-69830b882230",
+          "id": "6da6f6a5-4f60-4af2-a31e-1ebda3df4c65",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12303,7 +12251,7 @@
           },
           "response": [
             {
-              "id": "483c2431-159e-4906-b5df-c8e439c8c9d5",
+              "id": "ff355224-7ab9-44ba-bfd1-07d59098dbdb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12373,7 +12321,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "687d7ba0-4aa0-4ff4-9a4d-1cc163f0fe96",
+          "id": "6e6a6fa6-36cd-42fc-bc31-c3cb3513ff12",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12412,7 +12360,7 @@
           },
           "response": [
             {
-              "id": "4eacaf70-16a9-44c6-b8ff-11198f26a34e",
+              "id": "d83befd3-6d73-46bd-9bcd-f34addc1fcd1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12465,7 +12413,7 @@
           }
         },
         {
-          "id": "62be5b47-a7d9-48ec-80e9-b2ad5576aceb",
+          "id": "7eedd4cc-bd9a-4ed9-9334-17c197c41de6",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12497,7 +12445,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"oi-HD\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"02:46\",\n  \"quietHoursEnd\": \"08:04\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ss-LO\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:37\",\n  \"quietHoursEnd\": \"03:30\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12517,7 +12465,7 @@
           },
           "response": [
             {
-              "id": "462ed8ed-83c8-4b8b-b7a1-95d14ca5a049",
+              "id": "0a356c54-e9a2-4f4c-96f4-cc1939365474",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12555,7 +12503,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"oi-HD\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"02:46\",\n  \"quietHoursEnd\": \"08:04\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ss-LO\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:37\",\n  \"quietHoursEnd\": \"03:30\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12589,7 +12537,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "b523f129-e32c-4b1b-9816-08689c8f1acb",
+          "id": "7be3a51a-982d-4079-86dd-7164ca199774",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12631,7 +12579,7 @@
           },
           "response": [
             {
-              "id": "218537bf-f784-4a12-8f20-bdd61ca94d86",
+              "id": "5b5e722b-2513-4e38-8d77-74f2cb41e5b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12695,7 +12643,7 @@
           }
         },
         {
-          "id": "d308da9e-c1d6-4def-8fd1-f54ca3a09a1e",
+          "id": "e9d9cccd-da3b-4194-8309-ca542fafbbac",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12738,7 +12686,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#Cfd579\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#fc9F7d\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12750,7 +12698,7 @@
           },
           "response": [
             {
-              "id": "1728d726-7eff-403c-a12f-30b3fe1b5b4e",
+              "id": "d3f6e12a-2afb-4294-846d-00e21220af5e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12799,7 +12747,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#Cfd579\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#fc9F7d\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12827,7 +12775,7 @@
           }
         },
         {
-          "id": "57e99320-6d2f-4e47-9b38-db6df9a89c54",
+          "id": "87e07f5e-1c76-42ad-87f7-3846bae0c220",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12863,7 +12811,7 @@
           },
           "response": [
             {
-              "id": "c7193646-b553-4e2a-a8c7-06ce69ecb203",
+              "id": "df8c64fa-6d85-4c24-a87f-87f97bb7355f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12917,7 +12865,7 @@
           }
         },
         {
-          "id": "78e7f30a-abc0-438d-b32c-6f2384d371a0",
+          "id": "5588ee72-0357-40fa-8d68-b11bab643adc",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12947,7 +12895,7 @@
           },
           "response": [
             {
-              "id": "2af2175e-d5e7-4cba-ab4b-504c9e778130",
+              "id": "f9016086-e7df-467f-ba62-e0ddeeab074b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12999,7 +12947,7 @@
           }
         },
         {
-          "id": "07aec017-6b2b-4a5c-a24e-9fa44fb68ac5",
+          "id": "df575fbf-b936-49b1-b4d7-825d3e8b6220",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -13030,7 +12978,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6F5Ef5\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2CF6fF\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -13042,7 +12990,7 @@
           },
           "response": [
             {
-              "id": "dbd0f5ed-16c3-4925-9474-b943f1a733f9",
+              "id": "82c6d866-7864-4268-97ae-ab551dd9038b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13079,7 +13027,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#6F5Ef5\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2CF6fF\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13107,7 +13055,7 @@
           }
         },
         {
-          "id": "fc7f5bf7-770a-4c20-ab69-030d31cffe01",
+          "id": "e83405e9-fa50-49da-b3e1-2a2e7538a950",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13138,7 +13086,7 @@
           },
           "response": [
             {
-              "id": "30394cee-9f8b-4333-8b15-1e89181abcdb",
+              "id": "9f4c5910-47da-492b-a008-81eff2f733de",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13197,7 +13145,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "1d995b37-148b-4d6d-9de8-04fe6fc3c93d",
+          "id": "0d603ab2-7ae8-4f28-bfff-3c8f00e83649",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13250,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "f4524b9f-2eeb-4c76-a7da-14f55af2b288",
+              "id": "11111abc-b8b9-4502-983e-080f1c51f712",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13325,7 +13273,7 @@
           }
         },
         {
-          "id": "e291641c-6264-46c3-8850-702c022d2bae",
+          "id": "3b381418-3f91-4a6a-8fb3-2c165f24937f",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13391,7 +13339,7 @@
           },
           "response": [
             {
-              "id": "b1179871-1a06-4885-85be-80fc5988fca0",
+              "id": "e0a78c95-b88c-4207-9871-7c69eda4388c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13479,7 +13427,7 @@
           }
         },
         {
-          "id": "d8faa6bc-45cd-47cb-b7ac-3b0c3ac0b83a",
+          "id": "43620b00-b634-4520-af5b-be1ba4629f30",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13526,7 +13474,7 @@
           },
           "response": [
             {
-              "id": "c35f67e5-6792-43bc-8f95-6fe4a1c293c4",
+              "id": "2162b1f4-8639-4e4a-91a2-5667c5ca5a8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13591,7 +13539,7 @@
           }
         },
         {
-          "id": "5b29cff3-1379-440d-98ab-0e3550caf939",
+          "id": "866ea3bf-e42d-4c73-947c-fa00566344e2",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13633,7 +13581,7 @@
           },
           "response": [
             {
-              "id": "2bbf3142-4da6-48be-a31d-ca715f455fc4",
+              "id": "9c4f7028-13fe-46fb-a349-a96e4d68c968",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13697,7 +13645,7 @@
           }
         },
         {
-          "id": "c19981a8-119f-4cd6-8e01-b9a22338f270",
+          "id": "cc3ada1a-2da7-40e1-88e4-b7451f11789e",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13752,7 +13700,7 @@
           },
           "response": [
             {
-              "id": "4046b5e9-2a86-4871-a9bc-7d705112d1fd",
+              "id": "947d06ea-b965-41df-a4c8-1546e12ffdcd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13829,7 +13777,7 @@
           }
         },
         {
-          "id": "ba0dee55-21d1-42e7-821f-079e3426a5ce",
+          "id": "b8fbcd10-695e-4f2a-80b3-9265ca32c7dc",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13883,7 +13831,7 @@
           },
           "response": [
             {
-              "id": "591adbd2-4ff1-41a6-842e-764aa459b78b",
+              "id": "3f7b1195-e4e1-48bf-968f-136cc4954608",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13959,7 +13907,7 @@
           }
         },
         {
-          "id": "803dc81e-0a67-4ade-a4dd-9e9796684e53",
+          "id": "89027c13-48d4-4220-b27c-42bd48563f7e",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -14025,7 +13973,7 @@
           },
           "response": [
             {
-              "id": "554361e9-694a-412e-a3fc-04b189d3907b",
+              "id": "8cdfa93c-7d68-45fe-a19d-16cd334434ee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14113,7 +14061,7 @@
           }
         },
         {
-          "id": "dee39843-b1c4-46cc-9fb2-a6d7570b9e86",
+          "id": "12eb5cc1-6bc6-4e03-bb5a-cdfdc2c18c21",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14191,7 +14139,7 @@
           },
           "response": [
             {
-              "id": "6b28927c-7784-4e30-9386-7798f641783e",
+              "id": "688811b8-ae26-4f56-8451-79352c67f993",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14291,7 +14239,7 @@
           }
         },
         {
-          "id": "26c3ebf7-227f-4951-9da8-ec5eba257b90",
+          "id": "24cf314e-13af-4021-bc37-4771c1b483d0",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14357,7 +14305,7 @@
           },
           "response": [
             {
-              "id": "3caa0348-0d32-4ce4-9403-f3de0a3d566f",
+              "id": "dece6de8-1346-49b5-b7b8-c7b0a735ac39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14445,7 +14393,7 @@
           }
         },
         {
-          "id": "0456fe51-f32b-41c5-932d-b9b6ca54120a",
+          "id": "d64638b3-3969-421c-9df2-cd47fc115f99",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14500,7 +14448,7 @@
           },
           "response": [
             {
-              "id": "bb4ed5b4-7fec-4a6f-9ab9-050d59d218c7",
+              "id": "e5c9a227-a66e-43c0-8f06-89b6ab752a30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14583,7 +14531,7 @@
       "description": "",
       "item": [
         {
-          "id": "9d502408-4192-4319-91be-6ca74982d38d",
+          "id": "9d4ab14c-f74d-4c77-963e-b2bb19daac07",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14624,7 +14572,7 @@
           },
           "response": [
             {
-              "id": "8b14724f-d8ca-4329-9d7d-a05be7866ee4",
+              "id": "ec2458c2-6ae9-49f0-8b13-b50f55d39fb8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14687,7 +14635,7 @@
           }
         },
         {
-          "id": "954005c6-45db-4fa3-a268-b4a13e632d58",
+          "id": "7b567b26-6f42-4c95-aed5-fb44cc0d86c1",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14741,7 +14689,7 @@
           },
           "response": [
             {
-              "id": "bee13e4f-7b4d-48ed-8496-7969fe2796be",
+              "id": "39608ad6-fbe2-472e-8a2b-306031c52c0d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14817,7 +14765,7 @@
           }
         },
         {
-          "id": "b3af97f4-9322-4cbd-8ba9-42dd74a31e7a",
+          "id": "130a5cb3-77f1-4a63-bf8a-9a92c752963a",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14852,7 +14800,7 @@
           },
           "response": [
             {
-              "id": "15766437-3208-4212-a470-db860dbffc9b",
+              "id": "5139eac6-6593-452f-bc54-16e03b03079b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14905,7 +14853,7 @@
           }
         },
         {
-          "id": "eff32a09-74dc-4395-a88e-0d54a0fdc762",
+          "id": "6c32dbcd-debb-4400-b968-09fb2b458749",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14921,26 +14869,7 @@
               "host": [
                 "{{baseUrl}}"
               ],
-              "query": [
-                {
-                  "disabled": false,
-                  "description": {
-                    "content": "",
-                    "type": "text/plain"
-                  },
-                  "key": "userId",
-                  "value": "<long>"
-                },
-                {
-                  "disabled": false,
-                  "description": {
-                    "content": "",
-                    "type": "text/plain"
-                  },
-                  "key": "userName",
-                  "value": "<string>"
-                }
-              ],
+              "query": [],
               "variable": [
                 {
                   "type": "any",
@@ -14966,7 +14895,7 @@
           },
           "response": [
             {
-              "id": "57198c54-8362-4c03-8660-0326cce6ed4a",
+              "id": "20f37493-44cc-4163-8745-06fe1aa00fa6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14980,26 +14909,7 @@
                   "host": [
                     "{{baseUrl}}"
                   ],
-                  "query": [
-                    {
-                      "disabled": false,
-                      "description": {
-                        "content": "",
-                        "type": "text/plain"
-                      },
-                      "key": "userId",
-                      "value": "<long>"
-                    },
-                    {
-                      "disabled": false,
-                      "description": {
-                        "content": "",
-                        "type": "text/plain"
-                      },
-                      "key": "userName",
-                      "value": "<string>"
-                    }
-                  ],
+                  "query": [],
                   "variable": [
                     {
                       "disabled": false,
@@ -15049,7 +14959,7 @@
           }
         },
         {
-          "id": "c3b8deaa-5614-4acd-80e9-6b5f02067d38",
+          "id": "ce36fe95-f5c8-4bca-b3ba-9c9fecd80ff4",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15091,7 +15001,7 @@
           },
           "response": [
             {
-              "id": "513eaff2-e605-45de-97f5-dbf6d73d6187",
+              "id": "557bfbc1-c717-4a63-8c97-add2ba597c2a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15155,7 +15065,7 @@
           }
         },
         {
-          "id": "ae626943-27b7-4277-a15c-0a0fe723f859",
+          "id": "60e13fbc-6de6-444e-a873-aebae5094eda",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15230,7 +15140,7 @@
           },
           "response": [
             {
-              "id": "360fdafb-07de-4bc8-aee0-01a3931dc9f5",
+              "id": "be10fa8a-8ab8-44c3-b0ea-14f236ac871e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15327,7 +15237,7 @@
           }
         },
         {
-          "id": "2ec08564-3b9d-461f-aa4a-619282948154",
+          "id": "23245e26-41c9-4106-975b-efec49dfe391",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15369,7 +15279,7 @@
           },
           "response": [
             {
-              "id": "4eae6225-8e63-4299-a959-2b1a541d2276",
+              "id": "e3d4fe40-e3ff-4f7e-833d-77e9bbcbc909",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15433,7 +15343,7 @@
           }
         },
         {
-          "id": "3cc38262-8665-4b75-8a4d-e6ad586b3737",
+          "id": "d7ff6fc0-46ee-43db-a667-932055298ff1",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15476,7 +15386,7 @@
           },
           "response": [
             {
-              "id": "628feedd-6f25-463f-9219-d4edd5659e59",
+              "id": "59b8bf5c-bae9-44b3-8f9e-8b9be124662c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15541,7 +15451,7 @@
           }
         },
         {
-          "id": "6950fbb1-fdec-4cd7-ac34-2fe3f642bdca",
+          "id": "26d0d8e8-f42c-4958-a86b-1f2bf8fbd876",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15584,7 +15494,7 @@
           },
           "response": [
             {
-              "id": "6bfa2263-0cff-44fe-a63c-76acbb8b0d65",
+              "id": "c417501a-0558-4ad3-9153-96efdbb26d80",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15649,7 +15559,7 @@
           }
         },
         {
-          "id": "e51fef7f-213b-472d-aa3b-a19075069c02",
+          "id": "2af25a19-f992-4d15-8fb4-bb76c13184a2",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15701,7 +15611,7 @@
           },
           "response": [
             {
-              "id": "a671ed0f-b369-4b3e-8c23-071616aa6f71",
+              "id": "c8771cfc-556b-4345-b6b2-090c4873ab8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15775,7 +15685,7 @@
           }
         },
         {
-          "id": "49364b9b-c07c-4de0-ba8d-e8d17578b3ef",
+          "id": "3bd33534-6e14-43a7-865b-feab75c4719f",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15817,7 +15727,7 @@
           },
           "response": [
             {
-              "id": "a12afea1-68c1-4b02-b8f4-80e316876e9c",
+              "id": "69a8862f-950b-4c5e-a0b0-318dab07a008",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15881,7 +15791,7 @@
           }
         },
         {
-          "id": "ee81d431-56b9-4bd4-8420-bd8b9932ff7b",
+          "id": "10a0e657-88d8-40d6-92b8-c189a6a5d41b",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15934,7 +15844,7 @@
           },
           "response": [
             {
-              "id": "bea92c5e-3ef0-446a-a3be-64add60b3d3c",
+              "id": "6ebda41e-ceed-45c9-ad71-b6d554348967",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16009,7 +15919,7 @@
           }
         },
         {
-          "id": "f0490731-475a-499b-928f-4cdd6438f3d3",
+          "id": "317ff855-f41e-4718-8e6d-ff5b898ea080",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -16062,7 +15972,7 @@
           },
           "response": [
             {
-              "id": "fb920ad2-24e2-4208-92ea-ddfffb650bba",
+              "id": "7512ccf0-6f16-46a5-888f-e42c6a01d89a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16137,7 +16047,7 @@
           }
         },
         {
-          "id": "e5f16eec-72b5-4cbe-a327-3fcb9459e75b",
+          "id": "4f77da84-ca57-4123-886c-b0033060df2f",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16181,7 +16091,7 @@
           },
           "response": [
             {
-              "id": "9d83bf74-42b7-4211-84f7-223ef45e4386",
+              "id": "111f97e0-6f59-464b-a9fa-c0422f4ff43b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16236,7 +16146,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16247,7 +16157,7 @@
           }
         },
         {
-          "id": "fa785c36-2d31-4a50-aa20-a4627c5b7624",
+          "id": "d5c80e2c-4c13-461d-8df5-826dc462f562",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16291,7 +16201,7 @@
           },
           "response": [
             {
-              "id": "03f0b7d0-0c7b-453b-be39-a55f7fb023c3",
+              "id": "8adcb5c5-db42-47a8-a40d-d7182d9b0217",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16346,7 +16256,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16363,7 +16273,7 @@
       "description": "",
       "item": [
         {
-          "id": "ce0daf4d-2ae8-4d9a-a18d-ef3b632bc055",
+          "id": "49d145f8-f3bc-45cb-a804-016e7e1da9c8",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16405,7 +16315,7 @@
           },
           "response": [
             {
-              "id": "39199821-15db-401c-885c-8a3fd45b107f",
+              "id": "ebb4de59-fa5f-4828-99ec-3b9ac3391380",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16454,7 +16364,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "8c3402f3-2b9f-4884-b664-56d2e4d39945",
+              "id": "b123f4eb-a086-4726-98f9-67438a1a7de7",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16509,7 +16419,7 @@
           }
         },
         {
-          "id": "66082912-3e94-4a01-9602-a6dcb7f93c1a",
+          "id": "b802da57-78b7-4fff-bcf3-307a9f00dab8",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16555,7 +16465,7 @@
           },
           "response": [
             {
-              "id": "15d1c563-0ec5-4e96-856d-5966b0f8309d",
+              "id": "a5d10282-6c92-4f2b-b0e7-c66d2f5953bf",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16614,7 +16524,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d22eccd6-3aef-46df-bb8c-7965cd19177c",
+              "id": "5fee9323-61bf-4a17-a94b-b352b0de40f4",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16679,7 +16589,7 @@
           }
         },
         {
-          "id": "ea3e4693-6684-4577-b597-74b8d798ef7a",
+          "id": "2a8d0071-7a2d-4d1a-b715-514dd306db6c",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16725,7 +16635,7 @@
           },
           "response": [
             {
-              "id": "32fbb120-f7d0-445a-94d7-c9d9a50d8a3f",
+              "id": "c4d1de1f-0af0-4a72-b6d2-c50ec7fbf54d",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16784,7 +16694,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "27c75918-fe16-416d-a7a2-a491c1ffe21a",
+              "id": "79b833d6-21f1-42f6-89a4-be69e43aad5e",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16843,7 +16753,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0d0c3017-d214-42ae-a57f-67d88ffe6017",
+              "id": "4eea2c61-4a31-4da9-9d94-dc566f35a708",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16902,7 +16812,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "75b3ef7a-d318-45fd-9330-39daa620f765",
+              "id": "4d174b41-0d96-4096-98e5-e2162adbad53",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16967,7 +16877,7 @@
           }
         },
         {
-          "id": "4b3e7c28-52e1-4f60-acfd-bfa9d1044879",
+          "id": "f07f3354-bf06-4fef-b413-8a89a2f946c4",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -17013,7 +16923,7 @@
           },
           "response": [
             {
-              "id": "3e5bae3c-7df6-4224-808f-3f542cd52075",
+              "id": "786ebd2c-efce-445e-9038-2ba74a82171f",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -17072,7 +16982,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "9fa22a07-efe4-4aaf-91ed-3cde198e4b6e",
+              "id": "f310de59-80ed-4ff6-aaad-8964b1036a07",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17137,7 +17047,7 @@
           }
         },
         {
-          "id": "b85ce413-f23a-4748-8a62-4b6a3040f0cf",
+          "id": "daff3387-498b-470c-a303-f915086927fa",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17179,7 +17089,7 @@
           },
           "response": [
             {
-              "id": "35cd2e38-a371-4830-87e8-34327ebfcb91",
+              "id": "9997f39e-8610-45a2-ba54-3f98409268d0",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17240,7 +17150,7 @@
       "description": "",
       "item": [
         {
-          "id": "759411bc-a095-4069-9cdd-c3bd7068471f",
+          "id": "9c821c35-aff0-4deb-821b-3152731951e2",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17289,7 +17199,7 @@
           },
           "response": [
             {
-              "id": "fd23f4ab-df4f-440a-acb3-e763ac8c4e16",
+              "id": "8298a08b-7ca4-446d-85a2-2c09832e7685",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17349,7 +17259,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17360,7 +17270,7 @@
           }
         },
         {
-          "id": "6df53d15-80b6-43a6-9362-f25c833b57c5",
+          "id": "d5757e1a-b246-49e4-a09c-cb1978fd8db5",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17409,7 +17319,7 @@
           },
           "response": [
             {
-              "id": "92e7ac17-e208-435d-a5aa-9f1093ccdd1e",
+              "id": "62996fd4-2370-47f2-b6af-9904f2a69b42",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17480,7 +17390,7 @@
           }
         },
         {
-          "id": "0ef41a35-9e31-4665-8f30-b2826de25941",
+          "id": "f9264279-5452-4abc-b7b7-75906741e1a5",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17529,7 +17439,7 @@
           },
           "response": [
             {
-              "id": "c489b113-e625-49a5-817e-15b59fa44803",
+              "id": "fece3394-74a9-4a16-9c1d-684971a71f09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17600,7 +17510,7 @@
           }
         },
         {
-          "id": "286dcf7c-87cf-438f-ace3-1e2bd89606fb",
+          "id": "996f074b-0c09-49f6-a9a9-5990eb8b2fa3",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17649,7 +17559,7 @@
           },
           "response": [
             {
-              "id": "8dc0392d-3e18-47b5-94ad-c6dacd036e24",
+              "id": "791a9260-8938-4fe9-b106-d0cba909a08e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17726,7 +17636,7 @@
       "description": "",
       "item": [
         {
-          "id": "430ef6a3-6f9f-4e96-8571-9cfca8cdcf73",
+          "id": "9e8cc32d-d9e2-4377-91f9-7f83c0eac8f8",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17766,7 +17676,7 @@
           },
           "response": [
             {
-              "id": "e23f2e86-be31-4032-8f66-fa3ebe60d0d0",
+              "id": "92fe3077-a008-4ee3-bbfe-8bf508a6d4f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17828,7 +17738,7 @@
           }
         },
         {
-          "id": "e66c3ce9-eabc-4b25-98ac-5d67655f6ec8",
+          "id": "de380427-ac73-43d8-a797-66caed6df3c3",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17858,7 +17768,7 @@
           },
           "response": [
             {
-              "id": "743ffdb6-f37e-49fa-8222-ca006b8926ec",
+              "id": "f184de85-59c3-46a0-8d90-af15e2b47b35",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17899,7 +17809,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17910,7 +17820,7 @@
           }
         },
         {
-          "id": "82ddb46f-9b61-4807-8350-93690369831f",
+          "id": "8c00bc7e-88f8-4aa9-adc9-4435085483e4",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17962,7 +17872,7 @@
           },
           "response": [
             {
-              "id": "854c5dcd-db77-45fe-8535-2ac097e26b0b",
+              "id": "1d54db7f-0f99-4cc8-a903-64996f3655c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18042,7 +17952,7 @@
       "description": "",
       "item": [
         {
-          "id": "9e6361a1-06a4-471b-a6ba-7c4b87128b7e",
+          "id": "34e7cc1f-5509-44e0-b909-4fe872ea591e",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -18071,7 +17981,7 @@
           },
           "response": [
             {
-              "id": "8548b159-6f01-41c7-b0cc-68c3bbd9458f",
+              "id": "d3990ff8-862f-4f55-a1f7-0900e1df5bc5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18122,7 +18032,7 @@
           }
         },
         {
-          "id": "0f99597f-c493-477f-8e53-eba1939e8d0f",
+          "id": "fb891f00-29af-42c7-80d6-6301b7a00faf",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18163,7 +18073,7 @@
           },
           "response": [
             {
-              "id": "d819eede-c097-45e1-ac17-e3116dc83dd5",
+              "id": "c528b07f-b514-4366-8a35-bb062509e501",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18232,7 +18142,7 @@
       "description": "",
       "item": [
         {
-          "id": "0c5f6b28-e90e-4e4e-978b-408fcd4791d0",
+          "id": "150ef284-0357-440c-98ba-3d35a98b586e",
           "name": "health",
           "request": {
             "name": "health",
@@ -18261,7 +18171,7 @@
           },
           "response": [
             {
-              "id": "6dc72b2d-8233-4e26-9ad9-6fa9dce3c0be",
+              "id": "df2b49c4-6b5a-4aee-b880-e4450d4e4cc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18301,7 +18211,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 2268.546419457391,\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18318,7 +18228,7 @@
       "description": "",
       "item": [
         {
-          "id": "a9f3f142-c167-46ac-a3d2-64f52641bd73",
+          "id": "2e1324a8-0ae3-4c3b-98bc-9b177623f225",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18370,7 +18280,7 @@
           },
           "response": [
             {
-              "id": "7c932ac5-06d6-4fff-8144-76f2f0e2046f",
+              "id": "427e7a68-b728-492d-92c1-d71a30761e6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18444,7 +18354,7 @@
           }
         },
         {
-          "id": "a69db21e-bca3-488e-8d00-de8366b30eff",
+          "id": "b6ef7acc-61f8-4286-a986-675a14da81ea",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18485,7 +18395,7 @@
           },
           "response": [
             {
-              "id": "0b51f9ee-ee5e-404f-b6b2-5e42b8fcff4e",
+              "id": "ec861bd0-b1ee-4ea3-9a8f-3c267375ce90",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18537,7 +18447,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_3\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18548,7 +18458,7 @@
           }
         },
         {
-          "id": "bd90c6c0-c029-4682-b04b-699f335812fd",
+          "id": "f6b1530f-fc4f-4cc0-a581-2c9f894f886f",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18578,7 +18488,7 @@
           },
           "response": [
             {
-              "id": "b37e3006-0fdb-475d-9670-0dcd2796d0ba",
+              "id": "2cb866cc-31b6-4027-9f07-ac0716776f5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18619,7 +18529,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18650,9 +18560,9 @@
     }
   ],
   "info": {
-    "_postman_id": "547c1b38-06ca-4903-8989-e62e76eda9ef",
+    "_postman_id": "37f1fa71-68b9-4e2e-8222-d71a8fc396d6",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 02:39 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 02:58 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "6c79124c-7962-434e-b41e-506717c34784",
+          "id": "370b2835-e4bc-48fe-b463-a0af4e4d4683",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "0c852f6b-a08e-4458-97bc-0768d199af84",
+              "id": "04e22985-f693-4adb-a261-a7c2f431bd5c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "f6c9f20b-7a3c-411c-ad1b-cebd7d4def57",
+          "id": "fc424e90-652f-4f5f-9139-fe236ab935d9",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "036a1958-163a-4c9a-ba01-1e89a4fb4f9d",
+              "id": "fe68d1f1-7f55-4038-9bd8-f8feb411ac36",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "8e518385-4121-4907-9a80-5823ae016669",
+          "id": "e000c229-725b-4092-83e2-464cc13f5c00",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "a7969386-3a38-415b-9d7b-325f1f75991f",
+              "id": "cc8b026c-d052-418e-9e46-6031996ecc73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "3c40691c-12f1-4f56-8376-9b8f767ab238",
+          "id": "f0382922-42b9-48cd-8093-d239db9326ae",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "a30b10d3-cda9-468d-b995-2ea0b351599f",
+              "id": "9e100f74-8d3e-4f86-9de8-c1c276c3f842",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "7d6bf824-f609-43b2-8f14-ddbb66afe3a3",
+          "id": "92c02a32-334c-4846-9bbc-174dd48db858",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "03964a43-7f98-4c06-b2e8-50bee49b37f2",
+              "id": "04a7bf2d-2e14-4f5c-82fa-6f51fcaa16c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "bbf7fc61-6929-4ff0-81a5-52989a59b59a",
+          "id": "4db7d2b1-203a-4970-90c1-12ee10a79bf5",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "f00a06b0-82d7-44cb-b5cc-99de3fdcec89",
+              "id": "6510adbb-9ce3-4f11-9b88-6288f21db47d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "d4da6db4-a0e8-4d52-9455-f7969e024371",
+          "id": "8550f147-4deb-40a6-bbc8-fac4cdc3a606",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "cd5e6700-7dc2-4ad3-a5b4-d31db2f448f8",
+              "id": "818fcf7b-c5eb-422f-8f0c-bd896aabddfc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "b0b308a4-7c03-44c0-8f64-dce92ac45ad1",
+          "id": "2a2d61b7-2e59-4379-b75f-8dfb75315bcd",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "7fd050b9-9f5e-40b5-9503-715acf962661",
+              "id": "23d2f368-7bd7-4f7f-a2d8-669f40f83a57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "3464b3c9-d4f0-496e-bf59-298e21737765",
+          "id": "c2dd92b1-2dd5-4148-9069-0b59336030d6",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "bfaa5faf-0dbe-4ea4-b2c6-c674a88992ea",
+              "id": "26d3eabd-f7aa-4915-be22-e5ab2f36dc4b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "51f858c8-4d69-4a54-af67-875aa0c67de5",
+          "id": "d7944579-6976-4671-a459-8c226f814b46",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "cc5ebab7-f768-404e-9635-3bc5bb76ac2f",
+              "id": "6c1a2ad3-d50d-409f-a8be-0cf50319d0c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "8df6bdc0-2188-4465-aeb9-5ea431790a8f",
+          "id": "e7e6f588-bacb-4f22-a6b9-c838c9c3b8a9",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "ab343b75-a0bb-43b3-b166-b93e1b380c0c",
+              "id": "ad7cfc9f-f953-4865-b9bf-47ef64a4708f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "81d33514-8cb9-4630-8fce-1dc99060f070",
+          "id": "a3836023-a2b1-4ec3-b872-488026d2ae36",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "f51ca3a3-514a-4bb2-9dc4-b79f38cba9c2",
+              "id": "3b70a8d2-aa83-43aa-b9ad-6a6641e81a1e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "a9cf3cc3-8fce-46a7-ac03-9b4312f20db5",
+          "id": "35019c6b-b2c6-4535-87b6-22f394f2b8da",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "3a419be0-848b-4fa6-afd5-e0a5e2f5170e",
+              "id": "26732f0d-44bd-4e26-b473-46ac7ab60210",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "a76511ad-2a46-4eb0-88c4-19676cbd95d1",
+          "id": "58f40303-c290-4099-8b1a-a7ba98d3460c",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "fc434830-7c94-485c-bff9-158afa09d013",
+              "id": "fac2819b-fb5d-478c-ace7-d2138d67f713",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "3c1df1cb-86de-473b-953c-1d6a28da199e",
+          "id": "7beae4bf-e230-4474-b2b1-2b2bb3ed1eec",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "cb589d67-e526-4d30-b7a0-bc5996200a13",
+              "id": "f532046e-aec4-432b-a99b-f8d57fff4d9e",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "b69a4517-ae99-46bd-8eb6-7ae1ab41b137",
+          "id": "20c8e67d-871d-4051-881c-76e7e1c29fa1",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "2070c328-6a3b-44ab-9c3b-2ce7dac2077a",
+              "id": "ca39d657-8ac9-4176-a0e2-bcc98ccdbf3c",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "ef0c471a-091c-46b3-8023-926da27b4f6e",
+          "id": "656f40d1-4805-424f-88f6-647daa5f26f5",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "e9191eac-9229-4639-96ec-fbc5a0cb6b60",
+              "id": "cea11736-4b89-4c9b-9ff7-adfce0fcda87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "4fa08236-96ce-47c1-8cb2-321d6c736f91",
+          "id": "cb7ea12c-07fc-4c35-82cb-c0f9cf427e89",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "97c1322b-2f22-4aad-af7f-47d77189a97f",
+              "id": "50371770-3cd6-4418-b791-fc0a3d8b998c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "d7cd8681-8ede-4cc6-bf42-268a6f9136d2",
+          "id": "0b11197b-c8a6-40ed-b233-50dc2628e12d",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "c5f7ca94-3f74-4f94-8f3f-64ce3ce9c528",
+              "id": "37a80930-b3a9-433a-9dd2-7a3841e73ac7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "67c2ecde-3a27-4f59-8f82-dacb1bee3fc8",
+          "id": "2288b210-257e-4ec3-af23-25baa905ef7d",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "90205a4b-1bbc-4a61-bf52-01f7ca89bb9e",
+              "id": "2ea993cd-e5d0-42e4-a4c7-5d5dbd7c1683",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "90eb9691-27d6-412b-9c2f-26f3363d9911",
+          "id": "e0d2dd82-22fc-4de6-8e8f-f1f16b9cea45",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "5cc1c645-c0bb-413c-b946-b15439ada0bc",
+              "id": "56e57c20-563d-4f57-8541-89fb41fca6dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "686d9dbb-316e-404c-8482-203e9e8e30a3",
+          "id": "81b1ee49-f0ad-4cd6-b6b8-3f4a05a8db3a",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "9b52a8b4-fd03-450a-a855-bc7650b0f55c",
+              "id": "5d67fe4c-3199-4ec8-b496-309e4259a8ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "237914fc-2e68-4e98-8658-1a15423ba2d3",
+          "id": "cc217e6f-735d-4c79-8e97-6962489672e5",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "5e423021-9d30-4bff-86be-b78787088a0b",
+              "id": "c55f6337-cc7e-4c93-8844-25f54f92fc09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "f18920c6-6480-4b38-ad96-46ef5abca639",
+          "id": "80f0fe5b-2045-4d70-8791-84817a7933a2",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "bb60c55d-d133-4568-a6d1-d3576da41eb3",
+              "id": "880f5132-4964-494e-945d-2d44cbfeb04e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "b853fbe8-2c77-424e-8283-35d6056c6510",
+          "id": "54ad9144-d229-4624-a9bd-a54c292e07fa",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "24e234b0-b47c-406d-b0a2-41f043581bab",
+              "id": "26d0f13e-1bfa-41fc-abf3-528bb7dc2300",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "9e19bd52-f402-42dd-9283-0853dca48907",
+          "id": "21ab764a-02ab-459f-899c-8897ac2ec28d",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "03507850-082a-4af1-87a1-c18e36c1e392",
+              "id": "67c40d88-99ab-4b98-89df-4e14837c8518",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "2aadc98b-a2c5-4913-b3c0-f1ce7c8108db",
+          "id": "ac888187-2509-41ad-a508-280174a4c383",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "ecc9306b-a234-4e4b-b33d-05caa74a6bf9",
+              "id": "3b20546a-f983-4548-b94f-fcd5c2f8536d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "bbf2b577-7d6f-43ef-a794-74e2efa415a2",
+          "id": "93c34f6c-3650-4b62-a82c-ff40bee53c92",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "cb5352ba-96b8-4a7d-a089-1beff194d026",
+              "id": "ae1bacae-9a1f-416c-b12a-4ffb53ae90cb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "4bc45856-cb27-4074-bdcf-056f5bdef3cd",
+          "id": "881f6821-d6cb-4db0-80b9-b4cd8cd061f2",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "5f806dd8-b79e-478f-8765-12496c0d9e48",
+              "id": "57ca4bdf-0240-4383-9bec-6b9cfccfd54d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 8982.275582944161\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 5580.652375970941\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "51f36ec8-64de-4bb4-8e1b-df44aeb09837",
+          "id": "700ea626-0b33-46fa-8714-53b6713df6d8",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "02da0cb2-0e8e-4237-ab6a-7a55c554dd59",
+              "id": "6bd0a041-c347-4b89-9397-2981568af124",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "49441d58-6be2-4b80-a6fd-664b4e2ca5d5",
+          "id": "b0ac8912-8315-43c6-838a-18b287bdeaee",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#58da43\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#52CBB0\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "1c19135c-d589-4ef4-8968-4ff69efc1ad0",
+              "id": "cae0f226-fb3a-4aef-bf44-434ac0d80a3e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#58da43\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#52CBB0\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "3fa6156c-5c13-4efe-8e22-6c2f448d8403",
+          "id": "e8df75bc-88ce-4876-84fa-b224c62ac90f",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "edf27e19-3cdb-4005-8deb-53af292b71d5",
+              "id": "fd2ddc88-9b53-4761-97ee-41f7e0e2bda9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "7ba4dfb0-7997-4a01-bfc8-111487464b06",
+          "id": "98d6898e-d9bc-4272-89eb-a6d626870c39",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "d07cb96c-7453-43dc-9204-9fcd66147c00",
+              "id": "7ff71e50-c716-4392-907e-7018b043352b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "12780d08-200e-4a7c-9079-f2c2288048b1",
+          "id": "4cde7093-7cb8-469c-928e-af9ce7c73bb3",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2c5117\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3E03E9\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "c9b69f97-0ff4-4ccf-85ce-b3961fb1cecd",
+              "id": "5f68a18a-fa05-467a-a150-1c88766d1161",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2c5117\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3E03E9\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "261508cb-69c0-4c57-8bae-54859d83843f",
+          "id": "d966c303-b11a-485b-8e27-9e501f2c9ea3",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "23f10f49-6637-4974-9c34-0861f5dfe5a6",
+              "id": "a70aa06a-d41b-4fd0-a4b4-105fd36a017d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "a496f178-f5b5-40b6-bc30-ab770e49b47a",
+          "id": "9800195d-51d1-4195-8dc6-b666c1f2637a",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "6c484872-b5c4-44fb-ae8d-7308aa3ffe8d",
+              "id": "b398632a-a42e-47cb-bd51-332eb5d1fb3f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "8538ff50-3ff5-4abf-b34b-295fbc1fdbd3",
+          "id": "df2c44be-7370-4c10-b9a6-67e15b67f5ff",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "e1db996c-124f-4b53-b7b7-6c586b35fa4e",
+              "id": "abcf2bfc-d18a-41c6-bc8a-eda851247dbb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "93fc5d4d-19a0-4164-b45c-3be02ac20f9d",
+          "id": "1e0f25de-a2f5-4c52-a602-d8c997ce37bd",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "0468cad5-45ed-464e-aa97-99b47b7e8e89",
+              "id": "8f38e774-d6e4-442e-8b1b-24872ccec29c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "f0f76a1e-0257-47e2-91ff-36ec2c4f23ca",
+          "id": "71c940c3-0f58-4fa2-b1da-8393556a2cdc",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "7c3cdf3c-4e77-4c21-a323-41c336190668",
+              "id": "b7465e85-24d5-4b74-b2e4-032bb2927d3e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "92a06a0d-34c5-4d5e-bc41-f3a54c4c6857",
+          "id": "9d1b581b-81c7-40df-afaa-c6d756c02057",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "2dba7571-b7fe-4c49-a4cb-d5a91640e9a4",
+              "id": "4be008bd-1b83-44bf-b6b0-a9669ad9502b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "f81b378c-1c11-4dde-85cb-399ca911d2c7",
+          "id": "9b2e235b-0566-49f3-92f0-0dd20275a16c",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "fee20ba2-5e92-4d9b-b85c-317e0ed59dab",
+              "id": "236b4093-700f-4dca-8b7e-17678b87c992",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "bcd6d8fb-6844-4a72-9a49-72a6dc02c8ed",
+          "id": "6d21eeab-5a3e-4f85-ad5c-b5e47a48c6ba",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "e37ebbbd-ea95-4379-8c9a-f90958ba5612",
+              "id": "70005478-6b19-44e9-8198-eb226dece466",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "60e7259d-2ff0-4ab0-bb15-caca73b91ff5",
+          "id": "507ea5b6-d5e7-49ce-a9d7-c77626954f2b",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "1f13b459-9ff0-4d8f-bc6f-ff38a65e8136",
+              "id": "2ad992a0-c155-4f03-9f0d-1b88e4cf84ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "2b12538c-d035-4389-9205-c559f97056f7",
+          "id": "9ecca404-ae3b-47ea-9243-5295dca2daef",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "9083edfb-46a3-48df-a348-80c92f1d0a92",
+              "id": "0e742eda-eaad-4e67-b924-d31722bc2f47",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "cfdd456e-bfc3-43a8-9ac8-cfeff06740ec",
+          "id": "4e45e387-a665-4f11-a378-06b773646068",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "1101ce74-0ce6-40f2-ad09-d64d504082f2",
+              "id": "8a660891-2dbf-4643-af3a-a323ebafe7a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "6b94e6f1-8b20-4b2c-915a-a99aaec9847c",
+          "id": "1322cfcb-066e-480b-91d1-83ab5152d23d",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "1efe698b-f5af-4702-99b2-5140ccfa99a6",
+              "id": "261b350e-d79c-467c-8186-ac63c877abe4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "92628b19-28f0-45a9-b637-8abfc9369116",
+          "id": "063ae7b8-aeb7-48f8-a59e-309effaa5f57",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "68da8ff9-369f-45e7-99c4-8f99b86f1780",
+              "id": "e3d859f2-ead2-437b-a124-9f5949d88511",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "4ddc7746-8b89-444c-b9a3-8d102458817e",
+          "id": "ce765630-9d1e-4ec6-ad20-d1bc8f181b24",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "dd10004b-47b1-40c9-972e-eb731f413327",
+              "id": "e6d0cc95-b106-473a-8e81-c115c4eb95f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "99268abe-ee60-4e45-ad98-66a53143435e",
+          "id": "928ac308-7fd7-4090-9562-d687f68683ad",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "7ac57fe6-09f6-4d0b-b16a-8584b31a6653",
+              "id": "4a07e05b-64dc-4435-b7ea-370df633917d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "f7c3711b-b9cb-42bf-a60a-1aaf4b42585f",
+          "id": "eb4e24a8-7643-4c83-ba88-c39cd5e4d510",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "2772a808-3c8b-4d95-a72a-b00d022f8da3",
+              "id": "f62161ed-4e84-45f0-902b-369a91c0f741",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "27aa5b63-c9f4-444f-8b8e-0a85883215f3",
+          "id": "9c17b520-1581-496c-a4fd-bce416ea1d55",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "4dba9148-af09-47fa-a5af-7f347ec0d4b6",
+              "id": "2c3ac023-203d-416b-b959-ba79db6c34c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "2ad3ebde-c9a8-4a09-90e2-11eb65f3c7b5",
+          "id": "7e4028b6-34e2-4730-b449-60b4d9e71090",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "e2891435-f77f-4417-af67-3f5c92f0ebb6",
+              "id": "4d5c1977-c84d-4bf9-8171-b644b3a96358",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "f4cfd623-fc53-4366-aca7-b3e87b866dc7",
+          "id": "48191e4d-ab70-40dd-a6b4-2f0f82711a73",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "4c42b38a-9072-46f4-978b-0b0ae41514da",
+              "id": "eba440e0-ca0d-4a93-8bf6-9a41f6069bc8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "cc525664-6d2f-4eff-963a-779a1ba530c9",
+          "id": "28679cdc-1f6f-4ef1-92ed-f300193766f9",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "614ae574-7ffb-43a0-a367-5702ff275ca2",
+              "id": "bb390959-7981-4d24-ae43-634b98a2c271",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "ab4e00f6-010d-4292-b90b-b61dcb01333b",
+          "id": "57839a7b-3d89-4c84-8d56-d222456d160b",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "a7c6ae63-e75e-47da-a00b-847acc84eab3",
+              "id": "a372800d-9f2d-42fc-a849-96b4d71b54dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "58bb6dcb-7c01-4b09-bae8-dc478d486802",
+          "id": "3ae994e1-2a36-45fb-be50-1b09e8ff85ec",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "55d00833-3a45-4292-82e1-57bb0c7d0d5b",
+              "id": "0e0a44aa-4c13-40e1-b40a-5d952e671915",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "d131a215-6fbe-484b-b3de-6ec5bf15e2b5",
+          "id": "3c606685-cd99-4af4-ac60-2ca99fb2f3df",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "ebe97a2a-e880-467b-b8c4-08117bf21f13",
+              "id": "76c42f21-c5f2-4d69-afda-0287d6ca7f2c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "80eab7f3-2dc0-45ab-849c-803090fffdd9",
+          "id": "6967a738-896e-4b61-a4d0-b174e7493ef1",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "f0bdbccb-31ca-4a30-9c9c-f6e51d3b6d4e",
+              "id": "50a6951d-afae-4af8-bec8-14ac34c45f4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "c23b89f5-55b5-4f9b-9fb9-cd8d8c9a17dd",
+          "id": "0b416a40-3d6b-4bbb-8690-ef69495535c2",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "f84d2cc3-5a7b-4a90-b363-9dc6719b8bbb",
+              "id": "fce91a02-1c0e-42a3-9149-8724a5bd6aa2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "adb065c2-9b71-477f-b6a9-b70bb6fa614f",
+          "id": "fadc71de-ff0f-49bc-8a85-f5e772dd7a8c",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "ca765984-3153-4e22-91fd-c6a271bd33b1",
+              "id": "932ab523-cbbe-45f7-8273-588a486b7480",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "cdef7bd5-b459-4e8e-b2e3-ed92411ba111",
+          "id": "d2cabd93-6160-40d2-95cf-fa03359f0092",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "cfbccf08-745c-4794-86ab-c847873d8b8d",
+              "id": "4dad6910-d95d-47a6-b389-83d194a7630e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "b0b5be7d-54f3-4efe-a3d6-0617100c17ba",
+          "id": "2ac0dfaa-49f6-46e9-b46b-80d61f351c47",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "7ff678c3-222e-424b-b84a-130aec204d79",
+              "id": "66061ceb-41f3-4ba5-8988-d6ace2c742b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "bcf92867-8199-4ab4-9988-c11fed96b19a",
+          "id": "2205e572-5cb0-4d43-8ee2-b18321dad1a8",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7553,7 +7553,7 @@
           },
           "response": [
             {
-              "id": "5fd98490-1334-4b8d-9d89-a05faae6df87",
+              "id": "940c4f0f-5efa-4fa2-a0ac-69b538d92a18",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7629,7 +7629,7 @@
           }
         },
         {
-          "id": "5a9e4f95-610e-4b1d-90f5-85fd0dc2fd44",
+          "id": "c90a7d10-1248-49b5-b740-e882a641865b",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7683,7 +7683,7 @@
           },
           "response": [
             {
-              "id": "1f73b4d3-11bc-4c81-92f5-af6c970326ca",
+              "id": "33c49848-25fd-4adc-85e5-df1bdd5eb326",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7765,7 +7765,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "f40a9f8f-87fd-4521-bf25-e30d00555335",
+          "id": "25a6cae5-dd1b-4151-8bf4-113c5139f85e",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7818,7 +7818,7 @@
           },
           "response": [
             {
-              "id": "bc1ac55d-c567-4411-b9f8-5100d8d85b4e",
+              "id": "9e7061e5-b113-4d6c-8094-a760182ab1b4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
           }
         },
         {
-          "id": "effdea10-2638-4236-a265-be282173bab7",
+          "id": "e70b9afa-585e-4bd3-8647-a3dbfecf6a8f",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -7959,7 +7959,7 @@
           },
           "response": [
             {
-              "id": "660b1321-9d09-4ab4-937b-7126186300ee",
+              "id": "3a2eccf3-fa9b-4849-832f-9174b4861d90",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8047,7 +8047,7 @@
           }
         },
         {
-          "id": "7c50ebd6-a9b3-42f2-9f4a-de1a6dc632ee",
+          "id": "1733e1ff-d93b-42d9-a581-b3116476a332",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8094,7 +8094,7 @@
           },
           "response": [
             {
-              "id": "20a85623-2ad0-44ba-80f2-4332db4cacb7",
+              "id": "b12a838e-af6f-45eb-a363-22a0e5a1ad2d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8159,7 +8159,7 @@
           }
         },
         {
-          "id": "a96e7443-399c-487d-8b73-347847ee3141",
+          "id": "06ed6261-5086-4c8b-a005-a744c3ed616e",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8201,7 +8201,7 @@
           },
           "response": [
             {
-              "id": "cfa417e5-1886-4e03-8579-c07406d73087",
+              "id": "256de11e-a8d0-4ea0-96d5-4c4081778dca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8265,7 +8265,7 @@
           }
         },
         {
-          "id": "c5772145-9afb-4c6f-8627-27c41dcdff35",
+          "id": "724e93eb-4a30-49de-b899-6e02f05b2965",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8320,7 +8320,7 @@
           },
           "response": [
             {
-              "id": "117950fa-0451-4368-a8f7-3ace16c3c662",
+              "id": "fbeba9a9-ec31-49ae-9919-bd095f527d3b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8403,7 +8403,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "678781ea-9d4e-4b02-80e8-64d8f99e6798",
+          "id": "a3f994c6-feb5-47db-9c35-59b9fa4bfbdb",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8444,7 +8444,7 @@
           },
           "response": [
             {
-              "id": "1045ee25-2d26-400a-97ac-f06ba2d68845",
+              "id": "1ec40413-ba14-427c-bfc4-66ec5c05f677",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8507,7 +8507,7 @@
           }
         },
         {
-          "id": "02986ea1-31d8-451f-8455-400f9f54469c",
+          "id": "d4d50e0c-3c62-49bc-ba48-ea40992356a9",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8561,7 +8561,7 @@
           },
           "response": [
             {
-              "id": "acf716f7-bf45-4402-b019-5e62b25733c8",
+              "id": "b7193baa-174d-4126-bc6a-888c07de3492",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "6fa1349e-3483-42ee-8cd5-41865c9c191a",
+          "id": "84ef6582-8a4d-4c71-b9a0-fee2480d758b",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8672,7 +8672,7 @@
           },
           "response": [
             {
-              "id": "1cdd27b6-394c-4b72-a424-7c1f530309a2",
+              "id": "cd7dd41d-a4d3-4283-9743-0289cf490c1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8725,7 +8725,7 @@
           }
         },
         {
-          "id": "b72caf41-fc82-4e14-b530-7e57f301397b",
+          "id": "f4844326-ff34-4c53-9efd-00a2a4bdaa5d",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "7cf7d144-c035-4a57-84de-8607ae4a1ab9",
+              "id": "18678ea3-6c90-42f7-84cd-617aae049d28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8861,7 +8861,7 @@
           }
         },
         {
-          "id": "8b42759a-1bb2-4e85-8620-798dbb0dae37",
+          "id": "2f314f7c-51c0-4382-88f5-970646ade111",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8903,7 +8903,7 @@
           },
           "response": [
             {
-              "id": "8498c494-30ef-4453-9524-4cfaacbf8c6a",
+              "id": "095dd475-4955-439b-9fb8-9a65a97eb69f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8973,7 +8973,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "efda19a1-740c-445e-8055-3fc3028866ee",
+          "id": "c1f6d331-f475-4bf0-b027-66329b7651b7",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9026,7 +9026,7 @@
           },
           "response": [
             {
-              "id": "767a7167-8edb-42cc-9ddd-8bfe4270f496",
+              "id": "f06b01d0-ad89-4002-871f-09506620c4fb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9101,7 +9101,7 @@
           }
         },
         {
-          "id": "3f74f486-164b-443e-9517-7c04cac9d713",
+          "id": "3cb51816-d5d5-4a2f-83b7-1d01c3e1f707",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9167,7 +9167,7 @@
           },
           "response": [
             {
-              "id": "1555fd55-934b-4acf-9e09-b2b8e279e1eb",
+              "id": "9d88e934-339a-4285-b28e-9b8674f25676",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9255,7 +9255,7 @@
           }
         },
         {
-          "id": "8f8e451f-af28-484c-9c5f-88ddbb976403",
+          "id": "5d4834d9-bc6e-46ce-b1c5-994368049594",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9302,7 +9302,7 @@
           },
           "response": [
             {
-              "id": "a26223df-30eb-4c31-8d6f-baea417ab5f7",
+              "id": "766b479b-d5dd-4904-ba69-c058eb716017",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9367,7 +9367,7 @@
           }
         },
         {
-          "id": "af0361a5-4732-49fa-87f4-a768bc9090e5",
+          "id": "a8026786-dd3f-4b95-90e3-5bc8ecfa3a77",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9409,7 +9409,7 @@
           },
           "response": [
             {
-              "id": "09691f10-8fae-4571-be8f-a35ca385b301",
+              "id": "04b63017-ed05-42c2-8235-6a0ed3712c13",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9473,7 +9473,7 @@
           }
         },
         {
-          "id": "f8dd2bb9-8667-425f-b960-43c50ee917ef",
+          "id": "ae711595-5d4a-4cf1-b58b-ff78f4e3d4b5",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9528,7 +9528,7 @@
           },
           "response": [
             {
-              "id": "6c746e36-0d9d-4180-8502-147a8d0dfccb",
+              "id": "de434efc-8950-4bdb-8d0b-e42ea250fbe5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9611,7 +9611,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "bd4d8723-8fee-453e-a86e-772f615db5cc",
+          "id": "d3905455-59fc-43aa-a5b7-2cdd6feb0b65",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9653,7 +9653,7 @@
           },
           "response": [
             {
-              "id": "92d5bb7c-9cf9-44bd-815d-74f6213e5a8c",
+              "id": "1bd55cd8-1794-470c-939c-0d2d58a8703a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9717,7 +9717,7 @@
           }
         },
         {
-          "id": "8b6e490e-1149-4b6c-92fa-a53835ed72f4",
+          "id": "aba548f2-8e86-45d2-9c1d-176bbab3435b",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9772,7 +9772,7 @@
           },
           "response": [
             {
-              "id": "e128a3fd-0d39-4e1e-92f2-aa8e35e27142",
+              "id": "556828c3-202f-41e0-9957-f552f2226c9a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9849,7 +9849,7 @@
           }
         },
         {
-          "id": "54b3598c-011f-42e9-a8c8-41669a6894a8",
+          "id": "c1e0087e-8b47-4f13-b416-139a9ff8c952",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9885,7 +9885,7 @@
           },
           "response": [
             {
-              "id": "d39fcd31-5b36-4815-8b0d-6919ed8f949e",
+              "id": "7134a69e-2ed3-42b9-97b8-272cf366e744",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9939,7 +9939,7 @@
           }
         },
         {
-          "id": "df0bc9f1-491b-49e8-9b51-07e8512e8f4a",
+          "id": "23bfa5a0-a995-407c-b7b7-381000945bee",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -9969,7 +9969,7 @@
           },
           "response": [
             {
-              "id": "81b39f6a-e6e0-46ed-98e4-5e69241d0267",
+              "id": "c3152730-ec8c-4507-bba3-7fd3c605f5ce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10021,7 +10021,7 @@
           }
         },
         {
-          "id": "e886a15d-b641-4d21-a33c-2ae73812a385",
+          "id": "43d2003b-3502-4c0a-86dc-c2bc2e78fb98",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10064,7 +10064,7 @@
           },
           "response": [
             {
-              "id": "21670304-310e-4f49-aa46-91c7b668516d",
+              "id": "ad1a7833-925e-41d0-8aa9-549e4a399ac1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10135,7 +10135,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "d045e475-1d8d-4b62-83c8-4391c036d94a",
+          "id": "4a34b1e4-0dfd-41e4-be28-f65d4b3c0661",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10177,7 +10177,7 @@
           },
           "response": [
             {
-              "id": "fbbda877-091a-4e8c-aad1-c4e9f317bdc1",
+              "id": "5a67a284-baba-4e5c-a723-ed3961ee78b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10235,7 +10235,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "01d8674b-b53e-4fe1-88a5-7feb0e58859e",
+              "id": "92236d10-96ff-4cf6-b352-31c73a95fdb9",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10299,7 +10299,7 @@
           }
         },
         {
-          "id": "0e427400-fc46-4524-ac69-157c3c15de21",
+          "id": "7d099ead-31be-4fad-9576-8ab6c0ab4288",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10354,7 +10354,7 @@
           },
           "response": [
             {
-              "id": "7995aeed-ffc4-476e-8d3b-107f6da6fe23",
+              "id": "dd63aed5-84a1-4a01-b12b-d57cc2c57829",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10425,7 +10425,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f44d816d-3646-45a9-b1e8-a8ae7f1d7701",
+              "id": "871508ea-62b1-47f7-bcac-9817d41f50ae",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10496,7 +10496,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "94e2da3b-fd85-4965-b76f-678679b52eee",
+              "id": "3b1a8898-1fdd-461f-a04a-d0dd40a9b465",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10573,7 +10573,7 @@
           }
         },
         {
-          "id": "c3ee7a73-d310-408c-ae4a-54dc5ea444af",
+          "id": "f7b383b7-3257-4182-b229-eea655e3ec9d",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10609,7 +10609,7 @@
           },
           "response": [
             {
-              "id": "6664cfe0-d1f1-490c-8414-65e5e1144ecc",
+              "id": "9cbbbe99-f0f6-4f53-bce6-aad3801fdf0d",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10657,7 +10657,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0b0b5856-366c-4f38-8341-a9ab15c24b69",
+              "id": "eee9a17e-b2d6-44ef-8b07-4f51e3ef5742",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10705,7 +10705,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4bdbaaef-3657-469e-a076-89361df1cebf",
+              "id": "c2c322fe-ce8e-4633-ab39-a503537638f2",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10759,7 +10759,7 @@
           }
         },
         {
-          "id": "5e232531-f643-4a9a-9864-dc31fdb9d078",
+          "id": "2df815bb-eec7-4f92-a150-5d24e51f72cc",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10789,7 +10789,7 @@
           },
           "response": [
             {
-              "id": "139ce310-c063-4b10-b4ce-1f7b7d4edd89",
+              "id": "e0755930-629a-4b98-9df2-edc506cc0bb6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10841,7 +10841,7 @@
           }
         },
         {
-          "id": "109146d4-5515-49ce-a431-1f98bf74e745",
+          "id": "4fe2c243-73a7-47cd-97db-6751e23f3950",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10884,7 +10884,7 @@
           },
           "response": [
             {
-              "id": "80c94279-3233-4004-ae87-7acff424ad23",
+              "id": "1800a1f2-8044-478d-b917-79ba3601c0ff",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10943,7 +10943,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "2a694b64-9bba-42d1-aef0-0c3fd9ab0781",
+              "id": "6e678f0c-5516-44fd-84a7-c22e5f972a2a",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11014,7 +11014,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "2848db16-b129-4d29-a9cb-418a5e42b38b",
+          "id": "d9185c0a-b4ae-43f7-a429-115f5603d6f7",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11098,7 +11098,7 @@
           },
           "response": [
             {
-              "id": "6a6fb576-e8f5-4624-b7c2-d46f4c65048b",
+              "id": "ad70ceca-70c3-4c1b-9f55-4a95b3ff528e",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11201,7 +11201,7 @@
           }
         },
         {
-          "id": "c58084c1-bddb-429f-bc04-7fe0c5b92391",
+          "id": "4af645b0-e1ab-4020-a929-0dc9cbbafcc9",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11267,7 +11267,7 @@
           },
           "response": [
             {
-              "id": "d43e5b60-85c5-4ddf-9ccb-ec79221d43aa",
+              "id": "261ce6da-7915-4aa7-9fc9-ab719e3eb89e",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11352,7 +11352,7 @@
           }
         },
         {
-          "id": "a479f68c-8c3e-456f-ac7d-48835c1fd5c4",
+          "id": "f284aa13-8158-4c3b-b63f-fde33c6be084",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11436,7 +11436,7 @@
           },
           "response": [
             {
-              "id": "3a061eb0-8e21-4d76-80e4-b872911282e1",
+              "id": "4dc2d8a5-28ce-4406-bfbd-113d1fffd005",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11539,7 +11539,7 @@
           }
         },
         {
-          "id": "0931b878-9edb-43a0-81d7-439eb6b7e331",
+          "id": "66f4cf2c-dcc4-441d-aa5c-b0377bdd3002",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11614,7 +11614,7 @@
           },
           "response": [
             {
-              "id": "6a03375e-e475-4973-a1df-c15d2dd6f91f",
+              "id": "cd9952d6-49dc-4838-b909-0c180c125da7",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11708,7 +11708,7 @@
           }
         },
         {
-          "id": "e965f508-f641-4a96-b7c5-1be6f526dc0e",
+          "id": "e5fc318a-c8df-4cc4-bbd2-43797d488514",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11783,7 +11783,7 @@
           },
           "response": [
             {
-              "id": "af186919-78f8-4baa-927a-3f66a4881853",
+              "id": "d2a11ce4-4780-4548-b6ae-ed1b4e8b5967",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11877,7 +11877,7 @@
           }
         },
         {
-          "id": "27d945c7-cb95-4c01-bfcb-d355a61aff02",
+          "id": "d408def7-4de1-4a09-a576-d5aa362ad040",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -11952,7 +11952,7 @@
           },
           "response": [
             {
-              "id": "91c13f1b-7007-4461-b196-8a70a987e64e",
+              "id": "9b373af2-e854-44aa-a41b-e9ef677b9935",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12052,7 +12052,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "3f5a4c7e-7a1e-4d6e-9dff-9f0cf83c2e8a",
+          "id": "882bc682-3ac9-42a8-99c7-2ccf0e43a7b3",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12118,7 +12118,7 @@
           },
           "response": [
             {
-              "id": "b714e058-a1ce-4e7a-843e-eafab4db6eb3",
+              "id": "2a732aea-8236-4e0c-a298-61a00ac6fa06",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12192,7 +12192,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12209,7 +12209,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "6da6f6a5-4f60-4af2-a31e-1ebda3df4c65",
+          "id": "67b745b6-da5a-4def-a5c7-bbb571d6219a",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12251,7 +12251,7 @@
           },
           "response": [
             {
-              "id": "ff355224-7ab9-44ba-bfd1-07d59098dbdb",
+              "id": "48eb3b9f-0165-4021-8205-aacfe534f765",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12321,7 +12321,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "6e6a6fa6-36cd-42fc-bc31-c3cb3513ff12",
+          "id": "b2e730ae-a995-4392-b84e-8d943305961e",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12360,7 +12360,7 @@
           },
           "response": [
             {
-              "id": "d83befd3-6d73-46bd-9bcd-f34addc1fcd1",
+              "id": "329a759e-d57b-4aed-8976-1a368a95b5a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12413,7 +12413,7 @@
           }
         },
         {
-          "id": "7eedd4cc-bd9a-4ed9-9334-17c197c41de6",
+          "id": "7319cf4e-8de0-4254-980e-86529826c2c7",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12445,7 +12445,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ss-LO\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:37\",\n  \"quietHoursEnd\": \"03:30\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"gu-BT\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"07:11\",\n  \"quietHoursEnd\": \"22:26\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12465,7 +12465,7 @@
           },
           "response": [
             {
-              "id": "0a356c54-e9a2-4f4c-96f4-cc1939365474",
+              "id": "ba37b495-fbbf-4c04-a430-78fe57ce90c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12503,7 +12503,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ss-LO\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:37\",\n  \"quietHoursEnd\": \"03:30\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"gu-BT\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"07:11\",\n  \"quietHoursEnd\": \"22:26\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12537,7 +12537,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "7be3a51a-982d-4079-86dd-7164ca199774",
+          "id": "4c86aee5-5116-4612-874f-276bb81095f1",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12579,7 +12579,7 @@
           },
           "response": [
             {
-              "id": "5b5e722b-2513-4e38-8d77-74f2cb41e5b2",
+              "id": "81527599-60bf-48e5-a723-741875ec8bc2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12643,7 +12643,7 @@
           }
         },
         {
-          "id": "e9d9cccd-da3b-4194-8309-ca542fafbbac",
+          "id": "428c327c-e828-420b-b82e-c31f12711eb5",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12686,7 +12686,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#fc9F7d\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#3658A4\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12698,7 +12698,7 @@
           },
           "response": [
             {
-              "id": "d3f6e12a-2afb-4294-846d-00e21220af5e",
+              "id": "9a6af6cb-43e7-4660-8f62-b493111ae2de",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12747,7 +12747,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#fc9F7d\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#3658A4\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12775,7 +12775,7 @@
           }
         },
         {
-          "id": "87e07f5e-1c76-42ad-87f7-3846bae0c220",
+          "id": "3aa7a95b-8d71-4b36-81a4-369a100fc89b",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12811,7 +12811,7 @@
           },
           "response": [
             {
-              "id": "df8c64fa-6d85-4c24-a87f-87f97bb7355f",
+              "id": "f493d3a3-7d6b-4f8b-97fc-58058877c80c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12865,7 +12865,7 @@
           }
         },
         {
-          "id": "5588ee72-0357-40fa-8d68-b11bab643adc",
+          "id": "8f7c0af4-b095-4797-a2a8-ffaa30bf528b",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12895,7 +12895,7 @@
           },
           "response": [
             {
-              "id": "f9016086-e7df-467f-ba62-e0ddeeab074b",
+              "id": "6de6cd68-41e7-4eeb-b983-1f7365acc94e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12947,7 +12947,7 @@
           }
         },
         {
-          "id": "df575fbf-b936-49b1-b4d7-825d3e8b6220",
+          "id": "68c536f0-ca92-4897-82f4-d121650a0319",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -12978,7 +12978,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2CF6fF\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9CB713\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12990,7 +12990,7 @@
           },
           "response": [
             {
-              "id": "82c6d866-7864-4268-97ae-ab551dd9038b",
+              "id": "8f748f2d-8776-4269-b230-a574be234320",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13027,7 +13027,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2CF6fF\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9CB713\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13055,7 +13055,7 @@
           }
         },
         {
-          "id": "e83405e9-fa50-49da-b3e1-2a2e7538a950",
+          "id": "f266d3f8-b1d2-412d-b447-f02030f5be7e",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13086,7 +13086,7 @@
           },
           "response": [
             {
-              "id": "9f4c5910-47da-492b-a008-81eff2f733de",
+              "id": "5010573a-1d5e-4667-8c7d-0932379639e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13145,7 +13145,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "0d603ab2-7ae8-4f28-bfff-3c8f00e83649",
+          "id": "e347fcea-6fb5-40e6-a81a-450bc405b6fc",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "11111abc-b8b9-4502-983e-080f1c51f712",
+              "id": "59278115-1087-4881-ae2c-114af999b6d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13273,7 +13273,7 @@
           }
         },
         {
-          "id": "3b381418-3f91-4a6a-8fb3-2c165f24937f",
+          "id": "bf0b9e59-4508-414b-a8a0-345fe9b41b77",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13339,7 +13339,7 @@
           },
           "response": [
             {
-              "id": "e0a78c95-b88c-4207-9871-7c69eda4388c",
+              "id": "5dc94b39-b619-4caa-907f-653bf501fcbd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13427,7 +13427,7 @@
           }
         },
         {
-          "id": "43620b00-b634-4520-af5b-be1ba4629f30",
+          "id": "a45d01bb-d0cd-4a0a-b807-1b6ce88a66aa",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13474,7 +13474,7 @@
           },
           "response": [
             {
-              "id": "2162b1f4-8639-4e4a-91a2-5667c5ca5a8b",
+              "id": "c0aa6afd-99c3-4115-96ed-7f2783a21be6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13539,7 +13539,7 @@
           }
         },
         {
-          "id": "866ea3bf-e42d-4c73-947c-fa00566344e2",
+          "id": "d2a04ecf-fd2f-482b-808b-e6be77456ea2",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13581,7 +13581,7 @@
           },
           "response": [
             {
-              "id": "9c4f7028-13fe-46fb-a349-a96e4d68c968",
+              "id": "ce0d54fd-ee17-461a-a8a0-93d11a0b3224",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13645,7 +13645,7 @@
           }
         },
         {
-          "id": "cc3ada1a-2da7-40e1-88e4-b7451f11789e",
+          "id": "ee7f2a6e-9a03-4771-91b1-b1b966f491a5",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13700,7 +13700,7 @@
           },
           "response": [
             {
-              "id": "947d06ea-b965-41df-a4c8-1546e12ffdcd",
+              "id": "4eab6e74-8ea9-47f0-9f40-e993042fc899",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13777,7 +13777,7 @@
           }
         },
         {
-          "id": "b8fbcd10-695e-4f2a-80b3-9265ca32c7dc",
+          "id": "c6247748-4ef3-4966-8a12-8736a57356d9",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13831,7 +13831,7 @@
           },
           "response": [
             {
-              "id": "3f7b1195-e4e1-48bf-968f-136cc4954608",
+              "id": "e1626df9-49b5-4297-94a0-700b53618f24",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13907,7 +13907,7 @@
           }
         },
         {
-          "id": "89027c13-48d4-4220-b27c-42bd48563f7e",
+          "id": "b33b755a-2224-4761-bdca-60b808115a2b",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -13973,7 +13973,7 @@
           },
           "response": [
             {
-              "id": "8cdfa93c-7d68-45fe-a19d-16cd334434ee",
+              "id": "1a9a6c34-5209-4185-a184-a86be422387a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14061,7 +14061,7 @@
           }
         },
         {
-          "id": "12eb5cc1-6bc6-4e03-bb5a-cdfdc2c18c21",
+          "id": "ba7d4ab0-69b0-4d76-a424-e69773424693",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14139,7 +14139,7 @@
           },
           "response": [
             {
-              "id": "688811b8-ae26-4f56-8451-79352c67f993",
+              "id": "c4560ab0-cc5d-42b0-8ce0-986ebdd211b9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14239,7 +14239,7 @@
           }
         },
         {
-          "id": "24cf314e-13af-4021-bc37-4771c1b483d0",
+          "id": "14ffb63b-5b58-41cb-89a5-779861dcc4dd",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14305,7 +14305,7 @@
           },
           "response": [
             {
-              "id": "dece6de8-1346-49b5-b7b8-c7b0a735ac39",
+              "id": "b03210fe-61fa-4ff3-92d1-87f3a6add8a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14393,7 +14393,7 @@
           }
         },
         {
-          "id": "d64638b3-3969-421c-9df2-cd47fc115f99",
+          "id": "cf312bb6-0fbd-4d0c-a0ff-86cf6e94a47b",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14448,7 +14448,7 @@
           },
           "response": [
             {
-              "id": "e5c9a227-a66e-43c0-8f06-89b6ab752a30",
+              "id": "def1674f-808b-45a6-abb4-d826a6ec304b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14531,7 +14531,7 @@
       "description": "",
       "item": [
         {
-          "id": "9d4ab14c-f74d-4c77-963e-b2bb19daac07",
+          "id": "75ce526f-9e23-452a-98b9-ccb2bd1b79c8",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14572,7 +14572,7 @@
           },
           "response": [
             {
-              "id": "ec2458c2-6ae9-49f0-8b13-b50f55d39fb8",
+              "id": "389d5388-d88a-4b61-adfc-b745899e57a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14635,7 +14635,7 @@
           }
         },
         {
-          "id": "7b567b26-6f42-4c95-aed5-fb44cc0d86c1",
+          "id": "aad2d554-04c8-4619-8692-083ce6f5c54e",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14689,7 +14689,7 @@
           },
           "response": [
             {
-              "id": "39608ad6-fbe2-472e-8a2b-306031c52c0d",
+              "id": "1763afd1-4982-449a-a762-29e4b908cb45",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14765,7 +14765,7 @@
           }
         },
         {
-          "id": "130a5cb3-77f1-4a63-bf8a-9a92c752963a",
+          "id": "f9f3559e-4b7e-44bb-9729-774b892bc708",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14800,7 +14800,7 @@
           },
           "response": [
             {
-              "id": "5139eac6-6593-452f-bc54-16e03b03079b",
+              "id": "04d1e987-d55e-4308-9699-6391317956cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14853,7 +14853,7 @@
           }
         },
         {
-          "id": "6c32dbcd-debb-4400-b968-09fb2b458749",
+          "id": "3851d72d-e64d-4a62-8097-b46a1656a25b",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14895,7 +14895,7 @@
           },
           "response": [
             {
-              "id": "20f37493-44cc-4163-8745-06fe1aa00fa6",
+              "id": "a81d1b04-8ca2-40f5-91fa-741d217aa60c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14959,7 +14959,7 @@
           }
         },
         {
-          "id": "ce36fe95-f5c8-4bca-b3ba-9c9fecd80ff4",
+          "id": "0deddcce-d674-4c5b-9c12-fb2115b4f0f6",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15001,7 +15001,7 @@
           },
           "response": [
             {
-              "id": "557bfbc1-c717-4a63-8c97-add2ba597c2a",
+              "id": "0fc67db1-8e3b-4a10-a6b6-5bf9785be0ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15065,7 +15065,7 @@
           }
         },
         {
-          "id": "60e13fbc-6de6-444e-a873-aebae5094eda",
+          "id": "be2a39c1-38e8-4c34-8a5a-dd0d37403977",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15140,7 +15140,7 @@
           },
           "response": [
             {
-              "id": "be10fa8a-8ab8-44c3-b0ea-14f236ac871e",
+              "id": "c0f6449e-01c1-45b4-a404-1e1ac8f2f2f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15237,7 +15237,7 @@
           }
         },
         {
-          "id": "23245e26-41c9-4106-975b-efec49dfe391",
+          "id": "b72914e7-8295-4385-a96c-e4606f17cb05",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15279,7 +15279,7 @@
           },
           "response": [
             {
-              "id": "e3d4fe40-e3ff-4f7e-833d-77e9bbcbc909",
+              "id": "8d67167f-96a8-4d25-ae2a-db33ac12c620",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15343,7 +15343,7 @@
           }
         },
         {
-          "id": "d7ff6fc0-46ee-43db-a667-932055298ff1",
+          "id": "3e9d9b85-07c5-43e2-b1bf-eb3eef5281f4",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15386,7 +15386,7 @@
           },
           "response": [
             {
-              "id": "59b8bf5c-bae9-44b3-8f9e-8b9be124662c",
+              "id": "880bb875-4077-4575-b36a-9857634e082c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15451,7 +15451,7 @@
           }
         },
         {
-          "id": "26d0d8e8-f42c-4958-a86b-1f2bf8fbd876",
+          "id": "dec76b93-3085-4cf2-98de-6cee9ebbd7ce",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15494,7 +15494,7 @@
           },
           "response": [
             {
-              "id": "c417501a-0558-4ad3-9153-96efdbb26d80",
+              "id": "40511d5f-f1aa-4bef-ade5-e6ced42399ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15559,7 +15559,7 @@
           }
         },
         {
-          "id": "2af25a19-f992-4d15-8fb4-bb76c13184a2",
+          "id": "7ec5207b-bea8-47c2-93bf-4a86eee8157b",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15611,7 +15611,7 @@
           },
           "response": [
             {
-              "id": "c8771cfc-556b-4345-b6b2-090c4873ab8b",
+              "id": "313f2105-2573-48b7-b95b-bd0faa93047e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15685,7 +15685,7 @@
           }
         },
         {
-          "id": "3bd33534-6e14-43a7-865b-feab75c4719f",
+          "id": "1991e3a3-7dc2-4abe-b2ed-64c3e87cef53",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15727,7 +15727,7 @@
           },
           "response": [
             {
-              "id": "69a8862f-950b-4c5e-a0b0-318dab07a008",
+              "id": "068ec55b-fdf2-41c4-bd8e-4a7e41077eeb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15791,7 +15791,7 @@
           }
         },
         {
-          "id": "10a0e657-88d8-40d6-92b8-c189a6a5d41b",
+          "id": "cfe43522-1ae3-40e4-9c57-035acfa37e95",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15844,7 +15844,7 @@
           },
           "response": [
             {
-              "id": "6ebda41e-ceed-45c9-ad71-b6d554348967",
+              "id": "e860969c-0422-4c81-b641-a33a1e678d72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15919,7 +15919,7 @@
           }
         },
         {
-          "id": "317ff855-f41e-4718-8e6d-ff5b898ea080",
+          "id": "8f904663-ac2e-4925-b87c-2bb987ce39b3",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -15972,7 +15972,7 @@
           },
           "response": [
             {
-              "id": "7512ccf0-6f16-46a5-888f-e42c6a01d89a",
+              "id": "ccfdeaf4-0bab-4f00-bb3a-a7d4437fea20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16047,7 +16047,7 @@
           }
         },
         {
-          "id": "4f77da84-ca57-4123-886c-b0033060df2f",
+          "id": "a213eb24-27a6-4443-9b07-c84fe0473791",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16091,7 +16091,7 @@
           },
           "response": [
             {
-              "id": "111f97e0-6f59-464b-a9fa-c0422f4ff43b",
+              "id": "157c4c44-373f-4944-aca3-b16d51323376",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16146,7 +16146,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16157,7 +16157,7 @@
           }
         },
         {
-          "id": "d5c80e2c-4c13-461d-8df5-826dc462f562",
+          "id": "5cc59b87-2373-4ab8-9999-006bc74563b2",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16201,7 +16201,7 @@
           },
           "response": [
             {
-              "id": "8adcb5c5-db42-47a8-a40d-d7182d9b0217",
+              "id": "c6186d58-a24e-4f31-bc69-a30fc1c32a56",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16256,7 +16256,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16273,7 +16273,7 @@
       "description": "",
       "item": [
         {
-          "id": "49d145f8-f3bc-45cb-a804-016e7e1da9c8",
+          "id": "ed540ab9-6e63-4eab-97bb-d509d113a2eb",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16315,7 +16315,7 @@
           },
           "response": [
             {
-              "id": "ebb4de59-fa5f-4828-99ec-3b9ac3391380",
+              "id": "77b8077e-659d-4bb2-acc5-f7e01ea68c9c",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16364,7 +16364,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b123f4eb-a086-4726-98f9-67438a1a7de7",
+              "id": "9c1fe8b1-c816-4375-8b67-620e99632833",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16419,7 +16419,7 @@
           }
         },
         {
-          "id": "b802da57-78b7-4fff-bcf3-307a9f00dab8",
+          "id": "54df5198-1397-43ab-be54-919f69bde6bb",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16465,7 +16465,7 @@
           },
           "response": [
             {
-              "id": "a5d10282-6c92-4f2b-b0e7-c66d2f5953bf",
+              "id": "33d24c00-21e1-4ba3-a317-b598feeae6f4",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16524,7 +16524,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "5fee9323-61bf-4a17-a94b-b352b0de40f4",
+              "id": "917a4bd4-0348-4f48-8db8-b7d7a99ebb10",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16589,7 +16589,7 @@
           }
         },
         {
-          "id": "2a8d0071-7a2d-4d1a-b715-514dd306db6c",
+          "id": "21902f26-23cd-4d2b-af6e-08bb9ef5359e",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16635,7 +16635,7 @@
           },
           "response": [
             {
-              "id": "c4d1de1f-0af0-4a72-b6d2-c50ec7fbf54d",
+              "id": "21668f8c-d733-49c0-8c75-a8b0474d3b3e",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16694,7 +16694,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "79b833d6-21f1-42f6-89a4-be69e43aad5e",
+              "id": "1716024b-cb92-44fa-9745-94a9b00b1ab5",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16753,7 +16753,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4eea2c61-4a31-4da9-9d94-dc566f35a708",
+              "id": "de30a7e8-ac89-4ec6-bbd2-b8a44b43b6e7",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16812,7 +16812,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4d174b41-0d96-4096-98e5-e2162adbad53",
+              "id": "2049d86d-921c-4460-8d3c-ab15e22b2eba",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16877,7 +16877,7 @@
           }
         },
         {
-          "id": "f07f3354-bf06-4fef-b413-8a89a2f946c4",
+          "id": "966ed4d8-15bc-4b4d-a828-3d95b56adbb3",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -16923,7 +16923,7 @@
           },
           "response": [
             {
-              "id": "786ebd2c-efce-445e-9038-2ba74a82171f",
+              "id": "2fcdcece-37e4-4720-b97d-1d79dec5e9db",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -16982,7 +16982,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f310de59-80ed-4ff6-aaad-8964b1036a07",
+              "id": "6e07424e-86de-4fe0-9952-f903ace7b0ca",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17047,7 +17047,7 @@
           }
         },
         {
-          "id": "daff3387-498b-470c-a303-f915086927fa",
+          "id": "097c1256-18d3-49fc-8944-2e80c7fab727",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17089,7 +17089,7 @@
           },
           "response": [
             {
-              "id": "9997f39e-8610-45a2-ba54-3f98409268d0",
+              "id": "d865bdb6-e09f-465a-bd6f-6eb65013c7aa",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17150,7 +17150,7 @@
       "description": "",
       "item": [
         {
-          "id": "9c821c35-aff0-4deb-821b-3152731951e2",
+          "id": "de5afce3-a8c4-429e-baf4-cab25b62ebdd",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17199,7 +17199,7 @@
           },
           "response": [
             {
-              "id": "8298a08b-7ca4-446d-85a2-2c09832e7685",
+              "id": "111919e7-b682-4a07-be69-ca5659e324e2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17259,7 +17259,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17270,7 +17270,7 @@
           }
         },
         {
-          "id": "d5757e1a-b246-49e4-a09c-cb1978fd8db5",
+          "id": "1fbfa3f4-8287-4355-86e9-be71538eaa6c",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17319,7 +17319,7 @@
           },
           "response": [
             {
-              "id": "62996fd4-2370-47f2-b6af-9904f2a69b42",
+              "id": "0e7cd58a-a4b3-462a-ae52-c33b1b92d507",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17390,7 +17390,7 @@
           }
         },
         {
-          "id": "f9264279-5452-4abc-b7b7-75906741e1a5",
+          "id": "51f03337-787e-4c96-8407-296d1dd88002",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17439,7 +17439,7 @@
           },
           "response": [
             {
-              "id": "fece3394-74a9-4a16-9c1d-684971a71f09",
+              "id": "dc79acc2-ee7d-40cc-ac7d-042fc0a2b06b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17510,7 +17510,7 @@
           }
         },
         {
-          "id": "996f074b-0c09-49f6-a9a9-5990eb8b2fa3",
+          "id": "1e37358f-92f2-43e1-b8e6-3270ab9e2b94",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17559,7 +17559,7 @@
           },
           "response": [
             {
-              "id": "791a9260-8938-4fe9-b106-d0cba909a08e",
+              "id": "25253f2b-f8cd-4f9f-b0bd-04614f250c4f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17636,7 +17636,7 @@
       "description": "",
       "item": [
         {
-          "id": "9e8cc32d-d9e2-4377-91f9-7f83c0eac8f8",
+          "id": "a6b4d8b5-05f7-4377-b822-60d30e200c69",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17676,7 +17676,7 @@
           },
           "response": [
             {
-              "id": "92fe3077-a008-4ee3-bbfe-8bf508a6d4f2",
+              "id": "23e01473-a2c7-48e8-bf65-1b8c420f0f96",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17738,7 +17738,7 @@
           }
         },
         {
-          "id": "de380427-ac73-43d8-a797-66caed6df3c3",
+          "id": "8a7cf488-4918-4376-82de-2d7323cb488a",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17768,7 +17768,7 @@
           },
           "response": [
             {
-              "id": "f184de85-59c3-46a0-8d90-af15e2b47b35",
+              "id": "40559a3c-c885-4ed6-b11a-ca5ce6158a40",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17809,7 +17809,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17820,7 +17820,7 @@
           }
         },
         {
-          "id": "8c00bc7e-88f8-4aa9-adc9-4435085483e4",
+          "id": "2390403a-bcda-4426-b8d0-13d0cd685714",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17872,7 +17872,7 @@
           },
           "response": [
             {
-              "id": "1d54db7f-0f99-4cc8-a903-64996f3655c3",
+              "id": "cdfe2c4c-b62d-4f53-a85f-c28e060e3088",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17952,7 +17952,7 @@
       "description": "",
       "item": [
         {
-          "id": "34e7cc1f-5509-44e0-b909-4fe872ea591e",
+          "id": "48432146-cda0-4597-ad95-97395025d8c7",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -17981,7 +17981,7 @@
           },
           "response": [
             {
-              "id": "d3990ff8-862f-4f55-a1f7-0900e1df5bc5",
+              "id": "70fa996f-892a-47f7-aa85-e355605588ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18032,7 +18032,7 @@
           }
         },
         {
-          "id": "fb891f00-29af-42c7-80d6-6301b7a00faf",
+          "id": "0327c3f3-bca2-4983-86ec-21f61dbd95cb",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18073,7 +18073,7 @@
           },
           "response": [
             {
-              "id": "c528b07f-b514-4366-8a35-bb062509e501",
+              "id": "9a9029a7-360e-4687-8509-3eafd009477d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18142,7 +18142,7 @@
       "description": "",
       "item": [
         {
-          "id": "150ef284-0357-440c-98ba-3d35a98b586e",
+          "id": "d9f0a391-548f-4695-afc4-83289675c768",
           "name": "health",
           "request": {
             "name": "health",
@@ -18171,7 +18171,7 @@
           },
           "response": [
             {
-              "id": "df2b49c4-6b5a-4aee-b880-e4450d4e4cc4",
+              "id": "38b47d7c-8d48-451d-9dc7-fe7b6462e07c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18211,7 +18211,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": \"string\"\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18228,7 +18228,7 @@
       "description": "",
       "item": [
         {
-          "id": "2e1324a8-0ae3-4c3b-98bc-9b177623f225",
+          "id": "5ce4a5de-4d7c-4744-9f67-4f7b085fa197",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18280,7 +18280,7 @@
           },
           "response": [
             {
-              "id": "427e7a68-b728-492d-92c1-d71a30761e6e",
+              "id": "8ecfad24-afa8-4af9-b66a-b8f0123a6587",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18354,7 +18354,7 @@
           }
         },
         {
-          "id": "b6ef7acc-61f8-4286-a986-675a14da81ea",
+          "id": "ac661a09-cec2-4608-a4a5-e6a9cc64f394",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18395,7 +18395,7 @@
           },
           "response": [
             {
-              "id": "ec861bd0-b1ee-4ea3-9a8f-3c267375ce90",
+              "id": "d668f844-0661-4ef0-b1f4-f192281d7654",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18447,7 +18447,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_3\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18458,7 +18458,7 @@
           }
         },
         {
-          "id": "f6b1530f-fc4f-4cc0-a581-2c9f894f886f",
+          "id": "3de15b80-9ac6-460a-b27f-969c27e7fdaf",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18488,7 +18488,7 @@
           },
           "response": [
             {
-              "id": "2cb866cc-31b6-4027-9f07-ac0716776f5f",
+              "id": "b96437ca-6912-47af-aab0-4b54a6df2ec2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18560,9 +18560,9 @@
     }
   ],
   "info": {
-    "_postman_id": "37f1fa71-68b9-4e2e-8222-d71a8fc396d6",
+    "_postman_id": "c22b3b80-22ca-4a91-bf03-20cb1854e746",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 02:58 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 03:15 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1945,23 +1945,6 @@
               "type": "integer",
               "format": "int64"
             }
-          },
-          {
-            "name": "userId",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "userName",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -2567,15 +2550,6 @@
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AlertResolveRequest"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2617,15 +2591,6 @@
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AlertReopenRequest"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "OK",
@@ -7573,29 +7538,6 @@
         "required": [
           "sectorId"
         ]
-      },
-      "AlertResolveRequest": {
-        "type": "object",
-        "description": "Solicitud para resolver una Alerta",
-        "properties": {
-          "resolvedByUserId": {
-            "type": "integer",
-            "format": "int64",
-            "description": "ID del usuario que resuelve la alerta"
-          }
-        }
-      },
-      "AlertReopenRequest": {
-        "type": "object",
-        "description": "Request body for reopening a resolved alert",
-        "properties": {
-          "actorUserId": {
-            "type": "integer",
-            "format": "int64",
-            "description": "ID of the user who is reopening the alert. Null = system actor.",
-            "example": 42
-          }
-        }
       },
       "PushTokenRegisterRequest": {
         "type": "object",

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/Alert.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/Alert.kt
@@ -69,45 +69,45 @@ data class Alert(
 
     @field:NotNull(message = "Sector ID is required")
     @Column(name = "sector_id", nullable = false)
-    val sectorId: Long,
+    var sectorId: Long,
 
     @field:NotNull(message = "Tenant ID is required")
     @Column(name = "tenant_id", nullable = false)
-    val tenantId: Long,
+    var tenantId: Long,
 
     /**
      * FK al tipo de alerta (alert_types).
      * Nullable para compatibilidad con datos legacy.
      */
     @Column(name = "alert_type_id")
-    val alertTypeId: Short? = null,
+    var alertTypeId: Short? = null,
 
     /**
      * FK a la severidad (alert_severities).
      * Nullable para compatibilidad con datos legacy.
      */
     @Column(name = "severity_id")
-    val severityId: Short? = null,
+    var severityId: Short? = null,
 
     /**
      * Mensaje descriptivo de la alerta.
      * Nullable para permitir alertas sin mensaje inicial.
      */
     @Column(name = "message", columnDefinition = "TEXT")
-    val message: String? = null,
+    var message: String? = null,
 
     /**
      * Descripcion detallada de la alerta.
      * Separado de message para permitir titulo corto y descripcion larga.
      */
     @Column(name = "description", columnDefinition = "TEXT")
-    val description: String? = null,
+    var description: String? = null,
 
     /**
      * Indica si la alerta fue resuelta.
      */
     @Column(name = "client_name")
-    val clientName: String? = null,
+    var clientName: String? = null,
 
     @Column(name = "is_resolved", nullable = false)
     var isResolved: Boolean = false,

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
@@ -383,9 +383,8 @@ class AlertController(
      * Resuelve una alerta. Delegated to hexagonal use case so that an audit row is written
      * to alert_state_changes and the AlertStateChangedEvent is published.
      *
-     * Query params:
-     * - userId: ID del usuario que resuelve (opcional)
-     * - userName: Nombre del usuario (ignorado, kept for backward compat)
+     * Actor is derived from the authenticated JWT. Legacy userId/userName query
+     * parameters are ignored when present.
      *
      * Response: Alert resuelto
      *
@@ -393,9 +392,7 @@ class AlertController(
      */
     @PutMapping("/{id}/resolve")
     fun resolveAlert(
-        @PathVariable id: Long,
-        @RequestParam(required = false) userId: Long?,
-        @RequestParam(required = false) userName: String?
+        @PathVariable id: Long
     ): ResponseEntity<AlertResponse> {
         logger.debug("PUT /api/alerts/$id/resolve - Resolving alert (legacy)")
 
@@ -405,7 +402,7 @@ class AlertController(
         }
         val tenantId = TenantId(alert.tenantId)
 
-        return restInboundAdapter.resolve(id, tenantId, userId).fold(
+        return restInboundAdapter.resolve(id, tenantId, tenantContext.currentUserId()).fold(
             onLeft = { error ->
                 when (error) {
                     is AlertError.NotFound -> ResponseEntity.notFound().build()
@@ -444,7 +441,7 @@ class AlertController(
         }
         val tenantId = TenantId(alert.tenantId)
 
-        return restInboundAdapter.reopen(id, tenantId, actorUserId = null).fold(
+        return restInboundAdapter.reopen(id, tenantId, actorUserId = tenantContext.currentUserId()).fold(
             onLeft = { error ->
                 when (error) {
                     is AlertError.NotFound -> ResponseEntity.notFound().build()

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertReopenRequest.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertReopenRequest.kt
@@ -1,9 +1,0 @@
-package com.apptolast.invernaderos.features.alert.dto.request
-
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "Request body for reopening a resolved alert")
-data class AlertReopenRequest(
-    @Schema(description = "ID of the user who is reopening the alert. Null = system actor.", example = "42")
-    val actorUserId: Long? = null,
-)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertResolveRequest.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/dto/request/AlertResolveRequest.kt
@@ -1,9 +1,0 @@
-package com.apptolast.invernaderos.features.alert.dto.request
-
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "Solicitud para resolver una Alerta")
-data class AlertResolveRequest(
-    @Schema(description = "ID del usuario que resuelve la alerta")
-    val resolvedByUserId: Long? = null
-)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertRestInboundAdapter.kt
@@ -24,8 +24,8 @@ class AlertRestInboundAdapter(
 ) {
 
     @Transactional("metadataTransactionManager")
-    fun resolve(id: Long, tenantId: TenantId, resolvedByUserId: Long?): Either<AlertError, Alert> =
-        resolveUseCase.resolve(id, tenantId, resolvedByUserId)
+    fun resolve(id: Long, tenantId: TenantId, actorUserId: Long?): Either<AlertError, Alert> =
+        resolveUseCase.resolve(id, tenantId, actorUserId)
 
     @Transactional("metadataTransactionManager")
     fun reopen(id: Long, tenantId: TenantId, actorUserId: Long? = null): Either<AlertError, Alert> =

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -62,6 +63,7 @@ class TenantAlertController(
     @PostMapping
     @Operation(summary = "Crear una nueva alerta para un cliente")
     @RequiresTenantOwnership
+    @Transactional("metadataTransactionManager")
     fun create(
         @PathVariable tenantId: Long,
         @RequestBody request: AlertCreateRequest
@@ -89,6 +91,7 @@ class TenantAlertController(
     @PutMapping("/{alertId}")
     @Operation(summary = "Actualizar una alerta existente de un cliente")
     @RequiresTenantOwnership
+    @Transactional("metadataTransactionManager")
     fun update(
         @PathVariable tenantId: Long,
         @PathVariable alertId: Long,
@@ -117,6 +120,7 @@ class TenantAlertController(
     @DeleteMapping("/{alertId}")
     @Operation(summary = "Eliminar una alerta de un cliente")
     @RequiresTenantOwnership
+    @Transactional("metadataTransactionManager")
     fun delete(
         @PathVariable tenantId: Long,
         @PathVariable alertId: Long

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/TenantAlertController.kt
@@ -8,12 +8,11 @@ import com.apptolast.invernaderos.features.alert.domain.port.input.UpdateAlertUs
 import com.apptolast.invernaderos.features.alert.dto.mapper.toCommand
 import com.apptolast.invernaderos.features.alert.dto.mapper.toResponse
 import com.apptolast.invernaderos.features.alert.dto.request.AlertCreateRequest
-import com.apptolast.invernaderos.features.alert.dto.request.AlertReopenRequest
-import com.apptolast.invernaderos.features.alert.dto.request.AlertResolveRequest
 import com.apptolast.invernaderos.features.alert.dto.request.AlertUpdateRequest
 import com.apptolast.invernaderos.features.alert.dto.response.AlertResponse
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
 import com.apptolast.invernaderos.features.shared.security.RequiresTenantOwnership
+import com.apptolast.invernaderos.features.shared.security.TenantContext
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -35,7 +34,8 @@ class TenantAlertController(
     private val findUseCase: FindAlertUseCase,
     private val updateUseCase: UpdateAlertUseCase,
     private val deleteUseCase: DeleteAlertUseCase,
-    private val restInboundAdapter: AlertRestInboundAdapter
+    private val restInboundAdapter: AlertRestInboundAdapter,
+    private val tenantContext: TenantContext
 ) {
 
     @GetMapping
@@ -132,10 +132,9 @@ class TenantAlertController(
     @RequiresTenantOwnership
     fun resolve(
         @PathVariable tenantId: Long,
-        @PathVariable alertId: Long,
-        @RequestBody(required = false) request: AlertResolveRequest?
+        @PathVariable alertId: Long
     ): ResponseEntity<Any> {
-        return restInboundAdapter.resolve(alertId, TenantId(tenantId), request?.resolvedByUserId).fold(
+        return restInboundAdapter.resolve(alertId, TenantId(tenantId), tenantContext.currentUserId()).fold(
             onLeft = { error ->
                 // resolve() can only emit NotFound, AlreadyResolved or SectorNotOwnedByTenant.
                 // NotResolved is reachable only from reopen() — handled in /reopen below.
@@ -161,10 +160,9 @@ class TenantAlertController(
     @RequiresTenantOwnership
     fun reopen(
         @PathVariable tenantId: Long,
-        @PathVariable alertId: Long,
-        @RequestBody(required = false) request: AlertReopenRequest?
+        @PathVariable alertId: Long
     ): ResponseEntity<Any> {
-        return restInboundAdapter.reopen(alertId, TenantId(tenantId), request?.actorUserId).fold(
+        return restInboundAdapter.reopen(alertId, TenantId(tenantId), tenantContext.currentUserId()).fold(
             onLeft = { error ->
                 // reopen() can only emit NotFound or NotResolved.
                 // AlreadyResolved is reachable only from resolve() — handled in /resolve above.

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapter.kt
@@ -28,8 +28,15 @@ class AlertRepositoryAdapter(
     }
 
     override fun save(alert: Alert): Alert {
-        val entity = alert.toEntity()
-        val saved = jpaRepository.save(entity)
+        val saved = if (alert.id == null) {
+            jpaRepository.save(alert.toEntity())
+        } else {
+            val managed = jpaRepository.findById(alert.id).orElseThrow {
+                IllegalStateException("Alert with ID ${alert.id} cannot be found before update")
+            }
+            managed.applyScalarValuesFrom(alert)
+            managed
+        }
         // Force a fresh load with @EntityGraph("Alert.context"): without flush+detach,
         // findById returns the cached managed entity whose LAZY relations (severity,
         // sector, alertType) remain uninitialized. Downstream notification dispatch
@@ -38,6 +45,21 @@ class AlertRepositoryAdapter(
         entityManager.flush()
         entityManager.detach(saved)
         return jpaRepository.findById(savedId).orElseThrow().toDomain()
+    }
+
+    private fun com.apptolast.invernaderos.features.alert.Alert.applyScalarValuesFrom(alert: Alert) {
+        code = alert.code
+        tenantId = alert.tenantId.value
+        sectorId = alert.sectorId.value
+        alertTypeId = alert.alertTypeId
+        severityId = alert.severityId
+        message = alert.message
+        description = alert.description
+        clientName = alert.clientName
+        isResolved = alert.isResolved
+        resolvedAt = alert.resolvedAt
+        resolvedByUserId = alert.resolvedByUserId
+        updatedAt = alert.updatedAt
     }
 
     override fun delete(id: Long, tenantId: TenantId): Boolean {

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/LegacyAlertControllerActorTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/LegacyAlertControllerActorTest.kt
@@ -1,0 +1,91 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.Alert
+import com.apptolast.invernaderos.features.alert.AlertController
+import com.apptolast.invernaderos.features.alert.AlertService
+import com.apptolast.invernaderos.features.alert.domain.model.Alert as DomainAlert
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertRestInboundAdapter
+import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.shared.security.TenantContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import java.time.Instant
+
+class LegacyAlertControllerActorTest {
+
+    private val alertService = mockk<AlertService>()
+    private val restInboundAdapter = mockk<AlertRestInboundAdapter>()
+    private val tenantContext = mockk<TenantContext>()
+    private val controller = AlertController(alertService, restInboundAdapter, tenantContext)
+
+    @Test
+    fun `legacy resolve derives actor user id from authenticated context`() {
+        val legacyAlert = sampleLegacyAlert(isResolved = false, resolvedByUserId = null)
+        every { alertService.getById(1L) } returns legacyAlert
+        every { tenantContext.currentTenantId() } returns 10L
+        every { tenantContext.currentUserId() } returns 77L
+        every { restInboundAdapter.resolve(1L, TenantId(10L), 77L) } returns
+            Either.Right(sampleDomainAlert(isResolved = true, resolvedByUserId = 77L))
+
+        val response = controller.resolveAlert(1L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        verify(exactly = 1) { restInboundAdapter.resolve(1L, TenantId(10L), 77L) }
+    }
+
+    @Test
+    fun `legacy reopen derives actor user id from authenticated context`() {
+        val legacyAlert = sampleLegacyAlert(isResolved = true, resolvedByUserId = 77L)
+        every { alertService.getById(1L) } returns legacyAlert
+        every { tenantContext.currentTenantId() } returns 10L
+        every { tenantContext.currentUserId() } returns 77L
+        every { restInboundAdapter.reopen(1L, TenantId(10L), 77L) } returns
+            Either.Right(sampleDomainAlert(isResolved = false, resolvedByUserId = null))
+
+        val response = controller.reopenAlert(1L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        verify(exactly = 1) { restInboundAdapter.reopen(1L, TenantId(10L), 77L) }
+    }
+
+    private fun sampleLegacyAlert(isResolved: Boolean, resolvedByUserId: Long?) = Alert(
+        id = 1L,
+        code = "ALT-00001",
+        sectorId = 20L,
+        tenantId = 10L,
+        message = "Alert",
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.parse("2026-01-01T00:00:00Z") else null,
+        resolvedByUserId = resolvedByUserId,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    private fun sampleDomainAlert(isResolved: Boolean, resolvedByUserId: Long?) = DomainAlert(
+        id = 1L,
+        code = "ALT-00001",
+        tenantId = TenantId(10L),
+        sectorId = SectorId(20L),
+        sectorCode = null,
+        alertTypeId = null,
+        alertTypeName = null,
+        severityId = null,
+        severityName = null,
+        severityLevel = null,
+        message = "Alert",
+        description = null,
+        clientName = null,
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.parse("2026-01-01T00:00:00Z") else null,
+        resolvedByUserId = resolvedByUserId,
+        resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/TenantAlertControllerActorTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/TenantAlertControllerActorTest.kt
@@ -1,0 +1,80 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.port.input.CreateAlertUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.DeleteAlertUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.FindAlertUseCase
+import com.apptolast.invernaderos.features.alert.domain.port.input.UpdateAlertUseCase
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertRestInboundAdapter
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.TenantAlertController
+import com.apptolast.invernaderos.features.shared.domain.Either
+import com.apptolast.invernaderos.features.shared.domain.model.SectorId
+import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.shared.security.TenantContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import java.time.Instant
+
+class TenantAlertControllerActorTest {
+
+    private val restInboundAdapter = mockk<AlertRestInboundAdapter>()
+    private val tenantContext = mockk<TenantContext>()
+    private val controller = TenantAlertController(
+        createUseCase = mockk<CreateAlertUseCase>(),
+        findUseCase = mockk<FindAlertUseCase>(),
+        updateUseCase = mockk<UpdateAlertUseCase>(),
+        deleteUseCase = mockk<DeleteAlertUseCase>(),
+        restInboundAdapter = restInboundAdapter,
+        tenantContext = tenantContext,
+    )
+
+    @Test
+    fun `resolve derives actor user id from authenticated context`() {
+        every { tenantContext.currentUserId() } returns 77L
+        every { restInboundAdapter.resolve(1L, TenantId(10L), 77L) } returns
+            Either.Right(sampleAlert(isResolved = true, resolvedByUserId = 77L))
+
+        val response = controller.resolve(10L, 1L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        verify(exactly = 1) { restInboundAdapter.resolve(1L, TenantId(10L), 77L) }
+    }
+
+    @Test
+    fun `reopen derives actor user id from authenticated context`() {
+        every { tenantContext.currentUserId() } returns 77L
+        every { restInboundAdapter.reopen(1L, TenantId(10L), 77L) } returns
+            Either.Right(sampleAlert(isResolved = false, resolvedByUserId = null))
+
+        val response = controller.reopen(10L, 1L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        verify(exactly = 1) { restInboundAdapter.reopen(1L, TenantId(10L), 77L) }
+    }
+
+    private fun sampleAlert(isResolved: Boolean, resolvedByUserId: Long?) = Alert(
+        id = 1L,
+        code = "ALT-00001",
+        tenantId = TenantId(10L),
+        sectorId = SectorId(20L),
+        sectorCode = null,
+        alertTypeId = null,
+        alertTypeName = null,
+        severityId = null,
+        severityName = null,
+        severityLevel = null,
+        message = "Alert",
+        description = null,
+        clientName = null,
+        isResolved = isResolved,
+        resolvedAt = if (isResolved) Instant.parse("2026-01-01T00:00:00Z") else null,
+        resolvedByUserId = resolvedByUserId,
+        resolvedByUserName = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/TenantAlertControllerTransactionTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/TenantAlertControllerTransactionTest.kt
@@ -1,0 +1,37 @@
+package com.apptolast.invernaderos.features.alert.infrastructure
+
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.TenantAlertController
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.annotation.Transactional
+
+class TenantAlertControllerTransactionTest {
+
+    @Test
+    fun `tenant alert write endpoints use metadata transaction manager`() {
+        listOf(
+            TenantAlertController::class.java.getMethod(
+                "create",
+                Long::class.javaPrimitiveType,
+                Class.forName("com.apptolast.invernaderos.features.alert.dto.request.AlertCreateRequest"),
+            ),
+            TenantAlertController::class.java.getMethod(
+                "update",
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Class.forName("com.apptolast.invernaderos.features.alert.dto.request.AlertUpdateRequest"),
+            ),
+            TenantAlertController::class.java.getMethod(
+                "delete",
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+            ),
+        ).forEach { method ->
+            val transactional = method.getAnnotation(Transactional::class.java)
+            assertThat(transactional)
+                .describedAs("${method.name} must run in metadataTransactionManager")
+                .isNotNull
+            assertThat(transactional.value).isEqualTo("metadataTransactionManager")
+        }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapterTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/output/AlertRepositoryAdapterTest.kt
@@ -4,8 +4,11 @@ import com.apptolast.invernaderos.features.alert.Alert as AlertEntity
 import com.apptolast.invernaderos.features.alert.AlertRepository
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
 import com.apptolast.invernaderos.features.catalog.AlertSeverity
+import com.apptolast.invernaderos.features.sector.Sector
 import com.apptolast.invernaderos.features.shared.domain.model.SectorId
 import com.apptolast.invernaderos.features.shared.domain.model.TenantId
+import com.apptolast.invernaderos.features.tenant.Tenant
+import com.apptolast.invernaderos.features.user.User
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -125,5 +128,104 @@ class AlertRepositoryAdapterTest {
         }
         verify(exactly = 1) { entityManager.flush() }
         verify(exactly = 1) { entityManager.detach(rawSavedEntity) }
+    }
+
+    @Test
+    fun `save updates managed entity scalars without merging detached read-only associations`() {
+        val now = Instant.parse("2026-05-03T22:00:00Z")
+        val updatedAt = Instant.parse("2026-05-03T23:00:00Z")
+        val tenant = Tenant(id = 10L, code = "TNT-10", name = "Tenant", email = "tenant@example.com")
+        val sector = Sector(id = 20L, code = "SEC-20", tenantId = 10L, greenhouseId = 30L, name = "Sector")
+        val resolvedByUser = User(
+            id = 42L,
+            code = "USR-42",
+            tenantId = 10L,
+            username = "resolver",
+            email = "resolver@example.com",
+            passwordHash = "hash",
+            role = "USER",
+        )
+        val managedEntity = AlertEntity(
+            id = 99L,
+            code = "ALT-99",
+            tenantId = 10L,
+            sectorId = 20L,
+            alertTypeId = null,
+            severityId = null,
+            message = "Old message",
+            description = null,
+            clientName = null,
+            isResolved = false,
+            resolvedAt = null,
+            resolvedByUserId = null,
+            createdAt = now,
+            updatedAt = now
+        ).apply {
+            this.tenant = tenant
+            this.sector = sector
+        }
+        val reloadedEntity = AlertEntity(
+            id = 99L,
+            code = "ALT-99",
+            tenantId = 10L,
+            sectorId = 20L,
+            alertTypeId = null,
+            severityId = null,
+            message = "Resolved by API",
+            description = "Updated",
+            clientName = "client",
+            isResolved = true,
+            resolvedAt = updatedAt,
+            resolvedByUserId = 42L,
+            createdAt = now,
+            updatedAt = updatedAt
+        ).apply {
+            this.tenant = tenant
+            this.sector = sector
+            this.resolvedByUser = resolvedByUser
+        }
+        val domainInput = Alert(
+            id = 99L,
+            code = "ALT-99",
+            tenantId = TenantId(10L),
+            sectorId = SectorId(20L),
+            sectorCode = "SEC-20",
+            alertTypeId = null,
+            alertTypeName = null,
+            severityId = null,
+            severityName = null,
+            severityLevel = null,
+            message = "Resolved by API",
+            description = "Updated",
+            clientName = "client",
+            isResolved = true,
+            resolvedAt = updatedAt,
+            resolvedByUserId = 42L,
+            resolvedByUserName = "resolver",
+            createdAt = now,
+            updatedAt = updatedAt,
+        )
+
+        every { jpaRepository.findById(99L) } returnsMany listOf(Optional.of(managedEntity), Optional.of(reloadedEntity))
+        justRun { entityManager.flush() }
+        justRun { entityManager.detach(managedEntity) }
+
+        val result = adapter.save(domainInput)
+
+        assertThat(result.isResolved).isTrue()
+        assertThat(result.resolvedByUserId).isEqualTo(42L)
+        assertThat(result.resolvedByUserName).isEqualTo("resolver")
+        assertThat(managedEntity.message).isEqualTo("Resolved by API")
+        assertThat(managedEntity.resolvedByUserId).isEqualTo(42L)
+        assertThat(managedEntity.tenant).isSameAs(tenant)
+        assertThat(managedEntity.sector).isSameAs(sector)
+        assertThat(managedEntity.resolvedByUser).isNull()
+        verify(exactly = 0) { jpaRepository.save(any()) }
+        verifyOrder {
+            jpaRepository.findById(99L)
+            entityManager.flush()
+            entityManager.detach(managedEntity)
+            jpaRepository.findById(99L)
+        }
     }
 }


### PR DESCRIPTION
Promotes PR #127 plus required dev-smoke follow-ups #128 and #129 from develop to main.\n\nIncluded:\n- Resolve/reopen derive actor user id from authenticated JWT/TenantContext.\n- Client-controlled resolvedByUserId/actorUserId request DTOs removed from tenant resolve/reopen.\n- Legacy resolve ignores userId/userName query params and uses JWT user id.\n- Tenant alert create/update/delete run in metadataTransactionManager to prevent flush outside transaction.\n- AlertRepositoryAdapter updates existing managed entities through scalar columns only to avoid Hibernate HHH000502 read-only association warnings.\n- Generated API docs updates from develop.\n\nDev verification completed:\n- Local full suite passed with dev secret and no ERROR/WARN/FAILED/warning/MqttException/AccessDeniedException output.\n- CI green for #127, #128, #129.\n- develop Docker workflow green for b708926 and deployed to dev digest sha256:6796b3d733d7b9224dbcdcca466a220e0c6d384e724edd205e1a91718d4fb4c0.\n- Dev smoke created a temporary alert, resolved/reopened through tenant and legacy endpoints while sending fake client actor IDs, verified DB actor_user_id/resolved_by_user_id matched JWT user and ignored fake IDs, deleted temp alert, and verified alerts/state_changes cleanup counts 0|0.\n- Dev pod logs after final smoke: no ERROR/WARN/Exception/MqttException/AccessDeniedException matches.