### PR TITLE
fix(notification): persist FCM message ids

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/application/usecase/DispatchNotificationUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/application/usecase/DispatchNotificationUseCaseImpl.kt
@@ -173,7 +173,7 @@ class DispatchNotificationUseCaseImpl(
                             type = type,
                             status = NotificationStatus.SENT,
                             payloadJson = buildPayloadJson(content),
-                            fcmMessageId = null,
+                            fcmMessageId = sendResult.messageIdsByTokenId[recipient.tokenId],
                             error = null
                         )
                         totalSent++

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/domain/port/output/FcmSenderPort.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/domain/port/output/FcmSenderPort.kt
@@ -19,10 +19,12 @@ interface FcmSenderPort {
  * [invalidatedTokens] holds the [NotificationRecipient.tokenId] values whose FCM tokens
  * were rejected with UNREGISTERED or INVALID_ARGUMENT and have been (or must be) deleted.
  * [errors] maps tokenId to a human-readable error description for non-invalidating failures.
+ * [messageIdsByTokenId] maps successfully-sent token IDs to the FCM message ID returned by Firebase.
  */
 data class FcmSendResult(
     val success: Int,
     val failed: Int,
     val invalidatedTokens: List<Long>,
-    val errors: Map<Long, String>
+    val errors: Map<Long, String>,
+    val messageIdsByTokenId: Map<Long, String> = emptyMap()
 )

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapter.kt
@@ -57,6 +57,7 @@ class FcmSenderAdapter(
         var totalFailed = 0
         val invalidatedTokenIds = mutableListOf<Long>()
         val errors = mutableMapOf<Long, String>()
+        val messageIdsByTokenId = mutableMapOf<Long, String>()
 
         recipients.chunked(FCM_BATCH_SIZE).forEach { chunk ->
             val tokens = chunk.map { it.tokenValue }
@@ -84,6 +85,7 @@ class FcmSenderAdapter(
                 val recipient = chunk[index]
                 if (sendResponse.isSuccessful) {
                     totalSuccess++
+                    sendResponse.messageId?.let { messageIdsByTokenId[recipient.tokenId] = it }
                     meterRegistry.counter("notification.dispatched", "result", "SUCCESS").increment()
                 } else {
                     val code = sendResponse.exception?.messagingErrorCode
@@ -105,9 +107,9 @@ class FcmSenderAdapter(
                             "FCM send failure code={} tokenId={}: {}",
                             code?.name, recipient.tokenId, sendResponse.exception?.message
                         )
+                        totalFailed++
+                        meterRegistry.counter("notification.dispatched", "result", "FAILURE").increment()
                     }
-                    totalFailed++
-                    meterRegistry.counter("notification.dispatched", "result", "FAILURE").increment()
                 }
             }
         }
@@ -123,7 +125,8 @@ class FcmSenderAdapter(
             success = totalSuccess,
             failed = totalFailed,
             invalidatedTokens = invalidatedTokenIds,
-            errors = errors
+            errors = errors,
+            messageIdsByTokenId = messageIdsByTokenId
         )
     }
 

--- a/src/test/kotlin/com/apptolast/invernaderos/features/notification/application/usecase/DispatchNotificationUseCaseImplTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/notification/application/usecase/DispatchNotificationUseCaseImplTest.kt
@@ -134,7 +134,8 @@ class DispatchNotificationUseCaseImplTest {
         success = 1,
         failed = 0,
         invalidatedTokens = emptyList(),
-        errors = emptyMap()
+        errors = emptyMap(),
+        messageIdsByTokenId = mapOf(100L to "projects/demo/messages/msg-100")
     )
 
     // --- Tests ---
@@ -274,7 +275,10 @@ class DispatchNotificationUseCaseImplTest {
         verify(exactly = 1) { fcmSender.send(any(), eq(notificationContent)) }
         verify(exactly = 1) {
             notificationLogRepository.save(
-                match { it.status == NotificationStatus.SENT }
+                match {
+                    it.status == NotificationStatus.SENT &&
+                        it.fcmMessageId == "projects/demo/messages/msg-100"
+                }
             )
         }
     }
@@ -327,7 +331,8 @@ class DispatchNotificationUseCaseImplTest {
             success = 0,
             failed = 0,
             invalidatedTokens = listOf(100L),
-            errors = emptyMap()
+            errors = emptyMap(),
+            messageIdsByTokenId = emptyMap()
         )
         every { alertSeverityLookup.findById(3) } returns severity
         every { pushTokenLookup.findActiveTokensForTenant(10L) } returns listOf(token)

--- a/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapterTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapterTest.kt
@@ -1,0 +1,127 @@
+package com.apptolast.invernaderos.features.notification.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.notification.domain.model.NotificationContent
+import com.apptolast.invernaderos.features.notification.domain.model.NotificationRecipient
+import com.apptolast.invernaderos.features.push.PushTokenRepository
+import com.google.firebase.messaging.BatchResponse
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.SendResponse
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.retry.support.RetryTemplate
+import java.util.Locale
+
+class FcmSenderAdapterTest {
+
+    private val firebaseMessaging = mockk<FirebaseMessaging>()
+    private val pushTokenRepository = mockk<PushTokenRepository>(relaxed = true)
+    private val meterRegistry = SimpleMeterRegistry()
+    private val adapter = FcmSenderAdapter(
+        firebaseMessaging = firebaseMessaging,
+        pushTokenRepository = pushTokenRepository,
+        meterRegistry = meterRegistry,
+        fcmRetryTemplate = RetryTemplate()
+    )
+
+    @Test
+    fun `send captures FCM message ids by token id for successful responses`() {
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            success("projects/demo/messages/100"),
+            success("projects/demo/messages/101")
+        )
+
+        val result = adapter.send(
+            recipients = listOf(
+                recipient(tokenId = 100L, tokenValue = "token-a"),
+                recipient(tokenId = 101L, tokenValue = "token-b"),
+            ),
+            content = content()
+        )
+
+        assertThat(result.success).isEqualTo(2)
+        assertThat(result.failed).isZero()
+        assertThat(result.invalidatedTokens).isEmpty()
+        assertThat(result.messageIdsByTokenId).containsEntry(100L, "projects/demo/messages/100")
+        assertThat(result.messageIdsByTokenId).containsEntry(101L, "projects/demo/messages/101")
+    }
+
+    @Test
+    fun `send invalidates dead tokens without counting them as failed`() {
+        every { pushTokenRepository.deleteByToken("dead-token") } returns 1
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            invalid(MessagingErrorCode.UNREGISTERED),
+            success("projects/demo/messages/alive")
+        )
+
+        val result = adapter.send(
+            recipients = listOf(
+                recipient(tokenId = 100L, tokenValue = "dead-token"),
+                recipient(tokenId = 101L, tokenValue = "alive-token"),
+            ),
+            content = content()
+        )
+
+        assertThat(result.success).isEqualTo(1)
+        assertThat(result.failed).isZero()
+        assertThat(result.invalidatedTokens).containsExactly(100L)
+        assertThat(result.errors).isEmpty()
+        assertThat(result.messageIdsByTokenId).containsEntry(101L, "projects/demo/messages/alive")
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("dead-token") }
+    }
+
+    @Test
+    fun `send counts non-invalidating FCM errors as failed`() {
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            invalid(MessagingErrorCode.INTERNAL)
+        )
+
+        val result = adapter.send(listOf(recipient(tokenId = 100L, tokenValue = "token")), content())
+
+        assertThat(result.success).isZero()
+        assertThat(result.failed).isEqualTo(1)
+        assertThat(result.invalidatedTokens).isEmpty()
+        assertThat(result.errors).containsKey(100L)
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    private fun recipient(tokenId: Long, tokenValue: String) = NotificationRecipient(
+        userId = tokenId + 1,
+        tokenId = tokenId,
+        tokenValue = tokenValue,
+        locale = Locale.forLanguageTag("es-ES")
+    )
+
+    private fun content() = NotificationContent(
+        title = "title",
+        body = "body",
+        data = mapOf("alertId" to "1"),
+        androidChannelId = "alerts_default",
+        severityColor = "#FF0000"
+    )
+
+    private fun batch(vararg responses: SendResponse): BatchResponse = mockk {
+        every { this@mockk.responses } returns responses.toList()
+    }
+
+    private fun success(messageId: String): SendResponse = mockk {
+        every { isSuccessful } returns true
+        every { this@mockk.messageId } returns messageId
+    }
+
+    private fun invalid(code: MessagingErrorCode): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns code
+            every { message } returns code.name
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- capture Firebase FCM message IDs per token and persist them on SENT notification_log rows
- treat permanently invalidated FCM tokens as TOKEN_INVALIDATED only, not failed sends
- add regression tests for valid-token message IDs, invalid-token semantics, and transient failures

## Validation
- ./gradlew compileKotlin compileTestKotlin --warning-mode=all
- ./gradlew test --tests "*.features.notification.*" --warning-mode=all
- INVERNADEROS_TEST_DB_PASSWORD=<dev secret> ./gradlew compileKotlin compileTestKotlin test --warning-mode=all

Part of #121