### PR TITLE
fix(notification/fcm): only invalidate tokens on UNREGISTERED + SENDER_ID_MISMATCH

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapter.kt
@@ -89,7 +89,7 @@ class FcmSenderAdapter(
                     meterRegistry.counter("notification.dispatched", "result", "SUCCESS").increment()
                 } else {
                     val code = sendResponse.exception?.messagingErrorCode
-                    if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.INVALID_ARGUMENT) {
+                    if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.SENDER_ID_MISMATCH) {
                         val deletedRows = pushTokenRepository.deleteByToken(recipient.tokenValue)
                         logger.info(
                             "Removed invalid FCM token code={} deletedRows={} tokenId={}",

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/FcmPushService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/FcmPushService.kt
@@ -22,8 +22,8 @@ import org.springframework.transaction.annotation.Transactional
  * sobrepasar el límite del SDK.
  *
  * Limpieza automática de tokens muertos: cuando FCM responde con
- * `UNREGISTERED` (la app fue desinstalada) o `INVALID_ARGUMENT` (token
- * malformado o ya rotado), se borra la fila correspondiente para que el
+ * `UNREGISTERED` (la app fue desinstalada) o `SENDER_ID_MISMATCH` (token
+ * emitido para otro proyecto Firebase), se borra la fila correspondiente para que el
  * próximo envío no la incluya.
  *
  * Si no hay `FirebaseMessaging` (caso "sin credenciales", ver
@@ -74,7 +74,7 @@ class FcmPushService(
                         val code = sendResponse.exception?.messagingErrorCode
                         val deadToken = chunk[index]
                         if (code == MessagingErrorCode.UNREGISTERED ||
-                            code == MessagingErrorCode.INVALID_ARGUMENT) {
+                            code == MessagingErrorCode.SENDER_ID_MISMATCH) {
                             val deletedRows = pushTokenRepository.deleteByToken(deadToken)
                             logger.info(
                                 "Removed invalid FCM token (code={}) deletedRows={} alertCode={}",

--- a/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapterTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapterTest.kt
@@ -90,6 +90,37 @@ class FcmSenderAdapterTest {
         verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
     }
 
+    @Test
+    fun `send retains INVALID_ARGUMENT tokens and counts them as failed`() {
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            invalid(MessagingErrorCode.INVALID_ARGUMENT)
+        )
+
+        val result = adapter.send(listOf(recipient(tokenId = 100L, tokenValue = "token")), content())
+
+        assertThat(result.success).isZero()
+        assertThat(result.failed).isEqualTo(1)
+        assertThat(result.invalidatedTokens).isEmpty()
+        assertThat(result.errors).containsKey(100L)
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    @Test
+    fun `send invalidates SENDER_ID_MISMATCH tokens`() {
+        every { pushTokenRepository.deleteByToken("wrong-project-token") } returns 1
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            invalid(MessagingErrorCode.SENDER_ID_MISMATCH)
+        )
+
+        val result = adapter.send(listOf(recipient(tokenId = 100L, tokenValue = "wrong-project-token")), content())
+
+        assertThat(result.success).isZero()
+        assertThat(result.failed).isZero()
+        assertThat(result.invalidatedTokens).containsExactly(100L)
+        assertThat(result.errors).isEmpty()
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("wrong-project-token") }
+    }
+
     private fun recipient(tokenId: Long, tokenValue: String) = NotificationRecipient(
         userId = tokenId + 1,
         tokenId = tokenId,

--- a/src/test/kotlin/com/apptolast/invernaderos/features/push/FcmPushServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/push/FcmPushServiceTest.kt
@@ -125,9 +125,8 @@ class FcmPushServiceTest {
     }
 
     @Test
-    fun `should delete token returning INVALID_ARGUMENT error`() {
+    fun `should NOT delete token returning INVALID_ARGUMENT error`() {
         every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("garbage"))
-        every { pushTokenRepository.deleteByToken("garbage") } returns 1
         val invalid = invalidArgumentResponse()
         val response: BatchResponse = mockk {
             every { successCount } returns 0
@@ -138,7 +137,24 @@ class FcmPushServiceTest {
 
         service.sendAlertToTenant(samplePayload())
 
-        verify(exactly = 1) { pushTokenRepository.deleteByToken("garbage") }
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    @Test
+    fun `should delete token returning SENDER_ID_MISMATCH error`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("wrong-project"))
+        every { pushTokenRepository.deleteByToken("wrong-project") } returns 1
+        val senderMismatch = senderIdMismatchResponse()
+        val response: BatchResponse = mockk {
+            every { successCount } returns 0
+            every { failureCount } returns 1
+            every { responses } returns listOf(senderMismatch)
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("wrong-project") }
     }
 
     @Test
@@ -183,16 +199,15 @@ class FcmPushServiceTest {
         val response: BatchResponse = mockk {
             every { successCount } returns 0
             every { failureCount } returns 2
-            every { responses } returns listOf(unregisteredResponse(), invalidArgumentResponse())
+            every { responses } returns listOf(unregisteredResponse(), errorResponse(MessagingErrorCode.INTERNAL))
         }
         every { firebaseMessaging.sendEachForMulticast(any()) } returns response
 
         service.sendAlertToTenant(samplePayload())
 
         val unregMetric = meterRegistry.find("push.fcm.failed").tag("reason", "UNREGISTERED").counter()
-        val invalidMetric = meterRegistry.find("push.fcm.failed").tag("reason", "INVALID_ARGUMENT").counter()
         assertEquals(1.0, unregMetric?.count())
-        assertEquals(1.0, invalidMetric?.count())
+        assertEquals(2.0, meterRegistry.find("push.fcm.failed").counters().sumOf { it.count() })
     }
 
     // -------------------------------------------------------------------------
@@ -216,6 +231,16 @@ class FcmPushServiceTest {
     private fun invalidArgumentResponse(): SendResponse {
         val ex = mockk<FirebaseMessagingException> {
             every { messagingErrorCode } returns MessagingErrorCode.INVALID_ARGUMENT
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+
+    private fun senderIdMismatchResponse(): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns MessagingErrorCode.SENDER_ID_MISMATCH
         }
         return mockk {
             every { isSuccessful } returns false


### PR DESCRIPTION
## Summary

- `FcmSenderAdapter.kt:92` and `FcmPushService.kt:77`: replace `INVALID_ARGUMENT` with `SENDER_ID_MISMATCH` in the token-invalidation condition.
- `INVALID_ARGUMENT` covers malformed payload errors — deleting the token in that case discards perfectly valid user devices for the lifetime of any payload bug.
- `SENDER_ID_MISMATCH` is the canonical "token from another Firebase project" signal, equivalent to `UNREGISTERED` for invalidation.

Bug ID: H-1 (per audit `necesito-esto-title-sleepy-piglet`).

## Why two files

Two FCM dispatch paths exist in the codebase. Both shared the same bug; both get the same fix.

## Test Plan

- [x] `./gradlew compileKotlin compileTestKotlin --warning-mode=all` — 0 warnings, 0 errors
- [x] `./gradlew test --tests "*FcmSenderAdapterTest*" --tests "*FcmPushServiceTest*" --tests "*ArchitectureTest*"` — green
- [ ] CI green (`test` + `build-and-push`)
- [ ] Merge to `develop`, wait pod rollout (`apptolast-invernadero-api-dev`, ~3 min)
- [ ] Smoke dev: trigger ALERT_RESOLVED dispatch, verify `metadata.push_tokens.is_active=true` count unchanged for valid tokens
- [ ] `kubectl logs -n apptolast-invernadero-api-dev <pod> --tail=200` 5 min sin nuevas excepciones
- [ ] PR `develop → main`, CI green, merge
- [ ] Smoke prod with real user, same verification

## Tests added

`FcmSenderAdapterTest`:
- `send retains INVALID_ARGUMENT tokens and counts them as failed`
- `send invalidates SENDER_ID_MISMATCH tokens`

`FcmPushServiceTest`:
- `should NOT delete token returning INVALID_ARGUMENT error` (renamed + flipped from previous wrong assertion)
- `should delete token returning SENDER_ID_MISMATCH error`
- Updated metrics test: total failure counter = 2 (UNREGISTERED + INTERNAL) instead of separate INVALID_ARGUMENT counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)