### PR TITLE
merge: deploy fcm token-invalidation fix to prod (#132)

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "47430526-b66f-45a1-9087-28ab471e1278",
+          "id": "d79b3349-94d3-4f82-af73-91b2cd2ddaf6",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "3e990a16-4e85-499d-a894-4816854e31c7",
+              "id": "cbd3592d-4766-4986-8648-224719402335",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "349a9acf-ddf8-44ff-b783-9d849b6a76d6",
+          "id": "ac0a1631-858f-4de4-b43a-39c4a296d4d5",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "cbbf52eb-9956-4857-afba-730f423a9b78",
+              "id": "ee4ac156-b5d3-4942-a3cf-0be70ee5c351",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "db4341e7-ace2-4ea1-beb0-a8106dabd28f",
+          "id": "f670d8be-9701-42bc-a801-bd02406beb1f",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "79f61f5d-0094-40d2-a77a-1d31ce69201a",
+              "id": "23fb5a82-829a-4449-ba35-3c573cabf827",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "da9f7429-afa8-460e-ad74-3fd5fa594294",
+          "id": "92ab82ce-6317-44b6-a741-01aa340ad779",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "a11365b7-df36-410c-a007-4ac3e8a559b4",
+              "id": "948c1e86-bf40-4c64-81b5-52d862076fcb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "f03d2886-913d-4e14-ac0f-e31c42caaef8",
+          "id": "b69def31-16b1-437f-9674-365d446d14b7",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "a86ccf10-cc75-4164-90a8-41d71f633b97",
+              "id": "50c3d772-ea29-498f-93f7-95fe23d36548",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "b990495e-4630-40a9-9acc-8913875abe4e",
+          "id": "3a0d1db6-0da2-4b5c-9ea5-df863654e783",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "66536219-fe04-41ce-9587-ce9a5fd277ed",
+              "id": "ecf9308f-14ad-4e48-8914-eb7806cb2d84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "9c251825-4bec-467f-8afb-2fc6386a82b0",
+          "id": "84c51856-f735-4637-aeb4-d6f796213613",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "6a1d4414-90d9-4dd1-85a9-0a73ac1f5d9b",
+              "id": "484c6103-2a39-4290-affd-ba1eecdb46df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "7d0a0298-0ca7-42c7-ac41-ec8d01488ddb",
+          "id": "3ec86438-165c-495c-9e8f-745fcadfab86",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "aa78b61a-67b0-48af-8491-d91feab67f9c",
+              "id": "4df151a5-a4dd-455d-b11b-fa5323343bde",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "e6b2f180-942d-4afe-a788-888bc96115f9",
+          "id": "717624f5-8639-418a-b0c8-3f287104dada",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "8822a3d7-8ada-4c07-9075-3b3d4f770143",
+              "id": "cba9c45c-70cd-4ec7-be32-2084e9dea112",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "acb48e37-a2b7-41a1-8883-4df399db6e73",
+          "id": "8bb1a7c5-dfbb-4dd9-be4f-a47cd466f88b",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "f9229f92-4fda-4c13-bcc8-d2062d48ed21",
+              "id": "53ba7669-7821-443c-942c-af18dc22ccd4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "0ad4e4aa-877b-4825-90dc-cdc48a80c1ce",
+          "id": "47f7bbb9-0be3-43ce-b08c-bf7594c9ff92",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "ee174f1e-f892-4656-9d85-93a3a5e9ca83",
+              "id": "4633ac1b-9ea1-424b-8c25-9ac36c1bf361",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "789fade2-8ac1-4c47-a159-f85f3efa528c",
+          "id": "eed93e7b-5c7c-4830-88e6-b1180b46a2f8",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "5ab35f8d-9676-460f-9d0b-28b817f180be",
+              "id": "1ba81591-f929-481b-b1aa-ef8d713fc8bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "0b330e77-d502-4864-80ee-8a3204d6d6e0",
+          "id": "a07bcd49-4ec2-4f29-b9d3-0149594ff64a",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "bbd7dff4-9ecc-4f4d-a03d-51d9455149af",
+              "id": "05a79c4c-eeee-450e-8928-36f4f25bc889",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "aa21dba6-3f8f-4f0c-9e2f-4b9c7bc6e41a",
+          "id": "ac81293e-222c-4c12-86f7-cd56765a96d4",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "dbda1b06-45ea-4393-b4c8-fe5301f454d1",
+              "id": "2e78e58a-5f40-45cc-8bd3-8e6b203be25f",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "add4bc01-de89-4482-9c60-f994945f26b6",
+          "id": "ce361783-49ac-40cc-9954-6a33fe281f84",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "96729fee-5b14-4b7c-b6b4-cec24027279f",
+              "id": "19a88a7f-73f6-48da-befc-93e7a2de4644",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "36565d1d-8416-4704-8818-9e4a1487457c",
+          "id": "72d1bc49-6c58-4553-ab55-a46da3821d18",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "830cbf1f-e3a6-49af-8dd8-ce76650cf13c",
+              "id": "b910c27f-a8c3-4031-b018-250567875b7f",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "fb35fe0e-e4ab-4dd4-9abb-e206233a06c7",
+          "id": "6d79780e-bc7d-486d-9cb1-d118b8e14aa1",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "b9cb16f8-009f-4ac2-b7e7-0bdd5dde6ac5",
+              "id": "07d9d364-cf17-4b46-8400-8d1e533b257c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "ecc90ade-6e98-432a-9b2a-aad2a4bb3dc8",
+          "id": "51983e52-dcc8-4e3b-8f90-6c8e560c5520",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "cbba562a-fb4d-4445-a0bd-9f21502d0002",
+              "id": "9e6f07c3-1b85-45af-b4e1-f5f1844a9eb2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "76f26d43-946a-4cd1-b647-dfd34b71d615",
+          "id": "c3a9204f-6151-47ff-a2e3-da22d4d1b1f3",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "8c63aa8b-8ca2-4efa-b3de-c445779ccc19",
+              "id": "467713c5-be1c-41f3-80b2-186114010598",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "0e4f4d25-3bcb-4774-969d-d8e131014902",
+          "id": "18941733-d720-48e1-969e-96aca887b78c",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "d97036e2-30d4-4c22-bfeb-ac4ead7e54c9",
+              "id": "aae608fb-d817-4c62-8a55-f8e06a9ad5f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "283e5ab3-9403-408c-8c99-e10bab2bc032",
+          "id": "bba9ca03-fbcd-4513-8a27-c97a143e3565",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "6d1dbf69-74b5-49a3-8f08-2e0339eebdfa",
+              "id": "dcb826af-2926-4be3-a16c-066ac2302aaf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "d5677c3a-488c-4a33-acda-149746ea2e62",
+          "id": "fc47485b-d7b8-4c53-aec6-d06251209893",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "9a960030-901a-439b-a406-198a76e668df",
+              "id": "4bfa7275-4934-4a91-ae85-1b379a6e8070",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "24f32cae-9c4c-462b-bd1b-388110c327e6",
+          "id": "d5b22f3c-3858-4ab8-931c-951301b55b9e",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "84e55a60-0121-46bb-8b76-e2854bfb6813",
+              "id": "99c0a993-7c0c-4d50-a932-24a352f66585",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "9af48719-c230-496d-9411-f3f377717c8c",
+          "id": "b61a843d-2dd9-49e1-af34-d9de2581545b",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "0c40d892-73fa-41fe-859c-489d567501f4",
+              "id": "1e5ad7e0-0e04-46ec-8e81-85a1525b585c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "24ef0136-b1a3-4411-99c0-0e23cbf75e3c",
+          "id": "b433c6c9-62ff-4757-97bb-0a379814c0bd",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "38ef4f85-c916-473c-893d-bb8d30266516",
+              "id": "1cc88dea-5356-4fcd-b329-ae169c133448",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "bd6ebb2a-15d7-48e6-9984-61ae166553fa",
+          "id": "c3f30c73-b811-479a-aa2c-275ec94c7106",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "797c12ca-8f13-45d1-a207-a140787290ee",
+              "id": "53277d9c-6a59-4128-9372-3ca7a3687d28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "4688c49b-ed7a-491f-84e6-c6114c09c770",
+          "id": "9fae30fc-160c-43f2-8c87-ca5235ea7718",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "a2fe5ba1-0a16-4291-a798-066dc335b78f",
+              "id": "6c55e354-4c55-44b2-bd49-1ba3ccf94a9a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "567fae56-5c64-4044-8bd6-0e80f63c2c98",
+          "id": "6645b499-4cc8-4c83-a23c-04f79346da7c",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "c6bfe843-ec37-41fb-8183-e32494db0769",
+              "id": "cf84ecdb-5de2-4a37-a3ab-ca0a8a11e512",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "4d90c9de-aac2-4b34-aaf1-2c3f35dd7106",
+          "id": "afa86298-3640-4ab6-8d48-ce86e778c261",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "f9b7d194-bc63-43ee-9209-b5d20ba4a4df",
+              "id": "cc7c5a93-4caf-4256-80f0-fd4ecd83e042",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\",\n        \"key_1\": 1482.0935756559873\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": 4058.867279441936,\n        \"key_2\": 175,\n        \"key_3\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 8973.705455053187\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "768ef7de-f2de-455d-8975-280511fd885b",
+          "id": "7363bca0-4179-4caf-81b1-162413f1172b",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "416a670a-4dc2-457b-b8ef-1a107e28fbcf",
+              "id": "eaec9422-a4c9-4ca3-9b08-6c912d11c0e4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "3f5fa60d-0fec-4401-addb-619e21a73580",
+          "id": "9c629f24-10a1-4dfa-bc82-a77223d098d5",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#c5Ef5e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#dF4cbE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "65d95b85-e3d7-4157-b62f-3ef85c580154",
+              "id": "662a5cd7-2799-4a90-ac64-40db01e16886",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#c5Ef5e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#dF4cbE\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "f52c6005-c969-4b94-ae08-1e432dd277e2",
+          "id": "2609847d-2edf-4b65-b10f-41cdda767674",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "92ef9e1f-e03d-42b8-9243-2e67f00c985e",
+              "id": "be8795cb-9ce4-41ba-b2cb-be66020df4bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "f50508a8-a73e-49a7-ac32-5a05013b66c7",
+          "id": "bfa3a539-d67b-42b0-b118-4bfc3b43cd99",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "8753f7fd-feaa-4c3c-8a94-2f5f44ad2e42",
+              "id": "fb0fb181-d97c-4792-9b3e-f75b6925ce9d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "408081ca-dc42-4347-ad35-5620d78082ff",
+          "id": "6d3d6605-d0b1-4db5-a028-45e502114d7d",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bcCE8B\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2d84ca\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "4b8935f0-62dc-462a-ae3f-c0150b951e5b",
+              "id": "80dffb60-2987-4ca1-a2f5-55231c8913a9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bcCE8B\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#2d84ca\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "3ed9ac07-c9dd-4588-a5e3-618aeb8c433c",
+          "id": "7fcf3a50-1ece-4798-9f03-1bc90c57026f",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "adf4f0b4-3804-4607-822c-496c1789fcb0",
+              "id": "d4612bbb-5d66-49b3-9db8-6d94a01f16b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "398d9d9f-2d37-4166-aa45-195bbe22659b",
+          "id": "bee75860-fdc0-4762-9e88-3bc398156eb0",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "8b4cf250-db6e-4da8-82e5-5198ca7c5ba2",
+              "id": "6bd930a6-3e92-42a6-ae51-af034c01d302",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "67b1f1f4-217b-4350-86fd-453d83ba8972",
+          "id": "5574706c-4484-42e9-b8a2-fc01faa6dfa4",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "6fbbc1c0-8b1e-4233-a7c1-e430b234ed70",
+              "id": "53fa736f-969e-4f61-85b4-69c153511e6a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "9ca94834-6f4f-45db-89f4-02d6fdc95ae4",
+          "id": "0d2c2458-bd22-4c89-8fad-520374cc05bb",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "58528977-2f5d-461f-a9ee-7c1ad019a179",
+              "id": "9d0170c3-dcf0-4b0c-acf5-a362fe23ca42",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "bce60105-5acd-4b11-be70-1edb56a865d1",
+          "id": "48ab7fab-8a71-486a-bf71-a665526f1868",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "94b62a2a-bd80-422d-b224-0cdf00498575",
+              "id": "2bf4e46b-d334-4cb4-b8ec-f532cb19c8f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "773fd27e-eb06-4843-b7ad-6f9bedc0796e",
+          "id": "f7517211-7fbf-426f-a6ae-31dc63768536",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "c7e2149c-fc77-471b-a19d-eee385ead5f4",
+              "id": "a905c4d8-3b50-4d9e-bfe1-c9487925646b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "d8a1b588-9112-43d4-8d02-a621f7cdef8b",
+          "id": "dca2e460-5d09-4afe-8185-c59f3df40bbf",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "c1869a24-d81e-4912-b2e3-b4aba7522908",
+              "id": "ab094686-068a-4a84-90cb-982c92899a6a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 345\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "8c1c0240-85dd-4453-b17e-f972a4c8044a",
+          "id": "7f967ac6-5d33-4a77-bd60-31175d5d63c3",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "42237230-dcbc-4a3a-a6b3-f1428814acf2",
+              "id": "0b820e96-3373-4aa6-927c-c4c5baa6b0fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "58100c03-ac82-428a-b22a-af6954a1bae8",
+          "id": "efde1783-ad2d-48ab-8436-07b1d7087280",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "50b6a6ef-8af6-4462-859e-69dea883484c",
+              "id": "de513b36-f0eb-4414-91c9-d828ef748fc3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "501b8122-9736-4c4a-a620-20850b8fc4f2",
+          "id": "9b1bb522-461f-4dc0-880c-721dcaed9c58",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "fe8de42b-fa46-4640-a4f2-c648eefeba73",
+              "id": "322023ce-f62b-445f-abc6-ce17c573ee99",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "a1ef0402-a2b4-4374-8b15-0eaed0dc405b",
+          "id": "c9f02316-6c72-4cf5-a193-2845a72cb10e",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "25585ce9-56a4-4308-9e66-0dd051ea57bd",
+              "id": "0e8ecb82-4862-4d46-8d63-3d8f962cfdb2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "b0e7ec5a-fe93-4fcc-81ca-a393d8b69d67",
+          "id": "7d56e588-f592-4448-9ff6-899d64ed7501",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "5daa0982-be86-425c-8e26-cde96a204c1c",
+              "id": "c30ff33e-579e-4d46-9f18-8137f9b8c0c8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "562e78af-ce88-4026-8674-ce1f53de6804",
+          "id": "caf1f513-9c2d-4c50-ac67-fb2004260e9e",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "1a09e095-d4b9-4540-ad58-bb4e2f4c2521",
+              "id": "fa7e915a-a958-4f90-80bd-ac5d7d3fe09e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "d8f74d53-712a-4493-b9fc-b544b0e8785e",
+          "id": "aaea30d7-4351-45dc-9ce6-90872fc60285",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "5cc602f2-2d8b-421e-8669-3683a4859941",
+              "id": "a1088099-bfc1-4d71-bdd5-22599e5602b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "293e4f8b-96ae-4eea-af98-208d1cff45be",
+          "id": "4580561d-b6a5-4566-9da0-33c84886f013",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "9e3fd7c0-454b-4102-ad29-10f896d7fd72",
+              "id": "a4c5486f-076d-473d-8d1c-5a326c06bb82",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "952ed36f-2ee1-473c-83a3-4870079c7254",
+          "id": "3d2b17e0-1146-4dfd-a381-af5eefa4c063",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "25c0e952-5697-4807-a8f7-d2f34b9ffa11",
+              "id": "75e805e5-3719-4a80-bb5a-b2619213c0aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "282fd496-b00d-4583-a4bb-89d2d60dceaf",
+          "id": "49ddb633-8d74-4a58-b6bd-dad9074be568",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "afa9c7e2-27e6-4398-bfd4-a0ec09343953",
+              "id": "e422770a-6f33-4331-893d-1006047d9368",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "41787931-c28d-412a-b818-c5b9ae59f5b9",
+          "id": "32c11377-58ef-43c7-b129-044aa9b1e58e",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "bbf0c84c-33b6-4134-9f87-4f426a851adb",
+              "id": "c39a697d-b34d-4438-ba10-537e10a8c462",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "e68977ce-b367-4a2a-8c23-99457bd33c77",
+          "id": "d8fe5c35-667e-4b10-a055-627c3fa1e60a",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "c543797d-0eec-4ac4-a769-ef4624e9f94e",
+              "id": "8b2bca3e-b578-4f08-bc5e-203f0275cb3b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "e52d6ac4-99e1-4272-8848-967c15709cf6",
+          "id": "24632adf-eeb2-4036-b3a0-92b58a529ab0",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "91308feb-aeae-4bf2-a434-f37893d84ebc",
+              "id": "4973cc1e-b06a-4073-8f30-141eeb2b6be3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "6bde2642-1b0b-4f61-9107-dda84006b49f",
+          "id": "77d457ec-734b-4249-8476-3a46ffd198b7",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "31906165-278b-4e8d-992c-63755968f696",
+              "id": "a3ad0989-2cf4-412c-88a6-01437de80ba1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "7977b24f-71bc-4d5e-abbf-3b6f548ad7fd",
+          "id": "1a6b8c9d-bd50-4dd8-ba7e-9897aa5d1b83",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "b538b5d4-aa1b-498f-9f77-94b4364f13e1",
+              "id": "9c71315e-cb64-478b-b7ed-c65153b0bb02",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "431e32fc-238f-4c21-81a7-8c3996037726",
+          "id": "2e195a79-7e8e-4511-b401-ebb39eee0420",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "18a05616-3e7d-4171-9f48-a24b5056e89c",
+              "id": "a049f45e-a569-4647-8198-0db411c860b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "f2303774-7746-402f-a8ea-538e0c5ec385",
+          "id": "c1909295-9f4d-4330-b4ee-e5049c48ddc2",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "612df42c-b14b-4869-9857-5b0beab266f7",
+              "id": "55c1646e-141f-4407-a499-82ed5e6776c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "343916c4-0b7e-41df-9681-d893b577e862",
+          "id": "fcc8f693-5f5f-4d41-8b55-0a1e49dfcb03",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "7b4f55cb-7e2d-4bdd-bc78-73448e940cdf",
+              "id": "ed050e7c-c705-418f-8a8d-f5501f038a0f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "22b6d2f6-6459-4713-accc-68823df902cc",
+          "id": "8bdfcd9a-32d7-4983-84df-bacdf745da4a",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "9742339c-83f9-474a-8c6f-c4b91dae834a",
+              "id": "0ecfd55e-cc70-4afb-afa3-d77938c40f9c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "90b1d2bb-2df9-4b2d-a984-8b9bd60445e4",
+          "id": "3b9e96ec-49b6-47c4-bcfb-21c30d6891e2",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "89fa4ad7-6b8b-4ee9-8deb-6cde4ccf8a4e",
+              "id": "0339bf0a-2ce4-471f-8893-b3f4cde8edf2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "91b69173-98b0-4522-ae80-0f246c87e4e8",
+          "id": "361e41ba-4bef-471b-8efa-8a50b7b65392",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "e3934c42-4f87-414d-9ab6-b2b54cf00389",
+              "id": "cb2b98d9-48e4-4f10-8493-10c549f8edfc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "d4cea253-2613-4344-a9ec-77c96f5acb16",
+          "id": "893a980e-6f2b-40b2-9413-93fdcee169ce",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7553,7 +7553,7 @@
           },
           "response": [
             {
-              "id": "7592a9af-3033-4233-b088-da0a31d30ac8",
+              "id": "8c525779-5dbf-423c-94d8-9d19b50e4851",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7629,7 +7629,7 @@
           }
         },
         {
-          "id": "d546c9bf-1bc7-4135-b890-b74833ac8abc",
+          "id": "1b21a516-e421-4ded-ab9e-7e398f6f8f55",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7683,7 +7683,7 @@
           },
           "response": [
             {
-              "id": "32dcaeff-d657-4210-a133-492a9648190c",
+              "id": "1bd8414c-1e2a-4427-b48e-604d78fc952e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7765,7 +7765,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "f8b66010-afc0-48e0-847c-078dcda426d1",
+          "id": "4fbf728d-0073-4bee-a246-057ef31e2382",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7818,7 +7818,7 @@
           },
           "response": [
             {
-              "id": "03b5378a-2e37-406e-9755-f47e6199412d",
+              "id": "6980cde4-4238-4af9-8c23-6c67cd7e26bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
           }
         },
         {
-          "id": "022cdd72-cb95-403f-bd84-c1f5e61459d3",
+          "id": "7416cb46-67ff-4b50-90f3-8c89077b22ac",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -7959,7 +7959,7 @@
           },
           "response": [
             {
-              "id": "9370a9c4-ef2a-4483-8420-05da0caa2b4e",
+              "id": "a6a43d78-6e16-42cf-bb57-8e74575478ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8047,7 +8047,7 @@
           }
         },
         {
-          "id": "a8849303-f140-4666-b63b-ede11a0deaa3",
+          "id": "07f05bee-1af6-4d67-aa5d-ef99c32f28f9",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8094,7 +8094,7 @@
           },
           "response": [
             {
-              "id": "971ae01e-cb11-4b89-b6e3-d30789159c3e",
+              "id": "d463ab25-e0ea-47ef-9865-c3c4aa20eb6e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8159,7 +8159,7 @@
           }
         },
         {
-          "id": "42e42bfe-f643-4757-8d71-d1bf18b6f583",
+          "id": "c99c7e94-5e35-48f9-b3a7-218528450083",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8201,7 +8201,7 @@
           },
           "response": [
             {
-              "id": "c3278d6e-63b4-47f6-8b9a-2aa1cd27c7da",
+              "id": "bd3211d4-627a-407e-bb60-68b56a0b89bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8265,7 +8265,7 @@
           }
         },
         {
-          "id": "4a0db63c-88fc-4abd-a683-baa4b9e95807",
+          "id": "4a4da12c-dc1c-4917-8054-d694e0e9c692",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8320,7 +8320,7 @@
           },
           "response": [
             {
-              "id": "e761c280-2389-4f41-8b93-fdf3301850f6",
+              "id": "45f4b993-b8ec-4d9c-855a-7e5727777d7b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8403,7 +8403,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "23725d7a-ab78-494e-8e13-bfed606975d6",
+          "id": "6917fed4-0d1e-4178-87de-e6ca6fdceb19",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8444,7 +8444,7 @@
           },
           "response": [
             {
-              "id": "98980534-c25f-445e-8b98-282120080e13",
+              "id": "f2f38f7e-a28e-49ad-9b85-3c92d280b3ad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8507,7 +8507,7 @@
           }
         },
         {
-          "id": "bdf01d09-91b6-4362-a85d-e9dcd60fc2df",
+          "id": "e65197f2-6032-4df4-93ea-3eea634412eb",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8561,7 +8561,7 @@
           },
           "response": [
             {
-              "id": "0af73450-f7f1-4185-9895-ab4db8f62148",
+              "id": "4dd541d5-72d5-4e50-95ea-c30327efe8c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "48b844fb-ccc9-40ff-bd31-550ce7d7fae6",
+          "id": "d9dde1dc-224b-4060-aca4-28ed30f71bd2",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8672,7 +8672,7 @@
           },
           "response": [
             {
-              "id": "3440d922-8d65-487b-877e-348e97ccc6ab",
+              "id": "54fdba52-bfb8-433c-bb7f-dc2b4fc412d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8725,7 +8725,7 @@
           }
         },
         {
-          "id": "3d449cc4-0e8c-4936-8f36-59ad9f02d588",
+          "id": "dabb999e-c3de-444c-91ef-f61edba381db",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "a8b75cf8-cb7e-41a6-8adf-a90ddfa7c10a",
+              "id": "05e8bf75-b4cf-4614-9761-f2ceeb4c4587",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8861,7 +8861,7 @@
           }
         },
         {
-          "id": "6c8708e9-73de-4a8d-98d8-ab75641ec4b3",
+          "id": "383f9294-b952-4d50-9238-4442acc03404",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8903,7 +8903,7 @@
           },
           "response": [
             {
-              "id": "11423838-f18a-4052-9c38-cc1b4127cf79",
+              "id": "1be04802-307d-4a18-8251-fb207524d206",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8973,7 +8973,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "5b04b39b-1fa8-423e-ba1b-4668aafc6a14",
+          "id": "b1ee7532-81b3-4977-8a47-cd5d0229486a",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9026,7 +9026,7 @@
           },
           "response": [
             {
-              "id": "2396d1bb-ec16-4bf4-832d-8d7c36017f26",
+              "id": "0eaa15a7-7aca-4a6f-8e9c-0b84e73a80d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9101,7 +9101,7 @@
           }
         },
         {
-          "id": "6e3b69e2-72ef-4ea0-ba31-806ab1944ccb",
+          "id": "6a4357c0-b178-4910-84b1-8dff958f3526",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9167,7 +9167,7 @@
           },
           "response": [
             {
-              "id": "4cd89113-e347-4a3b-9b29-ec6e8033d8a4",
+              "id": "5d3a1b6b-32dc-4c0a-a6c8-faa58dbeee6f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9255,7 +9255,7 @@
           }
         },
         {
-          "id": "a533ce9a-2d68-4864-9944-01077b8a34ea",
+          "id": "b7c58c5c-8e64-4e1e-84a5-e681a6812ff9",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9302,7 +9302,7 @@
           },
           "response": [
             {
-              "id": "3da6a9bd-dad6-4d05-8d21-a141442d987d",
+              "id": "c9b908ac-ef4b-4619-9985-dca07748c3c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9367,7 +9367,7 @@
           }
         },
         {
-          "id": "de57f65f-0127-47b7-a94d-ca875256adcd",
+          "id": "1b0d36c8-3c00-4ced-a3d7-966a6a39552e",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9409,7 +9409,7 @@
           },
           "response": [
             {
-              "id": "4915779b-4d90-4764-9316-ea147aa69383",
+              "id": "4ceae3b9-e6b4-49c1-9673-e064a851cb94",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9473,7 +9473,7 @@
           }
         },
         {
-          "id": "05aa668b-a66c-42df-8198-47db43c748ce",
+          "id": "3ae7fb9d-d22c-4322-829d-3989aa042379",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9528,7 +9528,7 @@
           },
           "response": [
             {
-              "id": "ec4d4e42-847f-4de5-b83e-d142cef7755c",
+              "id": "2f1754ed-39a8-4023-96f5-d735e3d2de87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9611,7 +9611,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "c87eb494-c538-4858-8fc8-00e5dcbd83cf",
+          "id": "7b08da9d-520f-4a04-8c68-f048a3c9c4c6",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9653,7 +9653,7 @@
           },
           "response": [
             {
-              "id": "5ab0e125-2f1e-41c3-b99f-7aa3cc5f5f95",
+              "id": "13a0cb54-bdd5-4eb4-8ed0-18789c39a5d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9717,7 +9717,7 @@
           }
         },
         {
-          "id": "8d64a7e1-a6bc-48c6-8c03-3d0fb56cb923",
+          "id": "13ea23e4-6068-402f-a4c2-6b31c3bc40f6",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9772,7 +9772,7 @@
           },
           "response": [
             {
-              "id": "e7374be4-52bb-4a6d-a901-2fa5126ea95d",
+              "id": "ed9c7a8b-10bf-4a19-9718-128c2f0f70d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9849,7 +9849,7 @@
           }
         },
         {
-          "id": "8c62ef9e-fb63-4616-8f99-7d3909fc9adc",
+          "id": "89ad5d9b-60f0-4cb5-876d-d4a822086602",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9885,7 +9885,7 @@
           },
           "response": [
             {
-              "id": "0038d44d-7283-4a5c-81d3-af8809a32fe3",
+              "id": "a4d1cdb5-8543-4e41-a1bd-6d2cd65ccfec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9939,7 +9939,7 @@
           }
         },
         {
-          "id": "a320a008-b2fb-40f4-bcc2-7f06e30061f7",
+          "id": "50738237-70b5-4591-889d-f309953aeef4",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -9969,7 +9969,7 @@
           },
           "response": [
             {
-              "id": "a27c9101-a9a1-4ba1-a807-a58bde1f2351",
+              "id": "b354f61f-facb-4811-af37-16aba3f652c0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10021,7 +10021,7 @@
           }
         },
         {
-          "id": "b3e0dde1-4458-4ed6-95e7-4fed082fa637",
+          "id": "4e0c4475-6426-4cfc-a97d-5bbbc71ff363",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10064,7 +10064,7 @@
           },
           "response": [
             {
-              "id": "a14e453c-ece6-4927-a749-3efe1ffc0de4",
+              "id": "383935f2-7a9a-4830-87ef-2ff1fcfa0e53",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10135,7 +10135,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "6d31f8a4-e73c-43b0-8a83-eb960412efa7",
+          "id": "54f5be56-0f20-452e-af6a-a9a056c9abec",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10177,7 +10177,7 @@
           },
           "response": [
             {
-              "id": "79c2fda2-c607-43f1-ad7b-c66fb63e7a79",
+              "id": "486cb553-8c67-4602-b83d-9d89b923238a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10235,7 +10235,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "973f9711-2970-4f66-8831-322366d7e9f7",
+              "id": "0dfc1143-dfcb-4205-983c-2f482a0e19b0",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10299,7 +10299,7 @@
           }
         },
         {
-          "id": "33d55eae-30e8-48e1-bd23-8443d03f4d4a",
+          "id": "4665d023-54ed-4aa6-aee4-df4cf5a2f846",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10354,7 +10354,7 @@
           },
           "response": [
             {
-              "id": "f991a437-8402-497b-961b-935a4cad5970",
+              "id": "f3525bed-8ef0-49e2-8fe4-988dd31ed541",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10425,7 +10425,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a66c5cd0-ba2a-413a-8e96-c91a0933bbde",
+              "id": "a3d8baaa-cda2-47eb-b8c0-3ac37bde717b",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10496,7 +10496,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "731a0049-9ac0-4b8a-80a1-b035225463cc",
+              "id": "d95d5314-4cc0-4b10-808c-d0dd8a6020d2",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10573,7 +10573,7 @@
           }
         },
         {
-          "id": "f4082593-f6ac-4aa4-b792-070abfea482a",
+          "id": "b75630cc-4979-412f-ad33-c336fd0a05d5",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10609,7 +10609,7 @@
           },
           "response": [
             {
-              "id": "b1426b78-f0d0-4c7c-9f4a-4b3f72e49e91",
+              "id": "5ce0ef81-536c-4449-99d9-2a9b77c8b6dd",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10657,7 +10657,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "15be3c48-6c90-4451-bc2f-d5c22ecc6caa",
+              "id": "3b1a671f-a975-4eab-a46d-508af779848e",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10705,7 +10705,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "fef67385-06a5-4cf4-9a6c-623111c8d71b",
+              "id": "e9d7dd76-aa9b-4ec2-ab4b-9a6eb58fae1c",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10759,7 +10759,7 @@
           }
         },
         {
-          "id": "a3973332-c681-48ee-9658-16e5c5ef6b28",
+          "id": "9957d45d-c5da-4c07-b483-9649792ee3e5",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10789,7 +10789,7 @@
           },
           "response": [
             {
-              "id": "f7bd1df9-c70b-4581-9136-7c34526ab4e5",
+              "id": "e4d37d90-e6cc-43bf-a339-dc7d330e9290",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10841,7 +10841,7 @@
           }
         },
         {
-          "id": "f7e32316-3dfa-47a7-8b3f-3bec41cbd9d4",
+          "id": "cf0d34d0-1d99-4e41-af8e-02ab1cef775d",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10884,7 +10884,7 @@
           },
           "response": [
             {
-              "id": "3c9c34e7-f1dc-4c2c-854c-46c81f86dac5",
+              "id": "d0e0c7d8-a502-4390-bcbe-26551e61b111",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10943,7 +10943,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f65edef0-fc59-4389-8208-c9724f59b896",
+              "id": "3ce7f17f-7d87-4baf-99fe-71f7e394870d",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11014,7 +11014,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "3f4a2dfd-1573-4de1-b740-2b2abac79da3",
+          "id": "bf634d6b-8193-4fc0-a31a-3ce88b6406c5",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11098,7 +11098,7 @@
           },
           "response": [
             {
-              "id": "83130f7c-28c6-457f-953e-024e9ffe0888",
+              "id": "d7398c84-4a22-469f-b8dc-5538cb7eed1d",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11201,7 +11201,7 @@
           }
         },
         {
-          "id": "40ff795c-ad0c-473f-bef9-28ddf34b26a9",
+          "id": "893f6a6d-0418-46bb-8768-0544f99b3e58",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11267,7 +11267,7 @@
           },
           "response": [
             {
-              "id": "6fed9993-b68a-4aa5-8a40-c5f627791ef9",
+              "id": "ffd105eb-0b48-4823-a207-4f63b0000762",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11352,7 +11352,7 @@
           }
         },
         {
-          "id": "1f80f803-1a2c-4fa3-8848-0ea79622d6d2",
+          "id": "3f71f0f1-ec88-49d5-a396-48ce0e00fc7d",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11436,7 +11436,7 @@
           },
           "response": [
             {
-              "id": "d5ef7d84-c2cd-4b40-af58-383b9fb08916",
+              "id": "c5bc4f0a-4596-41af-a8f6-9dea0ea1e7b2",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11539,7 +11539,7 @@
           }
         },
         {
-          "id": "efab6b64-4a72-4f59-9f52-0cfd5040231e",
+          "id": "7040e7ed-4920-4242-9b13-30cb604ed621",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11614,7 +11614,7 @@
           },
           "response": [
             {
-              "id": "1c7267b6-3132-413c-bcaf-72b0235bb048",
+              "id": "06965ded-815b-494f-a16c-9026e2ad98fd",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11708,7 +11708,7 @@
           }
         },
         {
-          "id": "407fbb4d-02d1-4087-899c-78f99da7d4d1",
+          "id": "45e0392d-993a-4bc9-8995-f68e5e6a4331",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11783,7 +11783,7 @@
           },
           "response": [
             {
-              "id": "3a110607-b51e-47ed-b1f3-b8f4e338afe2",
+              "id": "a1d963cd-fad2-4b91-aab2-ddf0982ced2f",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11877,7 +11877,7 @@
           }
         },
         {
-          "id": "437a8395-df7a-4366-967e-dfb8e555fcd0",
+          "id": "b5733462-bd0a-4bdc-84f3-10b59851b7ce",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -11952,7 +11952,7 @@
           },
           "response": [
             {
-              "id": "4ab8e949-3e74-4e09-a9a7-4c288d92757a",
+              "id": "2dc88f98-b9fc-4503-8f5e-d10e904d8907",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12052,7 +12052,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "2731ffb4-2605-4b49-80d1-75548bb5117e",
+          "id": "1c4d8c2e-c06a-4e75-bfd0-6a3cce404c79",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12118,7 +12118,7 @@
           },
           "response": [
             {
-              "id": "7714f0fa-cf43-4800-ad6f-d0a0d44b9446",
+              "id": "84e88ef9-711e-4e6f-8907-42c2d8d1001b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12192,7 +12192,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 345\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12209,7 +12209,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "2e5a874d-7681-4dca-9097-bbaba030f509",
+          "id": "337207f3-aee0-4402-a98f-f83a67802dc2",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12251,7 +12251,7 @@
           },
           "response": [
             {
-              "id": "0b4e14c6-1528-460e-aeca-76e6ba5ffe84",
+              "id": "a71f47ee-de5d-48e2-aae8-8784e9fd66ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12321,7 +12321,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "1c239a38-4666-4ec1-987b-775386610df9",
+          "id": "82123d78-8fde-462e-b606-54183a712777",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12360,7 +12360,7 @@
           },
           "response": [
             {
-              "id": "e821a49e-fff7-425e-b69d-638f0c4cc08b",
+              "id": "285ef51d-0808-4003-bf18-d652850c58f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12413,7 +12413,7 @@
           }
         },
         {
-          "id": "6d2349ad-eeab-4dee-8bc3-b3735b65b7cc",
+          "id": "a60ee7cb-51c0-4c2c-9797-da348653534d",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12445,7 +12445,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"dq-VW\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"15:05\",\n  \"quietHoursEnd\": \"16:46\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"hk-AD\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:47\",\n  \"quietHoursEnd\": \"21:39\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12465,7 +12465,7 @@
           },
           "response": [
             {
-              "id": "37ca84fe-3616-42a7-a8a3-a042bfcfd200",
+              "id": "c6050f5a-85ee-418d-b212-78daa2c810c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12503,7 +12503,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"dq-VW\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"15:05\",\n  \"quietHoursEnd\": \"16:46\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"hk-AD\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:47\",\n  \"quietHoursEnd\": \"21:39\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12537,7 +12537,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "338a6596-ad30-4170-9163-cfd22519cb0d",
+          "id": "95c7e567-dde1-4bb3-a457-6386fffc202e",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12579,7 +12579,7 @@
           },
           "response": [
             {
-              "id": "7e507de8-37b9-4f75-93f1-cac0f7de6cdf",
+              "id": "074d8780-53a3-4862-8063-ed374d9220c0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12643,7 +12643,7 @@
           }
         },
         {
-          "id": "d7275286-a88d-4012-bd1d-214e0f74a32c",
+          "id": "c610329d-77f1-46ff-b1f2-a7c840426f5e",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12686,7 +12686,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#DFfe4a\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#9c1325\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12698,7 +12698,7 @@
           },
           "response": [
             {
-              "id": "e80f824e-f1c3-4ed3-ac62-ca81aa2662c3",
+              "id": "851b2c27-3bef-4cbc-9b1e-450bc0c40f27",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12747,7 +12747,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#DFfe4a\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#9c1325\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12775,7 +12775,7 @@
           }
         },
         {
-          "id": "6dbc04dd-4148-4d4b-8da5-67b64bcf9be6",
+          "id": "b34451af-a42c-4570-a427-d2acbccdd557",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12811,7 +12811,7 @@
           },
           "response": [
             {
-              "id": "2e2bdb1a-708e-446b-920b-8833acc85401",
+              "id": "f33abe27-e64e-4a48-98cf-c2e04f5a621b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12865,7 +12865,7 @@
           }
         },
         {
-          "id": "92c2c0bb-58cf-428f-b2a4-37fedade47ca",
+          "id": "9d711f99-d136-469d-b05b-bcf9074eb6ca",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12895,7 +12895,7 @@
           },
           "response": [
             {
-              "id": "842f0f1f-4b43-4fa3-ad7b-411b0a752bbd",
+              "id": "670ec82c-9f37-465a-9db4-dd12e05d240d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12947,7 +12947,7 @@
           }
         },
         {
-          "id": "ae1e83e5-a734-4183-a1f1-1ff38729306e",
+          "id": "0365b9bb-88af-4662-bbbd-43d74712980c",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -12978,7 +12978,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E6ecc1\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#63cF0e\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12990,7 +12990,7 @@
           },
           "response": [
             {
-              "id": "085b594f-0020-4626-80e3-b33a4e192f70",
+              "id": "07999606-9860-4078-8c5b-1a8e52b6f926",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13027,7 +13027,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E6ecc1\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#63cF0e\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13055,7 +13055,7 @@
           }
         },
         {
-          "id": "49659156-fbb0-41be-a750-e44a15d3e0c1",
+          "id": "15f90757-5018-48a1-ae84-e766d66890de",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13086,7 +13086,7 @@
           },
           "response": [
             {
-              "id": "53cef444-b789-41e8-9fd0-fc5994d28320",
+              "id": "e6d4a7b9-7297-4356-9c2e-9ef8574c7b01",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13145,7 +13145,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "9fd2ea04-dd04-4926-bb7f-572f2b6f0090",
+          "id": "cea9120c-63d9-4662-83b5-9050a4569b71",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "0231d9f1-356c-4c27-a2c0-7bda3c128213",
+              "id": "d86bc3d7-55cd-4e7d-b00b-4acfdccecf85",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13273,7 +13273,7 @@
           }
         },
         {
-          "id": "787942a2-be9b-4ec4-a4f3-7c9acfc9c998",
+          "id": "2489413a-e9c9-4aed-9402-079cfba9c1d3",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13339,7 +13339,7 @@
           },
           "response": [
             {
-              "id": "25c2d0d3-aac9-4fed-b652-6ba2f0afc860",
+              "id": "250e17a6-1827-4b7e-9f1e-0a13c4170e98",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13427,7 +13427,7 @@
           }
         },
         {
-          "id": "12ea8250-12e1-46da-bbe3-1302c344f1cb",
+          "id": "c133fca0-8a44-486e-9011-c7ee21f294b0",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13474,7 +13474,7 @@
           },
           "response": [
             {
-              "id": "74be3069-42af-4cac-b18a-9c894ee1eed7",
+              "id": "1d3debd1-9a30-4d94-8ec8-e795c607be03",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13539,7 +13539,7 @@
           }
         },
         {
-          "id": "da19797c-f48b-4fa7-8b98-e41db71fe245",
+          "id": "43543bc2-76d2-4532-a3a4-e717bdc92519",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13581,7 +13581,7 @@
           },
           "response": [
             {
-              "id": "08b91763-983c-4c26-a9ee-054647a7c2a6",
+              "id": "0a149df6-a85a-4629-bc9b-41538931aaea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13645,7 +13645,7 @@
           }
         },
         {
-          "id": "0de798da-9400-4e93-84d2-9fa3674cafe3",
+          "id": "12b19ac0-4776-4083-88a4-da61f1a5acfc",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13700,7 +13700,7 @@
           },
           "response": [
             {
-              "id": "ef2a8d75-7b87-4873-bb26-303052ee4408",
+              "id": "47599b2b-88a8-42c8-a26d-8014baa07cbc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13777,7 +13777,7 @@
           }
         },
         {
-          "id": "060e272f-01b5-4257-a1a5-8c4f06db2e5d",
+          "id": "54cea644-009b-4844-bb96-f94bce959e49",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13831,7 +13831,7 @@
           },
           "response": [
             {
-              "id": "438f7c3b-faf7-4f2b-b81b-010c5d3d655c",
+              "id": "48f064fe-8961-4451-b49f-80d6e33e9c9e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13907,7 +13907,7 @@
           }
         },
         {
-          "id": "06117c2d-80ca-4dad-acac-7e1ea6839d0a",
+          "id": "f14a558c-ac66-4ed6-a289-791152b8b729",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -13973,7 +13973,7 @@
           },
           "response": [
             {
-              "id": "359c254d-0275-4481-951d-8895d4c6ef10",
+              "id": "19949c06-7fd1-4526-a861-bbc00e473e8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14061,7 +14061,7 @@
           }
         },
         {
-          "id": "47162604-b77d-4b87-8f5b-04b94aeb06bd",
+          "id": "841fe227-7cec-497b-94ee-e553aee6a0e9",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14139,7 +14139,7 @@
           },
           "response": [
             {
-              "id": "87b7b2ae-72b4-49de-a463-36c8ebb3f907",
+              "id": "385a846f-1556-4a19-b58b-e3c826e922fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14239,7 +14239,7 @@
           }
         },
         {
-          "id": "ad9a9b6d-c5c6-4445-b128-d2a557bb6cb4",
+          "id": "9f68a141-a04d-44ea-a95c-62f2f6a27fdc",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14305,7 +14305,7 @@
           },
           "response": [
             {
-              "id": "f49e767b-682e-4946-9387-31a5cb333ca4",
+              "id": "8a9b6b8b-3545-4039-8444-60649a0838cb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14393,7 +14393,7 @@
           }
         },
         {
-          "id": "765d4aca-51b0-4cf8-9c7f-8404a50aa920",
+          "id": "30d0a8af-c018-450e-b5cd-9061e25a9f87",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14448,7 +14448,7 @@
           },
           "response": [
             {
-              "id": "d2bca48c-f8c8-4404-b69f-9277fc1da837",
+              "id": "c0d5b719-f358-4696-9349-193deebcdd58",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14531,7 +14531,7 @@
       "description": "",
       "item": [
         {
-          "id": "592f8ec9-ecd2-41c8-a7af-0f934dda9bc2",
+          "id": "4c392bfe-87fd-4501-b9a7-c0dd57bb1205",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14572,7 +14572,7 @@
           },
           "response": [
             {
-              "id": "9d619e24-0e28-4c41-8df3-f2bd02ff6a2d",
+              "id": "8665e6ec-412b-4ae9-9f84-21b120379b73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14635,7 +14635,7 @@
           }
         },
         {
-          "id": "ad7b6bae-7abd-4742-a78f-653bff323093",
+          "id": "20252416-3a2f-471f-8de8-cb3dcd231354",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14689,7 +14689,7 @@
           },
           "response": [
             {
-              "id": "3a41f771-2db7-4ad3-a704-7d235be8d58f",
+              "id": "0e9fdb62-570d-4f3f-bcdc-6b8c93c7cdbd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14765,7 +14765,7 @@
           }
         },
         {
-          "id": "3b330651-6154-49d5-a580-53960323ed8a",
+          "id": "4d9d513a-9849-4210-a2e0-8237629398d8",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14800,7 +14800,7 @@
           },
           "response": [
             {
-              "id": "1479faca-57f0-4fea-bfe0-6540d56609fa",
+              "id": "1e9e3848-06a1-41bf-a6db-d2c684aa976e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14853,7 +14853,7 @@
           }
         },
         {
-          "id": "cb13de7d-f79c-449a-b4a7-7e3fbf7ac1f2",
+          "id": "716b6e40-4b96-47ee-a0d7-6a5453b804dd",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14895,7 +14895,7 @@
           },
           "response": [
             {
-              "id": "ae56d655-aeb1-4517-9e67-e3ee7da3cd76",
+              "id": "2e6ca372-9379-4545-b35f-b20f094151c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14959,7 +14959,7 @@
           }
         },
         {
-          "id": "f56fb01c-c14f-4070-b6a6-0ff637bd6077",
+          "id": "e90fcaf2-ac92-45ed-8859-bbcfd2d75876",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15001,7 +15001,7 @@
           },
           "response": [
             {
-              "id": "fe861942-cddf-46b5-91ee-d18cb1b8b916",
+              "id": "cb892a41-678c-4b96-bd2b-2deb2f888511",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15065,7 +15065,7 @@
           }
         },
         {
-          "id": "6ae02578-ab99-4a9b-beef-bb235e67c434",
+          "id": "47f9047d-2961-4b1e-adc2-c741e46bdfe5",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15140,7 +15140,7 @@
           },
           "response": [
             {
-              "id": "6062d856-07ab-4b6c-b271-8507e31f3631",
+              "id": "25e5a20a-2f1c-479f-8bb7-fd3cbd868399",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15237,7 +15237,7 @@
           }
         },
         {
-          "id": "30be8da4-8334-410f-ba01-44e077f4dba7",
+          "id": "60529884-7a53-41a0-901e-be8eed62e4b1",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15279,7 +15279,7 @@
           },
           "response": [
             {
-              "id": "0ba442a6-a892-43ce-b0eb-27e3c586f162",
+              "id": "c5877013-4c9c-4e7f-9b7f-692071145667",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15343,7 +15343,7 @@
           }
         },
         {
-          "id": "513da259-f8cb-4e87-9033-987383c48498",
+          "id": "968bf704-3f82-4e57-ac79-de7531eb4ad1",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15386,7 +15386,7 @@
           },
           "response": [
             {
-              "id": "5a11c679-4aa8-47b8-817c-a081a79992e2",
+              "id": "d60b6035-3542-410f-9c1e-cb7d9b3baaca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15451,7 +15451,7 @@
           }
         },
         {
-          "id": "c694dd01-2c00-4306-bc35-da0ff0ba951a",
+          "id": "9ae00af6-6937-4f30-90e6-d7c269481ecd",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15494,7 +15494,7 @@
           },
           "response": [
             {
-              "id": "b1b1e8f0-cdce-467d-84aa-d0b9fe42b30e",
+              "id": "f3c122e1-e127-47cf-a975-4d5ab204459b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15559,7 +15559,7 @@
           }
         },
         {
-          "id": "43025e2e-3d59-4030-a676-138b188ac92d",
+          "id": "f5d4c9c3-2472-4b22-9708-ea25c7fd0561",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15611,7 +15611,7 @@
           },
           "response": [
             {
-              "id": "fc3056be-f500-4a1a-a3ac-afbaade7f158",
+              "id": "744dfd6c-113c-4e9f-b8ca-dc593d1fe452",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15685,7 +15685,7 @@
           }
         },
         {
-          "id": "c5092c12-ad2d-48ae-ab18-a3d05c18121e",
+          "id": "d230f982-4dba-4b6b-981d-4d39713dec02",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15727,7 +15727,7 @@
           },
           "response": [
             {
-              "id": "f5096a15-c557-4644-bc28-f184539e0a98",
+              "id": "6a400cae-9b95-4c0a-bf41-d1f59242b33a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15791,7 +15791,7 @@
           }
         },
         {
-          "id": "f280d080-5de3-4a5b-98bd-b51a38fd6537",
+          "id": "d8c587e9-a34d-43c4-91fe-a24cd7a47215",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15844,7 +15844,7 @@
           },
           "response": [
             {
-              "id": "bd003761-f5c3-4f6b-a8c9-4bbe98a7f151",
+              "id": "3e667659-a85b-4fe9-8e1e-1ecbb52eb42f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15919,7 +15919,7 @@
           }
         },
         {
-          "id": "e5135723-aaee-426c-b933-901d2ba89645",
+          "id": "c6e44551-396e-446d-84c6-bb85e6a9a3fc",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -15972,7 +15972,7 @@
           },
           "response": [
             {
-              "id": "ce3272e1-6fdb-4408-b430-4f0303759523",
+              "id": "40697d07-6d41-4e20-a5bb-c7ed2bebcecc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16047,7 +16047,7 @@
           }
         },
         {
-          "id": "bdc14eb4-9864-4d62-a362-f2c2afc37bed",
+          "id": "172cfb18-797e-4b0e-b2b2-47469923dbeb",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16091,7 +16091,7 @@
           },
           "response": [
             {
-              "id": "af615b20-50fa-4319-b3f1-e659db6954c9",
+              "id": "900f6d0a-aac7-485c-9a3d-d0617b20455b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16157,7 +16157,7 @@
           }
         },
         {
-          "id": "751cedda-9db6-41c3-b9b7-72957b53f1c8",
+          "id": "0d7a1bde-864e-4ce4-ae7a-c9f89d8182cc",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16201,7 +16201,7 @@
           },
           "response": [
             {
-              "id": "826d98c4-5a65-46bd-a2a0-9f1849cb92c0",
+              "id": "9852c314-31d2-4be1-8594-f2c0e91988f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16273,7 +16273,7 @@
       "description": "",
       "item": [
         {
-          "id": "cd7af0a5-5e21-405c-9016-965195df2d8f",
+          "id": "107fb924-bf2a-491e-8bec-69d644e7f771",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16315,7 +16315,7 @@
           },
           "response": [
             {
-              "id": "257d83d3-1447-4037-bdab-5b36301cdfdc",
+              "id": "6280f8b3-4ddb-4d69-9f30-d18ce60bd420",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16364,7 +16364,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "42bcc03f-adc4-4084-b719-9d0231a64c3c",
+              "id": "55dcf043-da1f-4c2b-aed7-161c5e7bb4e8",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16419,7 +16419,7 @@
           }
         },
         {
-          "id": "8a4d7ec2-04ed-4f0d-b258-9b52e2c85e2d",
+          "id": "c13fa0a5-5ab8-481a-98da-5bf34d4d1699",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16465,7 +16465,7 @@
           },
           "response": [
             {
-              "id": "bcabe948-570f-4103-b168-f8b228e47cbb",
+              "id": "ef2e2a20-460c-41ba-a4f6-0de641caeea0",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16524,7 +16524,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "55e6d66f-4cad-43c8-9ed7-62b574cbbda9",
+              "id": "6a3b07bc-f1e3-4403-92df-d4b36d043164",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16589,7 +16589,7 @@
           }
         },
         {
-          "id": "6d193740-08be-4e95-adda-075de499597b",
+          "id": "aa8476b5-ff52-4c57-be15-10163ca254f5",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16635,7 +16635,7 @@
           },
           "response": [
             {
-              "id": "bd0e86f1-dd62-4ab5-a2f3-4a0538a924e0",
+              "id": "0f4c7395-6671-4e2d-8fb0-a7b555cacf0d",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16694,7 +16694,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0decc633-0873-40aa-bf29-6518f257096f",
+              "id": "a9d59835-242b-4c73-a8b8-f6d3097e0bef",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16753,7 +16753,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e5e2e5b2-d3ed-4a67-8a41-19b5824153f6",
+              "id": "1705ec1b-e581-4f92-912e-383b13b4857c",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16812,7 +16812,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b8ab7548-3e76-41bc-826c-06975d60729a",
+              "id": "a78ae064-1565-4f42-a5b0-e4d7e7ea200b",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16877,7 +16877,7 @@
           }
         },
         {
-          "id": "774f1ea9-99ae-489a-831f-31ce19b3de01",
+          "id": "2d4e1236-fdc8-4da4-9e17-58d28c49f3d5",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -16923,7 +16923,7 @@
           },
           "response": [
             {
-              "id": "50951d12-b9d4-4e2b-af3e-2a3527d90ddc",
+              "id": "4042317e-71d2-46c0-9398-2ecbb7220503",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -16982,7 +16982,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "9a134b2c-cf4f-40b9-a6da-d792a014b79f",
+              "id": "87a4bdc2-83fc-4ed2-9d79-050814e1adec",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17047,7 +17047,7 @@
           }
         },
         {
-          "id": "ccbc03c4-fcd3-4cf6-84da-b6f213a3a0f9",
+          "id": "fe512d26-5857-42ae-9488-bc0c6bb8dc32",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17089,7 +17089,7 @@
           },
           "response": [
             {
-              "id": "ee2f665b-3729-4938-a8c2-548f79ebed48",
+              "id": "66df8d82-8e7f-4468-b112-8d5396d62458",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17150,7 +17150,7 @@
       "description": "",
       "item": [
         {
-          "id": "b7504bab-13c4-410a-9764-876fd04396ef",
+          "id": "4f40e22c-8d2a-4cdf-b932-dcfa166aac91",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17199,7 +17199,7 @@
           },
           "response": [
             {
-              "id": "d3ffcfcd-3cf7-4f70-9c8f-864812c2e198",
+              "id": "7708f26c-7ed4-469d-acf0-cb55f0313ca8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17259,7 +17259,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 345\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17270,7 +17270,7 @@
           }
         },
         {
-          "id": "3d7c696a-fdf8-4233-8855-2897522962b8",
+          "id": "69085cb5-6c1e-4b22-9b1d-3947f4a6e5f8",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17319,7 +17319,7 @@
           },
           "response": [
             {
-              "id": "a65d7d53-5d3a-452b-bc01-e2fc4aae49b1",
+              "id": "a073bef4-6147-4771-b036-7f03ab52859c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17390,7 +17390,7 @@
           }
         },
         {
-          "id": "9c66d002-e609-4967-ba4e-e22ccdd4ec14",
+          "id": "ad12fbc6-f613-44a1-a952-0685de4aa9bf",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17439,7 +17439,7 @@
           },
           "response": [
             {
-              "id": "3e308339-67bf-420e-998d-f7c5f34874a0",
+              "id": "27031b7b-320c-432a-9a45-9dc3976783b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17510,7 +17510,7 @@
           }
         },
         {
-          "id": "b737974a-3c7a-4975-be1f-135df98d2c79",
+          "id": "762a619b-6a0f-47be-8fc6-376eef2b0635",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17559,7 +17559,7 @@
           },
           "response": [
             {
-              "id": "3c9091aa-0d63-47c4-90ab-b4213b0d776f",
+              "id": "aa280cef-d711-4530-bca4-6a7e000750c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17636,7 +17636,7 @@
       "description": "",
       "item": [
         {
-          "id": "f4e13dfa-d196-4bd7-9c15-388e00a4ae3d",
+          "id": "46bc9a3f-86f7-40b8-8e57-2e7bddbb0877",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17676,7 +17676,7 @@
           },
           "response": [
             {
-              "id": "297140f7-9b4a-4d66-b5a4-6751db102e14",
+              "id": "83058f06-76fc-4303-a541-9db8e085f0f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17738,7 +17738,7 @@
           }
         },
         {
-          "id": "056c3cd4-cb04-4f46-8ce3-221da04900c5",
+          "id": "e065c038-a42e-45ba-8ac3-cb9f2a5d96e7",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17768,7 +17768,7 @@
           },
           "response": [
             {
-              "id": "3d2df2ec-ab25-4e03-ae54-0a7b68d17159",
+              "id": "8d1b3c67-2f89-4f34-9762-0d586ddc3f5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17809,7 +17809,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 345\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17820,7 +17820,7 @@
           }
         },
         {
-          "id": "586484ca-708c-40ad-bd1b-21c9df9ba698",
+          "id": "4670ba0b-b873-414d-b5a3-798329459e12",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17872,7 +17872,7 @@
           },
           "response": [
             {
-              "id": "974ac0a4-c199-4cc3-829e-926f0b031d6d",
+              "id": "cc25d763-c5b1-4220-a168-16b3e9f2dc84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17952,7 +17952,7 @@
       "description": "",
       "item": [
         {
-          "id": "987ff062-3d88-465c-b107-a045090058cb",
+          "id": "bb4530b2-e789-4431-82b0-36acfd071035",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -17981,7 +17981,7 @@
           },
           "response": [
             {
-              "id": "0b857b78-fcee-425d-a378-1eee37136691",
+              "id": "ebe682cb-4450-4a07-a24d-54854727ffb1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18032,7 +18032,7 @@
           }
         },
         {
-          "id": "f19e0bb2-efff-4b39-a238-466bf44797fb",
+          "id": "b553f157-d764-484c-8afc-563f06a37a65",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18073,7 +18073,7 @@
           },
           "response": [
             {
-              "id": "ab1b10e6-7d89-4f35-8f37-a23fc514795d",
+              "id": "e806b02e-ed0e-4608-b630-3bf018a13d3a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18142,7 +18142,7 @@
       "description": "",
       "item": [
         {
-          "id": "6307417d-6e11-4385-9ceb-ff3ba2fa96cf",
+          "id": "9211fe90-23f2-4406-baff-38509a6adad6",
           "name": "health",
           "request": {
             "name": "health",
@@ -18171,7 +18171,7 @@
           },
           "response": [
             {
-              "id": "42436193-e74e-4551-b9e4-9d073a157649",
+              "id": "3dcc344a-a9ca-4483-8751-15d393495b72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18211,7 +18211,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 345\n}",
+              "body": "{\n  \"key_0\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18228,7 +18228,7 @@
       "description": "",
       "item": [
         {
-          "id": "9d03b640-9f98-43b6-8575-0e13250df6e4",
+          "id": "81a3edda-6722-4376-8fcf-467b9ca6578c",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18280,7 +18280,7 @@
           },
           "response": [
             {
-              "id": "3b9bf754-f3a9-4abe-82dd-f8fb757826c6",
+              "id": "1d8e17e9-fde0-49df-947e-d881829025e2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18354,7 +18354,7 @@
           }
         },
         {
-          "id": "ff174fab-0383-42a9-a7bc-0cd1f16a9571",
+          "id": "46a8bf9f-ef86-4403-bbeb-40f25ee2a74d",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18395,7 +18395,7 @@
           },
           "response": [
             {
-              "id": "940ca54f-a495-4bc1-85e9-5f11c8c5edcc",
+              "id": "838c8271-42ae-44c8-a7a0-1e8df2bc3c48",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18447,7 +18447,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18458,7 +18458,7 @@
           }
         },
         {
-          "id": "b11b5eb8-f17b-454d-aaa6-27f67a9557d4",
+          "id": "a9e44b37-08b7-4b95-9f31-b1db4f92f327",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18488,7 +18488,7 @@
           },
           "response": [
             {
-              "id": "70c2a77c-60af-43d0-8a3e-513464bb8f68",
+              "id": "3ecf2cf5-f3c6-43dd-ac66-09984a7850f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18529,7 +18529,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18560,9 +18560,9 @@
     }
   ],
   "info": {
-    "_postman_id": "11d71fe0-5267-4023-9522-68024c0a0de5",
+    "_postman_id": "aac8fc6b-eb56-4b62-b497-af5516942dbe",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 03:46 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 09:28 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "b94e879c-2710-4323-a263-15aa4002567b",
+          "id": "47430526-b66f-45a1-9087-28ab471e1278",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "cea7eb63-f971-49fb-8e12-ae6d3c427224",
+              "id": "3e990a16-4e85-499d-a894-4816854e31c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "a23bf7a2-9077-4c8d-95ea-d48fa336cdad",
+          "id": "349a9acf-ddf8-44ff-b783-9d849b6a76d6",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "ccb621e0-d65e-4864-9827-34e3d50972ef",
+              "id": "cbbf52eb-9956-4857-afba-730f423a9b78",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "1d5f7ffa-3ee5-47dd-a430-344690bc34a8",
+          "id": "db4341e7-ace2-4ea1-beb0-a8106dabd28f",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "77c61e2f-f788-4f52-8631-4e3233aeb250",
+              "id": "79f61f5d-0094-40d2-a77a-1d31ce69201a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "8b1778cf-0aef-4ac2-b6a6-5a91bff171ca",
+          "id": "da9f7429-afa8-460e-ad74-3fd5fa594294",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "96958906-80c6-4539-97b8-e7566d142883",
+              "id": "a11365b7-df36-410c-a007-4ac3e8a559b4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "07c2dad2-e4e8-425b-b224-e1612905c6c9",
+          "id": "f03d2886-913d-4e14-ac0f-e31c42caaef8",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "1110d5b7-e313-442d-b09d-5d1c3edcce84",
+              "id": "a86ccf10-cc75-4164-90a8-41d71f633b97",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "d261acd4-9825-410c-a49e-14b7be4fbd46",
+          "id": "b990495e-4630-40a9-9acc-8913875abe4e",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "d204fb45-9a89-494f-b4bd-534fd5487bed",
+              "id": "66536219-fe04-41ce-9587-ce9a5fd277ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "12ed4cc7-1c08-49d6-87ec-91098218949a",
+          "id": "9c251825-4bec-467f-8afb-2fc6386a82b0",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "9de1d190-0a48-4a73-8acb-9428134e6447",
+              "id": "6a1d4414-90d9-4dd1-85a9-0a73ac1f5d9b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "3e175c2f-4b28-4aac-a1d6-f6df3b1177c2",
+          "id": "7d0a0298-0ca7-42c7-ac41-ec8d01488ddb",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "82a17681-702b-4ae7-ab94-933b69e1563e",
+              "id": "aa78b61a-67b0-48af-8491-d91feab67f9c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "3c0f6b78-22e6-4b96-8b3a-1f7c06b557b9",
+          "id": "e6b2f180-942d-4afe-a788-888bc96115f9",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "60c90001-962e-4665-83ca-ea4614d8af36",
+              "id": "8822a3d7-8ada-4c07-9075-3b3d4f770143",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "ad337143-6f2f-4d7c-bc55-ad9f11ce98b5",
+          "id": "acb48e37-a2b7-41a1-8883-4df399db6e73",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "1d44621f-d127-492a-a76e-6f59c1ca7c5f",
+              "id": "f9229f92-4fda-4c13-bcc8-d2062d48ed21",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "9abd7ad8-01a3-4fc5-965c-2db4d59bc8bf",
+          "id": "0ad4e4aa-877b-4825-90dc-cdc48a80c1ce",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "9e32c552-2d5f-4b44-942b-ecf5d6a8ebec",
+              "id": "ee174f1e-f892-4656-9d85-93a3a5e9ca83",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "ce59ced8-ad83-436b-80bf-d341501c5d89",
+          "id": "789fade2-8ac1-4c47-a159-f85f3efa528c",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "bfdaefb0-fa05-4afa-ac86-53dc3ba1274f",
+              "id": "5ab35f8d-9676-460f-9d0b-28b817f180be",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "e6e4a776-6f30-43f9-9897-c3469138d139",
+          "id": "0b330e77-d502-4864-80ee-8a3204d6d6e0",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "d17933a4-f5f4-45f2-ae94-9a6a391b39f5",
+              "id": "bbd7dff4-9ecc-4f4d-a03d-51d9455149af",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "bd50a52b-fe8d-44d5-b4e4-e1783435e3db",
+          "id": "aa21dba6-3f8f-4f0c-9e2f-4b9c7bc6e41a",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "bb111407-1119-4287-a49f-30fb7a71c258",
+              "id": "dbda1b06-45ea-4393-b4c8-fe5301f454d1",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "9770ba7c-5f67-4c8d-8d58-eddb3531ccea",
+          "id": "add4bc01-de89-4482-9c60-f994945f26b6",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "a9962599-090d-4ca5-9862-5c1424610caf",
+              "id": "96729fee-5b14-4b7c-b6b4-cec24027279f",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "81c37d86-e61b-488e-a771-4451b840a4e4",
+          "id": "36565d1d-8416-4704-8818-9e4a1487457c",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "fddff659-c8b4-4740-95ec-3ee911f21a6b",
+              "id": "830cbf1f-e3a6-49af-8dd8-ce76650cf13c",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "335390ac-78cc-469c-9dc8-61b9b2c36449",
+          "id": "fb35fe0e-e4ab-4dd4-9abb-e206233a06c7",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "b8d69fca-3868-4895-ad8a-bb798e5d8558",
+              "id": "b9cb16f8-009f-4ac2-b7e7-0bdd5dde6ac5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "9f85ff3e-1c65-4b74-81fe-78f5d104bdc6",
+          "id": "ecc90ade-6e98-432a-9b2a-aad2a4bb3dc8",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "9bdd29f2-e796-41f7-af31-3ac3ee6e7f3f",
+              "id": "cbba562a-fb4d-4445-a0bd-9f21502d0002",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "0672b660-202f-43d3-be54-34a2860344f4",
+          "id": "76f26d43-946a-4cd1-b647-dfd34b71d615",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "fb141cf8-309a-4659-bd82-601c4dd1127f",
+              "id": "8c63aa8b-8ca2-4efa-b3de-c445779ccc19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "e02c88ca-7138-457a-a783-727cdcd9459f",
+          "id": "0e4f4d25-3bcb-4774-969d-d8e131014902",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "ff5d0d70-6869-4769-9452-e065ea2c958c",
+              "id": "d97036e2-30d4-4c22-bfeb-ac4ead7e54c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "c6b69d52-eac2-4998-ad95-aaa47a283eab",
+          "id": "283e5ab3-9403-408c-8c99-e10bab2bc032",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "a57632e7-f5ad-47f9-9697-08df683f5621",
+              "id": "6d1dbf69-74b5-49a3-8f08-2e0339eebdfa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "228daeb0-f7a5-43e3-8179-981c1b7c0800",
+          "id": "d5677c3a-488c-4a33-acda-149746ea2e62",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "2525e431-a267-445d-9d30-c1fc1b40b242",
+              "id": "9a960030-901a-439b-a406-198a76e668df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "e2f66926-d9ef-42c8-96ff-b8a487869154",
+          "id": "24f32cae-9c4c-462b-bd1b-388110c327e6",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "a5130316-4724-4289-842c-9b97808a02b0",
+              "id": "84e55a60-0121-46bb-8b76-e2854bfb6813",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "9df171bb-cc53-4962-9891-27f4c2fa6105",
+          "id": "9af48719-c230-496d-9411-f3f377717c8c",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "a6e85a81-a749-4965-bd02-737dca2ca4bf",
+              "id": "0c40d892-73fa-41fe-859c-489d567501f4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "20595b05-61b2-4bfc-98db-9b1571bc071f",
+          "id": "24ef0136-b1a3-4411-99c0-0e23cbf75e3c",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "52092609-1305-4e66-8f5f-67cadd5da2bb",
+              "id": "38ef4f85-c916-473c-893d-bb8d30266516",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "e77b7206-8e0a-4444-b002-f01568b9f397",
+          "id": "bd6ebb2a-15d7-48e6-9984-61ae166553fa",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "34601c89-1235-4f23-a3c3-ef213f1e2e86",
+              "id": "797c12ca-8f13-45d1-a207-a140787290ee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "703781e2-6551-42f3-9ddf-7b498f6f418b",
+          "id": "4688c49b-ed7a-491f-84e6-c6114c09c770",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "472defbf-0bef-4572-bfd8-1d200ac74a5f",
+              "id": "a2fe5ba1-0a16-4291-a798-066dc335b78f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "efbc0fb1-ca79-4381-98c7-82f5895c00fa",
+          "id": "567fae56-5c64-4044-8bd6-0e80f63c2c98",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "8d79388e-d9be-434a-a56a-e55dad9b526a",
+              "id": "c6bfe843-ec37-41fb-8183-e32494db0769",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "7bb547ca-1979-409b-b5b4-07136c5df1b1",
+          "id": "4d90c9de-aac2-4b34-aaf1-2c3f35dd7106",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "46b589d6-a39a-4c71-9b2f-8d25eafea5e3",
+              "id": "f9b7d194-bc63-43ee-9209-b5d20ba4a4df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 3898,\n        \"key_1\": 5600\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\",\n        \"key_1\": 1482.0935756559873\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": 4058.867279441936,\n        \"key_2\": 175,\n        \"key_3\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "6cc20f20-efd6-48c8-b268-cdee99f7d892",
+          "id": "768ef7de-f2de-455d-8975-280511fd885b",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "9426049c-870f-4b68-8914-f2e38fc5b4a6",
+              "id": "416a670a-4dc2-457b-b8ef-1a107e28fbcf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "a60046f2-58db-4707-a617-2ef106a29c06",
+          "id": "3f5fa60d-0fec-4401-addb-619e21a73580",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#eAB23A\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#c5Ef5e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "432cb377-3cc1-4b61-9ba2-84534c020b99",
+              "id": "65d95b85-e3d7-4157-b62f-3ef85c580154",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#eAB23A\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#c5Ef5e\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "2e3f2f87-17ef-4653-a0de-a03562e1764c",
+          "id": "f52c6005-c969-4b94-ae08-1e432dd277e2",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "e8146134-defd-4f6c-8d22-0f2a84c7ffbb",
+              "id": "92ef9e1f-e03d-42b8-9243-2e67f00c985e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "5c1a3599-ebab-42b4-9052-20e64460a37b",
+          "id": "f50508a8-a73e-49a7-ac32-5a05013b66c7",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "9075930d-6586-4cd4-b1c9-6aca44453d60",
+              "id": "8753f7fd-feaa-4c3c-8a94-2f5f44ad2e42",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "e92ff881-e54b-4ef4-827b-aed3b6a9c513",
+          "id": "408081ca-dc42-4347-ad35-5620d78082ff",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#037688\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bcCE8B\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "69929502-372f-44a4-ae1d-615e53fe823d",
+              "id": "4b8935f0-62dc-462a-ae3f-c0150b951e5b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#037688\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#bcCE8B\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "88d3edd3-3ece-4351-86ba-8b4550dd0e89",
+          "id": "3ed9ac07-c9dd-4588-a5e3-618aeb8c433c",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "ebdea98a-7855-48d8-8a7b-12e4ce61e28d",
+              "id": "adf4f0b4-3804-4607-822c-496c1789fcb0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "cbdcf503-3a75-495a-935f-0fd0f09b3efc",
+          "id": "398d9d9f-2d37-4166-aa45-195bbe22659b",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "aafcf236-fc65-46a9-9da5-383b2f312964",
+              "id": "8b4cf250-db6e-4da8-82e5-5198ca7c5ba2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "e54dbc24-5a16-4e6e-b063-8e732e1c6efa",
+          "id": "67b1f1f4-217b-4350-86fd-453d83ba8972",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "7b00d409-625c-4b66-94c1-11871084c717",
+              "id": "6fbbc1c0-8b1e-4233-a7c1-e430b234ed70",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "d97fddc1-9218-4696-950d-d571c3eb674b",
+          "id": "9ca94834-6f4f-45db-89f4-02d6fdc95ae4",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "d6dfc70c-7eb9-407d-99e8-1f04733e5a09",
+              "id": "58528977-2f5d-461f-a9ee-7c1ad019a179",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "1eb476d1-c832-4670-b9f3-c68fbdd66100",
+          "id": "bce60105-5acd-4b11-be70-1edb56a865d1",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "cef8f952-d6eb-4505-a57f-df92a6bd7364",
+              "id": "94b62a2a-bd80-422d-b224-0cdf00498575",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "af4b5d01-2e3a-476e-85ac-e6f18676d11f",
+          "id": "773fd27e-eb06-4843-b7ad-6f9bedc0796e",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "f77e1a4f-f01e-42b0-8e5d-90ceb1bc32fe",
+              "id": "c7e2149c-fc77-471b-a19d-eee385ead5f4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "b59d47ee-43d2-463c-96f5-f233ac129c66",
+          "id": "d8a1b588-9112-43d4-8d02-a621f7cdef8b",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "cb6fdbc2-47bd-4cb9-9299-02dad6fff390",
+              "id": "c1869a24-d81e-4912-b2e3-b4aba7522908",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
+              "body": "{\n  \"key_0\": 345\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "db522ed3-0943-4072-ac62-b88b82fd694b",
+          "id": "8c1c0240-85dd-4453-b17e-f972a4c8044a",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "9d7ec5ac-d0bc-4e53-94e6-509e80bd1df9",
+              "id": "42237230-dcbc-4a3a-a6b3-f1428814acf2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "a6972910-41e0-48a0-92c8-5ff839fb087e",
+          "id": "58100c03-ac82-428a-b22a-af6954a1bae8",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "4eef50c2-e84d-42a1-9a0b-a32d57230682",
+              "id": "50b6a6ef-8af6-4462-859e-69dea883484c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "921f27fb-ba4d-4f7d-9629-59cd629626ec",
+          "id": "501b8122-9736-4c4a-a620-20850b8fc4f2",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "ba5253e1-3947-4506-a9ee-ce9c25ff131d",
+              "id": "fe8de42b-fa46-4640-a4f2-c648eefeba73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "639d835a-9cdd-433c-adba-d2410e43ae52",
+          "id": "a1ef0402-a2b4-4374-8b15-0eaed0dc405b",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "7d9b5045-f0ec-4dc3-8bfd-1753615bd029",
+              "id": "25585ce9-56a4-4308-9e66-0dd051ea57bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "5741f968-3a77-448c-96f1-9ab500e6db99",
+          "id": "b0e7ec5a-fe93-4fcc-81ca-a393d8b69d67",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "3bd3864b-22c0-4cc1-86ae-2995f61a5e77",
+              "id": "5daa0982-be86-425c-8e26-cde96a204c1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "e5b8705b-c5a0-469b-9980-29349ead445a",
+          "id": "562e78af-ce88-4026-8674-ce1f53de6804",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "74578517-296c-4668-88c8-c318b3cd98e0",
+              "id": "1a09e095-d4b9-4540-ad58-bb4e2f4c2521",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "db4d9b97-10cc-4cbf-ba69-6b4f72791a77",
+          "id": "d8f74d53-712a-4493-b9fc-b544b0e8785e",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "84b88b61-6d66-4eb0-983a-a7110c189c40",
+              "id": "5cc602f2-2d8b-421e-8669-3683a4859941",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "547b4c13-ea0d-4c89-893e-6f9d878e2dc9",
+          "id": "293e4f8b-96ae-4eea-af98-208d1cff45be",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "32bc3a49-7ccd-4e27-aac4-23a9e4198fd8",
+              "id": "9e3fd7c0-454b-4102-ad29-10f896d7fd72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "d12b9758-64cb-4204-8738-b9992a4511e2",
+          "id": "952ed36f-2ee1-473c-83a3-4870079c7254",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "5b74ddbf-75d7-4fab-b5a9-132546643914",
+              "id": "25c0e952-5697-4807-a8f7-d2f34b9ffa11",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "a591fe9a-2f63-4a9b-acaa-02eb6c0865b0",
+          "id": "282fd496-b00d-4583-a4bb-89d2d60dceaf",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "b1ddeb6f-694d-43ac-8df8-e94097b73ccb",
+              "id": "afa9c7e2-27e6-4398-bfd4-a0ec09343953",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "f247bb01-1514-4225-953b-04069de2c6a2",
+          "id": "41787931-c28d-412a-b818-c5b9ae59f5b9",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "9cd124a4-faec-4905-8db2-fc3a2a253595",
+              "id": "bbf0c84c-33b6-4134-9f87-4f426a851adb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "b8243ef2-dcd5-4d8f-94cf-410654404d81",
+          "id": "e68977ce-b367-4a2a-8c23-99457bd33c77",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "a55209ba-28c0-4d8e-9114-2dd02911a856",
+              "id": "c543797d-0eec-4ac4-a769-ef4624e9f94e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "6308ca5a-e57e-462d-b6af-42c9b1dc160a",
+          "id": "e52d6ac4-99e1-4272-8848-967c15709cf6",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "87ce905a-fb02-41bb-a231-a52164bd64b9",
+              "id": "91308feb-aeae-4bf2-a434-f37893d84ebc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "788b86c2-393e-42d2-8545-8323ffa42a5e",
+          "id": "6bde2642-1b0b-4f61-9107-dda84006b49f",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "35ecb41b-244d-4624-95eb-45f34f5d75f2",
+              "id": "31906165-278b-4e8d-992c-63755968f696",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "908d227d-e6e1-40e1-bb3d-9deffb7230e6",
+          "id": "7977b24f-71bc-4d5e-abbf-3b6f548ad7fd",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "9da5aaa4-3f98-4974-ba8d-b5c0f88b0f1d",
+              "id": "b538b5d4-aa1b-498f-9f77-94b4364f13e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "70965edc-df29-4391-a757-d62edb9337a5",
+          "id": "431e32fc-238f-4c21-81a7-8c3996037726",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "17739e84-91a2-4bf8-9077-36eba0d7298b",
+              "id": "18a05616-3e7d-4171-9f48-a24b5056e89c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "4ad6babb-4fea-4178-b25d-8ab7a24a0961",
+          "id": "f2303774-7746-402f-a8ea-538e0c5ec385",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "2bf89b12-6892-497c-b113-533f24674d02",
+              "id": "612df42c-b14b-4869-9857-5b0beab266f7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "c56141d8-dc11-4771-ace2-afe595a66a80",
+          "id": "343916c4-0b7e-41df-9681-d893b577e862",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "56369df6-96b5-4956-a1db-6eb0d325ee46",
+              "id": "7b4f55cb-7e2d-4bdd-bc78-73448e940cdf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "722bda41-b2e0-430e-b0a2-13a996e28143",
+          "id": "22b6d2f6-6459-4713-accc-68823df902cc",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "d189cbfc-4304-4bfc-995e-267b954ea393",
+              "id": "9742339c-83f9-474a-8c6f-c4b91dae834a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "3dbec969-3c73-4aa1-8ddf-e76f20682dcb",
+          "id": "90b1d2bb-2df9-4b2d-a984-8b9bd60445e4",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "f7a60645-90dc-4c1f-9f30-459facc04975",
+              "id": "89fa4ad7-6b8b-4ee9-8deb-6cde4ccf8a4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "b9993bee-670f-4358-8bd4-5960a02082de",
+          "id": "91b69173-98b0-4522-ae80-0f246c87e4e8",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "2aee0d61-27f5-43ba-b0f9-147bbb7dc74b",
+              "id": "e3934c42-4f87-414d-9ab6-b2b54cf00389",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "70cae55b-9715-4f4f-8851-467da79bb00a",
+          "id": "d4cea253-2613-4344-a9ec-77c96f5acb16",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7553,7 +7553,7 @@
           },
           "response": [
             {
-              "id": "4298175d-01a1-4598-96dd-ae2a40fb00bc",
+              "id": "7592a9af-3033-4233-b088-da0a31d30ac8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7629,7 +7629,7 @@
           }
         },
         {
-          "id": "83499d60-ce53-451c-bd4f-7a7e308b9320",
+          "id": "d546c9bf-1bc7-4135-b890-b74833ac8abc",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7683,7 +7683,7 @@
           },
           "response": [
             {
-              "id": "044a26c2-927e-4a4b-b0e3-eadd051a216b",
+              "id": "32dcaeff-d657-4210-a133-492a9648190c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7765,7 +7765,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "64954996-e86a-467b-a762-dba6c0a360ad",
+          "id": "f8b66010-afc0-48e0-847c-078dcda426d1",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7818,7 +7818,7 @@
           },
           "response": [
             {
-              "id": "35a4dabe-af07-40c4-ac8f-4c858116da2e",
+              "id": "03b5378a-2e37-406e-9755-f47e6199412d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
           }
         },
         {
-          "id": "466d05a2-c773-46bd-a887-cccd132c2252",
+          "id": "022cdd72-cb95-403f-bd84-c1f5e61459d3",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -7959,7 +7959,7 @@
           },
           "response": [
             {
-              "id": "cfd40629-df6c-4f82-99c7-e321cae25dce",
+              "id": "9370a9c4-ef2a-4483-8420-05da0caa2b4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8047,7 +8047,7 @@
           }
         },
         {
-          "id": "8c7c328c-2db5-45f7-b6cf-0ccf992004a0",
+          "id": "a8849303-f140-4666-b63b-ede11a0deaa3",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8094,7 +8094,7 @@
           },
           "response": [
             {
-              "id": "6c1f6f31-0d54-4e98-b540-3e99cdc2794b",
+              "id": "971ae01e-cb11-4b89-b6e3-d30789159c3e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8159,7 +8159,7 @@
           }
         },
         {
-          "id": "cf344c43-10a6-47cb-8ce4-1c3932a055e4",
+          "id": "42e42bfe-f643-4757-8d71-d1bf18b6f583",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8201,7 +8201,7 @@
           },
           "response": [
             {
-              "id": "3fdd3fac-5c19-4fab-8572-0a1f0471e16e",
+              "id": "c3278d6e-63b4-47f6-8b9a-2aa1cd27c7da",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8265,7 +8265,7 @@
           }
         },
         {
-          "id": "b5841cc0-7f52-4c96-95f9-16fc3572b085",
+          "id": "4a0db63c-88fc-4abd-a683-baa4b9e95807",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8320,7 +8320,7 @@
           },
           "response": [
             {
-              "id": "8122ef3e-d250-41fd-8165-a024eb5ecc55",
+              "id": "e761c280-2389-4f41-8b93-fdf3301850f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8403,7 +8403,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "791b9727-526c-409d-8448-37905eee8ed1",
+          "id": "23725d7a-ab78-494e-8e13-bfed606975d6",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8444,7 +8444,7 @@
           },
           "response": [
             {
-              "id": "8c092348-7f25-4546-9069-295a2e4ebc3c",
+              "id": "98980534-c25f-445e-8b98-282120080e13",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8507,7 +8507,7 @@
           }
         },
         {
-          "id": "d1049024-72e2-42ca-860c-3bdea3e32e36",
+          "id": "bdf01d09-91b6-4362-a85d-e9dcd60fc2df",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8561,7 +8561,7 @@
           },
           "response": [
             {
-              "id": "0fdcd737-0a7b-4e93-8d32-d4751e1de0b5",
+              "id": "0af73450-f7f1-4185-9895-ab4db8f62148",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "2d7ff989-f2af-4fc9-8947-c4053bf0e674",
+          "id": "48b844fb-ccc9-40ff-bd31-550ce7d7fae6",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8672,7 +8672,7 @@
           },
           "response": [
             {
-              "id": "759a36e3-0a96-44d7-b6e5-1b50218499c4",
+              "id": "3440d922-8d65-487b-877e-348e97ccc6ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8725,7 +8725,7 @@
           }
         },
         {
-          "id": "86967a62-793a-415e-b58b-69ca3db30a83",
+          "id": "3d449cc4-0e8c-4936-8f36-59ad9f02d588",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "b236889d-75f9-4c9d-aa43-130475b3f203",
+              "id": "a8b75cf8-cb7e-41a6-8adf-a90ddfa7c10a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8861,7 +8861,7 @@
           }
         },
         {
-          "id": "7834e82e-0469-46d7-924d-a2d4ae19bede",
+          "id": "6c8708e9-73de-4a8d-98d8-ab75641ec4b3",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8903,7 +8903,7 @@
           },
           "response": [
             {
-              "id": "d8dd23ef-e4e6-46f1-ab78-be8690d64d3d",
+              "id": "11423838-f18a-4052-9c38-cc1b4127cf79",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8973,7 +8973,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "d7c3feb1-90a3-4eb2-83ca-8623d377d3fe",
+          "id": "5b04b39b-1fa8-423e-ba1b-4668aafc6a14",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9026,7 +9026,7 @@
           },
           "response": [
             {
-              "id": "ae70ecb1-2891-4b91-b014-d0988e9903d7",
+              "id": "2396d1bb-ec16-4bf4-832d-8d7c36017f26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9101,7 +9101,7 @@
           }
         },
         {
-          "id": "7415bfa2-cef4-4d22-9054-e93ddda9dca5",
+          "id": "6e3b69e2-72ef-4ea0-ba31-806ab1944ccb",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9167,7 +9167,7 @@
           },
           "response": [
             {
-              "id": "f12c4444-fdeb-492b-8a1f-6a7293412473",
+              "id": "4cd89113-e347-4a3b-9b29-ec6e8033d8a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9255,7 +9255,7 @@
           }
         },
         {
-          "id": "9a407dbf-3129-4bb0-bc7b-2d557f7fe1f7",
+          "id": "a533ce9a-2d68-4864-9944-01077b8a34ea",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9302,7 +9302,7 @@
           },
           "response": [
             {
-              "id": "78e54f45-5652-4db5-8fdf-3e3335df45a2",
+              "id": "3da6a9bd-dad6-4d05-8d21-a141442d987d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9367,7 +9367,7 @@
           }
         },
         {
-          "id": "8f0b727e-29b3-434d-bd79-25665443d75a",
+          "id": "de57f65f-0127-47b7-a94d-ca875256adcd",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9409,7 +9409,7 @@
           },
           "response": [
             {
-              "id": "65289e72-895b-443d-a721-600dac1c84ef",
+              "id": "4915779b-4d90-4764-9316-ea147aa69383",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9473,7 +9473,7 @@
           }
         },
         {
-          "id": "cf53c5aa-63ee-495f-8b60-216a12bad9ba",
+          "id": "05aa668b-a66c-42df-8198-47db43c748ce",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9528,7 +9528,7 @@
           },
           "response": [
             {
-              "id": "f718d4fc-fa57-479a-a797-2d2a6a73f636",
+              "id": "ec4d4e42-847f-4de5-b83e-d142cef7755c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9611,7 +9611,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "5adf35ed-615d-422a-84c4-7096b0a2fbd4",
+          "id": "c87eb494-c538-4858-8fc8-00e5dcbd83cf",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9653,7 +9653,7 @@
           },
           "response": [
             {
-              "id": "f387f5e6-d43f-4a2b-9e49-ac1625420ebd",
+              "id": "5ab0e125-2f1e-41c3-b99f-7aa3cc5f5f95",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9717,7 +9717,7 @@
           }
         },
         {
-          "id": "95ed165e-8a2f-4fc5-a546-71a6b91f308a",
+          "id": "8d64a7e1-a6bc-48c6-8c03-3d0fb56cb923",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9772,7 +9772,7 @@
           },
           "response": [
             {
-              "id": "547d8f0f-9a32-49f8-8578-b75ef844ee01",
+              "id": "e7374be4-52bb-4a6d-a901-2fa5126ea95d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9849,7 +9849,7 @@
           }
         },
         {
-          "id": "868b24be-df5c-4efb-8690-514b0c79486d",
+          "id": "8c62ef9e-fb63-4616-8f99-7d3909fc9adc",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9885,7 +9885,7 @@
           },
           "response": [
             {
-              "id": "ede38f37-e988-4de6-a12e-8b02951f366e",
+              "id": "0038d44d-7283-4a5c-81d3-af8809a32fe3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9939,7 +9939,7 @@
           }
         },
         {
-          "id": "60a11e09-995f-4ea7-85f9-dcaa874832b2",
+          "id": "a320a008-b2fb-40f4-bcc2-7f06e30061f7",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -9969,7 +9969,7 @@
           },
           "response": [
             {
-              "id": "e96c1101-0458-4b8e-9e8e-2c6f837ead7f",
+              "id": "a27c9101-a9a1-4ba1-a807-a58bde1f2351",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10021,7 +10021,7 @@
           }
         },
         {
-          "id": "f6fe12a9-ea59-4abb-888a-36db3fcd51c1",
+          "id": "b3e0dde1-4458-4ed6-95e7-4fed082fa637",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10064,7 +10064,7 @@
           },
           "response": [
             {
-              "id": "ded91302-399a-4f63-a95b-697906a06320",
+              "id": "a14e453c-ece6-4927-a749-3efe1ffc0de4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10135,7 +10135,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "3e3f31d8-4a2e-4c89-81b9-6a3e251ab0a5",
+          "id": "6d31f8a4-e73c-43b0-8a83-eb960412efa7",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10177,7 +10177,7 @@
           },
           "response": [
             {
-              "id": "06d51b90-277a-4d40-84c2-a37f4e3b148d",
+              "id": "79c2fda2-c607-43f1-ad7b-c66fb63e7a79",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10235,7 +10235,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "15e57e73-9712-4741-a20f-58448537f3b6",
+              "id": "973f9711-2970-4f66-8831-322366d7e9f7",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10299,7 +10299,7 @@
           }
         },
         {
-          "id": "fc7a7858-92f0-41aa-ba79-9123df8af0c3",
+          "id": "33d55eae-30e8-48e1-bd23-8443d03f4d4a",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10354,7 +10354,7 @@
           },
           "response": [
             {
-              "id": "7c9b34f9-395f-4f71-9814-da893e16e8a5",
+              "id": "f991a437-8402-497b-961b-935a4cad5970",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10425,7 +10425,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "77953318-dc41-4f76-b4f0-38654b7114cc",
+              "id": "a66c5cd0-ba2a-413a-8e96-c91a0933bbde",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10496,7 +10496,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "9fac4618-4844-456f-8324-0f6ce51c55c0",
+              "id": "731a0049-9ac0-4b8a-80a1-b035225463cc",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10573,7 +10573,7 @@
           }
         },
         {
-          "id": "533f45d8-195e-4dcf-a27c-a60ded4676a1",
+          "id": "f4082593-f6ac-4aa4-b792-070abfea482a",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10609,7 +10609,7 @@
           },
           "response": [
             {
-              "id": "5bd64020-37e0-4977-8daf-0c95a31bf19e",
+              "id": "b1426b78-f0d0-4c7c-9f4a-4b3f72e49e91",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10657,7 +10657,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3aa02f9d-3fcc-438f-b366-bd8ca1e5fd78",
+              "id": "15be3c48-6c90-4451-bc2f-d5c22ecc6caa",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10705,7 +10705,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "081ce0b4-11ce-42b1-ab79-05e4594a224a",
+              "id": "fef67385-06a5-4cf4-9a6c-623111c8d71b",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10759,7 +10759,7 @@
           }
         },
         {
-          "id": "d8e4520b-e3d0-43b6-9a4e-bfc404f97e45",
+          "id": "a3973332-c681-48ee-9658-16e5c5ef6b28",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10789,7 +10789,7 @@
           },
           "response": [
             {
-              "id": "9055affb-530c-493a-ba10-521c4d5f218e",
+              "id": "f7bd1df9-c70b-4581-9136-7c34526ab4e5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10841,7 +10841,7 @@
           }
         },
         {
-          "id": "eea06d5b-9b9a-49ec-b0d1-0262030b2ec0",
+          "id": "f7e32316-3dfa-47a7-8b3f-3bec41cbd9d4",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10884,7 +10884,7 @@
           },
           "response": [
             {
-              "id": "6f2578d8-6f96-4960-9976-8ee967d98fe0",
+              "id": "3c9c34e7-f1dc-4c2c-854c-46c81f86dac5",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10943,7 +10943,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6b66885c-988f-4f6d-b507-be26b3d82e03",
+              "id": "f65edef0-fc59-4389-8208-c9724f59b896",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11014,7 +11014,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "abdce9d8-fd79-40b2-a818-af5365f6f2fc",
+          "id": "3f4a2dfd-1573-4de1-b740-2b2abac79da3",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11098,7 +11098,7 @@
           },
           "response": [
             {
-              "id": "fe117cbb-ed12-49b2-9f90-4491e578769b",
+              "id": "83130f7c-28c6-457f-953e-024e9ffe0888",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11201,7 +11201,7 @@
           }
         },
         {
-          "id": "7ec96e53-1109-4588-9e43-80203a0e8dde",
+          "id": "40ff795c-ad0c-473f-bef9-28ddf34b26a9",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11267,7 +11267,7 @@
           },
           "response": [
             {
-              "id": "d20cf3ac-cad7-457d-bad9-fba3a62985f2",
+              "id": "6fed9993-b68a-4aa5-8a40-c5f627791ef9",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11352,7 +11352,7 @@
           }
         },
         {
-          "id": "bce2857a-bcb3-4d22-a658-8da84418e4c8",
+          "id": "1f80f803-1a2c-4fa3-8848-0ea79622d6d2",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11436,7 +11436,7 @@
           },
           "response": [
             {
-              "id": "08629006-a4ed-4635-91b6-aff4ce8305bf",
+              "id": "d5ef7d84-c2cd-4b40-af58-383b9fb08916",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11539,7 +11539,7 @@
           }
         },
         {
-          "id": "ac9f4a44-2953-4bb1-8520-7ef6fa66287d",
+          "id": "efab6b64-4a72-4f59-9f52-0cfd5040231e",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11614,7 +11614,7 @@
           },
           "response": [
             {
-              "id": "5b6bac1f-52ef-4080-a4ea-4f35ee028386",
+              "id": "1c7267b6-3132-413c-bcaf-72b0235bb048",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11708,7 +11708,7 @@
           }
         },
         {
-          "id": "967ef239-b51e-4ae5-86fd-0c6337cd4001",
+          "id": "407fbb4d-02d1-4087-899c-78f99da7d4d1",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11783,7 +11783,7 @@
           },
           "response": [
             {
-              "id": "55d8a5c1-6659-4577-8215-2d1faadb967e",
+              "id": "3a110607-b51e-47ed-b1f3-b8f4e338afe2",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11877,7 +11877,7 @@
           }
         },
         {
-          "id": "069c7da5-b488-41cf-9a12-a996e5026248",
+          "id": "437a8395-df7a-4366-967e-dfb8e555fcd0",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -11952,7 +11952,7 @@
           },
           "response": [
             {
-              "id": "b6e5405b-c505-47b7-8e8e-1b89c6f9091b",
+              "id": "4ab8e949-3e74-4e09-a9a7-4c288d92757a",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12052,7 +12052,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "7e956951-4d2e-4da3-9b82-4c65032f2781",
+          "id": "2731ffb4-2605-4b49-80d1-75548bb5117e",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12118,7 +12118,7 @@
           },
           "response": [
             {
-              "id": "6a66f0ed-e053-454e-9ca7-c345ccbf7676",
+              "id": "7714f0fa-cf43-4800-ad6f-d0a0d44b9446",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12192,7 +12192,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
+              "body": "{\n  \"key_0\": 345\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12209,7 +12209,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "0e7dfe2d-2358-42f5-86f3-5725bd032339",
+          "id": "2e5a874d-7681-4dca-9097-bbaba030f509",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12251,7 +12251,7 @@
           },
           "response": [
             {
-              "id": "1846e737-0197-446d-af38-426b974b8528",
+              "id": "0b4e14c6-1528-460e-aeca-76e6ba5ffe84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12321,7 +12321,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "9fa1f0ed-7a08-44a9-a6cd-2bde10e858f1",
+          "id": "1c239a38-4666-4ec1-987b-775386610df9",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12360,7 +12360,7 @@
           },
           "response": [
             {
-              "id": "e27411b1-6b20-4298-9b4c-75b6c88142d1",
+              "id": "e821a49e-fff7-425e-b69d-638f0c4cc08b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12413,7 +12413,7 @@
           }
         },
         {
-          "id": "6360cf81-787c-4f34-9ba9-67b6226af422",
+          "id": "6d2349ad-eeab-4dee-8bc3-b3735b65b7cc",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12445,7 +12445,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"oq-VV\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"05:02\",\n  \"quietHoursEnd\": \"20:05\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"dq-VW\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"15:05\",\n  \"quietHoursEnd\": \"16:46\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12465,7 +12465,7 @@
           },
           "response": [
             {
-              "id": "74d6a116-4e63-48a1-b9ad-ff130bd0b187",
+              "id": "37ca84fe-3616-42a7-a8a3-a042bfcfd200",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12503,7 +12503,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"oq-VV\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"05:02\",\n  \"quietHoursEnd\": \"20:05\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"dq-VW\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"15:05\",\n  \"quietHoursEnd\": \"16:46\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12537,7 +12537,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "1f0d28b9-fc55-4ca7-83e9-c0ca5fa09061",
+          "id": "338a6596-ad30-4170-9163-cfd22519cb0d",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12579,7 +12579,7 @@
           },
           "response": [
             {
-              "id": "626fff60-6a19-4c9c-bedd-c3354d4d7318",
+              "id": "7e507de8-37b9-4f75-93f1-cac0f7de6cdf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12643,7 +12643,7 @@
           }
         },
         {
-          "id": "4f4647f6-e1b3-473d-9d3f-21ee350ae55d",
+          "id": "d7275286-a88d-4012-bd1d-214e0f74a32c",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12686,7 +12686,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#aBAde5\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#DFfe4a\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12698,7 +12698,7 @@
           },
           "response": [
             {
-              "id": "a9d34fc1-13fa-42a2-aca0-4acc1e647f09",
+              "id": "e80f824e-f1c3-4ed3-ac62-ca81aa2662c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12747,7 +12747,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#aBAde5\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#DFfe4a\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12775,7 +12775,7 @@
           }
         },
         {
-          "id": "8c6720c3-adc5-4d4f-a11b-106a663cb3b9",
+          "id": "6dbc04dd-4148-4d4b-8da5-67b64bcf9be6",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12811,7 +12811,7 @@
           },
           "response": [
             {
-              "id": "1c4e34f3-8ee4-4cec-bb7c-691f71f0ae58",
+              "id": "2e2bdb1a-708e-446b-920b-8833acc85401",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12865,7 +12865,7 @@
           }
         },
         {
-          "id": "397a2964-3210-4236-8e59-2f6573899e99",
+          "id": "92c2c0bb-58cf-428f-b2a4-37fedade47ca",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12895,7 +12895,7 @@
           },
           "response": [
             {
-              "id": "7d60d382-0e8f-49d9-b551-94ece2953d14",
+              "id": "842f0f1f-4b43-4fa3-ad7b-411b0a752bbd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12947,7 +12947,7 @@
           }
         },
         {
-          "id": "f3deedfb-1fcf-480b-a259-425bcbde2a6c",
+          "id": "ae1e83e5-a734-4183-a1f1-1ff38729306e",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -12978,7 +12978,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e4ECfc\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E6ecc1\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12990,7 +12990,7 @@
           },
           "response": [
             {
-              "id": "e1f2813f-2499-4ca0-bfd3-789a3b9ddc72",
+              "id": "085b594f-0020-4626-80e3-b33a4e192f70",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13027,7 +13027,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e4ECfc\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E6ecc1\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13055,7 +13055,7 @@
           }
         },
         {
-          "id": "c86f5471-d7b6-42d2-8229-0ab07e85caa1",
+          "id": "49659156-fbb0-41be-a750-e44a15d3e0c1",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13086,7 +13086,7 @@
           },
           "response": [
             {
-              "id": "07485e81-9756-4382-a90b-c1a0bb2cff5f",
+              "id": "53cef444-b789-41e8-9fd0-fc5994d28320",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13145,7 +13145,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "a248e1aa-e736-4d58-aab0-e71cf6bd9da2",
+          "id": "9fd2ea04-dd04-4926-bb7f-572f2b6f0090",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "fe77c181-332b-4bf3-ba2a-0e27e9b4ccb4",
+              "id": "0231d9f1-356c-4c27-a2c0-7bda3c128213",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13273,7 +13273,7 @@
           }
         },
         {
-          "id": "97b8ec8d-9973-46aa-802c-8668db499d52",
+          "id": "787942a2-be9b-4ec4-a4f3-7c9acfc9c998",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13339,7 +13339,7 @@
           },
           "response": [
             {
-              "id": "a517ff9e-4a45-42ec-b19c-d052c0b2d962",
+              "id": "25c2d0d3-aac9-4fed-b652-6ba2f0afc860",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13427,7 +13427,7 @@
           }
         },
         {
-          "id": "aa663a22-50fe-4fc7-9baf-bceb234a2682",
+          "id": "12ea8250-12e1-46da-bbe3-1302c344f1cb",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13474,7 +13474,7 @@
           },
           "response": [
             {
-              "id": "bdd8f7ed-2238-42b7-a3ac-a2fbc825432e",
+              "id": "74be3069-42af-4cac-b18a-9c894ee1eed7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13539,7 +13539,7 @@
           }
         },
         {
-          "id": "7317d63d-50e5-42ab-8a1f-8cd3de627175",
+          "id": "da19797c-f48b-4fa7-8b98-e41db71fe245",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13581,7 +13581,7 @@
           },
           "response": [
             {
-              "id": "456e5fd8-ef2b-4db6-8e46-29a192f55e20",
+              "id": "08b91763-983c-4c26-a9ee-054647a7c2a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13645,7 +13645,7 @@
           }
         },
         {
-          "id": "bca3da8c-636e-4e16-b8a6-0c7d583ea4e5",
+          "id": "0de798da-9400-4e93-84d2-9fa3674cafe3",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13700,7 +13700,7 @@
           },
           "response": [
             {
-              "id": "fb8aa62d-a5fc-4b0e-acc2-17a091fa0bda",
+              "id": "ef2a8d75-7b87-4873-bb26-303052ee4408",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13777,7 +13777,7 @@
           }
         },
         {
-          "id": "197e1f16-d414-43ce-b3a3-6bbe2a3317c3",
+          "id": "060e272f-01b5-4257-a1a5-8c4f06db2e5d",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13831,7 +13831,7 @@
           },
           "response": [
             {
-              "id": "fa1ec129-e545-48da-9345-abffef565d5a",
+              "id": "438f7c3b-faf7-4f2b-b81b-010c5d3d655c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13907,7 +13907,7 @@
           }
         },
         {
-          "id": "e390d637-b15c-43e1-9c2e-4868df1d09df",
+          "id": "06117c2d-80ca-4dad-acac-7e1ea6839d0a",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -13973,7 +13973,7 @@
           },
           "response": [
             {
-              "id": "adc1f3c4-2e3c-4f57-a0dd-d4f66188dcb5",
+              "id": "359c254d-0275-4481-951d-8895d4c6ef10",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14061,7 +14061,7 @@
           }
         },
         {
-          "id": "ded95d45-d565-4b1c-95f9-b4fec6bd43c3",
+          "id": "47162604-b77d-4b87-8f5b-04b94aeb06bd",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14139,7 +14139,7 @@
           },
           "response": [
             {
-              "id": "d1be77aa-9c3d-435a-83e8-09d0eefaec07",
+              "id": "87b7b2ae-72b4-49de-a463-36c8ebb3f907",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14239,7 +14239,7 @@
           }
         },
         {
-          "id": "790dfbad-75c8-42d5-b7c5-732c5ba8e88e",
+          "id": "ad9a9b6d-c5c6-4445-b128-d2a557bb6cb4",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14305,7 +14305,7 @@
           },
           "response": [
             {
-              "id": "c2509fd6-c728-4b92-9d1d-8f6e8ba37d1f",
+              "id": "f49e767b-682e-4946-9387-31a5cb333ca4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14393,7 +14393,7 @@
           }
         },
         {
-          "id": "c0872321-1b32-49c8-9b3f-dee569c2718b",
+          "id": "765d4aca-51b0-4cf8-9c7f-8404a50aa920",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14448,7 +14448,7 @@
           },
           "response": [
             {
-              "id": "b889e99d-ac8d-465c-b3fa-339f41169fd0",
+              "id": "d2bca48c-f8c8-4404-b69f-9277fc1da837",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14531,7 +14531,7 @@
       "description": "",
       "item": [
         {
-          "id": "a8857fe8-7219-4d17-9ac3-5a956e4ed997",
+          "id": "592f8ec9-ecd2-41c8-a7af-0f934dda9bc2",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14572,7 +14572,7 @@
           },
           "response": [
             {
-              "id": "8971106f-0bf5-4530-9d00-2720dc689f20",
+              "id": "9d619e24-0e28-4c41-8df3-f2bd02ff6a2d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14635,7 +14635,7 @@
           }
         },
         {
-          "id": "3b1b3c90-5cf0-4ed5-b164-cc872b1ed17a",
+          "id": "ad7b6bae-7abd-4742-a78f-653bff323093",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14689,7 +14689,7 @@
           },
           "response": [
             {
-              "id": "09d5e6c7-34fe-4115-a30a-0842d8447664",
+              "id": "3a41f771-2db7-4ad3-a704-7d235be8d58f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14765,7 +14765,7 @@
           }
         },
         {
-          "id": "0a7d8135-a758-4343-b0b8-1d30626cb393",
+          "id": "3b330651-6154-49d5-a580-53960323ed8a",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14800,7 +14800,7 @@
           },
           "response": [
             {
-              "id": "3a4ceed4-f89a-4e41-b004-26f0fa29bb0a",
+              "id": "1479faca-57f0-4fea-bfe0-6540d56609fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14853,7 +14853,7 @@
           }
         },
         {
-          "id": "6927b4db-0c7e-4b9d-b46b-602543590325",
+          "id": "cb13de7d-f79c-449a-b4a7-7e3fbf7ac1f2",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14895,7 +14895,7 @@
           },
           "response": [
             {
-              "id": "899745e4-1b45-4532-b216-5b84f7dfb1a4",
+              "id": "ae56d655-aeb1-4517-9e67-e3ee7da3cd76",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14959,7 +14959,7 @@
           }
         },
         {
-          "id": "0321fb5b-56f6-44c4-9e4e-0381c907af14",
+          "id": "f56fb01c-c14f-4070-b6a6-0ff637bd6077",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15001,7 +15001,7 @@
           },
           "response": [
             {
-              "id": "5ecb16e0-cd9b-4474-8614-b1eaf5ab7e39",
+              "id": "fe861942-cddf-46b5-91ee-d18cb1b8b916",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15065,7 +15065,7 @@
           }
         },
         {
-          "id": "e9e0e4b7-77a5-49d5-a55c-bd7802319a50",
+          "id": "6ae02578-ab99-4a9b-beef-bb235e67c434",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15140,7 +15140,7 @@
           },
           "response": [
             {
-              "id": "6f7b12e5-78a6-4c92-9ec7-c98328f63728",
+              "id": "6062d856-07ab-4b6c-b271-8507e31f3631",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15237,7 +15237,7 @@
           }
         },
         {
-          "id": "eb46ad52-d59b-4cd1-87c4-01e3394c5a3f",
+          "id": "30be8da4-8334-410f-ba01-44e077f4dba7",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15279,7 +15279,7 @@
           },
           "response": [
             {
-              "id": "4ac4b17f-4b7b-4f6b-8089-6b2447428849",
+              "id": "0ba442a6-a892-43ce-b0eb-27e3c586f162",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15343,7 +15343,7 @@
           }
         },
         {
-          "id": "1267ad53-9463-41ff-bc61-41d557341d25",
+          "id": "513da259-f8cb-4e87-9033-987383c48498",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15386,7 +15386,7 @@
           },
           "response": [
             {
-              "id": "72414bd1-8180-4877-81c7-b0bb3b75440f",
+              "id": "5a11c679-4aa8-47b8-817c-a081a79992e2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15451,7 +15451,7 @@
           }
         },
         {
-          "id": "b4f79449-cb1f-4733-b6b7-864b357f5ac9",
+          "id": "c694dd01-2c00-4306-bc35-da0ff0ba951a",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15494,7 +15494,7 @@
           },
           "response": [
             {
-              "id": "3621723e-283f-4ea6-9cba-000ce43ebeac",
+              "id": "b1b1e8f0-cdce-467d-84aa-d0b9fe42b30e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15559,7 +15559,7 @@
           }
         },
         {
-          "id": "36685043-8075-4041-b869-2ad549f5cd4d",
+          "id": "43025e2e-3d59-4030-a676-138b188ac92d",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15611,7 +15611,7 @@
           },
           "response": [
             {
-              "id": "4adf6654-83e2-4bce-baae-517920f7576a",
+              "id": "fc3056be-f500-4a1a-a3ac-afbaade7f158",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15685,7 +15685,7 @@
           }
         },
         {
-          "id": "e8c5df40-2b04-42b7-931c-c29a67a0e0fd",
+          "id": "c5092c12-ad2d-48ae-ab18-a3d05c18121e",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15727,7 +15727,7 @@
           },
           "response": [
             {
-              "id": "1720fb9f-1afa-45a6-8848-6152c879fd2b",
+              "id": "f5096a15-c557-4644-bc28-f184539e0a98",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15791,7 +15791,7 @@
           }
         },
         {
-          "id": "cd29cd5b-5f40-40fa-928c-7ca9b8392939",
+          "id": "f280d080-5de3-4a5b-98bd-b51a38fd6537",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15844,7 +15844,7 @@
           },
           "response": [
             {
-              "id": "b8672dd4-d869-43b6-9c61-7e7dd039b852",
+              "id": "bd003761-f5c3-4f6b-a8c9-4bbe98a7f151",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15919,7 +15919,7 @@
           }
         },
         {
-          "id": "08d10f9d-0aa9-4c74-98f2-0f89709352ef",
+          "id": "e5135723-aaee-426c-b933-901d2ba89645",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -15972,7 +15972,7 @@
           },
           "response": [
             {
-              "id": "a1bf1a62-3604-4d9a-ad59-9d21500ae293",
+              "id": "ce3272e1-6fdb-4408-b430-4f0303759523",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16047,7 +16047,7 @@
           }
         },
         {
-          "id": "df17dce6-8053-4930-839e-cc0fc9454463",
+          "id": "bdc14eb4-9864-4d62-a362-f2c2afc37bed",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16091,7 +16091,7 @@
           },
           "response": [
             {
-              "id": "1953c80d-36fe-47fd-b0a0-400ff7fa532c",
+              "id": "af615b20-50fa-4319-b3f1-e659db6954c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16146,7 +16146,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16157,7 +16157,7 @@
           }
         },
         {
-          "id": "d4f08fa3-d6dc-4deb-8a57-69ef178f5329",
+          "id": "751cedda-9db6-41c3-b9b7-72957b53f1c8",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16201,7 +16201,7 @@
           },
           "response": [
             {
-              "id": "c1eb411e-e7b6-42fa-bf91-d58c0bddf863",
+              "id": "826d98c4-5a65-46bd-a2a0-9f1849cb92c0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16256,7 +16256,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16273,7 +16273,7 @@
       "description": "",
       "item": [
         {
-          "id": "1bb45792-6999-45e8-8cca-59117cdfbf96",
+          "id": "cd7af0a5-5e21-405c-9016-965195df2d8f",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16315,7 +16315,7 @@
           },
           "response": [
             {
-              "id": "b778d4fe-8ceb-49a5-9941-024f4ad3653a",
+              "id": "257d83d3-1447-4037-bdab-5b36301cdfdc",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16364,7 +16364,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "839fa3e4-4816-4551-8faf-a4bbba2010cf",
+              "id": "42bcc03f-adc4-4084-b719-9d0231a64c3c",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16419,7 +16419,7 @@
           }
         },
         {
-          "id": "22f064fa-ce44-4be7-bd59-9fb9584d2e8c",
+          "id": "8a4d7ec2-04ed-4f0d-b258-9b52e2c85e2d",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16465,7 +16465,7 @@
           },
           "response": [
             {
-              "id": "ef90e960-6a36-45e2-856d-cc16c8b30b89",
+              "id": "bcabe948-570f-4103-b168-f8b228e47cbb",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16524,7 +16524,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "06f9dc2d-3d44-439f-813c-74f37df769f6",
+              "id": "55e6d66f-4cad-43c8-9ed7-62b574cbbda9",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16589,7 +16589,7 @@
           }
         },
         {
-          "id": "1f4321e2-9beb-466b-8c7a-0d8b3be4afb4",
+          "id": "6d193740-08be-4e95-adda-075de499597b",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16635,7 +16635,7 @@
           },
           "response": [
             {
-              "id": "44c38af0-c4d6-4cb1-904f-81ccca6181ab",
+              "id": "bd0e86f1-dd62-4ab5-a2f3-4a0538a924e0",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16694,7 +16694,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d1fbc68a-b333-4f1c-ae91-f5f29e8d0470",
+              "id": "0decc633-0873-40aa-bf29-6518f257096f",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16753,7 +16753,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c6ed54c1-0047-4c4c-9b7b-a76142d573f3",
+              "id": "e5e2e5b2-d3ed-4a67-8a41-19b5824153f6",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16812,7 +16812,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1bded701-1ed0-4464-9910-46f1b5e37654",
+              "id": "b8ab7548-3e76-41bc-826c-06975d60729a",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16877,7 +16877,7 @@
           }
         },
         {
-          "id": "6abd3a6f-2a57-47a1-aa53-a7528aa383d1",
+          "id": "774f1ea9-99ae-489a-831f-31ce19b3de01",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -16923,7 +16923,7 @@
           },
           "response": [
             {
-              "id": "4f30b81e-face-4ed1-b557-9cbaee3a6505",
+              "id": "50951d12-b9d4-4e2b-af3e-2a3527d90ddc",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -16982,7 +16982,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1f6bbdd9-09d8-4c6d-9628-99a788d0db28",
+              "id": "9a134b2c-cf4f-40b9-a6da-d792a014b79f",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17047,7 +17047,7 @@
           }
         },
         {
-          "id": "2c5a4609-c344-4024-833a-cbc81319e852",
+          "id": "ccbc03c4-fcd3-4cf6-84da-b6f213a3a0f9",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17089,7 +17089,7 @@
           },
           "response": [
             {
-              "id": "1e58dcdb-b053-421b-aec9-44196c956cd0",
+              "id": "ee2f665b-3729-4938-a8c2-548f79ebed48",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17150,7 +17150,7 @@
       "description": "",
       "item": [
         {
-          "id": "9671ab26-7f0d-46f0-bb11-60f7b6fd4426",
+          "id": "b7504bab-13c4-410a-9764-876fd04396ef",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17199,7 +17199,7 @@
           },
           "response": [
             {
-              "id": "8aea66d3-5d4d-4c0a-a74d-da463c974d2a",
+              "id": "d3ffcfcd-3cf7-4f70-9c8f-864812c2e198",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17259,7 +17259,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
+              "body": "{\n  \"key_0\": 345\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17270,7 +17270,7 @@
           }
         },
         {
-          "id": "34498337-625a-48d9-9fe7-8d8a9dee3860",
+          "id": "3d7c696a-fdf8-4233-8855-2897522962b8",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17319,7 +17319,7 @@
           },
           "response": [
             {
-              "id": "4d1ee9ac-c5aa-4a07-9d64-92c858ef8490",
+              "id": "a65d7d53-5d3a-452b-bc01-e2fc4aae49b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17390,7 +17390,7 @@
           }
         },
         {
-          "id": "823d2a6d-44a1-4aad-9525-21de12c4b7b5",
+          "id": "9c66d002-e609-4967-ba4e-e22ccdd4ec14",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17439,7 +17439,7 @@
           },
           "response": [
             {
-              "id": "71321600-52e0-4fb1-82e5-78c463e0c25b",
+              "id": "3e308339-67bf-420e-998d-f7c5f34874a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17510,7 +17510,7 @@
           }
         },
         {
-          "id": "33e1517c-d08f-4ca7-99c5-6daad62109f1",
+          "id": "b737974a-3c7a-4975-be1f-135df98d2c79",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17559,7 +17559,7 @@
           },
           "response": [
             {
-              "id": "6734c05f-8995-4b7b-a29b-f891abad8b75",
+              "id": "3c9091aa-0d63-47c4-90ab-b4213b0d776f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17636,7 +17636,7 @@
       "description": "",
       "item": [
         {
-          "id": "af9162b4-6233-4061-bd1e-a906379bf1c6",
+          "id": "f4e13dfa-d196-4bd7-9c15-388e00a4ae3d",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17676,7 +17676,7 @@
           },
           "response": [
             {
-              "id": "3ca74aa8-36e9-4054-927b-693d96b86239",
+              "id": "297140f7-9b4a-4d66-b5a4-6751db102e14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17738,7 +17738,7 @@
           }
         },
         {
-          "id": "60285325-6ebf-40cd-a970-8f15d3d84e57",
+          "id": "056c3cd4-cb04-4f46-8ce3-221da04900c5",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17768,7 +17768,7 @@
           },
           "response": [
             {
-              "id": "4499836b-d076-41da-9db2-b582177190a2",
+              "id": "3d2df2ec-ab25-4e03-ae54-0a7b68d17159",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17809,7 +17809,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
+              "body": "{\n  \"key_0\": 345\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17820,7 +17820,7 @@
           }
         },
         {
-          "id": "e2daa9af-227e-4358-9ceb-efbacde543a2",
+          "id": "586484ca-708c-40ad-bd1b-21c9df9ba698",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17872,7 +17872,7 @@
           },
           "response": [
             {
-              "id": "3143bfa2-6c4b-4187-b130-763f45bf5f29",
+              "id": "974ac0a4-c199-4cc3-829e-926f0b031d6d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17952,7 +17952,7 @@
       "description": "",
       "item": [
         {
-          "id": "a306dd4e-1142-441e-b2ac-875da8a9676a",
+          "id": "987ff062-3d88-465c-b107-a045090058cb",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -17981,7 +17981,7 @@
           },
           "response": [
             {
-              "id": "f0816bea-d0bf-4491-b500-b23611111d38",
+              "id": "0b857b78-fcee-425d-a378-1eee37136691",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18032,7 +18032,7 @@
           }
         },
         {
-          "id": "822ad633-5d16-4876-9d28-4ba01326ee21",
+          "id": "f19e0bb2-efff-4b39-a238-466bf44797fb",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18073,7 +18073,7 @@
           },
           "response": [
             {
-              "id": "60024d13-381c-4ff2-a25d-a694d9be74a2",
+              "id": "ab1b10e6-7d89-4f35-8f37-a23fc514795d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18142,7 +18142,7 @@
       "description": "",
       "item": [
         {
-          "id": "228d28a5-fb06-42e7-a24f-2c8a09e03ef5",
+          "id": "6307417d-6e11-4385-9ceb-ff3ba2fa96cf",
           "name": "health",
           "request": {
             "name": "health",
@@ -18171,7 +18171,7 @@
           },
           "response": [
             {
-              "id": "8023cb5b-006b-4c1a-ba99-710881357b41",
+              "id": "42436193-e74e-4551-b9e4-9d073a157649",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18211,7 +18211,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
+              "body": "{\n  \"key_0\": 345\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18228,7 +18228,7 @@
       "description": "",
       "item": [
         {
-          "id": "647c2ed2-af72-43b8-a1b2-4bcfd5cc862f",
+          "id": "9d03b640-9f98-43b6-8575-0e13250df6e4",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18280,7 +18280,7 @@
           },
           "response": [
             {
-              "id": "e184ecf3-8f1d-4709-96f5-f505d2f44f91",
+              "id": "3b9bf754-f3a9-4abe-82dd-f8fb757826c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18354,7 +18354,7 @@
           }
         },
         {
-          "id": "7a982fbc-e7aa-40e3-9d43-90010d517783",
+          "id": "ff174fab-0383-42a9-a7bc-0cd1f16a9571",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18395,7 +18395,7 @@
           },
           "response": [
             {
-              "id": "4f9ac7ab-6adf-4f8d-ae63-a264240be328",
+              "id": "940ca54f-a495-4bc1-85e9-5f11c8c5edcc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18447,7 +18447,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_2\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18458,7 +18458,7 @@
           }
         },
         {
-          "id": "2a9879e6-032e-43df-bb4d-b91c424d8bb3",
+          "id": "b11b5eb8-f17b-454d-aaa6-27f67a9557d4",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18488,7 +18488,7 @@
           },
           "response": [
             {
-              "id": "465b3a86-3044-4a62-a762-19436f2e9afc",
+              "id": "70c2a77c-60af-43d0-8a3e-513464bb8f68",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18529,7 +18529,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18560,9 +18560,9 @@
     }
   ],
   "info": {
-    "_postman_id": "20cadb99-f141-48b5-8545-7eeae2167189",
+    "_postman_id": "11d71fe0-5267-4023-9522-68024c0a0de5",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 03:23 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 03:46 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "efc8c352-89d9-436b-ad57-831bd9406966",
+          "id": "b94e879c-2710-4323-a263-15aa4002567b",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "99a4f0cb-6073-44e3-aef9-b5da6dc2f860",
+              "id": "cea7eb63-f971-49fb-8e12-ae6d3c427224",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "5904a089-2da9-4f29-bf24-4f00ab58dba0",
+          "id": "a23bf7a2-9077-4c8d-95ea-d48fa336cdad",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "2f0341c3-b410-48af-8d56-a15e24c548fb",
+              "id": "ccb621e0-d65e-4864-9827-34e3d50972ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "8bbd6c8b-7de3-41c7-89d9-8bb6eb1caad2",
+          "id": "1d5f7ffa-3ee5-47dd-a430-344690bc34a8",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "3fe753ee-55d7-442b-b877-ceb3a06fccf5",
+              "id": "77c61e2f-f788-4f52-8631-4e3233aeb250",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "880621c7-73e5-40d3-bc99-e4e9d4c6b347",
+          "id": "8b1778cf-0aef-4ac2-b6a6-5a91bff171ca",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "5a97cb42-dc1d-4b03-8e3d-c3d1c2a6702f",
+              "id": "96958906-80c6-4539-97b8-e7566d142883",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "1ea9d9c7-d77f-4127-896c-2d84360031b6",
+          "id": "07c2dad2-e4e8-425b-b224-e1612905c6c9",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "c8b6ea23-e366-49fa-b233-6aef3db09b6c",
+              "id": "1110d5b7-e313-442d-b09d-5d1c3edcce84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "0c698367-f01a-4248-976b-c9936e6d8220",
+          "id": "d261acd4-9825-410c-a49e-14b7be4fbd46",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "ac7a6a87-1fc0-4862-b6c1-64b77989c389",
+              "id": "d204fb45-9a89-494f-b4bd-534fd5487bed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "d97a4a64-6f00-4aea-b67b-6e847f4ae090",
+          "id": "12ed4cc7-1c08-49d6-87ec-91098218949a",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "aabcc333-4edd-4b4a-87fa-5baa480f892e",
+              "id": "9de1d190-0a48-4a73-8acb-9428134e6447",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "a06eb76c-391f-4b21-9407-e1a2f8b31838",
+          "id": "3e175c2f-4b28-4aac-a1d6-f6df3b1177c2",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "1c1e1056-0cbb-483c-8b0b-c8345874aafe",
+              "id": "82a17681-702b-4ae7-ab94-933b69e1563e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "6424662f-fcf2-4876-a971-52a9974b96d6",
+          "id": "3c0f6b78-22e6-4b96-8b3a-1f7c06b557b9",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "8e31a1e9-11ba-46ae-b3ee-23221f1f259d",
+              "id": "60c90001-962e-4665-83ca-ea4614d8af36",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "8fe35d6a-9583-4899-bc25-06e9d7d8b28c",
+          "id": "ad337143-6f2f-4d7c-bc55-ad9f11ce98b5",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "8c75cdd0-9e76-474b-a702-addf982b73d3",
+              "id": "1d44621f-d127-492a-a76e-6f59c1ca7c5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "6e491c15-17ec-4a54-9849-11ae9042d48d",
+          "id": "9abd7ad8-01a3-4fc5-965c-2db4d59bc8bf",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "82d6621e-f589-43fa-9daa-8cc95a16f842",
+              "id": "9e32c552-2d5f-4b44-942b-ecf5d6a8ebec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "eea66eef-620c-4f16-b06c-af0ebd9621b0",
+          "id": "ce59ced8-ad83-436b-80bf-d341501c5d89",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "d7b16876-88e2-4ff6-bf13-0919119b884e",
+              "id": "bfdaefb0-fa05-4afa-ac86-53dc3ba1274f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "fbdb02f8-e0a6-4529-bba5-cea1f1d43163",
+          "id": "e6e4a776-6f30-43f9-9897-c3469138d139",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "fbfc3cd4-1f01-4a65-a968-53968d3c118f",
+              "id": "d17933a4-f5f4-45f2-ae94-9a6a391b39f5",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "1128156f-5932-4ab0-a02e-be0b41fc022d",
+          "id": "bd50a52b-fe8d-44d5-b4e4-e1783435e3db",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "36793486-614c-4985-9d1c-6af35ade0594",
+              "id": "bb111407-1119-4287-a49f-30fb7a71c258",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\",\n  \"key_4\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "79d73b5e-654b-4a62-97ff-0f469743d7a3",
+          "id": "9770ba7c-5f67-4c8d-8d58-eddb3531ccea",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "53aaaa2c-f646-4aac-9ee8-6be2f32d1394",
+              "id": "a9962599-090d-4ca5-9862-5c1424610caf",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "250a6029-bac5-45cf-9936-7024b2093a2d",
+          "id": "81c37d86-e61b-488e-a771-4451b840a4e4",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "6de313fd-ae01-4d18-9cdf-b77433ffacbf",
+              "id": "fddff659-c8b4-4740-95ec-3ee911f21a6b",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "c76d883c-6a7a-40ca-a1ec-45e242713f41",
+          "id": "335390ac-78cc-469c-9dc8-61b9b2c36449",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "3ae438a1-c212-4159-9d6d-8af88a8b6c10",
+              "id": "b8d69fca-3868-4895-ad8a-bb798e5d8558",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "21d8c13c-688e-4ec4-8111-9f06321b8de1",
+          "id": "9f85ff3e-1c65-4b74-81fe-78f5d104bdc6",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "d1f3241d-5184-4504-977d-60d8f2044dae",
+              "id": "9bdd29f2-e796-41f7-af31-3ac3ee6e7f3f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "677a2a7f-e627-4bb4-922b-7143358b8d34",
+          "id": "0672b660-202f-43d3-be54-34a2860344f4",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "dd79f4f8-3706-49a2-96f3-6a49cb3668e8",
+              "id": "fb141cf8-309a-4659-bd82-601c4dd1127f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "758caa0b-d773-4445-824a-64c78e933014",
+          "id": "e02c88ca-7138-457a-a783-727cdcd9459f",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "efdebcf7-c948-438b-98d5-f745fdc33da0",
+              "id": "ff5d0d70-6869-4769-9452-e065ea2c958c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "3ff69f65-2934-4a00-8751-54b4e489e038",
+          "id": "c6b69d52-eac2-4998-ad95-aaa47a283eab",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "7479ba6d-0f65-4697-b3cd-81cf53243882",
+              "id": "a57632e7-f5ad-47f9-9697-08df683f5621",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "442b5935-73ee-40c2-8152-503fc882f00f",
+          "id": "228daeb0-f7a5-43e3-8179-981c1b7c0800",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "4fa3d076-8802-4a9c-bc38-d3ea4a73d6fd",
+              "id": "2525e431-a267-445d-9d30-c1fc1b40b242",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "e39215c1-bf14-4af2-b6f8-e7d0a674ffbd",
+          "id": "e2f66926-d9ef-42c8-96ff-b8a487869154",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "dbfd557e-edf6-4df9-92db-f01e7753d6b6",
+              "id": "a5130316-4724-4289-842c-9b97808a02b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "d18b17d7-b97a-4410-b462-790eb2c75d88",
+          "id": "9df171bb-cc53-4962-9891-27f4c2fa6105",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "842fc83b-8590-4970-8e78-3f57e486854d",
+              "id": "a6e85a81-a749-4965-bd02-737dca2ca4bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "78620fa0-1e2a-406b-ae4e-ee1a9ee62b71",
+          "id": "20595b05-61b2-4bfc-98db-9b1571bc071f",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "fa9a03eb-54a7-4f3c-b34f-8b8a1f4b1814",
+              "id": "52092609-1305-4e66-8f5f-67cadd5da2bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "2b2ff761-a3fa-48aa-bd09-825cfdbf604b",
+          "id": "e77b7206-8e0a-4444-b002-f01568b9f397",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "aaab3362-c3a4-4f3b-ad1f-8497d09d582e",
+              "id": "34601c89-1235-4f23-a3c3-ef213f1e2e86",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "487d2fb4-9fb9-48c5-b22d-7511ce2a49fa",
+          "id": "703781e2-6551-42f3-9ddf-7b498f6f418b",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "82d2fa60-0a86-4fe9-a499-f414c5cbb34d",
+              "id": "472defbf-0bef-4572-bfd8-1d200ac74a5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "ad963bbb-ea00-4733-b720-83d9d39f9725",
+          "id": "efbc0fb1-ca79-4381-98c7-82f5895c00fa",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "2c9b8e2a-0a2f-45b0-8d59-e5ef317147a8",
+              "id": "8d79388e-d9be-434a-a56a-e55dad9b526a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "84dedd67-1b17-438d-8683-812251cfcc5b",
+          "id": "7bb547ca-1979-409b-b5b4-07136c5df1b1",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "5efac089-8e7b-4520-b0eb-d88a5a33c4e6",
+              "id": "46b589d6-a39a-4c71-9b2f-8d25eafea5e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 3169.7144878187955,\n        \"key_1\": false\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 8062.768016473827,\n        \"key_1\": \"string\",\n        \"key_2\": 2160\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 3898,\n        \"key_1\": 5600\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "e36981cb-4908-4054-8b52-da66bdb68606",
+          "id": "6cc20f20-efd6-48c8-b268-cdee99f7d892",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "e6873271-d38f-4df8-a55c-d8f1f7f7f123",
+              "id": "9426049c-870f-4b68-8914-f2e38fc5b4a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "dbfa7bc8-9342-4536-8594-fcdceb409645",
+          "id": "a60046f2-58db-4707-a617-2ef106a29c06",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4e78C3\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#eAB23A\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "50b6fc7f-0af5-40cb-b929-7996f83f60e2",
+              "id": "432cb377-3cc1-4b61-9ba2-84534c020b99",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4e78C3\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#eAB23A\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "695c005e-f633-4081-a399-1fda5c5f6e98",
+          "id": "2e3f2f87-17ef-4653-a0de-a03562e1764c",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "feb08ec0-996f-4865-9e09-8b4386f09f98",
+              "id": "e8146134-defd-4f6c-8d22-0f2a84c7ffbb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "6dba2eaf-f630-48f1-b6a1-d8c83ca9856e",
+          "id": "5c1a3599-ebab-42b4-9052-20e64460a37b",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "8781d659-4a42-4c24-ab84-3d2e64a16fc7",
+              "id": "9075930d-6586-4cd4-b1c9-6aca44453d60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "87b650a5-e30f-4761-b6fd-0cd2d2655fa2",
+          "id": "e92ff881-e54b-4ef4-827b-aed3b6a9c513",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F2f9Cc\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#037688\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "a9079a5b-5ac9-449c-93de-64bc15af5097",
+              "id": "69929502-372f-44a4-ae1d-615e53fe823d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F2f9Cc\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#037688\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "451d0f5c-f2bf-4702-9cf3-98f01b629ef3",
+          "id": "88d3edd3-3ece-4351-86ba-8b4550dd0e89",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "d6d0170b-6e68-460b-a130-af65cbfea51d",
+              "id": "ebdea98a-7855-48d8-8a7b-12e4ce61e28d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "b57b64a7-2bf9-4bd8-86af-78d893f29919",
+          "id": "cbdcf503-3a75-495a-935f-0fd0f09b3efc",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "06cefe63-b00f-4a23-bde2-da1973c0c3bc",
+              "id": "aafcf236-fc65-46a9-9da5-383b2f312964",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "e995e8e4-6123-49d4-a3c8-a2c85aa0aa20",
+          "id": "e54dbc24-5a16-4e6e-b063-8e732e1c6efa",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "4e9e39ff-a6a6-44ec-b9d4-5c4fe80a3a2a",
+              "id": "7b00d409-625c-4b66-94c1-11871084c717",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "9b3fc7f7-b2a5-4f7f-bd41-73179a21ff12",
+          "id": "d97fddc1-9218-4696-950d-d571c3eb674b",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "7f84f3fa-8221-4a61-92d1-27e22fe1665b",
+              "id": "d6dfc70c-7eb9-407d-99e8-1f04733e5a09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "fa8ab1a6-2af5-48c7-87f7-e1d25c11b1cc",
+          "id": "1eb476d1-c832-4670-b9f3-c68fbdd66100",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "8f795cea-d5e8-4ef9-8f5d-284b4ace3a60",
+              "id": "cef8f952-d6eb-4505-a57f-df92a6bd7364",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "7fc17e45-8122-47e9-b144-4423e8608905",
+          "id": "af4b5d01-2e3a-476e-85ac-e6f18676d11f",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "ca61ceac-2a45-4138-9595-6dc22a74832e",
+              "id": "f77e1a4f-f01e-42b0-8e5d-90ceb1bc32fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "824b8cd4-bc7b-4017-825b-5bc7d85deff6",
+          "id": "b59d47ee-43d2-463c-96f5-f233ac129c66",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "4333785f-bb1d-4d2d-b2c9-38480207561e",
+              "id": "cb6fdbc2-47bd-4cb9-9299-02dad6fff390",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 8546.008607788148\n}",
+              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "6e143274-9907-40ac-9763-426c7aec021b",
+          "id": "db522ed3-0943-4072-ac62-b88b82fd694b",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "3fad5279-0a92-44ea-b3fb-d8e17b835034",
+              "id": "9d7ec5ac-d0bc-4e53-94e6-509e80bd1df9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "64ec2e9a-f558-45af-bad0-10c7a6f90fb4",
+          "id": "a6972910-41e0-48a0-92c8-5ff839fb087e",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "055fa0e2-d171-413f-8be8-313cbcb2676a",
+              "id": "4eef50c2-e84d-42a1-9a0b-a32d57230682",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "5afd4397-8e62-4cab-9aed-f27972ff0726",
+          "id": "921f27fb-ba4d-4f7d-9629-59cd629626ec",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "9e3e7082-a74e-471a-af03-5604a43dc554",
+              "id": "ba5253e1-3947-4506-a9ee-ce9c25ff131d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "1454457b-bf87-49f1-93f6-1116b303a938",
+          "id": "639d835a-9cdd-433c-adba-d2410e43ae52",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "54fe61c3-05a9-42d5-bd6f-b5e50012c933",
+              "id": "7d9b5045-f0ec-4dc3-8bfd-1753615bd029",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "6490e2cb-74e3-4d0f-a87b-6781ad66e2f3",
+          "id": "5741f968-3a77-448c-96f1-9ab500e6db99",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "79d4d3a1-0c05-42bc-994a-6608dfa3f13f",
+              "id": "3bd3864b-22c0-4cc1-86ae-2995f61a5e77",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "638d2eb3-34a5-47fe-a568-eb60c5f5978f",
+          "id": "e5b8705b-c5a0-469b-9980-29349ead445a",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "6479b119-7a50-4942-a823-dfa4c4905d32",
+              "id": "74578517-296c-4668-88c8-c318b3cd98e0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "d4c2c3b7-d7fb-4b14-80db-77b985b8f58d",
+          "id": "db4d9b97-10cc-4cbf-ba69-6b4f72791a77",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "e42ea0de-9ef0-496e-be3a-cd10d1f55f0a",
+              "id": "84b88b61-6d66-4eb0-983a-a7110c189c40",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "e9ce5537-02bb-483f-930d-86e59e864e13",
+          "id": "547b4c13-ea0d-4c89-893e-6f9d878e2dc9",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "e5c86328-9f44-4ce5-8244-66ad7fcbcdb1",
+              "id": "32bc3a49-7ccd-4e27-aac4-23a9e4198fd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "f0ff2411-e716-451e-91cb-d4efef41667a",
+          "id": "d12b9758-64cb-4204-8738-b9992a4511e2",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "a213a373-fff7-4c3a-8ca5-1de890d51d2a",
+              "id": "5b74ddbf-75d7-4fab-b5a9-132546643914",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "4e1695a5-4ee2-4ea3-853f-5417f5011cb7",
+          "id": "a591fe9a-2f63-4a9b-acaa-02eb6c0865b0",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "f96337b9-8a68-47b3-bbad-1361fb9607d7",
+              "id": "b1ddeb6f-694d-43ac-8df8-e94097b73ccb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "157dce2c-9519-48a7-9e6e-f1fb4b7a47ad",
+          "id": "f247bb01-1514-4225-953b-04069de2c6a2",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "350aaeb5-a32b-40b4-a361-04dba59fd4dd",
+              "id": "9cd124a4-faec-4905-8db2-fc3a2a253595",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "26452405-ad65-47b6-88cc-5e5946ceae27",
+          "id": "b8243ef2-dcd5-4d8f-94cf-410654404d81",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "76237446-6437-451a-9257-e288e98a699b",
+              "id": "a55209ba-28c0-4d8e-9114-2dd02911a856",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "2c9a008f-08da-4c6b-ba7a-28b084a4d236",
+          "id": "6308ca5a-e57e-462d-b6af-42c9b1dc160a",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "4c33e95c-3fe8-4283-8f73-b9779dfbea5b",
+              "id": "87ce905a-fb02-41bb-a231-a52164bd64b9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "bf79e152-f876-4dc9-85c7-5116a3f75228",
+          "id": "788b86c2-393e-42d2-8545-8323ffa42a5e",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "b6db7e63-c034-42be-a0ea-283fea34d286",
+              "id": "35ecb41b-244d-4624-95eb-45f34f5d75f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "789eecf8-2e40-4f31-bd20-2ee146f4cb4e",
+          "id": "908d227d-e6e1-40e1-bb3d-9deffb7230e6",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "356f31ad-24e9-4f66-80c2-eaf8bfc81845",
+              "id": "9da5aaa4-3f98-4974-ba8d-b5c0f88b0f1d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "f1d6dc17-3ac6-4569-8609-2f67569f8943",
+          "id": "70965edc-df29-4391-a757-d62edb9337a5",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "e05e1355-cceb-4a3e-8209-7fb7045d3f00",
+              "id": "17739e84-91a2-4bf8-9077-36eba0d7298b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "a733606d-f5ae-48d4-a33b-a163a978e6b9",
+          "id": "4ad6babb-4fea-4178-b25d-8ab7a24a0961",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "4fbf33d8-0c77-4b86-9161-1f07b12fec96",
+              "id": "2bf89b12-6892-497c-b113-533f24674d02",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "835f764d-2896-4903-b739-734e214df965",
+          "id": "c56141d8-dc11-4771-ace2-afe595a66a80",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "6ea9b151-4842-4b01-9fa3-f05fd0b67d22",
+              "id": "56369df6-96b5-4956-a1db-6eb0d325ee46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "d7109aa8-370e-4477-ae4c-d531660539fb",
+          "id": "722bda41-b2e0-430e-b0a2-13a996e28143",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "407c1eb4-3d77-46cc-a816-146850923e76",
+              "id": "d189cbfc-4304-4bfc-995e-267b954ea393",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "a619ea8b-c7ca-4ea0-95b4-c56dbdb6f535",
+          "id": "3dbec969-3c73-4aa1-8ddf-e76f20682dcb",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "72a979ed-771e-43c3-b1df-70e4008774c4",
+              "id": "f7a60645-90dc-4c1f-9f30-459facc04975",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "182253c0-1453-4c4e-9859-cc8738af3925",
+          "id": "b9993bee-670f-4358-8bd4-5960a02082de",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "fdf84e84-61c9-492f-8222-be1706af5a9e",
+              "id": "2aee0d61-27f5-43ba-b0f9-147bbb7dc74b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "40349b98-f8e2-4ad7-ba80-997b4e1b2c13",
+          "id": "70cae55b-9715-4f4f-8851-467da79bb00a",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7543,30 +7543,17 @@
             },
             "header": [
               {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
                 "key": "Accept",
                 "value": "*/*"
               }
             ],
             "method": "POST",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"resolvedByUserId\": \"<long>\"\n}",
-              "options": {
-                "raw": {
-                  "headerFamily": "json",
-                  "language": "json"
-                }
-              }
-            },
+            "body": {},
             "auth": null
           },
           "response": [
             {
-              "id": "bd241b77-2db4-413e-aa76-d414934f32ff",
+              "id": "4298175d-01a1-4598-96dd-ae2a40fb00bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7608,10 +7595,6 @@
                 },
                 "header": [
                   {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
                     "key": "Accept",
                     "value": "*/*"
                   },
@@ -7625,16 +7608,7 @@
                   }
                 ],
                 "method": "POST",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"resolvedByUserId\": \"<long>\"\n}",
-                  "options": {
-                    "raw": {
-                      "headerFamily": "json",
-                      "language": "json"
-                    }
-                  }
-                }
+                "body": {}
               },
               "status": "OK",
               "code": 200,
@@ -7655,7 +7629,7 @@
           }
         },
         {
-          "id": "c452efe3-f48c-4860-97f8-ac775096ccae",
+          "id": "83499d60-ce53-451c-bd4f-7a7e308b9320",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7699,30 +7673,17 @@
             },
             "header": [
               {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
                 "key": "Accept",
                 "value": "*/*"
               }
             ],
             "method": "POST",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"actorUserId\": \"<long>\"\n}",
-              "options": {
-                "raw": {
-                  "headerFamily": "json",
-                  "language": "json"
-                }
-              }
-            },
+            "body": {},
             "auth": null
           },
           "response": [
             {
-              "id": "8f6f003d-2a67-4fc4-b149-839a788575b4",
+              "id": "044a26c2-927e-4a4b-b0e3-eadd051a216b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7764,10 +7725,6 @@
                 },
                 "header": [
                   {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
                     "key": "Accept",
                     "value": "*/*"
                   },
@@ -7781,16 +7738,7 @@
                   }
                 ],
                 "method": "POST",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"actorUserId\": \"<long>\"\n}",
-                  "options": {
-                    "raw": {
-                      "headerFamily": "json",
-                      "language": "json"
-                    }
-                  }
-                }
+                "body": {}
               },
               "status": "OK",
               "code": 200,
@@ -7817,7 +7765,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "d18a753d-c441-4ed8-b170-43eaa5775c05",
+          "id": "64954996-e86a-467b-a762-dba6c0a360ad",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7870,7 +7818,7 @@
           },
           "response": [
             {
-              "id": "2580dbcf-fd73-4b30-b852-a3966031add7",
+              "id": "35a4dabe-af07-40c4-ac8f-4c858116da2e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7945,7 +7893,7 @@
           }
         },
         {
-          "id": "130873bc-d7dd-4035-b4ac-58c44dad6b60",
+          "id": "466d05a2-c773-46bd-a887-cccd132c2252",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -8011,7 +7959,7 @@
           },
           "response": [
             {
-              "id": "e2626adb-447b-49a4-9a34-f645cae9d956",
+              "id": "cfd40629-df6c-4f82-99c7-e321cae25dce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8099,7 +8047,7 @@
           }
         },
         {
-          "id": "78d3a755-b9d4-44bc-b46f-89039da7db52",
+          "id": "8c7c328c-2db5-45f7-b6cf-0ccf992004a0",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8146,7 +8094,7 @@
           },
           "response": [
             {
-              "id": "c6ecad9b-ce3e-4fc6-837d-b5160459c7fe",
+              "id": "6c1f6f31-0d54-4e98-b540-3e99cdc2794b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8211,7 +8159,7 @@
           }
         },
         {
-          "id": "08a8c555-87f8-4c87-98c5-e3c7e5122044",
+          "id": "cf344c43-10a6-47cb-8ce4-1c3932a055e4",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8253,7 +8201,7 @@
           },
           "response": [
             {
-              "id": "76a0c225-b319-4d16-b715-1b57b35203f0",
+              "id": "3fdd3fac-5c19-4fab-8572-0a1f0471e16e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8317,7 +8265,7 @@
           }
         },
         {
-          "id": "d562ee7a-8bda-47f4-92e1-268a36091072",
+          "id": "b5841cc0-7f52-4c96-95f9-16fc3572b085",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8372,7 +8320,7 @@
           },
           "response": [
             {
-              "id": "bb371c9c-0c31-4e2b-b8b4-08ea6c56dcef",
+              "id": "8122ef3e-d250-41fd-8165-a024eb5ecc55",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8455,7 +8403,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "bdd30d87-ec43-4d32-976a-a7eac970cc64",
+          "id": "791b9727-526c-409d-8448-37905eee8ed1",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8496,7 +8444,7 @@
           },
           "response": [
             {
-              "id": "ad789e5e-b666-4e4b-9ed3-29e3375ab816",
+              "id": "8c092348-7f25-4546-9069-295a2e4ebc3c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8559,7 +8507,7 @@
           }
         },
         {
-          "id": "86069ff1-f2af-44f1-817d-726c3529d7d5",
+          "id": "d1049024-72e2-42ca-860c-3bdea3e32e36",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8613,7 +8561,7 @@
           },
           "response": [
             {
-              "id": "ca75753d-362c-4b22-8cc9-b73467e1c60d",
+              "id": "0fdcd737-0a7b-4e93-8d32-d4751e1de0b5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8689,7 +8637,7 @@
           }
         },
         {
-          "id": "e7a63bd7-4a7e-4612-839a-2d4423be437b",
+          "id": "2d7ff989-f2af-4fc9-8947-c4053bf0e674",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8724,7 +8672,7 @@
           },
           "response": [
             {
-              "id": "e451f6a4-de35-4455-b1c5-3a4357e73d25",
+              "id": "759a36e3-0a96-44d7-b6e5-1b50218499c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8777,7 +8725,7 @@
           }
         },
         {
-          "id": "f0ae9d50-b3e8-4a1d-81cb-29d4116e8528",
+          "id": "86967a62-793a-415e-b58b-69ca3db30a83",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8834,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "00084baf-27d9-46eb-90bc-fa5a78cf3c9e",
+              "id": "b236889d-75f9-4c9d-aa43-130475b3f203",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8913,7 +8861,7 @@
           }
         },
         {
-          "id": "64a1cac5-cb12-40ed-b5e7-109f85cdf055",
+          "id": "7834e82e-0469-46d7-924d-a2d4ae19bede",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8955,7 +8903,7 @@
           },
           "response": [
             {
-              "id": "348d5593-90d2-4486-824e-2fc1ec4eeae0",
+              "id": "d8dd23ef-e4e6-46f1-ab78-be8690d64d3d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9025,7 +8973,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "1de66ad9-3767-4f49-815c-6056ee6685d7",
+          "id": "d7c3feb1-90a3-4eb2-83ca-8623d377d3fe",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9078,7 +9026,7 @@
           },
           "response": [
             {
-              "id": "279ff4ac-dcd0-410b-9b33-4cbe84546260",
+              "id": "ae70ecb1-2891-4b91-b014-d0988e9903d7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9153,7 +9101,7 @@
           }
         },
         {
-          "id": "a6ec08f9-6c7a-4f85-9b48-fe296673fb18",
+          "id": "7415bfa2-cef4-4d22-9054-e93ddda9dca5",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9219,7 +9167,7 @@
           },
           "response": [
             {
-              "id": "a1ca2957-6358-4373-89a8-0b626a0e87b2",
+              "id": "f12c4444-fdeb-492b-8a1f-6a7293412473",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9307,7 +9255,7 @@
           }
         },
         {
-          "id": "04a40929-1735-4cf7-9fd3-b89f9d4f3f53",
+          "id": "9a407dbf-3129-4bb0-bc7b-2d557f7fe1f7",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9354,7 +9302,7 @@
           },
           "response": [
             {
-              "id": "468019d8-8fb8-4a0f-940e-2be37756d56f",
+              "id": "78e54f45-5652-4db5-8fdf-3e3335df45a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9419,7 +9367,7 @@
           }
         },
         {
-          "id": "4ff0bc4c-29d2-46a9-8fb8-6efadac47198",
+          "id": "8f0b727e-29b3-434d-bd79-25665443d75a",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9461,7 +9409,7 @@
           },
           "response": [
             {
-              "id": "4518146b-48d9-492d-8c2e-702e7362eb4d",
+              "id": "65289e72-895b-443d-a721-600dac1c84ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9525,7 +9473,7 @@
           }
         },
         {
-          "id": "84764d3a-f614-4dd1-bf68-cdc3c732f9dc",
+          "id": "cf53c5aa-63ee-495f-8b60-216a12bad9ba",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9580,7 +9528,7 @@
           },
           "response": [
             {
-              "id": "707ba13a-770b-43cc-a11d-947e4c1c7090",
+              "id": "f718d4fc-fa57-479a-a797-2d2a6a73f636",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9663,7 +9611,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "b49456e3-65af-49e3-9f3e-a1cdfdb6420b",
+          "id": "5adf35ed-615d-422a-84c4-7096b0a2fbd4",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9705,7 +9653,7 @@
           },
           "response": [
             {
-              "id": "6dbb23eb-1d69-4858-9ce3-f9be261ae6b4",
+              "id": "f387f5e6-d43f-4a2b-9e49-ac1625420ebd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9769,7 +9717,7 @@
           }
         },
         {
-          "id": "899fde18-161e-4677-9b28-6d6ad105c2ec",
+          "id": "95ed165e-8a2f-4fc5-a546-71a6b91f308a",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9824,7 +9772,7 @@
           },
           "response": [
             {
-              "id": "64d11de9-f069-43ac-966b-47d9cdffbb63",
+              "id": "547d8f0f-9a32-49f8-8578-b75ef844ee01",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9901,7 +9849,7 @@
           }
         },
         {
-          "id": "28c1311e-ccf1-441a-9100-a8add386470b",
+          "id": "868b24be-df5c-4efb-8690-514b0c79486d",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9937,7 +9885,7 @@
           },
           "response": [
             {
-              "id": "a2321690-ddf4-4a19-a964-3c8e7b1df2a3",
+              "id": "ede38f37-e988-4de6-a12e-8b02951f366e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9991,7 +9939,7 @@
           }
         },
         {
-          "id": "436f09e3-6314-485a-858b-4002aca10bf0",
+          "id": "60a11e09-995f-4ea7-85f9-dcaa874832b2",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -10021,7 +9969,7 @@
           },
           "response": [
             {
-              "id": "b7612e3a-fb1d-4ed9-b474-590adb66aa51",
+              "id": "e96c1101-0458-4b8e-9e8e-2c6f837ead7f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10073,7 +10021,7 @@
           }
         },
         {
-          "id": "1778ca2a-2ba8-48c3-9917-3dd960bcd9c6",
+          "id": "f6fe12a9-ea59-4abb-888a-36db3fcd51c1",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10116,7 +10064,7 @@
           },
           "response": [
             {
-              "id": "7c829780-dc2a-4cd7-860d-bb5a6e144e89",
+              "id": "ded91302-399a-4f63-a95b-697906a06320",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10187,7 +10135,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "eccd15e8-5420-49d4-8ec6-dfbe597b72fb",
+          "id": "3e3f31d8-4a2e-4c89-81b9-6a3e251ab0a5",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10229,7 +10177,7 @@
           },
           "response": [
             {
-              "id": "9cc81f78-0417-4403-8093-a6a93d2895e0",
+              "id": "06d51b90-277a-4d40-84c2-a37f4e3b148d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10287,7 +10235,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f32e6fbb-4e6c-45c8-a3d9-2e506b4e0e38",
+              "id": "15e57e73-9712-4741-a20f-58448537f3b6",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10351,7 +10299,7 @@
           }
         },
         {
-          "id": "cfcc9275-86ae-4688-832f-c47eaabb12d1",
+          "id": "fc7a7858-92f0-41aa-ba79-9123df8af0c3",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10406,7 +10354,7 @@
           },
           "response": [
             {
-              "id": "01174257-683f-4c54-bad9-1bc2ada03cb3",
+              "id": "7c9b34f9-395f-4f71-9814-da893e16e8a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10477,7 +10425,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "73059393-a7a0-4fd0-b55e-744ba8318a9f",
+              "id": "77953318-dc41-4f76-b4f0-38654b7114cc",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10548,7 +10496,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e34a85f0-b29c-4d5a-bbd4-b87142c223eb",
+              "id": "9fac4618-4844-456f-8324-0f6ce51c55c0",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10625,7 +10573,7 @@
           }
         },
         {
-          "id": "858d2d2d-faad-4a1a-a086-cb5ec718c111",
+          "id": "533f45d8-195e-4dcf-a27c-a60ded4676a1",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10661,7 +10609,7 @@
           },
           "response": [
             {
-              "id": "57ec0a44-1566-4de0-84ce-ae2ed7845856",
+              "id": "5bd64020-37e0-4977-8daf-0c95a31bf19e",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10709,7 +10657,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "6d0e1886-4616-43af-9f92-0c6b8c6c10d1",
+              "id": "3aa02f9d-3fcc-438f-b366-bd8ca1e5fd78",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10757,7 +10705,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "80f4da4b-ca46-483e-a4fb-09185737cd34",
+              "id": "081ce0b4-11ce-42b1-ab79-05e4594a224a",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10811,7 +10759,7 @@
           }
         },
         {
-          "id": "10fd5d5e-3346-4d1d-b540-0c441cf2a4a4",
+          "id": "d8e4520b-e3d0-43b6-9a4e-bfc404f97e45",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10841,7 +10789,7 @@
           },
           "response": [
             {
-              "id": "dbdab05d-969f-474c-ad36-dcb6ef0d7d4d",
+              "id": "9055affb-530c-493a-ba10-521c4d5f218e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10893,7 +10841,7 @@
           }
         },
         {
-          "id": "a49005fe-cb8e-42fe-860c-b3d09f057d03",
+          "id": "eea06d5b-9b9a-49ec-b0d1-0262030b2ec0",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10936,7 +10884,7 @@
           },
           "response": [
             {
-              "id": "ac6afbb5-1413-41e0-bf70-d991ee9b71ae",
+              "id": "6f2578d8-6f96-4960-9976-8ee967d98fe0",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10995,7 +10943,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "cdd12fb1-1917-43fb-80b5-dcd4db5f8e70",
+              "id": "6b66885c-988f-4f6d-b507-be26b3d82e03",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11066,7 +11014,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "c8723b9e-107b-47ad-bbad-549c32a9380b",
+          "id": "abdce9d8-fd79-40b2-a818-af5365f6f2fc",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11150,7 +11098,7 @@
           },
           "response": [
             {
-              "id": "c48b74e0-886a-474a-8b14-4ced9f559ec3",
+              "id": "fe117cbb-ed12-49b2-9f90-4491e578769b",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11253,7 +11201,7 @@
           }
         },
         {
-          "id": "45613c6a-60b1-4fb9-b0c8-0c58149ce34f",
+          "id": "7ec96e53-1109-4588-9e43-80203a0e8dde",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11319,7 +11267,7 @@
           },
           "response": [
             {
-              "id": "4fb45e75-d7cc-4087-b453-d1b367c075fb",
+              "id": "d20cf3ac-cad7-457d-bad9-fba3a62985f2",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11404,7 +11352,7 @@
           }
         },
         {
-          "id": "78e942b7-2b53-4cdb-9a3c-6324fc9de707",
+          "id": "bce2857a-bcb3-4d22-a658-8da84418e4c8",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11488,7 +11436,7 @@
           },
           "response": [
             {
-              "id": "d62fa466-c442-40d5-b809-0c7e494dd787",
+              "id": "08629006-a4ed-4635-91b6-aff4ce8305bf",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11591,7 +11539,7 @@
           }
         },
         {
-          "id": "4a8c37a8-cf7a-49a4-9923-a6df8a276e94",
+          "id": "ac9f4a44-2953-4bb1-8520-7ef6fa66287d",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11666,7 +11614,7 @@
           },
           "response": [
             {
-              "id": "c0568f3d-2166-4ec3-a279-933d79c3936f",
+              "id": "5b6bac1f-52ef-4080-a4ea-4f35ee028386",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11760,7 +11708,7 @@
           }
         },
         {
-          "id": "83f1255d-585e-4f3c-9fb2-f0d3d03955c3",
+          "id": "967ef239-b51e-4ae5-86fd-0c6337cd4001",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11835,7 +11783,7 @@
           },
           "response": [
             {
-              "id": "1994dc89-a5c9-41fc-b827-2bba7116b41e",
+              "id": "55d8a5c1-6659-4577-8215-2d1faadb967e",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11929,7 +11877,7 @@
           }
         },
         {
-          "id": "a9f5268a-56c1-4270-8776-c5b54da4de21",
+          "id": "069c7da5-b488-41cf-9a12-a996e5026248",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -12004,7 +11952,7 @@
           },
           "response": [
             {
-              "id": "01184a40-4688-4d21-b82c-a8bf1486fef5",
+              "id": "b6e5405b-c505-47b7-8e8e-1b89c6f9091b",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12104,7 +12052,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "bdbcda08-3aca-4d3a-a26f-cdc121236079",
+          "id": "7e956951-4d2e-4da3-9b82-4c65032f2781",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12170,7 +12118,7 @@
           },
           "response": [
             {
-              "id": "a1ea665b-107f-47a7-8689-ff923429ac5a",
+              "id": "6a66f0ed-e053-454e-9ca7-c345ccbf7676",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12244,7 +12192,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 8546.008607788148\n}",
+              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12261,7 +12209,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "a24ad9c7-4ab8-4d6e-b991-b9f75b3089dc",
+          "id": "0e7dfe2d-2358-42f5-86f3-5725bd032339",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12303,7 +12251,7 @@
           },
           "response": [
             {
-              "id": "d05a4941-41b4-43dc-a530-8f54fbafe57b",
+              "id": "1846e737-0197-446d-af38-426b974b8528",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12373,7 +12321,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "205ab5fa-37cb-43bd-8d99-def561f07d07",
+          "id": "9fa1f0ed-7a08-44a9-a6cd-2bde10e858f1",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12412,7 +12360,7 @@
           },
           "response": [
             {
-              "id": "03bf7764-ad34-4c7e-b14a-b65229bb581f",
+              "id": "e27411b1-6b20-4298-9b4c-75b6c88142d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12465,7 +12413,7 @@
           }
         },
         {
-          "id": "fed4640d-669e-4f21-9a3a-8b766b5ce674",
+          "id": "6360cf81-787c-4f34-9ba9-67b6226af422",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12497,7 +12445,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"pk-XC\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"22:14\",\n  \"quietHoursEnd\": \"22:25\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"oq-VV\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"05:02\",\n  \"quietHoursEnd\": \"20:05\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12517,7 +12465,7 @@
           },
           "response": [
             {
-              "id": "cd2c798f-0c10-4ce0-b5cf-9f3dfe7a44ff",
+              "id": "74d6a116-4e63-48a1-b9ad-ff130bd0b187",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12555,7 +12503,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"pk-XC\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"22:14\",\n  \"quietHoursEnd\": \"22:25\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"oq-VV\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"05:02\",\n  \"quietHoursEnd\": \"20:05\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12589,7 +12537,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "83ba6dcd-f740-4f01-847b-4742db0af030",
+          "id": "1f0d28b9-fc55-4ca7-83e9-c0ca5fa09061",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12631,7 +12579,7 @@
           },
           "response": [
             {
-              "id": "b4bba74b-2202-43c6-a4cd-d2232bd92650",
+              "id": "626fff60-6a19-4c9c-bedd-c3354d4d7318",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12695,7 +12643,7 @@
           }
         },
         {
-          "id": "8ad1e3f8-9c11-451c-bb31-a947c4d739c0",
+          "id": "4f4647f6-e1b3-473d-9d3f-21ee350ae55d",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12738,7 +12686,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#7f8aC7\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#aBAde5\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12750,7 +12698,7 @@
           },
           "response": [
             {
-              "id": "6d1bfdf2-1350-4a15-897f-824375af049d",
+              "id": "a9d34fc1-13fa-42a2-aca0-4acc1e647f09",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12799,7 +12747,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#7f8aC7\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#aBAde5\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12827,7 +12775,7 @@
           }
         },
         {
-          "id": "05590d54-c42a-4616-9615-7f3ec79ab0a7",
+          "id": "8c6720c3-adc5-4d4f-a11b-106a663cb3b9",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12863,7 +12811,7 @@
           },
           "response": [
             {
-              "id": "46299458-25d7-4c60-8a7b-da861a248c9c",
+              "id": "1c4e34f3-8ee4-4cec-bb7c-691f71f0ae58",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12917,7 +12865,7 @@
           }
         },
         {
-          "id": "9b22ea69-57e1-4059-8caa-aa2ed85c34dc",
+          "id": "397a2964-3210-4236-8e59-2f6573899e99",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12947,7 +12895,7 @@
           },
           "response": [
             {
-              "id": "35151094-aaaf-4137-a9fe-8b0f6cdcd97d",
+              "id": "7d60d382-0e8f-49d9-b551-94ece2953d14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12999,7 +12947,7 @@
           }
         },
         {
-          "id": "da77eb95-63ee-4200-abbc-54660f5dfda4",
+          "id": "f3deedfb-1fcf-480b-a259-425bcbde2a6c",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -13030,7 +12978,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3EA036\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e4ECfc\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -13042,7 +12990,7 @@
           },
           "response": [
             {
-              "id": "e8c206a4-d7d3-4207-9689-6de09423d4a7",
+              "id": "e1f2813f-2499-4ca0-bfd3-789a3b9ddc72",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13079,7 +13027,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#3EA036\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#e4ECfc\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13107,7 +13055,7 @@
           }
         },
         {
-          "id": "fcb97cda-3216-4c12-ad06-c88dcd22bd46",
+          "id": "c86f5471-d7b6-42d2-8229-0ab07e85caa1",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13138,7 +13086,7 @@
           },
           "response": [
             {
-              "id": "eaffae92-e5f0-4a06-a296-d21e04c81c9e",
+              "id": "07485e81-9756-4382-a90b-c1a0bb2cff5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13197,7 +13145,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "ecad9e06-b35b-4556-b4ce-81038056aba8",
+          "id": "a248e1aa-e736-4d58-aab0-e71cf6bd9da2",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13250,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "d299c723-f136-43c9-afbd-ef4a8e71af8d",
+              "id": "fe77c181-332b-4bf3-ba2a-0e27e9b4ccb4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13325,7 +13273,7 @@
           }
         },
         {
-          "id": "22a64504-f03a-412c-946c-0856d7cd49b5",
+          "id": "97b8ec8d-9973-46aa-802c-8668db499d52",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13391,7 +13339,7 @@
           },
           "response": [
             {
-              "id": "7bc5e8e0-1be2-45cf-8e55-034c523a7e77",
+              "id": "a517ff9e-4a45-42ec-b19c-d052c0b2d962",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13479,7 +13427,7 @@
           }
         },
         {
-          "id": "86dc7d3f-3263-4b53-9715-5f3910e17dd0",
+          "id": "aa663a22-50fe-4fc7-9baf-bceb234a2682",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13526,7 +13474,7 @@
           },
           "response": [
             {
-              "id": "49721088-9517-46c3-b2bf-8b405debbfa2",
+              "id": "bdd8f7ed-2238-42b7-a3ac-a2fbc825432e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13591,7 +13539,7 @@
           }
         },
         {
-          "id": "0ff357a2-323d-44b0-aa60-b8955c8e1c3f",
+          "id": "7317d63d-50e5-42ab-8a1f-8cd3de627175",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13633,7 +13581,7 @@
           },
           "response": [
             {
-              "id": "2aca2566-af0f-4e68-ac3f-be06c6807dc7",
+              "id": "456e5fd8-ef2b-4db6-8e46-29a192f55e20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13697,7 +13645,7 @@
           }
         },
         {
-          "id": "2eee70d9-4744-4931-ae99-9d554be5c7c9",
+          "id": "bca3da8c-636e-4e16-b8a6-0c7d583ea4e5",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13752,7 +13700,7 @@
           },
           "response": [
             {
-              "id": "de363db8-dee7-4cd5-8b0d-66f0b4c2e13b",
+              "id": "fb8aa62d-a5fc-4b0e-acc2-17a091fa0bda",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13829,7 +13777,7 @@
           }
         },
         {
-          "id": "e9f0d574-8c1e-4b57-a7be-0e18b82529cd",
+          "id": "197e1f16-d414-43ce-b3a3-6bbe2a3317c3",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13883,7 +13831,7 @@
           },
           "response": [
             {
-              "id": "d3172979-b2f3-4b11-8b56-fd0f16018d00",
+              "id": "fa1ec129-e545-48da-9345-abffef565d5a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13959,7 +13907,7 @@
           }
         },
         {
-          "id": "8162185d-0473-4872-abfe-6e374555d3ca",
+          "id": "e390d637-b15c-43e1-9c2e-4868df1d09df",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -14025,7 +13973,7 @@
           },
           "response": [
             {
-              "id": "cd27b3dc-8a96-46b0-aad0-9204a4525995",
+              "id": "adc1f3c4-2e3c-4f57-a0dd-d4f66188dcb5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14113,7 +14061,7 @@
           }
         },
         {
-          "id": "6f374738-b917-4848-a98b-46b062afcf02",
+          "id": "ded95d45-d565-4b1c-95f9-b4fec6bd43c3",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14191,7 +14139,7 @@
           },
           "response": [
             {
-              "id": "5a26d202-29de-4851-b769-d6731c8d3d2a",
+              "id": "d1be77aa-9c3d-435a-83e8-09d0eefaec07",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14291,7 +14239,7 @@
           }
         },
         {
-          "id": "960df700-bd7d-4fe5-971b-0eeece4818a0",
+          "id": "790dfbad-75c8-42d5-b7c5-732c5ba8e88e",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14357,7 +14305,7 @@
           },
           "response": [
             {
-              "id": "cc676c2d-70a3-4fb6-8595-9f2df8ee7179",
+              "id": "c2509fd6-c728-4b92-9d1d-8f6e8ba37d1f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14445,7 +14393,7 @@
           }
         },
         {
-          "id": "c918eac3-cbd1-416e-8486-f71a5d695d2c",
+          "id": "c0872321-1b32-49c8-9b3f-dee569c2718b",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14500,7 +14448,7 @@
           },
           "response": [
             {
-              "id": "370e06bc-ec92-4476-8013-5232fcd83f04",
+              "id": "b889e99d-ac8d-465c-b3fa-339f41169fd0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14583,7 +14531,7 @@
       "description": "",
       "item": [
         {
-          "id": "83ed250b-96ea-4362-8b2d-1acb453ad961",
+          "id": "a8857fe8-7219-4d17-9ac3-5a956e4ed997",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14624,7 +14572,7 @@
           },
           "response": [
             {
-              "id": "ea6e0cd2-761b-4d0f-8c0d-f59f3a598e0b",
+              "id": "8971106f-0bf5-4530-9d00-2720dc689f20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14687,7 +14635,7 @@
           }
         },
         {
-          "id": "633abbdf-720b-45bb-9dca-d17314b8e383",
+          "id": "3b1b3c90-5cf0-4ed5-b164-cc872b1ed17a",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14741,7 +14689,7 @@
           },
           "response": [
             {
-              "id": "dca6226f-4ee1-4d6a-bbd8-1e0f58e2e088",
+              "id": "09d5e6c7-34fe-4115-a30a-0842d8447664",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14817,7 +14765,7 @@
           }
         },
         {
-          "id": "ae114df8-584b-4909-b2b3-02de44e6ef00",
+          "id": "0a7d8135-a758-4343-b0b8-1d30626cb393",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14852,7 +14800,7 @@
           },
           "response": [
             {
-              "id": "e73c6277-37a5-49e9-8acb-02e509a3afc9",
+              "id": "3a4ceed4-f89a-4e41-b004-26f0fa29bb0a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14905,7 +14853,7 @@
           }
         },
         {
-          "id": "b270df23-254c-4a89-b37f-495a83491e20",
+          "id": "6927b4db-0c7e-4b9d-b46b-602543590325",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14921,26 +14869,7 @@
               "host": [
                 "{{baseUrl}}"
               ],
-              "query": [
-                {
-                  "disabled": false,
-                  "description": {
-                    "content": "",
-                    "type": "text/plain"
-                  },
-                  "key": "userId",
-                  "value": "<long>"
-                },
-                {
-                  "disabled": false,
-                  "description": {
-                    "content": "",
-                    "type": "text/plain"
-                  },
-                  "key": "userName",
-                  "value": "<string>"
-                }
-              ],
+              "query": [],
               "variable": [
                 {
                   "type": "any",
@@ -14966,7 +14895,7 @@
           },
           "response": [
             {
-              "id": "514f8918-ba3e-4ace-8179-21e1459f56ee",
+              "id": "899745e4-1b45-4532-b216-5b84f7dfb1a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14980,26 +14909,7 @@
                   "host": [
                     "{{baseUrl}}"
                   ],
-                  "query": [
-                    {
-                      "disabled": false,
-                      "description": {
-                        "content": "",
-                        "type": "text/plain"
-                      },
-                      "key": "userId",
-                      "value": "<long>"
-                    },
-                    {
-                      "disabled": false,
-                      "description": {
-                        "content": "",
-                        "type": "text/plain"
-                      },
-                      "key": "userName",
-                      "value": "<string>"
-                    }
-                  ],
+                  "query": [],
                   "variable": [
                     {
                       "disabled": false,
@@ -15049,7 +14959,7 @@
           }
         },
         {
-          "id": "1401542d-562d-4e84-9b05-4b77a8b0cc40",
+          "id": "0321fb5b-56f6-44c4-9e4e-0381c907af14",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15091,7 +15001,7 @@
           },
           "response": [
             {
-              "id": "f49b2932-2f8a-415f-8568-63334596f3db",
+              "id": "5ecb16e0-cd9b-4474-8614-b1eaf5ab7e39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15155,7 +15065,7 @@
           }
         },
         {
-          "id": "aa0a238f-4cef-4c10-a7fe-7cf1f16b8e1a",
+          "id": "e9e0e4b7-77a5-49d5-a55c-bd7802319a50",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15230,7 +15140,7 @@
           },
           "response": [
             {
-              "id": "ff248227-fcec-4291-b496-fd953e869bc6",
+              "id": "6f7b12e5-78a6-4c92-9ec7-c98328f63728",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15327,7 +15237,7 @@
           }
         },
         {
-          "id": "0194a563-2796-4e8c-8971-6e4296036c39",
+          "id": "eb46ad52-d59b-4cd1-87c4-01e3394c5a3f",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15369,7 +15279,7 @@
           },
           "response": [
             {
-              "id": "e197f52f-0a09-4657-9119-6f8b5701215c",
+              "id": "4ac4b17f-4b7b-4f6b-8089-6b2447428849",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15433,7 +15343,7 @@
           }
         },
         {
-          "id": "eb2e1fbd-6082-42a8-963a-b70aa75d9089",
+          "id": "1267ad53-9463-41ff-bc61-41d557341d25",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15476,7 +15386,7 @@
           },
           "response": [
             {
-              "id": "d7f8fab7-2b37-480b-ad96-6b63f17e7b10",
+              "id": "72414bd1-8180-4877-81c7-b0bb3b75440f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15541,7 +15451,7 @@
           }
         },
         {
-          "id": "96649deb-bb6e-45db-86b3-488aed972f68",
+          "id": "b4f79449-cb1f-4733-b6b7-864b357f5ac9",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15584,7 +15494,7 @@
           },
           "response": [
             {
-              "id": "4071fcb2-257f-4d31-9dc8-b070002be2f5",
+              "id": "3621723e-283f-4ea6-9cba-000ce43ebeac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15649,7 +15559,7 @@
           }
         },
         {
-          "id": "c2144748-87ea-47f3-95c0-c2d14c6fd04a",
+          "id": "36685043-8075-4041-b869-2ad549f5cd4d",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15701,7 +15611,7 @@
           },
           "response": [
             {
-              "id": "b624eae8-06cc-403a-847d-df04e6db5c88",
+              "id": "4adf6654-83e2-4bce-baae-517920f7576a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15775,7 +15685,7 @@
           }
         },
         {
-          "id": "49e84eba-f3dd-478f-a409-8dc504a778a8",
+          "id": "e8c5df40-2b04-42b7-931c-c29a67a0e0fd",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15817,7 +15727,7 @@
           },
           "response": [
             {
-              "id": "8613e996-3344-4f0f-a635-545505f880f8",
+              "id": "1720fb9f-1afa-45a6-8848-6152c879fd2b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15881,7 +15791,7 @@
           }
         },
         {
-          "id": "774f521f-a045-41ea-b23a-ebf368c32582",
+          "id": "cd29cd5b-5f40-40fa-928c-7ca9b8392939",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15934,7 +15844,7 @@
           },
           "response": [
             {
-              "id": "71cc790f-8ebc-4776-b76a-20f0c8963247",
+              "id": "b8672dd4-d869-43b6-9c61-7e7dd039b852",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16009,7 +15919,7 @@
           }
         },
         {
-          "id": "565781ed-943b-4c2f-b689-4a6672c534d1",
+          "id": "08d10f9d-0aa9-4c74-98f2-0f89709352ef",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -16062,7 +15972,7 @@
           },
           "response": [
             {
-              "id": "445c69b1-c2e1-4569-91d3-6a5516e30a89",
+              "id": "a1bf1a62-3604-4d9a-ad59-9d21500ae293",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16137,7 +16047,7 @@
           }
         },
         {
-          "id": "d86042df-6f77-475b-80d5-61c1ae83a3e7",
+          "id": "df17dce6-8053-4930-839e-cc0fc9454463",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16181,7 +16091,7 @@
           },
           "response": [
             {
-              "id": "e0d26b4c-778c-4433-807b-ac40e4fa98a2",
+              "id": "1953c80d-36fe-47fd-b0a0-400ff7fa532c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16236,7 +16146,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\",\n  \"key_4\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16247,7 +16157,7 @@
           }
         },
         {
-          "id": "13153f47-b345-4d14-b112-56a424a2b6ed",
+          "id": "d4f08fa3-d6dc-4deb-8a57-69ef178f5329",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16291,7 +16201,7 @@
           },
           "response": [
             {
-              "id": "265ef37f-c975-493a-8254-33e071362beb",
+              "id": "c1eb411e-e7b6-42fa-bf91-d58c0bddf863",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16346,7 +16256,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\",\n  \"key_3\": \"<long>\",\n  \"key_4\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16363,7 +16273,7 @@
       "description": "",
       "item": [
         {
-          "id": "00908406-8953-43ee-b5a4-70d33e4883de",
+          "id": "1bb45792-6999-45e8-8cca-59117cdfbf96",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16405,7 +16315,7 @@
           },
           "response": [
             {
-              "id": "80cd7464-885a-4bce-b368-85fe97dcbb76",
+              "id": "b778d4fe-8ceb-49a5-9941-024f4ad3653a",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16454,7 +16364,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c3a1f255-3797-41b6-baf0-fddbc6030fd7",
+              "id": "839fa3e4-4816-4551-8faf-a4bbba2010cf",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16509,7 +16419,7 @@
           }
         },
         {
-          "id": "f401866f-04fa-425d-af8a-5df037385cf8",
+          "id": "22f064fa-ce44-4be7-bd59-9fb9584d2e8c",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16555,7 +16465,7 @@
           },
           "response": [
             {
-              "id": "93006fcd-2477-446d-8134-894b6a0d6f76",
+              "id": "ef90e960-6a36-45e2-856d-cc16c8b30b89",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16614,7 +16524,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "029197df-92b8-4d87-9a75-8a8709f9a51f",
+              "id": "06f9dc2d-3d44-439f-813c-74f37df769f6",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16679,7 +16589,7 @@
           }
         },
         {
-          "id": "d3c474d0-9e94-4f64-a85b-2611ede1c2b1",
+          "id": "1f4321e2-9beb-466b-8c7a-0d8b3be4afb4",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16725,7 +16635,7 @@
           },
           "response": [
             {
-              "id": "7c3a4eb2-eab5-424c-8337-1e337ea4064f",
+              "id": "44c38af0-c4d6-4cb1-904f-81ccca6181ab",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16784,7 +16694,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ae6dab29-58dc-488d-876c-2bea715b9282",
+              "id": "d1fbc68a-b333-4f1c-ae91-f5f29e8d0470",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16843,7 +16753,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "ca60a88f-bfe7-41d5-bfbf-4dc7d55dd58f",
+              "id": "c6ed54c1-0047-4c4c-9b7b-a76142d573f3",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16902,7 +16812,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f9c9c56e-ec75-4fee-bc0f-6555d731d5bd",
+              "id": "1bded701-1ed0-4464-9910-46f1b5e37654",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16967,7 +16877,7 @@
           }
         },
         {
-          "id": "c472b69f-06a4-4479-90c6-1e7827e9a81c",
+          "id": "6abd3a6f-2a57-47a1-aa53-a7528aa383d1",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -17013,7 +16923,7 @@
           },
           "response": [
             {
-              "id": "7b75580a-339f-435b-bcd3-af03e47fde89",
+              "id": "4f30b81e-face-4ed1-b557-9cbaee3a6505",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -17072,7 +16982,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0bb80ad4-a249-49b2-a9d1-7984a46a49b8",
+              "id": "1f6bbdd9-09d8-4c6d-9628-99a788d0db28",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17137,7 +17047,7 @@
           }
         },
         {
-          "id": "a669b7d0-e333-415d-a8fd-1cc4dfd21fb5",
+          "id": "2c5a4609-c344-4024-833a-cbc81319e852",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17179,7 +17089,7 @@
           },
           "response": [
             {
-              "id": "8966adc0-bc5b-49fc-abcc-70c6dbc3d183",
+              "id": "1e58dcdb-b053-421b-aec9-44196c956cd0",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17240,7 +17150,7 @@
       "description": "",
       "item": [
         {
-          "id": "f2c2c68c-6354-4e90-b5e2-90c8bff804d6",
+          "id": "9671ab26-7f0d-46f0-bb11-60f7b6fd4426",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17289,7 +17199,7 @@
           },
           "response": [
             {
-              "id": "5fce1818-ef68-4fea-8cd3-c1da604e26f4",
+              "id": "8aea66d3-5d4d-4c0a-a74d-da463c974d2a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17349,7 +17259,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 8546.008607788148\n}",
+              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17360,7 +17270,7 @@
           }
         },
         {
-          "id": "953829a3-0623-4f5b-83e0-bd7324ddd7f5",
+          "id": "34498337-625a-48d9-9fe7-8d8a9dee3860",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17409,7 +17319,7 @@
           },
           "response": [
             {
-              "id": "91250869-d34e-4ceb-8466-73848ca36c33",
+              "id": "4d1ee9ac-c5aa-4a07-9d64-92c858ef8490",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17480,7 +17390,7 @@
           }
         },
         {
-          "id": "a9b5a88b-45bd-4198-836a-0061f3ce2520",
+          "id": "823d2a6d-44a1-4aad-9525-21de12c4b7b5",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17529,7 +17439,7 @@
           },
           "response": [
             {
-              "id": "8429e5ea-817a-4178-8a5a-8132aa5b8219",
+              "id": "71321600-52e0-4fb1-82e5-78c463e0c25b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17600,7 +17510,7 @@
           }
         },
         {
-          "id": "744c95b4-c064-4c26-b8a4-38e80ac17ca1",
+          "id": "33e1517c-d08f-4ca7-99c5-6daad62109f1",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17649,7 +17559,7 @@
           },
           "response": [
             {
-              "id": "1de566a5-6272-4675-8d4f-37a6cae85002",
+              "id": "6734c05f-8995-4b7b-a29b-f891abad8b75",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17726,7 +17636,7 @@
       "description": "",
       "item": [
         {
-          "id": "8b31025c-198a-4e86-a7d4-e877c7f2bccc",
+          "id": "af9162b4-6233-4061-bd1e-a906379bf1c6",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17766,7 +17676,7 @@
           },
           "response": [
             {
-              "id": "0e5cda2f-6b9d-4939-a733-4a348a44e895",
+              "id": "3ca74aa8-36e9-4054-927b-693d96b86239",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17828,7 +17738,7 @@
           }
         },
         {
-          "id": "95a30809-f1a0-4a19-8887-8811ce077319",
+          "id": "60285325-6ebf-40cd-a970-8f15d3d84e57",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17858,7 +17768,7 @@
           },
           "response": [
             {
-              "id": "0fe84fcc-1e8c-4c3b-8dc9-7abbf4ebf3ef",
+              "id": "4499836b-d076-41da-9db2-b582177190a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17899,7 +17809,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 8546.008607788148\n}",
+              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17910,7 +17820,7 @@
           }
         },
         {
-          "id": "b4ace95a-1685-459c-9652-52a2c3f82890",
+          "id": "e2daa9af-227e-4358-9ceb-efbacde543a2",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17962,7 +17872,7 @@
           },
           "response": [
             {
-              "id": "3a309bb5-bd87-4cb1-a5ed-61ef3011001c",
+              "id": "3143bfa2-6c4b-4187-b130-763f45bf5f29",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18042,7 +17952,7 @@
       "description": "",
       "item": [
         {
-          "id": "92125531-61e7-4ba4-bfb2-33b92c62f2d5",
+          "id": "a306dd4e-1142-441e-b2ac-875da8a9676a",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -18071,7 +17981,7 @@
           },
           "response": [
             {
-              "id": "b3f36b74-0cd5-4844-87c1-df8f26414b66",
+              "id": "f0816bea-d0bf-4491-b500-b23611111d38",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18122,7 +18032,7 @@
           }
         },
         {
-          "id": "c9afd0ec-639b-4dc8-baa0-3f5a31e4b4c8",
+          "id": "822ad633-5d16-4876-9d28-4ba01326ee21",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18163,7 +18073,7 @@
           },
           "response": [
             {
-              "id": "108952b1-f065-405f-ba7a-cc0ce40a2ac2",
+              "id": "60024d13-381c-4ff2-a25d-a694d9be74a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18232,7 +18142,7 @@
       "description": "",
       "item": [
         {
-          "id": "d37b7b29-d3f5-4ac5-b6a4-e36fb668693c",
+          "id": "228d28a5-fb06-42e7-a24f-2c8a09e03ef5",
           "name": "health",
           "request": {
             "name": "health",
@@ -18261,7 +18171,7 @@
           },
           "response": [
             {
-              "id": "467c5cc0-7257-46df-b96d-29ab1d5b4019",
+              "id": "8023cb5b-006b-4c1a-ba99-710881357b41",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18301,7 +18211,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 8546.008607788148\n}",
+              "body": "{\n  \"key_0\": 1749,\n  \"key_1\": 9630,\n  \"key_2\": \"string\",\n  \"key_3\": 9631.906878476986\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18318,7 +18228,7 @@
       "description": "",
       "item": [
         {
-          "id": "23cc11c1-3b92-4916-a898-57a4f60be6e0",
+          "id": "647c2ed2-af72-43b8-a1b2-4bcfd5cc862f",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18370,7 +18280,7 @@
           },
           "response": [
             {
-              "id": "3082bcb4-8acb-4c9e-9f55-6496d8d55630",
+              "id": "e184ecf3-8f1d-4709-96f5-f505d2f44f91",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18444,7 +18354,7 @@
           }
         },
         {
-          "id": "7acf5149-2f49-423f-a6b3-93cc60fbb963",
+          "id": "7a982fbc-e7aa-40e3-9d43-90010d517783",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18485,7 +18395,7 @@
           },
           "response": [
             {
-              "id": "9b11a89d-6efb-4bc6-acf0-f13d4d803cb1",
+              "id": "4f9ac7ab-6adf-4f8d-ae63-a264240be328",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18537,7 +18447,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18548,7 +18458,7 @@
           }
         },
         {
-          "id": "31ad306c-3fa4-486a-8d66-a7ff91e4fad2",
+          "id": "2a9879e6-032e-43df-bb4d-b91c424d8bb3",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18578,7 +18488,7 @@
           },
           "response": [
             {
-              "id": "8af326ba-4631-4b40-80ce-ed5c0adb159c",
+              "id": "465b3a86-3044-4a62-a762-19436f2e9afc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18619,7 +18529,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18650,9 +18560,9 @@
     }
   ],
   "info": {
-    "_postman_id": "68bdc43b-9dd1-404b-b716-06bac2f7367d",
+    "_postman_id": "20cadb99-f141-48b5-8545-7eeae2167189",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 02:21 UTC\nRama: main\nEntorno: prod\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 03:23 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/application/usecase/DispatchNotificationUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/application/usecase/DispatchNotificationUseCaseImpl.kt
@@ -173,7 +173,7 @@ class DispatchNotificationUseCaseImpl(
                             type = type,
                             status = NotificationStatus.SENT,
                             payloadJson = buildPayloadJson(content),
-                            fcmMessageId = null,
+                            fcmMessageId = sendResult.messageIdsByTokenId[recipient.tokenId],
                             error = null
                         )
                         totalSent++

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/domain/port/output/FcmSenderPort.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/domain/port/output/FcmSenderPort.kt
@@ -19,10 +19,12 @@ interface FcmSenderPort {
  * [invalidatedTokens] holds the [NotificationRecipient.tokenId] values whose FCM tokens
  * were rejected with UNREGISTERED or INVALID_ARGUMENT and have been (or must be) deleted.
  * [errors] maps tokenId to a human-readable error description for non-invalidating failures.
+ * [messageIdsByTokenId] maps successfully-sent token IDs to the FCM message ID returned by Firebase.
  */
 data class FcmSendResult(
     val success: Int,
     val failed: Int,
     val invalidatedTokens: List<Long>,
-    val errors: Map<Long, String>
+    val errors: Map<Long, String>,
+    val messageIdsByTokenId: Map<Long, String> = emptyMap()
 )

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapter.kt
@@ -57,6 +57,7 @@ class FcmSenderAdapter(
         var totalFailed = 0
         val invalidatedTokenIds = mutableListOf<Long>()
         val errors = mutableMapOf<Long, String>()
+        val messageIdsByTokenId = mutableMapOf<Long, String>()
 
         recipients.chunked(FCM_BATCH_SIZE).forEach { chunk ->
             val tokens = chunk.map { it.tokenValue }
@@ -84,6 +85,7 @@ class FcmSenderAdapter(
                 val recipient = chunk[index]
                 if (sendResponse.isSuccessful) {
                     totalSuccess++
+                    sendResponse.messageId?.let { messageIdsByTokenId[recipient.tokenId] = it }
                     meterRegistry.counter("notification.dispatched", "result", "SUCCESS").increment()
                 } else {
                     val code = sendResponse.exception?.messagingErrorCode
@@ -105,9 +107,9 @@ class FcmSenderAdapter(
                             "FCM send failure code={} tokenId={}: {}",
                             code?.name, recipient.tokenId, sendResponse.exception?.message
                         )
+                        totalFailed++
+                        meterRegistry.counter("notification.dispatched", "result", "FAILURE").increment()
                     }
-                    totalFailed++
-                    meterRegistry.counter("notification.dispatched", "result", "FAILURE").increment()
                 }
             }
         }
@@ -123,7 +125,8 @@ class FcmSenderAdapter(
             success = totalSuccess,
             failed = totalFailed,
             invalidatedTokens = invalidatedTokenIds,
-            errors = errors
+            errors = errors,
+            messageIdsByTokenId = messageIdsByTokenId
         )
     }
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapter.kt
@@ -89,7 +89,7 @@ class FcmSenderAdapter(
                     meterRegistry.counter("notification.dispatched", "result", "SUCCESS").increment()
                 } else {
                     val code = sendResponse.exception?.messagingErrorCode
-                    if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.INVALID_ARGUMENT) {
+                    if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.SENDER_ID_MISMATCH) {
                         val deletedRows = pushTokenRepository.deleteByToken(recipient.tokenValue)
                         logger.info(
                             "Removed invalid FCM token code={} deletedRows={} tokenId={}",

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/FcmPushService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/FcmPushService.kt
@@ -22,8 +22,8 @@ import org.springframework.transaction.annotation.Transactional
  * sobrepasar el límite del SDK.
  *
  * Limpieza automática de tokens muertos: cuando FCM responde con
- * `UNREGISTERED` (la app fue desinstalada) o `INVALID_ARGUMENT` (token
- * malformado o ya rotado), se borra la fila correspondiente para que el
+ * `UNREGISTERED` (la app fue desinstalada) o `SENDER_ID_MISMATCH` (token
+ * emitido para otro proyecto Firebase), se borra la fila correspondiente para que el
  * próximo envío no la incluya.
  *
  * Si no hay `FirebaseMessaging` (caso "sin credenciales", ver
@@ -74,7 +74,7 @@ class FcmPushService(
                         val code = sendResponse.exception?.messagingErrorCode
                         val deadToken = chunk[index]
                         if (code == MessagingErrorCode.UNREGISTERED ||
-                            code == MessagingErrorCode.INVALID_ARGUMENT) {
+                            code == MessagingErrorCode.SENDER_ID_MISMATCH) {
                             val deletedRows = pushTokenRepository.deleteByToken(deadToken)
                             logger.info(
                                 "Removed invalid FCM token (code={}) deletedRows={} alertCode={}",

--- a/src/test/kotlin/com/apptolast/invernaderos/features/notification/application/usecase/DispatchNotificationUseCaseImplTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/notification/application/usecase/DispatchNotificationUseCaseImplTest.kt
@@ -134,7 +134,8 @@ class DispatchNotificationUseCaseImplTest {
         success = 1,
         failed = 0,
         invalidatedTokens = emptyList(),
-        errors = emptyMap()
+        errors = emptyMap(),
+        messageIdsByTokenId = mapOf(100L to "projects/demo/messages/msg-100")
     )
 
     // --- Tests ---
@@ -274,7 +275,10 @@ class DispatchNotificationUseCaseImplTest {
         verify(exactly = 1) { fcmSender.send(any(), eq(notificationContent)) }
         verify(exactly = 1) {
             notificationLogRepository.save(
-                match { it.status == NotificationStatus.SENT }
+                match {
+                    it.status == NotificationStatus.SENT &&
+                        it.fcmMessageId == "projects/demo/messages/msg-100"
+                }
             )
         }
     }
@@ -327,7 +331,8 @@ class DispatchNotificationUseCaseImplTest {
             success = 0,
             failed = 0,
             invalidatedTokens = listOf(100L),
-            errors = emptyMap()
+            errors = emptyMap(),
+            messageIdsByTokenId = emptyMap()
         )
         every { alertSeverityLookup.findById(3) } returns severity
         every { pushTokenLookup.findActiveTokensForTenant(10L) } returns listOf(token)

--- a/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapterTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapterTest.kt
@@ -90,6 +90,37 @@ class FcmSenderAdapterTest {
         verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
     }
 
+    @Test
+    fun `send retains INVALID_ARGUMENT tokens and counts them as failed`() {
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            invalid(MessagingErrorCode.INVALID_ARGUMENT)
+        )
+
+        val result = adapter.send(listOf(recipient(tokenId = 100L, tokenValue = "token")), content())
+
+        assertThat(result.success).isZero()
+        assertThat(result.failed).isEqualTo(1)
+        assertThat(result.invalidatedTokens).isEmpty()
+        assertThat(result.errors).containsKey(100L)
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    @Test
+    fun `send invalidates SENDER_ID_MISMATCH tokens`() {
+        every { pushTokenRepository.deleteByToken("wrong-project-token") } returns 1
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            invalid(MessagingErrorCode.SENDER_ID_MISMATCH)
+        )
+
+        val result = adapter.send(listOf(recipient(tokenId = 100L, tokenValue = "wrong-project-token")), content())
+
+        assertThat(result.success).isZero()
+        assertThat(result.failed).isZero()
+        assertThat(result.invalidatedTokens).containsExactly(100L)
+        assertThat(result.errors).isEmpty()
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("wrong-project-token") }
+    }
+
     private fun recipient(tokenId: Long, tokenValue: String) = NotificationRecipient(
         userId = tokenId + 1,
         tokenId = tokenId,

--- a/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapterTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/output/FcmSenderAdapterTest.kt
@@ -1,0 +1,127 @@
+package com.apptolast.invernaderos.features.notification.infrastructure.adapter.output
+
+import com.apptolast.invernaderos.features.notification.domain.model.NotificationContent
+import com.apptolast.invernaderos.features.notification.domain.model.NotificationRecipient
+import com.apptolast.invernaderos.features.push.PushTokenRepository
+import com.google.firebase.messaging.BatchResponse
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.SendResponse
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.retry.support.RetryTemplate
+import java.util.Locale
+
+class FcmSenderAdapterTest {
+
+    private val firebaseMessaging = mockk<FirebaseMessaging>()
+    private val pushTokenRepository = mockk<PushTokenRepository>(relaxed = true)
+    private val meterRegistry = SimpleMeterRegistry()
+    private val adapter = FcmSenderAdapter(
+        firebaseMessaging = firebaseMessaging,
+        pushTokenRepository = pushTokenRepository,
+        meterRegistry = meterRegistry,
+        fcmRetryTemplate = RetryTemplate()
+    )
+
+    @Test
+    fun `send captures FCM message ids by token id for successful responses`() {
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            success("projects/demo/messages/100"),
+            success("projects/demo/messages/101")
+        )
+
+        val result = adapter.send(
+            recipients = listOf(
+                recipient(tokenId = 100L, tokenValue = "token-a"),
+                recipient(tokenId = 101L, tokenValue = "token-b"),
+            ),
+            content = content()
+        )
+
+        assertThat(result.success).isEqualTo(2)
+        assertThat(result.failed).isZero()
+        assertThat(result.invalidatedTokens).isEmpty()
+        assertThat(result.messageIdsByTokenId).containsEntry(100L, "projects/demo/messages/100")
+        assertThat(result.messageIdsByTokenId).containsEntry(101L, "projects/demo/messages/101")
+    }
+
+    @Test
+    fun `send invalidates dead tokens without counting them as failed`() {
+        every { pushTokenRepository.deleteByToken("dead-token") } returns 1
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            invalid(MessagingErrorCode.UNREGISTERED),
+            success("projects/demo/messages/alive")
+        )
+
+        val result = adapter.send(
+            recipients = listOf(
+                recipient(tokenId = 100L, tokenValue = "dead-token"),
+                recipient(tokenId = 101L, tokenValue = "alive-token"),
+            ),
+            content = content()
+        )
+
+        assertThat(result.success).isEqualTo(1)
+        assertThat(result.failed).isZero()
+        assertThat(result.invalidatedTokens).containsExactly(100L)
+        assertThat(result.errors).isEmpty()
+        assertThat(result.messageIdsByTokenId).containsEntry(101L, "projects/demo/messages/alive")
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("dead-token") }
+    }
+
+    @Test
+    fun `send counts non-invalidating FCM errors as failed`() {
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns batch(
+            invalid(MessagingErrorCode.INTERNAL)
+        )
+
+        val result = adapter.send(listOf(recipient(tokenId = 100L, tokenValue = "token")), content())
+
+        assertThat(result.success).isZero()
+        assertThat(result.failed).isEqualTo(1)
+        assertThat(result.invalidatedTokens).isEmpty()
+        assertThat(result.errors).containsKey(100L)
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    private fun recipient(tokenId: Long, tokenValue: String) = NotificationRecipient(
+        userId = tokenId + 1,
+        tokenId = tokenId,
+        tokenValue = tokenValue,
+        locale = Locale.forLanguageTag("es-ES")
+    )
+
+    private fun content() = NotificationContent(
+        title = "title",
+        body = "body",
+        data = mapOf("alertId" to "1"),
+        androidChannelId = "alerts_default",
+        severityColor = "#FF0000"
+    )
+
+    private fun batch(vararg responses: SendResponse): BatchResponse = mockk {
+        every { this@mockk.responses } returns responses.toList()
+    }
+
+    private fun success(messageId: String): SendResponse = mockk {
+        every { isSuccessful } returns true
+        every { this@mockk.messageId } returns messageId
+    }
+
+    private fun invalid(code: MessagingErrorCode): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns code
+            every { message } returns code.name
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/push/FcmPushServiceTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/push/FcmPushServiceTest.kt
@@ -125,9 +125,8 @@ class FcmPushServiceTest {
     }
 
     @Test
-    fun `should delete token returning INVALID_ARGUMENT error`() {
+    fun `should NOT delete token returning INVALID_ARGUMENT error`() {
         every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("garbage"))
-        every { pushTokenRepository.deleteByToken("garbage") } returns 1
         val invalid = invalidArgumentResponse()
         val response: BatchResponse = mockk {
             every { successCount } returns 0
@@ -138,7 +137,24 @@ class FcmPushServiceTest {
 
         service.sendAlertToTenant(samplePayload())
 
-        verify(exactly = 1) { pushTokenRepository.deleteByToken("garbage") }
+        verify(exactly = 0) { pushTokenRepository.deleteByToken(any()) }
+    }
+
+    @Test
+    fun `should delete token returning SENDER_ID_MISMATCH error`() {
+        every { pushTokenRepository.findAllByTenantId(10L) } returns listOf(pushToken("wrong-project"))
+        every { pushTokenRepository.deleteByToken("wrong-project") } returns 1
+        val senderMismatch = senderIdMismatchResponse()
+        val response: BatchResponse = mockk {
+            every { successCount } returns 0
+            every { failureCount } returns 1
+            every { responses } returns listOf(senderMismatch)
+        }
+        every { firebaseMessaging.sendEachForMulticast(any()) } returns response
+
+        service.sendAlertToTenant(samplePayload())
+
+        verify(exactly = 1) { pushTokenRepository.deleteByToken("wrong-project") }
     }
 
     @Test
@@ -183,16 +199,15 @@ class FcmPushServiceTest {
         val response: BatchResponse = mockk {
             every { successCount } returns 0
             every { failureCount } returns 2
-            every { responses } returns listOf(unregisteredResponse(), invalidArgumentResponse())
+            every { responses } returns listOf(unregisteredResponse(), errorResponse(MessagingErrorCode.INTERNAL))
         }
         every { firebaseMessaging.sendEachForMulticast(any()) } returns response
 
         service.sendAlertToTenant(samplePayload())
 
         val unregMetric = meterRegistry.find("push.fcm.failed").tag("reason", "UNREGISTERED").counter()
-        val invalidMetric = meterRegistry.find("push.fcm.failed").tag("reason", "INVALID_ARGUMENT").counter()
         assertEquals(1.0, unregMetric?.count())
-        assertEquals(1.0, invalidMetric?.count())
+        assertEquals(2.0, meterRegistry.find("push.fcm.failed").counters().sumOf { it.count() })
     }
 
     // -------------------------------------------------------------------------
@@ -216,6 +231,16 @@ class FcmPushServiceTest {
     private fun invalidArgumentResponse(): SendResponse {
         val ex = mockk<FirebaseMessagingException> {
             every { messagingErrorCode } returns MessagingErrorCode.INVALID_ARGUMENT
+        }
+        return mockk {
+            every { isSuccessful } returns false
+            every { exception } returns ex
+        }
+    }
+
+    private fun senderIdMismatchResponse(): SendResponse {
+        val ex = mockk<FirebaseMessagingException> {
+            every { messagingErrorCode } returns MessagingErrorCode.SENDER_ID_MISMATCH
         }
         return mockk {
             every { isSuccessful } returns false


### PR DESCRIPTION
## Summary

Promotes PR #132 (`fix(notification/fcm)`) from `develop` to `main` for production deployment.

Includes the merge commit `d46b1b7`:
> fix(notification/fcm): only invalidate tokens on permanent FCM errors

## Why

H-1 fix per audit `necesito-esto-title-sleepy-piglet`: `INVALID_ARGUMENT` should NOT delete tokens (transient payload errors). `SENDER_ID_MISMATCH` is the canonical permanent-error code, equivalent to `UNREGISTERED`.

Applied to both FCM dispatch paths (`FcmSenderAdapter` + `FcmPushService`).

## Test Plan

- [x] Dev deploy verified (pod `invernaderos-api-58cc84f58-z4zwp`, image digest `sha256:93fc2ec3...`)
- [x] Dev `/actuator/health` → 200
- [x] Dev pod logs clean (no new ERRORs)
- [ ] Prod CI green (`test` + `build-and-push`)
- [ ] Merge to `main`, deploy via `kubectl set image` with new commit SHA tag
- [ ] Prod `/actuator/health` → 200 on both replicas
- [ ] Prod logs clean for 5 min
- [ ] Verify `metadata.push_tokens` count stable for valid tokens (no regression in invalidation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)