### PR TITLE
feat(notification): nightly purge of notification_log per retention-days

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,8 @@ dependencies {
     // Spring Retry (notificaciones FCM con backoff exponencial)
     implementation("org.springframework.retry:spring-retry")
     implementation("org.springframework:spring-aspects")
+    implementation("net.javacrumbs.shedlock:shedlock-spring:5.16.0")
+    implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.16.0")
     annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/com/apptolast/invernaderos/InvernaderosApplication.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/InvernaderosApplication.kt
@@ -1,11 +1,13 @@
 package com.apptolast.invernaderos
 
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT15M")
 class InvernaderosApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/NotificationLogRetentionScheduler.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/NotificationLogRetentionScheduler.kt
@@ -21,14 +21,35 @@ class NotificationLogRetentionScheduler(
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Scheduled(cron = "0 30 3 * * *", zone = "UTC")
-    @SchedulerLock(name = "purge-notification-log", lockAtLeastFor = "PT5M", lockAtMostFor = "PT15M")
+    @SchedulerLock(name = "purge-notification-log", lockAtLeastFor = "PT5M", lockAtMostFor = "PT2H")
     fun purge() {
         val cutoff = Instant.now().minus(props.log.retentionDays.toLong(), ChronoUnit.DAYS)
-        val deleted = jdbc.update(
-            "DELETE FROM metadata.notification_log WHERE sent_at < ?",
-            Timestamp.from(cutoff)
-        )
-        meterRegistry.counter("notification_log_purged_rows_total").increment(deleted.toDouble())
-        log.info("Purged {} notification_log rows older than {}", deleted, cutoff)
+        var deletedTotal = 0L
+        do {
+            val deleted = jdbc.update(
+                """
+                WITH stale AS (
+                    SELECT id
+                    FROM metadata.notification_log
+                    WHERE sent_at < ?
+                    ORDER BY sent_at, id
+                    LIMIT ?
+                )
+                DELETE FROM metadata.notification_log nl
+                USING stale
+                WHERE nl.id = stale.id
+                """.trimIndent(),
+                Timestamp.from(cutoff),
+                DELETE_BATCH_SIZE
+            )
+            deletedTotal += deleted
+        } while (deleted == DELETE_BATCH_SIZE)
+
+        meterRegistry.counter("notification_log_purged_rows").increment(deletedTotal.toDouble())
+        log.info("Purged {} notification_log rows older than {}", deletedTotal, cutoff)
+    }
+
+    private companion object {
+        const val DELETE_BATCH_SIZE = 5_000
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/NotificationLogRetentionScheduler.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/NotificationLogRetentionScheduler.kt
@@ -1,0 +1,34 @@
+package com.apptolast.invernaderos.features.notification.infrastructure.adapter.input
+
+import com.apptolast.invernaderos.features.notification.infrastructure.config.NotificationProperties
+import io.micrometer.core.instrument.MeterRegistry
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@Component
+class NotificationLogRetentionScheduler(
+    @Qualifier("metadataJdbcTemplate") private val jdbc: JdbcTemplate,
+    private val props: NotificationProperties,
+    private val meterRegistry: MeterRegistry
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "0 30 3 * * *", zone = "UTC")
+    @SchedulerLock(name = "purge-notification-log", lockAtLeastFor = "PT5M", lockAtMostFor = "PT15M")
+    fun purge() {
+        val cutoff = Instant.now().minus(props.log.retentionDays.toLong(), ChronoUnit.DAYS)
+        val deleted = jdbc.update(
+            "DELETE FROM metadata.notification_log WHERE sent_at < ?",
+            Timestamp.from(cutoff)
+        )
+        meterRegistry.counter("notification_log_purged_rows_total").increment(deleted.toDouble())
+        log.info("Purged {} notification_log rows older than {}", deleted, cutoff)
+    }
+}

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/config/NotificationProperties.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/config/NotificationProperties.kt
@@ -1,12 +1,16 @@
 package com.apptolast.invernaderos.features.notification.infrastructure.config
 
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
 import java.time.Duration
 
 @ConfigurationProperties(prefix = "notification")
+@Validated
 data class NotificationProperties(
     val dedup: DedupProps = DedupProps(),
-    val log: LogProps = LogProps(),
+    @field:Valid val log: LogProps = LogProps(),
     val fcm: FcmProps = FcmProps(),
     val i18n: I18nProps = I18nProps()
 ) {
@@ -20,7 +24,7 @@ data class NotificationProperties(
         val alertResolved: Duration = Duration.ofSeconds(60)
     )
 
-    data class LogProps(val retentionDays: Int = 90)
+    data class LogProps(@field:Min(1) val retentionDays: Int = 90)
 
     data class FcmProps(val retry: RetryProps = RetryProps())
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/config/ShedLockConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/config/ShedLockConfig.kt
@@ -1,0 +1,22 @@
+package com.apptolast.invernaderos.features.notification.infrastructure.config
+
+import net.javacrumbs.shedlock.core.LockProvider
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.JdbcTemplate
+
+@Configuration
+class ShedLockConfig {
+
+    @Bean
+    fun lockProvider(@Qualifier("metadataJdbcTemplate") jdbcTemplate: JdbcTemplate): LockProvider =
+        JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(jdbcTemplate)
+                .withTableName("metadata.shedlock")
+                .usingDbTime()
+                .build()
+        )
+}

--- a/src/main/resources/db/migration/V45__create_shedlock_table.sql
+++ b/src/main/resources/db/migration/V45__create_shedlock_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS metadata.shedlock (
+    name VARCHAR(64) NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL DEFAULT now(),
+    locked_by VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);

--- a/src/main/resources/db/migration/V45__create_shedlock_table.sql
+++ b/src/main/resources/db/migration/V45__create_shedlock_table.sql
@@ -5,3 +5,6 @@ CREATE TABLE IF NOT EXISTS metadata.shedlock (
     locked_by VARCHAR(255) NOT NULL,
     PRIMARY KEY (name)
 );
+
+CREATE INDEX IF NOT EXISTS idx_notification_log_sent_at
+    ON metadata.notification_log(sent_at);

--- a/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/NotificationLogRetentionSchedulerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/NotificationLogRetentionSchedulerTest.kt
@@ -1,0 +1,37 @@
+package com.apptolast.invernaderos.features.notification.infrastructure.adapter.input
+
+import com.apptolast.invernaderos.features.notification.infrastructure.config.NotificationProperties
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.JdbcTemplate
+import java.sql.Timestamp
+
+class NotificationLogRetentionSchedulerTest {
+
+    private val jdbc = mockk<JdbcTemplate>()
+    private val meterRegistry = SimpleMeterRegistry()
+    private val scheduler = NotificationLogRetentionScheduler(
+        jdbc = jdbc,
+        props = NotificationProperties(log = NotificationProperties.LogProps(retentionDays = 90)),
+        meterRegistry = meterRegistry
+    )
+
+    @Test
+    fun `should purge notification logs older than retention window`() {
+        every { jdbc.update(any<String>(), any<Timestamp>()) } returns 3
+
+        scheduler.purge()
+
+        verify(exactly = 1) {
+            jdbc.update(
+                "DELETE FROM metadata.notification_log WHERE sent_at < ?",
+                any<Timestamp>()
+            )
+        }
+        assertThat(meterRegistry.counter("notification_log_purged_rows_total").count()).isEqualTo(3.0)
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/NotificationLogRetentionSchedulerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/NotificationLogRetentionSchedulerTest.kt
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import jakarta.validation.Validation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.jdbc.core.JdbcTemplate
@@ -22,16 +23,42 @@ class NotificationLogRetentionSchedulerTest {
 
     @Test
     fun `should purge notification logs older than retention window`() {
-        every { jdbc.update(any<String>(), any<Timestamp>()) } returns 3
+        every { jdbc.update(any<String>(), any<Timestamp>(), any<Int>()) } returns 3
 
         scheduler.purge()
 
         verify(exactly = 1) {
             jdbc.update(
-                "DELETE FROM metadata.notification_log WHERE sent_at < ?",
-                any<Timestamp>()
+                match { it.contains("DELETE FROM metadata.notification_log") },
+                any<Timestamp>(),
+                5000
             )
         }
-        assertThat(meterRegistry.counter("notification_log_purged_rows_total").count()).isEqualTo(3.0)
+        assertThat(meterRegistry.counter("notification_log_purged_rows").count()).isEqualTo(3.0)
+    }
+
+    @Test
+    fun `should purge notification logs in batches`() {
+        every { jdbc.update(any<String>(), any<Timestamp>(), any<Int>()) } returnsMany listOf(5000, 2)
+
+        scheduler.purge()
+
+        verify(exactly = 2) {
+            jdbc.update(
+                match { it.contains("WITH stale AS") },
+                any<Timestamp>(),
+                5000
+            )
+        }
+        assertThat(meterRegistry.counter("notification_log_purged_rows").count()).isEqualTo(5002.0)
+    }
+
+    @Test
+    fun `should reject unsafe retention window`() {
+        val violations = Validation.buildDefaultValidatorFactory()
+            .validator
+            .validate(NotificationProperties.LogProps(retentionDays = 0))
+
+        assertThat(violations).isNotEmpty
     }
 }


### PR DESCRIPTION
M-1 per audit. Shedlock-coordinated nightly @Scheduled job at 03:30 UTC purges `metadata.notification_log` rows older than `notification.log.retention-days` (default 90). New V45 migration for shedlock table. Multi-replica safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)