### PR TITLE
fix(db): make notification retention index migration non-blocking

### DIFF
--- a/.github/workflows/flyway-migrate.yml
+++ b/.github/workflows/flyway-migrate.yml
@@ -134,6 +134,7 @@ jobs:
                  -password="${DB_PASSWORD}" \
                  -schemas=metadata \
                  -locations="filesystem:src/main/resources/db/migration" \
+                 -postgresql.transactional.lock=false \
                  -baselineOnMigrate=true \
                  -baselineVersion=1 \
                  info
@@ -144,6 +145,7 @@ jobs:
                  -password="${DB_PASSWORD}" \
                  -schemas=metadata \
                  -locations="filesystem:src/main/resources/db/migration" \
+                 -postgresql.transactional.lock=false \
                  -baselineOnMigrate=true \
                  -baselineVersion=1 \
                  -ignoreMigrationPatterns='*:pending' \
@@ -236,6 +238,7 @@ jobs:
                    -password="${DB_PASSWORD}" \
                    -schemas=metadata \
                    -locations="filesystem:src/main/resources/db/migration" \
+                   -postgresql.transactional.lock=false \
                    -baselineOnMigrate=true \
                    -baselineVersion=1 \
                    -dryRunOutput=flyway-metadata-dryrun.sql \
@@ -249,6 +252,7 @@ jobs:
                    -password="${DB_PASSWORD}" \
                    -schemas=metadata \
                    -locations="filesystem:src/main/resources/db/migration" \
+                   -postgresql.transactional.lock=false \
                    -baselineOnMigrate=true \
                    -baselineVersion=1 \
                    -cleanDisabled=true \
@@ -316,6 +320,7 @@ jobs:
                  -password="${DB_PASSWORD}" \
                  -schemas=metadata \
                  -locations="filesystem:src/main/resources/db/migration" \
+                 -postgresql.transactional.lock=false \
                  info
 
           if [[ -n "${TSDB_URL}" ]]; then

--- a/src/main/kotlin/com/apptolast/invernaderos/config/FlywayConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/FlywayConfig.kt
@@ -49,6 +49,7 @@ class FlywayConfig {
     @Bean
     fun flyway(@Qualifier("metadataDataSource") metadataDataSource: DataSource): Flyway {
         return Flyway.configure()
+            .configuration(mapOf("flyway.postgresql.transactional.lock" to "false"))
             .dataSource(metadataDataSource)
             .locations("classpath:db/migration")
             .schemas("metadata")

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -13,6 +13,7 @@
 #          -user=admin -password=xxx \
 #          -schemas=metadata \
 #          -locations=classpath:db/migration \
+#          -postgresql.transactional.lock=false \
 #          migrate
 #
 # Documentación: https://documentation.red-gate.com/fd/recommended-practices-150700352.html

--- a/src/main/resources/db/migration/V45_1__create_notification_log_retention_index.sql
+++ b/src/main/resources/db/migration/V45_1__create_notification_log_retention_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_log_sent_at
+    ON metadata.notification_log(sent_at);

--- a/src/main/resources/db/migration/V45_1__create_notification_log_retention_index.sql.conf
+++ b/src/main/resources/db/migration/V45_1__create_notification_log_retention_index.sql.conf
@@ -1,0 +1,1 @@
+executeInTransaction=false

--- a/src/main/resources/db/migration/V45__create_shedlock_table.sql
+++ b/src/main/resources/db/migration/V45__create_shedlock_table.sql
@@ -5,6 +5,3 @@ CREATE TABLE IF NOT EXISTS metadata.shedlock (
     locked_by VARCHAR(255) NOT NULL,
     PRIMARY KEY (name)
 );
-
-CREATE INDEX IF NOT EXISTS idx_notification_log_sent_at
-    ON metadata.notification_log(sent_at);


### PR DESCRIPTION
Follow-up to #138.\n\nThis keeps notification_log retention production-safe by:\n- moving the retention index to V45_1 with CREATE INDEX CONCURRENTLY\n- marking V45_1 as non-transactional via Flyway script config\n- using PostgreSQL session locks for Flyway metadata migrations\n- documenting the prod Flyway CLI flag\n\nLocal quality gate already passed with DEV DB credentials: ./gradlew compileKotlin compileTestKotlin test --warning-mode=all