### PR TITLE
feat(alert/mqtt): persist actor_ref with deviceId from MQTT topic

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt
@@ -1,5 +1,6 @@
 package com.apptolast.invernaderos.config
 
+import com.apptolast.invernaderos.features.alert.infrastructure.adapter.input.AlertMqttInboundAdapter
 import com.apptolast.invernaderos.mqtt.listener.ActuatorStatusListener
 import com.apptolast.invernaderos.mqtt.listener.DeviceStatusListener
 import com.apptolast.invernaderos.mqtt.listener.SensorDataListener
@@ -81,7 +82,9 @@ class MqttConfig(
 
     private val actuatorStatusListener: ActuatorStatusListener,
 
-    private val deviceStatusListener: DeviceStatusListener
+    private val deviceStatusListener: DeviceStatusListener,
+
+    private val alertMqttInboundAdapter: AlertMqttInboundAdapter
 ) {
 
     private val logger = LoggerFactory.getLogger(MqttConfig::class.java)
@@ -206,7 +209,19 @@ class MqttConfig(
 
                     topic.contains("/sensors/") -> sensorDataListener.handleSensorData(message)
                     topic.contains("/actuators/status") -> actuatorStatusListener.handleActuatorStatus(message)
-                    topic.contains("/alerts/") -> logger.info("Alert received on topic: {}", topic)
+                    topic.contains("/alerts/") -> {
+                        val parts = topic.split("/")
+                        if (parts.size >= 4 && parts[0] == "greenhouse" && parts[2] == "alerts") {
+                            logger.debug("MQTT alert topic message - Topic: {}, Payload: {}", topic, payload)
+                            alertMqttInboundAdapter.handleSignal(
+                                code = parts[3],
+                                rawValue = payload,
+                                deviceRef = parts[1].takeIf { it.isNotBlank() }
+                            )
+                        } else {
+                            logger.warn("Unhandled alert topic: {}", topic)
+                        }
+                    }
                     else -> logger.warn("Unhandled topic: {}", topic)
                 }
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ApplyAlertMqttSignalUseCaseImpl.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/application/usecase/ApplyAlertMqttSignalUseCaseImpl.kt
@@ -81,7 +81,6 @@ class ApplyAlertMqttSignalUseCaseImpl(
         val persistedAlert = alertByCodeRepository.save(updatedAlert)
 
         // 7. Persist state change
-        // actor_ref is null because we do not have device id available at this point in the MQTT pipeline.
         val change = AlertStateChange(
             id = null,
             alertId = persistedAlert.id ?: throw IllegalStateException("Alert ID cannot be null after save"),
@@ -90,7 +89,7 @@ class ApplyAlertMqttSignalUseCaseImpl(
             source = AlertSignalSource.MQTT,
             rawValue = signal.rawValue,
             at = Instant.now(),
-            actor = AlertActor.Device(deviceRef = null),
+            actor = AlertActor.Device(deviceRef = signal.deviceRef),
         )
         val persistedChange = stateChangePort.save(change)
 

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertMqttSignal.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/domain/model/AlertMqttSignal.kt
@@ -2,5 +2,6 @@ package com.apptolast.invernaderos.features.alert.domain.model
 
 data class AlertMqttSignal(
     val code: String,      // e.g. "ALT-00010"
-    val rawValue: String   // e.g. "1" or "0" — already converted by the listener
+    val rawValue: String,  // e.g. "1" or "0" — already converted by the listener
+    val deviceRef: String? = null
 )

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertMqttInboundAdapter.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/adapter/input/AlertMqttInboundAdapter.kt
@@ -24,9 +24,9 @@ class AlertMqttInboundAdapter(
      * logged so that a downstream alert misconfiguration cannot break telemetry ingestion.
      */
     @Transactional("metadataTransactionManager")
-    fun handleSignal(code: String, rawValue: String) {
+    fun handleSignal(code: String, rawValue: String, deviceRef: String? = null) {
         try {
-            val signal = AlertMqttSignal(code = code, rawValue = rawValue)
+            val signal = AlertMqttSignal(code = code, rawValue = rawValue, deviceRef = deviceRef)
             applyUseCase.execute(signal).fold(
                 onLeft = { error ->
                     // UnknownCode, NoTransitionRequired and InvalidSignalValue are

--- a/src/main/kotlin/com/apptolast/invernaderos/mqtt/listener/DeviceStatusListener.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/mqtt/listener/DeviceStatusListener.kt
@@ -52,10 +52,18 @@ class DeviceStatusListener(
                 else -> valueNode.toString()
             }
 
-            deviceStatusProcessor.processStatusUpdate(code, value)
+            deviceStatusProcessor.processStatusUpdate(code, value, extractDeviceRef(topic))
 
         } catch (e: Exception) {
             logger.error("Error processing GREENHOUSE/STATUS message: {}", e.message, e)
         }
+    }
+
+    private fun extractDeviceRef(topic: String): String? {
+        val parts = topic.split("/")
+        return parts
+            .takeIf { it.size >= 4 && it[0] == "greenhouse" && it[2] == "alerts" }
+            ?.get(1)
+            ?.takeIf { it.isNotBlank() }
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/mqtt/service/DeviceStatusProcessor.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/mqtt/service/DeviceStatusProcessor.kt
@@ -69,7 +69,7 @@ class DeviceStatusProcessor(
      * 2. Siempre actualiza current_values (ultimo valor para WebSocket)
      * 3. Solo encola para deduped si pasa el dedup check (Redis)
      */
-    fun processStatusUpdate(code: String, value: String) {
+    fun processStatusUpdate(code: String, value: String, deviceRef: String? = null) {
         val now = Instant.now()
         lastKnownValues[code] = value
 
@@ -89,7 +89,7 @@ class DeviceStatusProcessor(
         // handleSignal catches all exceptions internally (see AlertMqttInboundAdapter)
         // so a downstream alert misconfiguration cannot break the telemetry path above.
         if (code.startsWith("ALT-")) {
-            alertMqttInboundAdapter.handleSignal(code, value)
+            alertMqttInboundAdapter.handleSignal(code, value, deviceRef)
         }
     }
 

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/domain/usecase/ApplyAlertMqttSignalUseCaseTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/domain/usecase/ApplyAlertMqttSignalUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.apptolast.invernaderos.features.alert.domain.usecase
 import com.apptolast.invernaderos.features.alert.application.usecase.ApplyAlertMqttSignalUseCaseImpl
 import com.apptolast.invernaderos.features.alert.domain.error.AlertError
 import com.apptolast.invernaderos.features.alert.domain.model.Alert
+import com.apptolast.invernaderos.features.alert.domain.model.AlertActor
 import com.apptolast.invernaderos.features.alert.domain.model.AlertMqttSignal
 import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalDecision
 import com.apptolast.invernaderos.features.alert.domain.model.AlertSignalSource
@@ -265,5 +266,23 @@ class ApplyAlertMqttSignalUseCaseTest {
         assertThat(result).isInstanceOf(Either.Right::class.java)
         val savedAlert = (result as Either.Right).value.alert
         assertThat(savedAlert.resolvedByUserId).isNull()
+    }
+
+    @Test
+    fun `should persist deviceRef as MQTT actor reference`() {
+        val unresolvedAlert = anUnresolvedAlert()
+        every { alertByCodeRepository.findByCode("ALT-00010") } returns unresolvedAlert
+        every { decisionPort.decide(any(), any()) } returns AlertSignalDecision.RESOLVE
+        every { alertByCodeRepository.save(any()) } answers { firstArg() }
+        every { stateChangePort.save(any()) } answers { firstArg() }
+        justRun { eventPublisher.publish(any(), any()) }
+
+        val result = useCase.execute(
+            AlertMqttSignal(code = "ALT-00010", rawValue = "0", deviceRef = "GW-001")
+        )
+
+        assertThat(result).isInstanceOf(Either.Right::class.java)
+        val change = (result as Either.Right).value.change
+        assertThat(change?.actor).isEqualTo(AlertActor.Device(deviceRef = "GW-001"))
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertMqttSignalIntegrationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/alert/infrastructure/AlertMqttSignalIntegrationTest.kt
@@ -69,11 +69,11 @@ class AlertMqttSignalIntegrationTest {
     @Test
     fun `should route ALT- code to AlertMqttInboundAdapter handleSignal`() {
         every { deduplicationService.shouldPersistToDeduped(any(), any()) } returns false
-        justRun { alertMqttInboundAdapter.handleSignal(any(), any()) }
+        justRun { alertMqttInboundAdapter.handleSignal(any(), any(), any()) }
 
         processor.processStatusUpdate("ALT-99999", "0")
 
-        verify(exactly = 1) { alertMqttInboundAdapter.handleSignal("ALT-99999", "0") }
+        verify(exactly = 1) { alertMqttInboundAdapter.handleSignal("ALT-99999", "0", null) }
     }
 
     @Test
@@ -81,7 +81,7 @@ class AlertMqttSignalIntegrationTest {
         every { deduplicationService.shouldPersistToDeduped(any(), any()) } returns false
         val codeSlot = slot<String>()
         val valueSlot = slot<String>()
-        justRun { alertMqttInboundAdapter.handleSignal(capture(codeSlot), capture(valueSlot)) }
+        justRun { alertMqttInboundAdapter.handleSignal(capture(codeSlot), capture(valueSlot), any()) }
 
         processor.processStatusUpdate("ALT-99999", "0")
 
@@ -97,30 +97,30 @@ class AlertMqttSignalIntegrationTest {
         processor.processStatusUpdate("DEV-00001", "1")
         processor.processStatusUpdate("TMP-00042", "23.5")
 
-        verify(exactly = 0) { alertMqttInboundAdapter.handleSignal(any(), any()) }
+        verify(exactly = 0) { alertMqttInboundAdapter.handleSignal(any(), any(), any()) }
     }
 
     @Test
     fun `should invoke handleSignal for every ALT- message regardless of value`() {
         every { deduplicationService.shouldPersistToDeduped(any(), any()) } returns false
-        justRun { alertMqttInboundAdapter.handleSignal(any(), any()) }
+        justRun { alertMqttInboundAdapter.handleSignal(any(), any(), any()) }
 
         processor.processStatusUpdate("ALT-00001", "1")
         processor.processStatusUpdate("ALT-00002", "0")
         processor.processStatusUpdate("ALT-00003", "true")
 
-        verify(exactly = 3) { alertMqttInboundAdapter.handleSignal(any(), any()) }
+        verify(exactly = 3) { alertMqttInboundAdapter.handleSignal(any(), any(), any()) }
     }
 
     @Test
     fun `should still invoke handleSignal even when deduplication suppresses sensor write`() {
         // Dedup blocks the sensor_readings write but alert routing is independent
         every { deduplicationService.shouldPersistToDeduped(any(), any()) } returns false
-        justRun { alertMqttInboundAdapter.handleSignal(any(), any()) }
+        justRun { alertMqttInboundAdapter.handleSignal(any(), any(), any()) }
 
         processor.processStatusUpdate("ALT-99999", "1")
 
-        verify(exactly = 1) { alertMqttInboundAdapter.handleSignal("ALT-99999", "1") }
+        verify(exactly = 1) { alertMqttInboundAdapter.handleSignal("ALT-99999", "1", null) }
     }
 
     /**
@@ -131,12 +131,22 @@ class AlertMqttSignalIntegrationTest {
     @Test
     fun `should still feed telemetry buffers for ALT- codes (non-regression)`() {
         every { deduplicationService.shouldPersistToDeduped(any(), any()) } returns false
-        justRun { alertMqttInboundAdapter.handleSignal(any(), any()) }
+        justRun { alertMqttInboundAdapter.handleSignal(any(), any(), any()) }
 
         processor.processStatusUpdate("ALT-99999", "1")
 
         // lastKnownValues is the public side-effect of the telemetry branch — if it is set,
         // raw and current_values buffers also received the entry (same code path).
         assertThat(processor.lastKnownValues["ALT-99999"]).isEqualTo("1")
+    }
+
+    @Test
+    fun `should pass device reference to AlertMqttInboundAdapter`() {
+        every { deduplicationService.shouldPersistToDeduped(any(), any()) } returns false
+        justRun { alertMqttInboundAdapter.handleSignal(any(), any(), any()) }
+
+        processor.processStatusUpdate("ALT-99999", "0", "GW-001")
+
+        verify(exactly = 1) { alertMqttInboundAdapter.handleSignal("ALT-99999", "0", "GW-001") }
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/mqtt/listener/DeviceStatusListenerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/mqtt/listener/DeviceStatusListenerTest.kt
@@ -1,0 +1,42 @@
+package com.apptolast.invernaderos.mqtt.listener
+
+import com.apptolast.invernaderos.mqtt.service.DeviceStatusProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.integration.mqtt.support.MqttHeaders
+import org.springframework.integration.support.MessageBuilder
+
+class DeviceStatusListenerTest {
+
+    private val processor = mockk<DeviceStatusProcessor>()
+    private val listener = DeviceStatusListener(processor, ObjectMapper())
+
+    @Test
+    fun `should extract device reference from greenhouse alert topic`() {
+        justRun { processor.processStatusUpdate(any(), any(), any()) }
+
+        listener.handleDeviceStatus(
+            MessageBuilder.withPayload("""{"id":"ALT-00010","value":false}""")
+                .setHeader(MqttHeaders.RECEIVED_TOPIC, "greenhouse/GW-001/alerts/ALT-00010")
+                .build()
+        )
+
+        verify(exactly = 1) { processor.processStatusUpdate("ALT-00010", "0", "GW-001") }
+    }
+
+    @Test
+    fun `should keep device reference null for legacy status topic`() {
+        justRun { processor.processStatusUpdate(any(), any(), any()) }
+
+        listener.handleDeviceStatus(
+            MessageBuilder.withPayload("""{"id":"ALT-00010","value":true}""")
+                .setHeader(MqttHeaders.RECEIVED_TOPIC, "GREENHOUSE/STATUS")
+                .build()
+        )
+
+        verify(exactly = 1) { processor.processStatusUpdate("ALT-00010", "1", null) }
+    }
+}


### PR DESCRIPTION
M-3 per audit. Threads the deviceId from MQTT topic header (`greenhouse/{deviceId}/alerts/{code}`) all the way to `alert_state_changes.actor_ref`. Previously hardcoded null, audit-blind.

Includes also routing of `/alerts/` topics in MqttConfig directly to the inbound adapter and forwarding deviceRef through DeviceStatusListener+Processor for the legacy ALT- code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)