### PR TITLE
chore(security): drop redundant @CrossOrigin overrides

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertController.kt
@@ -46,7 +46,6 @@ import org.springframework.web.bind.annotation.*
  */
 @RestController
 @RequestMapping("/api/v1/alerts")
-@CrossOrigin(origins = ["*"]) // wildcard kept until prod ingress narrows the allowed list
 @Validated
 class AlertController(
     private val alertService: AlertService,

--- a/src/main/kotlin/com/apptolast/invernaderos/features/command/infrastructure/adapter/input/DeviceCommandController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/command/infrastructure/adapter/input/DeviceCommandController.kt
@@ -16,7 +16,6 @@ import java.time.Instant
 
 @RestController
 @RequestMapping("/api/v1/commands")
-@CrossOrigin(origins = ["*"])
 @Tag(name = "Device Commands", description = "Endpoints para enviar comandos al PLC via MQTT")
 class DeviceCommandController(
     private val sendCommandUseCase: SendCommandUseCase,

--- a/src/main/kotlin/com/apptolast/invernaderos/features/mqtt/MqttPublishController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/mqtt/MqttPublishController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/v1/mqtt")
 @Tag(name = "MQTT", description = "Endpoints para publicacion manual de mensajes MQTT")
-@CrossOrigin(origins = ["*"])
 class MqttPublishController(
     private val mqttPublishService: MqttPublishService
 ) {

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/UserNotificationLogController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/UserNotificationLogController.kt
@@ -15,7 +15,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/users/me/notifications")
-@CrossOrigin(origins = ["*"])
 @Tag(
     name = "User Notification Log",
     description = "Paginated history of push notifications received"

--- a/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/UserNotificationPreferencesController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/notification/infrastructure/adapter/input/UserNotificationPreferencesController.kt
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.userdetails.UsernameNotFoundException
-import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/users/me/notification-preferences")
-@CrossOrigin(origins = ["*"])
 @Tag(
     name = "User Notification Preferences",
     description = "Per-user notification preferences (categories, severity, quiet hours, locale)"

--- a/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/input/PushTokenController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/push/infrastructure/adapter/input/PushTokenController.kt
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.*
  */
 @RestController
 @RequestMapping("/api/v1/push-tokens")
-@CrossOrigin(origins = ["*"])
 @Tag(name = "Push Tokens", description = "Registro de tokens FCM de dispositivos para notificaciones push")
 @SecurityRequirement(name = "bearerAuth")
 class PushTokenController(

--- a/src/main/kotlin/com/apptolast/invernaderos/features/statistics/GreenhouseStatisticsController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/statistics/GreenhouseStatisticsController.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*
  */
 @RestController
 @RequestMapping("/api/v1/greenhouse")
-@CrossOrigin(origins = ["*"])
 class GreenhouseStatisticsController(private val greenhouseDataService: GreenhouseDataService) {
 
     private val logger = LoggerFactory.getLogger(GreenhouseStatisticsController::class.java)

--- a/src/main/kotlin/com/apptolast/invernaderos/features/statistics/StatisticsController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/statistics/StatisticsController.kt
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.*
  */
 @RestController
 @RequestMapping("/api/v1/statistics")
-@CrossOrigin(origins = ["*"])
 class StatisticsController(
     private val statisticsService: StatisticsService
 ) {

--- a/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
@@ -34,12 +34,9 @@ class MqttSubscriptionGuardTest {
         @Suppress("UNCHECKED_CAST")
         val root = Yaml().load<Map<String, Any?>>(yamlStream)
 
-        val spring = root["spring"] as? Map<String, Any?>
-            ?: error("spring section missing in application.yaml")
-        val mqtt = spring["mqtt"] as? Map<String, Any?>
-            ?: error("spring.mqtt section missing in application.yaml")
-        val topics = mqtt["topics"] as? Map<String, Any?>
-            ?: error("spring.mqtt.topics section missing in application.yaml")
+        val spring = mapSection(root["spring"], "spring")
+        val mqtt = mapSection(spring["mqtt"], "spring.mqtt")
+        val topics = mapSection(mqtt["topics"], "spring.mqtt.topics")
 
         topics.forEach { (key, value) ->
             val str = value?.toString().orEmpty()
@@ -140,4 +137,7 @@ class MqttSubscriptionGuardTest {
         }
         return -1
     }
+
+    private fun mapSection(value: Any?, path: String): Map<*, *> =
+        value as? Map<*, *> ?: error("$path section missing in application.yaml")
 }


### PR DESCRIPTION
Removes controller-level wildcard CORS annotations and relies on the centralized SecurityConfig CORS mapping for /**.\n\nAlso cleans up unsafe casts in MqttSubscriptionGuardTest so the full quality gate is warning-free.\n\nVerified locally with DEV DB credentials: ./gradlew compileKotlin compileTestKotlin test --warning-mode=all, with no warning lines detected.