### PR TITLE
chore(alert): replace JPQL LIMIT with Spring Data Pageable

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertRepository.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertRepository.kt
@@ -2,6 +2,7 @@ package com.apptolast.invernaderos.features.alert
 
 import java.time.Instant
 import java.util.Optional
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -129,16 +130,21 @@ interface AlertRepository : JpaRepository<Alert, Long> {
     fun countCriticalUnresolvedByTenant(@Param("tenantId") tenantId: Long): Long
 
     /**
-     * Busca las ultimas N alertas por tenant.
+     * Busca las ultimas N alertas por tenant. El caller controla el tamaño de página
+     * vía [Pageable] (típicamente PageRequest.of(0, n)).
+     *
+     * Antes esta query usaba `LIMIT :limit` directo en JPQL, lo cual no es portable
+     * (Hibernate 6 lo soporta pero es una extensión, no SQL estándar). Pageable es la
+     * forma idiomática en Spring Data y deja que Hibernate emita la cláusula nativa
+     * apropiada por dialecto.
      */
     @EntityGraph(value = "Alert.context")
     @Query("""
         SELECT a FROM Alert a
         WHERE a.tenantId = :tenantId
         ORDER BY a.createdAt DESC
-        LIMIT :limit
     """)
-    fun findRecentByTenant(@Param("tenantId") tenantId: Long, @Param("limit") limit: Int): List<Alert>
+    fun findRecentByTenant(@Param("tenantId") tenantId: Long, pageable: Pageable): List<Alert>
 
     /**
      * Busca alertas por tenant, sector, severidad y estado.

--- a/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertService.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/alert/AlertService.kt
@@ -7,6 +7,7 @@ import com.apptolast.invernaderos.features.alert.dto.request.AlertUpdateRequest
 import com.apptolast.invernaderos.features.alert.dto.response.AlertResponse
 import com.apptolast.invernaderos.features.sector.SectorRepository
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -161,7 +162,7 @@ class AlertService(
     @Transactional("postgreSQLTransactionManager", readOnly = true)
     fun getRecentByTenant(tenantId: Long, limit: Int = 50): List<Alert> {
         logger.debug("Getting recent $limit alerts for tenant: $tenantId")
-        return alertRepository.findRecentByTenant(tenantId, limit)
+        return alertRepository.findRecentByTenant(tenantId, PageRequest.of(0, limit))
     }
 
     /**
@@ -173,7 +174,7 @@ class AlertService(
     @Transactional("postgreSQLTransactionManager", readOnly = true)
     fun getHistoryByTenant(tenantId: Long, limit: Int = 100): List<Alert> {
         logger.debug("Getting alert history for tenant: $tenantId (limit=$limit)")
-        return alertRepository.findRecentByTenant(tenantId, limit)
+        return alertRepository.findRecentByTenant(tenantId, PageRequest.of(0, limit))
     }
 
     /**


### PR DESCRIPTION
M-4 per audit. Drop `LIMIT :limit` from JPQL (Hibernate-specific extension), accept `Pageable` instead. Callers updated to pass `PageRequest.of(0, limit)`. Behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)