### PR TITLE
fix(mqtt): subscribe to direct alert topics

### DIFF
--- a/src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/MqttConfig.kt
@@ -75,6 +75,9 @@ class MqttConfig(
     @param:Value("\${spring.mqtt.topics.system-events:system/events/#}")
     private val systemEventsTopicPattern: String,
 
+    @param:Value("\${spring.mqtt.topics.alerts:greenhouse/+/alerts/#}")
+    private val alertsTopicPattern: String,
+
     @param:Value("\${spring.mqtt.qos.default:0}")
     private val defaultQos: Int,
 
@@ -158,7 +161,8 @@ class MqttConfig(
             greenhouseStatusTopic,           // Device/setting status: GREENHOUSE/STATUS
             sensorsTopicPattern,
             actuatorsTopicPattern,
-            systemEventsTopicPattern
+            systemEventsTopicPattern,
+            alertsTopicPattern
         )
 
         // Crear el adapter con el client ID, factory y topics

--- a/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/mqtt/MqttSubscriptionGuardTest.kt
@@ -21,7 +21,9 @@ import java.nio.file.Paths
  *  3. The wildcard pattern `greenhouseMultiTenantPattern` (`GREENHOUSE/+`) is
  *     NOT included in the inbound topics array — including it would match
  *     `GREENHOUSE/RESPONSE` and defeat L1.
- *  4. The MqttConfig source file is actually located (no silent pass when the
+ *  4. The direct alert topic pattern IS included, so
+ *     `greenhouse/{deviceId}/alerts/{code}` messages can carry actor_ref.
+ *  5. The MqttConfig source file is actually located (no silent pass when the
  *     path resolution fails).
  */
 class MqttSubscriptionGuardTest {
@@ -94,6 +96,13 @@ class MqttSubscriptionGuardTest {
                     "Including this in the inbound subscription defeats L1 of the loop-prevention defense."
             )
             .doesNotContain("greenhouseMultiTenant")
+
+        assertThat(topicsArray)
+            .withFailMessage(
+                "MqttConfig.mqttInbound() must subscribe to alertsTopicPattern so MQTT topics " +
+                    "'greenhouse/{deviceId}/alerts/{code}' reach AlertMqttInboundAdapter with actor_ref."
+            )
+            .contains("alertsTopicPattern")
     }
 
     /**


### PR DESCRIPTION
## Summary
- Subscribe MQTT inbound adapter to `spring.mqtt.topics.alerts` (`greenhouse/+/alerts/#`) so direct alert topics reach `AlertMqttInboundAdapter`.
- Keep the existing loop-prevention guard against `GREENHOUSE/RESPONSE` and add a regression assertion that `alertsTopicPattern` remains in the inbound topics array.

## Verification
- `INVERNADEROS_TEST_DB_PASSWORD=*** ./gradlew compileKotlin compileTestKotlin test --warning-mode=all`

## Impact
This completes the MQTT actor_ref path introduced by PR #144: new messages on `greenhouse/{deviceId}/alerts/{code}` can now persist `{deviceId}` as `metadata.alert_state_changes.actor_ref`. Historical rows are not rewritten.