### PR TITLE
ci: run JavaScript actions on Node 24

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -27,6 +27,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: docker.io
   IMAGE_NAME: apptolast/invernaderos-api
 
@@ -51,13 +52,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run gradle test
         env:
@@ -66,7 +67,7 @@ jobs:
 
       - name: Upload test reports on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: |
@@ -118,10 +119,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -129,7 +130,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -145,7 +146,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/flyway-migrate.yml
+++ b/.github/workflows/flyway-migrate.yml
@@ -52,6 +52,7 @@ on:
         default: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   FLYWAY_VERSION: '10.20.1'
 
 jobs:
@@ -66,7 +67,7 @@ jobs:
       has_timescaledb_migrations: ${{ steps.check.outputs.has_timescaledb_migrations }}
       target_env: ${{ steps.env.outputs.target_env }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ needs.detect-changes.outputs.target_env }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flyway
         run: |
@@ -198,7 +199,7 @@ jobs:
     environment:
       name: ${{ needs.detect-changes.outputs.target_env }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flyway
         run: |

--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -36,6 +36,7 @@ on:
           - prod
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # URLs de las APIs desplegadas (Traefik IngressRoute)
   API_URL_DEV: https://inverapi-dev.apptolast.com
   API_URL_PROD: https://inverapi-prod.apptolast.com
@@ -49,14 +50,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Necesario para poder hacer push
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 


### PR DESCRIPTION
## Summary
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` in build, Flyway, and API docs workflows.
- Removes GitHub Actions Node.js 20 deprecation annotations without changing application runtime code.

## Verification
- `git diff --check`