### PR TITLE
feat(security): WS auth hardening + tenant isolation + payload observability

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "3383b9a7-e491-4ff8-aa6c-60ea8e57cb28",
+          "id": "f40f79dc-6ef5-43a8-8b58-5485fae823b8",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "7277cecb-31b5-45cc-a89e-4c52ea5b6686",
+              "id": "2a823b62-1541-43ff-b9d9-0209ee52d1a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "2ebbb33b-1a9c-4a67-a7c0-bf0c9e4fda0e",
+          "id": "7b68f288-8e3e-422d-8b34-586556658aa6",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "3cb09b95-1aec-417e-bc59-b97e6aa7df6d",
+              "id": "94b3d75c-0fe2-475f-8180-576c4d3a2621",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "08ac0abc-8ed3-40f6-82b2-adcc5201367c",
+          "id": "4c889fb1-7bf4-473d-a987-a66efd9bab06",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "63e72d9f-9170-496f-8e29-c6e11fe171c9",
+              "id": "205253e7-ea4a-4281-a023-5744297a7e0c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "59426f6e-9b08-42cd-b6fa-853aa0cdd6e3",
+          "id": "3cb566d5-2694-4e4d-b28f-068affb0eb88",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "dad7f909-647f-4e4b-a132-cde5a3d6cf53",
+              "id": "3e97a35b-82bb-49ec-bb2f-bc4b409e6d83",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "c75e1218-5c2b-4a59-ac77-a9e5eb4c86da",
+          "id": "d446e603-1931-48b2-9bd9-ba0054b59c79",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "3b7b037b-e818-4f67-87b0-c5269f15fa44",
+              "id": "9f1e8a0f-2961-494a-bcae-457d7c6e84e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "bb12f9ec-887e-4578-935c-4389357db187",
+          "id": "926ce61f-5611-4321-b2dc-93f741585a76",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "14edc18e-e7bb-41b7-af95-d91be503ffa3",
+              "id": "cc540281-d5a9-4cf8-b743-4e3710763cbb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "3659d8f4-999b-418d-9cba-5fba45304655",
+          "id": "f3efc029-9ac1-41f1-a2aa-dd6743830a23",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "9b8be1a3-5a94-4a1d-84f0-dd3a7fe0aa25",
+              "id": "313b7b59-9102-4eed-aa75-5f0608462f67",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "f9eb3858-d3c9-492c-b3b1-dbd5d6b32eaf",
+          "id": "bc8a0135-51d9-47ed-90b3-76de29540721",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "c2680b4f-4f7b-4319-9bba-ca58a4097f46",
+              "id": "8b366773-1bc9-4fd6-9783-8754ff54f1f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "7fe2a889-2c32-48c8-b6b7-3f0735969261",
+          "id": "53289988-a316-4ff4-9f40-7b48cae64072",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "45179eb5-b6cf-4ef2-9077-8ff778ebb62d",
+              "id": "5c6ecd9c-3e5c-4c52-85aa-d8e9ea3343f4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "86d0364b-cf09-4064-b826-fe2c8bfb5426",
+          "id": "be6bc150-ebbf-4ed1-b528-395dcb5d4c49",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "89ebec9f-7ef3-4da2-ae52-b9cc2f92706c",
+              "id": "7fdad8f4-71cb-4a5f-bf25-85fd78f49391",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "065b9e4b-9017-42e7-8f0e-6a838677c34c",
+          "id": "ac8a5547-b46f-4771-87d5-83faa3d0bdb5",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "0d128245-30cd-4749-85c2-15793657f0d3",
+              "id": "52460288-bad9-4f9c-84f2-87e1df68b7b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "012c22fa-a81b-4571-9a51-d4114b7b57ef",
+          "id": "dd76a37b-63ff-427a-b8e9-6698d53b64df",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "17242c1c-34e7-40ec-9f31-8b8346530b50",
+              "id": "f4d0d7fa-89e1-4002-a0a2-eb4047212538",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "c70834d8-65b4-4008-9152-2ad5e15700fa",
+          "id": "549b21f1-e246-4561-9ea5-860f5ab05d8c",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "4fa18c82-3637-4cf8-9711-a59ab5169193",
+              "id": "9df19afa-66ed-46a7-ba44-70b3a94a8679",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "e96d5f30-3f10-4c58-b54e-1fe162274bb3",
+          "id": "aaf44722-2ece-4d00-a87c-070478d42511",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "fa5bf96e-4b83-4bd5-9790-e037a7a733f7",
+              "id": "94ee8267-502d-4924-944c-111174ead59d",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "4eb3c546-df75-4da5-b213-d737e9b315b6",
+          "id": "8fd29d5c-03cb-4b9e-991c-c75abd4323c2",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "8b62e44f-fccd-4e52-9fd0-a3ef5f523b0c",
+              "id": "5f99f2b0-e94e-4018-abc7-f477bc075dc3",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "3ec8c8ea-5834-47fb-a9cb-6a095a13185c",
+          "id": "615bbe0a-bd1b-4b36-87e0-63ca47e9ca22",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "bf5444d6-37b8-4341-8ff5-66962e99f7eb",
+              "id": "6cfc961f-73e9-4190-8a82-6c0e89e48d48",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "e648703b-ff11-44bb-9fd6-774c69c8f04d",
+          "id": "3437910d-402c-4327-8d44-db30fa0a7fdc",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "45db77d6-a16e-4ac4-9aa4-01729dfdf0cd",
+              "id": "94bea59b-9398-4cb6-9797-3ef5b1565dd1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "a4e6eb9e-6181-4daf-be79-dadfb4973297",
+          "id": "6f8b56e1-552a-4f45-b69f-b24caa6d545e",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "73fbef44-329f-4c92-939d-dd47f4cf042a",
+              "id": "7a653b35-abed-4cb1-9c98-28211157aab8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "79d3e062-b907-4781-889f-dad50a3250db",
+          "id": "b0cd5e08-9cff-4bac-ab5d-68faf3156689",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "66b975af-b5e5-42ac-87f3-afe75f2efb75",
+              "id": "6c819a63-6879-4562-beba-5dd3955f3b48",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "b404f4a1-7868-4e32-b183-2023cce87de1",
+          "id": "593298cb-fd87-4fdb-b379-d934acc8fc19",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "5fbe4a59-8712-428a-b714-c24c3173853a",
+              "id": "aaebeec1-07ac-4b28-8074-78a9d94afbed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "4a133c03-5824-4142-bc84-43e726efd6b3",
+          "id": "7cc591c2-612c-4c2a-bccd-9f1d8cd02db4",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "647eb086-834f-48ca-a96b-e79e114cb5c7",
+              "id": "bd07faa1-0746-4ff4-9bd9-083ef5996f5d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "a2315f45-9d41-4464-aeeb-b479088d8d4c",
+          "id": "3d9bd56e-d8bd-4d0a-bc21-e307a67906e0",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "487e9db2-338a-47cd-bc84-ebfae5abe025",
+              "id": "b491fc73-c83b-4d42-b315-ba6458e5048f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "eb0742b5-ca9a-4464-9239-32e6173f7793",
+          "id": "9731a551-2193-4baf-bf81-fc629584d449",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "11a9aa34-0b0d-43c0-b522-68501922baf9",
+              "id": "d33a5847-694b-4d59-bfab-172602952c8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "9061a032-fa70-405c-b69d-626cba1559c0",
+          "id": "85985b48-340f-4f0f-a860-6d7173e08396",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "58589966-cd4b-4b32-b0a0-f3dac3899f9e",
+              "id": "1e023cf2-30ea-4992-813c-86b5faa54635",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "26220ae7-8223-4f5d-9faf-3f5d192c9d3f",
+          "id": "2bd69670-cd35-41dc-9522-412125607609",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "f987acfe-db84-4ed4-9cde-7dd13880ff48",
+              "id": "f1e5e339-08c7-41bb-a37b-f3012fac975e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "4b2badad-63be-4d6a-9661-9eeb5cf77bba",
+          "id": "6622a218-2d4b-43be-a7ea-ac4cbb6eef93",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "005c270f-6de8-432b-9e68-80082aa47a8f",
+              "id": "e42960f8-c86f-4ad0-a8fa-b9368a4c63f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "8891ba14-9a73-4952-81e6-c223df24456c",
+          "id": "83e88bcc-94ac-44de-b874-792b4eeea815",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "e9bda7bd-394f-4d1a-944c-b6e3c9458682",
+              "id": "4b432526-bec6-4add-ab56-69d2239f4966",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "74cb6b92-d0c7-4d07-80f5-8ee6b5eade81",
+          "id": "c54e0ba3-c4e6-4f8e-b53a-0758c69e0848",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "7d2aadfc-2990-4aa3-a35a-ddbbd6ed631c",
+              "id": "5df4a765-7c32-4abe-9725-2ab88a9d7d5b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "2c3ea562-55e8-4fe6-9cca-28becef8a6c6",
+          "id": "f107e48c-90e3-40e8-ba98-dbc4643ac04d",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "c1111bfb-f39c-484b-b072-24359295d58c",
+              "id": "af074e61-2ad7-4fc7-a8f1-0c278f44ccd7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 9627.297417706888,\n        \"key_1\": 9479.557797122627\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 9548.899726558113,\n        \"key_1\": 9454,\n        \"key_2\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "281469c3-c293-455b-828d-136115d37dc8",
+          "id": "8541c949-09ed-4701-bd6c-76e29558dbfe",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "50146f09-f7b2-474a-a7a1-8700c628dd02",
+              "id": "90f2326e-6bcb-474c-9d96-b666032b03ff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "faf1d9f7-c0e1-414c-a9b4-e7800ca64614",
+          "id": "cf788a69-ed94-4e13-9925-193dc03aadc6",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E4b87A\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cE9CA1\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "b5d7f74c-383f-4816-b9e0-fac9a1ba0ffc",
+              "id": "f1ef1834-7c3e-411f-98fe-e407fd4c5e91",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#E4b87A\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cE9CA1\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "1b9491c9-d11b-47be-a702-df38ce14805f",
+          "id": "c23736cc-5dd2-4d2e-a951-7da4fc190dc0",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "367c50fd-2736-489f-9411-5bbff1fcd524",
+              "id": "2d86c1e5-f324-49a4-bb14-5c2e25045a3c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "a868c758-0d36-46ef-a8ac-9874a991c89e",
+          "id": "28519127-286b-4297-9b9d-f5cb8bb8e131",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "b2ae33ed-1a9e-454b-bd6d-bd09e65d7c59",
+              "id": "0b484968-0daf-4be9-a9e8-6b077fe61f37",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "e9a6eb03-8128-4a75-8feb-e5c1fe8eebea",
+          "id": "54ca48f6-1a25-441b-8195-bbb076510f5b",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4cEBee\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#78eb5b\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "440a4244-4336-41e3-a37c-2e430080f739",
+              "id": "ed97a807-1d02-454e-8703-15b48de09e8a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#4cEBee\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#78eb5b\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "99984719-462b-4cfc-97d9-c5d3820336e5",
+          "id": "8697f387-0c19-44f7-a8e9-d8a8e410e299",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "e1350f10-7a17-451c-ae43-227ebba07f4a",
+              "id": "bd4c48ad-12f0-4c4d-8032-fc8687e97681",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "a013f0c4-93fd-4d6a-a92b-c47d521c6e88",
+          "id": "97209f6a-f2f1-4194-a6a9-1ec4cb6aaa1e",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "8a6ab6ee-4320-4ac5-bb03-4911d0b48d28",
+              "id": "f02f9947-8960-4916-b95f-6af4ee1af87c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "d3d8884f-8556-4a8b-bb14-f865cad30ef9",
+          "id": "459cf73a-2ee8-4f0b-9c5e-b0367ba43ace",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "6c0a2692-b222-4640-b664-426a7a586dd2",
+              "id": "f8d9f537-56fd-4cfa-8444-a39220185886",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "624d329e-0836-4813-b79f-dde436069721",
+          "id": "163fd304-0f9a-4265-b847-fd6f0c36b287",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "54d115ae-4943-40e9-8538-900ce5089fec",
+              "id": "129789e8-5e6d-49fa-8121-9540c6ce59e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "8391b3fd-c40c-4d3b-83c7-aea3b2c63366",
+          "id": "aced9904-7d71-474e-8c53-494789d613f9",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "bafd28ca-d337-4d3c-9648-702c5b9f2f36",
+              "id": "63a09455-cb5f-4d07-a83c-cce9f7d957d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "ec8e62af-d7bf-4d57-86c4-79aa007c47dd",
+          "id": "8144ca31-a708-4f8d-bf80-8934d7135af3",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "62b2a5f1-1e2c-464f-85fe-88407161be51",
+              "id": "74deda63-a65b-462a-9d40-1155b791f0f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "31e2c836-6fe1-42fc-9301-5591b7e2b967",
+          "id": "2a1ccee2-cf13-43cd-b8ec-48761178c915",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "db2404d5-908c-445e-b9f7-e3bf0d17f2dc",
+              "id": "dac722af-dfc0-4180-bcf3-4a25029da044",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3332.173044992013,\n  \"key_1\": 5459\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "e282a53f-0626-4c12-bb86-f8bbb3b420ee",
+          "id": "a6925ec8-7bff-4d55-bf7a-e878805c0a11",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "305d4729-6247-4932-84b4-88b8f21b72f6",
+              "id": "f7d79115-bd4e-461f-9f80-d0a9d13a90dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "165a5691-b9da-4377-bcb1-30e1c8e9b9d5",
+          "id": "9e30ec78-3864-4906-ae66-4c39801a5728",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "d20b9a2b-ac70-4bf9-819a-67bb6ef36e18",
+              "id": "59f5daa2-b121-4dd0-a5a4-307516e8cdf4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "af507a7b-9b03-4db6-8b67-c29435b7ed1f",
+          "id": "4bb5e208-6a5f-448b-90c6-34510bcb2014",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "d3fcf33b-aafd-4e23-8f59-74f741c11872",
+              "id": "ba5a55fa-8fd1-4b87-9b47-51639f2b5c52",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "c7494831-18d0-4dfc-aadc-71adf3c80638",
+          "id": "e6b042ba-e7e3-4c5c-a7b5-fb53d252269a",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "c573a5a2-49a2-4cc7-98fc-3671d0171623",
+              "id": "23a8b886-5b57-4ef7-b433-99e50065a529",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "169541d7-5e94-41b1-9525-a6f8275ddb8a",
+          "id": "760d2e18-269e-4a12-abe1-62e797855f43",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "d52fe3ec-7aaf-4816-becc-337a0675910a",
+              "id": "0f1b7945-7063-42c8-a150-3680ced88944",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "784c926b-7532-4145-b8e9-ce61cabe06d2",
+          "id": "2e95de8b-306c-485f-951a-864f56bff470",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "b914f633-e8df-4380-8ba8-55e610a5f66f",
+              "id": "8ec1a744-f3c5-4e73-afa9-ece882e4be94",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "a70876e4-aefe-455c-b411-180afd72a6c8",
+          "id": "7c28a870-75d3-42f6-a8d7-691a5e9da3ff",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "ed722799-fb8f-4e03-bb62-3a3bfe2be641",
+              "id": "7796f5ec-b457-4ff5-a2e1-96b271a7a2a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "28807b5b-98b4-40e9-adf4-de0e443ac233",
+          "id": "ef060f1d-3768-4f02-9336-54e16a8835d0",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "7d3b6736-1d1c-4310-b8fc-5beb57cf2c8c",
+              "id": "23886ceb-fde7-4ed7-bcdc-e5db17f9d638",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "96cb3294-cf3d-4af7-8365-c1b3e4d88e93",
+          "id": "57c17680-165c-40d7-bdb0-36d0d714c76e",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "bf944524-2368-4da8-83e0-e0ff3245ae0a",
+              "id": "758d3da6-faa6-48e9-aef3-d2bfa8655159",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "5262b942-bdbb-4427-a212-2190455aeb8e",
+          "id": "4deaae85-c2af-4de4-a0a2-b138e512b179",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "5ad5bc21-397c-44b9-821c-69f0c376d765",
+              "id": "b64df23f-73f0-4e1e-9413-f878bd880bf4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "c5fedd5f-08a0-4bd7-8b1f-9bd2229de942",
+          "id": "e9fc1e32-0583-4d33-9b3b-5ba83411bb0c",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "6ed34ca5-7028-4df8-b3cf-4090869f295a",
+              "id": "bf2b75e6-588d-42c4-81b0-94684597f898",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "d0afdc70-004f-42c0-b5bd-b485a7352f84",
+          "id": "a62eecaa-db43-4532-acbb-f78487dad434",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "78dd193d-6cfc-4775-b4c7-694db4bdbcdf",
+              "id": "7b50d4a3-a9ce-4f2c-9e9e-b2f815906913",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "e12ea9e7-8aea-4968-ae72-bdb41fd4b1c0",
+          "id": "e2e4ee71-3e90-4489-87b4-b14a8fe7f3d2",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "cd41dae1-20da-4e1a-ab77-8602dad50969",
+              "id": "1b5d5362-ef8f-430c-afa2-831e6c537903",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "37191426-f55f-413f-85d8-caaeeb33b5c1",
+          "id": "359875c4-964b-4ab3-ade2-89929665da88",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "8b810999-bbf4-43b9-ba8b-b0e71e9553b0",
+              "id": "2e5de7d7-ceef-4d6c-8c84-43e73de3b3d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "45b3a449-dcab-4423-9d2f-16fd21ae0462",
+          "id": "328bce4b-5113-4f7d-91cb-51867f8a0f39",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "04034117-db58-45ba-a632-3f44c88c9768",
+              "id": "4cddc01f-ceb8-4b60-8116-812b2767ab60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "f52af9f2-bdd0-490b-a55e-893f035699a7",
+          "id": "c85f32ce-4826-4211-b72a-82f91f2d12b3",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "3d169d36-e2c4-4b10-b64b-fd71eb7b53f6",
+              "id": "281fd107-b9a0-4f46-92fe-0435121bb040",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "72f4ead0-3b4f-468e-8cff-ab422bbcaa0e",
+          "id": "af5f3d09-43db-4cdc-82f6-1def98c38bd5",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "c0228de6-0ee8-4ee5-9d44-17865a117d9d",
+              "id": "4bf82c1d-a48e-4e44-8db8-0161b1f5f64f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "0336aacd-e830-4c19-8200-7d8b6b20105a",
+          "id": "568269fe-7464-4427-b5a1-6dff273498c6",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "bcee9227-e77c-4785-ad1a-cd4154a6bafa",
+              "id": "4364b5e0-5084-41bd-acc4-9f08d13e824a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "47f0735c-cd06-4eee-bd95-74b40e452c44",
+          "id": "111239cd-e30c-4605-9e78-d3d8cd34ba36",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "3fa82fa4-a017-4a8c-821a-9bc4da45e5c0",
+              "id": "2ab409d7-5025-4ce2-8ed7-f2cd42a4a0c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "a30e9671-45c3-4d90-86ac-1d07f3c468d8",
+          "id": "d1b732e6-c000-4063-a5c2-dee668e28e5d",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "4bc3f2fe-0bb1-455f-a1f3-cc2ba3a567d2",
+              "id": "10b36839-2546-435f-91a2-d5705d9e7c49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "72941fc3-c4a3-4e5e-afd0-82e2460f09fa",
+          "id": "414140d9-dd84-433a-8160-a23a7208de23",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "3e6ad683-e753-422c-8e91-e768443b9fb1",
+              "id": "74e86484-7310-426b-afbd-3d3953a4005b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "b55cb4e1-1d59-4812-b65f-a2332f69cb37",
+          "id": "5950d9da-07ca-42fb-bbab-0ce4b019dc44",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7553,7 +7553,7 @@
           },
           "response": [
             {
-              "id": "617063ba-6dc5-461d-bf5f-13a83f9b94a6",
+              "id": "d4ffebcc-646e-4ffe-aaac-325a9e2109f1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7629,7 +7629,7 @@
           }
         },
         {
-          "id": "4e5ab3b5-ecdd-4f80-b82e-23be5a4021ca",
+          "id": "f03d8a8a-a548-4a86-8b87-984a42f730a7",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7683,7 +7683,7 @@
           },
           "response": [
             {
-              "id": "332a3900-4465-48ec-b5eb-f24235517b50",
+              "id": "3300f6d4-63c1-493a-9759-313d8397e9f4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7765,7 +7765,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "60035121-67bb-4a1e-a976-b50a0f0c5aad",
+          "id": "c93cd207-7a72-45ce-97a3-17093b74e5be",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7818,7 +7818,7 @@
           },
           "response": [
             {
-              "id": "6fde394b-a226-4b0e-a06e-91e1e3bf8719",
+              "id": "cffe7fb4-caa8-4018-a9d9-3dc620b02ddd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
           }
         },
         {
-          "id": "e1d7c22e-8151-4805-8d92-9c54fd77242a",
+          "id": "0bc95644-28dd-4c02-8f8a-fdd91ee82bfe",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -7959,7 +7959,7 @@
           },
           "response": [
             {
-              "id": "ca3361ed-644b-4fd3-bb70-13f8fcb05827",
+              "id": "5998fe92-4489-4c2b-97a8-c3bca63d5f38",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8047,7 +8047,7 @@
           }
         },
         {
-          "id": "7f0881c6-77fe-445c-bc5f-798e4364a719",
+          "id": "12b33b78-b54c-4e29-8f99-17b232513d6c",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8094,7 +8094,7 @@
           },
           "response": [
             {
-              "id": "327b9e78-b42f-4c52-934a-a5ee2b409b2f",
+              "id": "5a0e1f72-a540-402c-be4e-9bd945add3be",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8159,7 +8159,7 @@
           }
         },
         {
-          "id": "bf7f8ce4-0d28-4c91-819d-b3270cfeedb4",
+          "id": "1128dc42-9160-40e0-94dc-84c9164ffea7",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8201,7 +8201,7 @@
           },
           "response": [
             {
-              "id": "7b8dda9d-60c4-4eb5-9704-eb2a3c5d5afb",
+              "id": "f43d4287-2642-4f95-ab93-82bee2b5d6ff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8265,7 +8265,7 @@
           }
         },
         {
-          "id": "18e38691-dfd5-4f8e-a6d0-2c68cf1995fb",
+          "id": "26bd29a5-e190-471e-b926-85fcc0e67eed",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8320,7 +8320,7 @@
           },
           "response": [
             {
-              "id": "d22459c5-d3c8-4663-82a1-329a90171fb4",
+              "id": "210e2295-4745-4eeb-a449-c09412ef4ba1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8403,7 +8403,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "5f78ff10-3332-449b-8248-2d1c9d4c5967",
+          "id": "cbb74a15-8582-4286-b9f4-fa2a5610630c",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8444,7 +8444,7 @@
           },
           "response": [
             {
-              "id": "1392da1e-5349-42cf-936a-63a5949c75fd",
+              "id": "ba876784-8e10-4f71-a01a-d7fe0312b185",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8507,7 +8507,7 @@
           }
         },
         {
-          "id": "b2305a91-7552-4e0f-9659-58a9ed064e34",
+          "id": "eeb3c548-4110-407b-9904-1cc2fce7fa88",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8561,7 +8561,7 @@
           },
           "response": [
             {
-              "id": "213fb58d-e76e-4f34-97e6-a10ac2bf0946",
+              "id": "3e17f998-5aab-4de0-941b-07dbc1979ba7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "194ce67d-a670-422b-babe-29b47e8c2122",
+          "id": "c659f60c-6a73-4ee7-add3-54eda1c4f929",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8672,7 +8672,7 @@
           },
           "response": [
             {
-              "id": "fd0e96a3-4c2c-4e4a-a53a-6316f538d92d",
+              "id": "cf951ece-0ca0-4c90-9162-dcd3a190e738",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8725,7 +8725,7 @@
           }
         },
         {
-          "id": "57a108dc-59ff-4371-aca5-6a61c3a7a866",
+          "id": "585cf04a-1476-49ed-8f67-f57a9474570c",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "c659a6c9-6d75-4661-9294-6255a83b7243",
+              "id": "b329e514-fc05-4273-8ca8-7fc86b123dd1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8861,7 +8861,7 @@
           }
         },
         {
-          "id": "a4ff9a22-02d3-4bfa-8ac5-28ae03fee414",
+          "id": "4e6d7666-f7fc-47f2-9ea4-b91d87d37efa",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8903,7 +8903,7 @@
           },
           "response": [
             {
-              "id": "c0065852-4560-4fb6-90ae-6c2cc9b7d0fa",
+              "id": "29eb5acd-ca8d-4ee4-90f6-2122eed88511",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8973,7 +8973,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "4c5388cb-9e75-4d4c-850a-f9a785771c98",
+          "id": "5b354bfc-821e-4d4a-8e75-039643847875",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9026,7 +9026,7 @@
           },
           "response": [
             {
-              "id": "28f3ef16-57b6-4d20-8469-69a957e36310",
+              "id": "6b04d2d6-0348-46b3-b452-039570cd0cd6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9101,7 +9101,7 @@
           }
         },
         {
-          "id": "87456fa7-9e71-4c5b-aed4-39695a80823d",
+          "id": "8864e0c6-f151-45c6-8196-6b65ee1898d2",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9167,7 +9167,7 @@
           },
           "response": [
             {
-              "id": "9e1206ac-036f-472c-b049-424483f2eccc",
+              "id": "80c5138d-d7be-4e8e-809b-9162373798d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9255,7 +9255,7 @@
           }
         },
         {
-          "id": "79ef7f03-8edf-460f-820d-3bded645627e",
+          "id": "03a8f120-a760-460b-8d0a-34a66e710487",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9302,7 +9302,7 @@
           },
           "response": [
             {
-              "id": "60260452-58ac-4b31-bfcf-3ab5221547f7",
+              "id": "72f960d5-43e4-44e6-9d65-baf34b24109b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9367,7 +9367,7 @@
           }
         },
         {
-          "id": "40bb26ac-3082-4f14-ba7e-35d21f563dd5",
+          "id": "b8f88603-629f-412d-aae2-71a2ca406c8d",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9409,7 +9409,7 @@
           },
           "response": [
             {
-              "id": "92866309-1936-4270-b5f9-024ab7b3a467",
+              "id": "90dc8c44-5fcd-4e5f-9f22-65ca94955f69",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9473,7 +9473,7 @@
           }
         },
         {
-          "id": "e2b304fe-096b-4642-9b04-938603f07905",
+          "id": "c5d5836a-22fc-4aed-b2bb-e995ddf2146c",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9528,7 +9528,7 @@
           },
           "response": [
             {
-              "id": "ab551a62-9e92-4d11-a6cc-98b14220b643",
+              "id": "f9177e69-27dd-4112-8127-469565c370c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9611,7 +9611,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "2118b56d-d5ef-4d98-876f-2c8b012c6816",
+          "id": "d4a9a014-c018-48f7-a841-c0fe50a2dd35",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9653,7 +9653,7 @@
           },
           "response": [
             {
-              "id": "066bf2cb-0286-4ac7-be3d-d721f1cc0d51",
+              "id": "7394a303-31f6-4e17-b919-e9609c599ab7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9717,7 +9717,7 @@
           }
         },
         {
-          "id": "40104e7a-ef3e-4c5a-bc06-e603f21bb52e",
+          "id": "d9481df5-1c35-4dcb-bdaa-9d6ac9a4955a",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9772,7 +9772,7 @@
           },
           "response": [
             {
-              "id": "9ab9393f-7fa0-4c4a-b966-1a16f60e9827",
+              "id": "9865ad60-2095-4b7e-bbbb-833e6ad3d987",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9849,7 +9849,7 @@
           }
         },
         {
-          "id": "6737a615-682d-4d94-a0a0-ca9926dac40e",
+          "id": "0e34080f-36a1-41b2-94aa-72765a473bc6",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9885,7 +9885,7 @@
           },
           "response": [
             {
-              "id": "2cae2bf6-75cf-41aa-b2ce-c631e76fcaac",
+              "id": "756e624f-e67e-4071-a332-77483488bb23",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9939,7 +9939,7 @@
           }
         },
         {
-          "id": "2e567a87-a82d-4271-b497-395c9f4375c9",
+          "id": "80d0f627-d448-4219-9f09-e414323f19a7",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -9969,7 +9969,7 @@
           },
           "response": [
             {
-              "id": "bf32973d-ccb0-43b0-8084-e49ed2bca8ed",
+              "id": "57b4d8a7-ba3d-4090-90f9-88eb02f1fed3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10021,7 +10021,7 @@
           }
         },
         {
-          "id": "2a6e7498-0eae-45ef-8c9b-713bf9706661",
+          "id": "5424cb2b-fd0a-49d6-ae46-22658abe328d",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10064,7 +10064,7 @@
           },
           "response": [
             {
-              "id": "6b6eedb6-dda8-4253-b411-95ead655e0c0",
+              "id": "446f4d18-2ad5-4ed0-abab-98bada4d75b6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10135,7 +10135,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "c2a89cbf-4709-4c39-80a9-3c3252d96e3e",
+          "id": "dc0a3719-bfdd-4829-a62e-ca059ee85318",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10177,7 +10177,7 @@
           },
           "response": [
             {
-              "id": "c216c4be-12a0-49c1-9bf1-b28e04e907ec",
+              "id": "47bd9645-b2d1-4c93-abab-0528a84a822c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10235,7 +10235,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c0087c66-3095-4c77-b8d8-f0e3661f1fb4",
+              "id": "ee3e5e45-a561-4aaf-84af-5f4e48001f47",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10299,7 +10299,7 @@
           }
         },
         {
-          "id": "e8987904-d571-46f5-ac67-d38bcd677113",
+          "id": "68c52452-595d-4930-8f55-57609fce8041",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10354,7 +10354,7 @@
           },
           "response": [
             {
-              "id": "84975ae6-a088-43ce-b570-45937107d92c",
+              "id": "604a2592-f1d6-4fe7-a295-61799537b83e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10425,7 +10425,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "47c6c633-5df6-45d0-9807-1f492eae7a0c",
+              "id": "57937c71-2b87-4c5e-95f3-15ba4e1e12a9",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10496,7 +10496,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0ec6ca78-163f-4545-9234-b5deaf48c603",
+              "id": "1f3f1a26-9ac1-475d-b4c8-4cb9d29e2cd1",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10573,7 +10573,7 @@
           }
         },
         {
-          "id": "fc419f8c-c53d-4195-bc42-daa4418c3390",
+          "id": "d459d3c3-7c8c-4a4d-9066-3532f96ad885",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10609,7 +10609,7 @@
           },
           "response": [
             {
-              "id": "0f859729-e137-4a0d-975b-6533aebbe90d",
+              "id": "406d39f2-4e6c-40f3-81b3-dd0521589c1f",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10657,7 +10657,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0b1bd870-54e5-450c-a234-c8063693b8ee",
+              "id": "c6af79d0-d6eb-41a8-9a59-7e211c3fb82c",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10705,7 +10705,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "50eae2c4-de6c-4b15-ae0a-72d36e4a4ef2",
+              "id": "4b1ac511-1108-433c-bc98-5135c763285a",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10759,7 +10759,7 @@
           }
         },
         {
-          "id": "dedbd54c-5262-4c1e-be67-585eb1718956",
+          "id": "07ea834a-db36-4d81-92fa-1e5418d49666",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10789,7 +10789,7 @@
           },
           "response": [
             {
-              "id": "58b4b9e5-9eb2-4d46-9013-a77b2a8ee6ed",
+              "id": "6d20ea47-36bf-40ee-bdb3-7fa48bfefb30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10841,7 +10841,7 @@
           }
         },
         {
-          "id": "65abbc5c-df38-44be-bcea-df3293675ddd",
+          "id": "3f560baa-3d48-4503-9c99-c9b2dd4b1236",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10884,7 +10884,7 @@
           },
           "response": [
             {
-              "id": "ebb217d8-d1d9-4383-b042-83312b8d23c0",
+              "id": "41939bbe-8b94-4e69-a16d-0c7099e76319",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10943,7 +10943,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "7e35a48a-0837-4496-87b0-da7b06a484ec",
+              "id": "cca4cfdd-17d2-4278-99d9-551eba54789b",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11014,7 +11014,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "83c4d915-8eac-46d4-bea5-cc566f8e89f5",
+          "id": "a48f6026-973a-4e91-92b5-153030980808",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11098,7 +11098,7 @@
           },
           "response": [
             {
-              "id": "cf5b1c0d-4da8-4208-8ed3-094d414dcd92",
+              "id": "4a81e24e-48f4-41c4-840a-de50dbc936e9",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11201,7 +11201,7 @@
           }
         },
         {
-          "id": "32dee9ce-ee50-4786-8cc6-d4236b340fec",
+          "id": "c9469c10-1145-4b66-b4ba-99a87d021589",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11267,7 +11267,7 @@
           },
           "response": [
             {
-              "id": "8579cb1b-a9f1-4b30-9331-399e0d31fabb",
+              "id": "3739beaa-46e5-4f05-969c-58505e499555",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11352,7 +11352,7 @@
           }
         },
         {
-          "id": "b7945713-5e35-49d2-98e0-1f793dcce468",
+          "id": "84406655-71da-4368-9d2a-03bb0c2fd845",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11436,7 +11436,7 @@
           },
           "response": [
             {
-              "id": "bef9dd0c-0d24-4e38-bdbb-49e697ecc9fe",
+              "id": "be42bbde-613b-4a6e-91f9-7635bf90083b",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11539,7 +11539,7 @@
           }
         },
         {
-          "id": "16e021da-17d1-4415-b362-5abdd25afa6b",
+          "id": "b803ce1a-46ca-4b06-9813-15a43b43be97",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11614,7 +11614,7 @@
           },
           "response": [
             {
-              "id": "57d4c4b0-46b3-43b3-9cec-c73c21a70e10",
+              "id": "f3d14a98-0eb0-420e-bcc7-eef94da0e4b2",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11708,7 +11708,7 @@
           }
         },
         {
-          "id": "a6d9d845-c84f-48dd-91d8-e86a5a5f244d",
+          "id": "b1a12f28-486e-4dfd-9a7c-a733b53f0205",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11783,7 +11783,7 @@
           },
           "response": [
             {
-              "id": "96e70702-f512-4dc8-a194-3d3183c5aad9",
+              "id": "2a1caff3-56a7-4f0f-b10c-06721a813ed0",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11877,7 +11877,7 @@
           }
         },
         {
-          "id": "3fd29210-8367-4898-8c76-3bf1b0e8890f",
+          "id": "4b54d241-a595-421c-a5db-7d5de3161b28",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -11952,7 +11952,7 @@
           },
           "response": [
             {
-              "id": "3e9745af-cd04-4758-ae1a-d740a093b155",
+              "id": "30fbf085-23ee-425c-8bc2-9c019e7fe39a",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12052,7 +12052,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "5ec6738c-456a-4da6-9a32-1449ccae7257",
+          "id": "215d4b75-3938-4ac0-b525-89e1433e53c7",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12118,7 +12118,7 @@
           },
           "response": [
             {
-              "id": "783d3508-b7ba-4b40-a35a-a4722215af31",
+              "id": "834dcf65-734d-4f54-9001-ef107ba7b534",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12192,7 +12192,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3332.173044992013,\n  \"key_1\": 5459\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12209,7 +12209,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "2cfd761d-c506-4ac0-afc3-270aa1ab8874",
+          "id": "7f48867b-e036-4654-85f8-e854b50559d5",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12251,7 +12251,7 @@
           },
           "response": [
             {
-              "id": "929373ee-d10f-4009-9f09-dd92cf86fcc2",
+              "id": "46fd6232-537a-4e8d-9b97-b4443301db96",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12321,7 +12321,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "fb28f73e-bc45-43f9-b4bc-df7611a65b62",
+          "id": "4797e844-5b7d-451a-8fa0-89bca5fc338b",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12360,7 +12360,7 @@
           },
           "response": [
             {
-              "id": "a747a965-1792-4797-be9d-5d797f9a9815",
+              "id": "50db522c-bb6a-40bf-b293-60987ee0882c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12413,7 +12413,7 @@
           }
         },
         {
-          "id": "2ae3746c-019f-4a81-bda1-be4913a3a8b2",
+          "id": "e29e1371-9adf-4fd0-b1f4-e84e17b0db54",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12445,7 +12445,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"iw-OG\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:01\",\n  \"quietHoursEnd\": \"23:15\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"yn-XD\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"06:51\",\n  \"quietHoursEnd\": \"23:58\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12465,7 +12465,7 @@
           },
           "response": [
             {
-              "id": "e63e29f5-d51d-421e-a1c2-a01fbb2120b7",
+              "id": "eb8a55e0-7c10-4dca-8a4f-ca42cc44a9b4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12503,7 +12503,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"iw-OG\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:01\",\n  \"quietHoursEnd\": \"23:15\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"yn-XD\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"06:51\",\n  \"quietHoursEnd\": \"23:58\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12537,7 +12537,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "7abdc2a8-a2f7-4787-b887-10c9202eeacf",
+          "id": "b02e5e1d-7aa9-4922-aa72-a87f0e54485a",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12579,7 +12579,7 @@
           },
           "response": [
             {
-              "id": "b515c022-0ef3-4c58-9d15-c3252f7547ab",
+              "id": "67075d42-8510-4806-b3cc-a0a707c26eb2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12643,7 +12643,7 @@
           }
         },
         {
-          "id": "9c4dd56e-4146-4ad0-86c2-a3cfbf64bcfc",
+          "id": "7ad6b1e6-2cf5-495b-acf8-1720e16f583b",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12686,7 +12686,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#84265A\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#ddFB5B\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12698,7 +12698,7 @@
           },
           "response": [
             {
-              "id": "f371a37f-87ef-49ce-87b6-e6744a8e4c2e",
+              "id": "682eac64-11bd-4c10-b25f-515c5118f51c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12747,7 +12747,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#84265A\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#ddFB5B\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12775,7 +12775,7 @@
           }
         },
         {
-          "id": "6f010a0b-d594-49e0-abc8-f85a1b85dfc8",
+          "id": "c3440c1e-19ab-4d0f-9e35-f1a76534ec71",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12811,7 +12811,7 @@
           },
           "response": [
             {
-              "id": "f54a623c-3298-4edb-9608-97e35bb193df",
+              "id": "a77f9445-f345-4058-92fb-0b0cceb9aa54",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12865,7 +12865,7 @@
           }
         },
         {
-          "id": "83995549-d0e6-4d5b-92b8-99521013e715",
+          "id": "16b0970a-e600-4776-9d2d-b77ebab88e9c",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12895,7 +12895,7 @@
           },
           "response": [
             {
-              "id": "0d9da167-2152-493a-b4d2-ab7787201eda",
+              "id": "75da9fe0-278d-4d88-890b-b96b94446a92",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12947,7 +12947,7 @@
           }
         },
         {
-          "id": "d99ddb2a-1a4b-4005-91c2-aa5c15d4813f",
+          "id": "5e252cb9-e597-49a0-a60f-5dd4b3bcba16",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -12978,7 +12978,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#AdCbEA\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cd3507\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12990,7 +12990,7 @@
           },
           "response": [
             {
-              "id": "fb0fe75d-b9a6-4921-815c-19adba96eacb",
+              "id": "e8b9838e-4ec9-4f46-a4db-9f337884510e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13027,7 +13027,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#AdCbEA\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cd3507\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13055,7 +13055,7 @@
           }
         },
         {
-          "id": "5a4947c8-2b42-4ff9-b75a-b461315f5249",
+          "id": "e0ad7d0c-166c-4e21-ba82-ec414e0e0368",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13086,7 +13086,7 @@
           },
           "response": [
             {
-              "id": "a94a5564-c817-459f-8603-c06d9c4bbaec",
+              "id": "9d6ffd27-8ee7-4dac-b2c4-99ec25fb0cb6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13145,7 +13145,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "bb5e4ee1-57eb-498c-a908-5f8d913f6f68",
+          "id": "abd3a249-abb4-457c-87a8-97da14c32aeb",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "63c37011-d53b-4e44-a07f-bdb2f71bd461",
+              "id": "9b079f12-d084-4942-b32b-8283b09a55ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13273,7 +13273,7 @@
           }
         },
         {
-          "id": "8e910f3b-078f-4707-a124-26d924dfe42b",
+          "id": "ec54577d-d3fb-4516-b6f6-04fee56b018e",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13339,7 +13339,7 @@
           },
           "response": [
             {
-              "id": "a9bbfb7e-f887-4ae3-bc47-9219e79a00a5",
+              "id": "0255a301-52bc-447e-a0a8-589ef9a0b4b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13427,7 +13427,7 @@
           }
         },
         {
-          "id": "ed87fe21-c4fd-4e3a-9792-b26e95b01b02",
+          "id": "62502c1b-9367-41e6-93ca-6623aa475f76",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13474,7 +13474,7 @@
           },
           "response": [
             {
-              "id": "3468e703-4716-4375-bbc3-e41f2ae19c2d",
+              "id": "83c3fcc2-838b-4ae1-9462-8004bf996a10",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13539,7 +13539,7 @@
           }
         },
         {
-          "id": "3a800fe9-4a3a-4187-bee6-b478309d0d89",
+          "id": "dd4cfb08-1ab1-4ae6-b65c-075bf9d84492",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13581,7 +13581,7 @@
           },
           "response": [
             {
-              "id": "cf39999c-c601-448b-9f2f-1957283301c5",
+              "id": "71796a16-4217-4bd6-bb96-be19a946a6a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13645,7 +13645,7 @@
           }
         },
         {
-          "id": "83a328ca-5cd6-46d6-be90-107bd3191019",
+          "id": "65360a2a-26a5-4ee2-a9ca-46c72f87e826",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13700,7 +13700,7 @@
           },
           "response": [
             {
-              "id": "ec95c33f-0fc8-4f17-b422-ebed34ecf5e9",
+              "id": "c9572890-da52-4093-a709-ae8244c781c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13777,7 +13777,7 @@
           }
         },
         {
-          "id": "e6247dd5-b1fe-4a2b-9cba-19c2e4210e44",
+          "id": "18871bf2-1a1b-4f63-94df-f622d6877cea",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13831,7 +13831,7 @@
           },
           "response": [
             {
-              "id": "4f4a59c1-05c4-4561-929d-489e789433a9",
+              "id": "3715e235-68d5-43f6-98a5-bfdddd3c7644",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13907,7 +13907,7 @@
           }
         },
         {
-          "id": "f7d4e394-c006-4909-bde0-6171e91ecba7",
+          "id": "7ffff27a-e70b-4feb-9981-637348eacc2c",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -13973,7 +13973,7 @@
           },
           "response": [
             {
-              "id": "63a49287-0563-4396-b98d-833682ad1a0e",
+              "id": "2e100f84-cf34-404c-9826-7672fca0284e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14061,7 +14061,7 @@
           }
         },
         {
-          "id": "f1332a9f-8134-4ccc-8565-e4b5d087c142",
+          "id": "5f933b89-a51f-4e7c-a699-a7305f2d8248",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14139,7 +14139,7 @@
           },
           "response": [
             {
-              "id": "95643204-cc6a-4603-946b-0129efd16152",
+              "id": "fda46911-0c8a-442b-a038-fcea8f4bead5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14239,7 +14239,7 @@
           }
         },
         {
-          "id": "d11f59f3-ea43-4448-9573-280bdd156344",
+          "id": "9f0ea4d8-5ae2-4119-ab42-f1fd85e0c177",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14305,7 +14305,7 @@
           },
           "response": [
             {
-              "id": "2f0a9b96-5038-4163-aa01-964dc3338961",
+              "id": "82d87103-ee56-42bb-ab26-889b3c653263",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14393,7 +14393,7 @@
           }
         },
         {
-          "id": "d196773b-4fe5-452f-bece-a122c04d3424",
+          "id": "a2fdbe0b-024e-4560-94cd-35979372e24a",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14448,7 +14448,7 @@
           },
           "response": [
             {
-              "id": "635799a3-0987-40fe-8c3b-756a94b0bd32",
+              "id": "2781b85b-32c1-4c88-a9e0-92a918ba18c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14531,7 +14531,7 @@
       "description": "",
       "item": [
         {
-          "id": "19952a97-909d-4564-8bb6-934898607bc0",
+          "id": "b3724016-aab1-4a3d-9ce0-b7912944624e",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14572,7 +14572,7 @@
           },
           "response": [
             {
-              "id": "a5e04d9d-be32-4407-853a-b05405a516ad",
+              "id": "65876f1d-ebc4-4895-b06f-d03b6648a1e0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14635,7 +14635,7 @@
           }
         },
         {
-          "id": "c07f97cf-11f7-415e-88c2-eab94d8f28f3",
+          "id": "0bb60717-b78a-4ff1-a735-07a067f1a3e4",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14689,7 +14689,7 @@
           },
           "response": [
             {
-              "id": "01a0fac4-9c48-4679-b936-f3301f5448ad",
+              "id": "dd002440-11f2-46d6-b0fc-c4a41a11fb22",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14765,7 +14765,7 @@
           }
         },
         {
-          "id": "803a9e01-4920-4bc1-b5aa-48e48b76ec27",
+          "id": "edc2d9cf-6e2e-4ca4-b09d-fdcf282236c4",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14800,7 +14800,7 @@
           },
           "response": [
             {
-              "id": "728e019a-51fd-46ed-99f4-aaa15e9d34cd",
+              "id": "dbee3cda-1249-45b5-86de-b7f045cdd493",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14853,7 +14853,7 @@
           }
         },
         {
-          "id": "4bc7fd02-eab3-4d82-99ff-016d9f976945",
+          "id": "d526f571-a453-44b4-9825-092b18151d3e",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14895,7 +14895,7 @@
           },
           "response": [
             {
-              "id": "bb39596d-66f2-4226-9e12-3936c13174b2",
+              "id": "45f0b229-f28e-4305-9567-750fb3253749",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14959,7 +14959,7 @@
           }
         },
         {
-          "id": "b1262c9b-e1cb-42cb-978e-33268b604d67",
+          "id": "63237e58-cb42-4235-a925-a3a505de6c0f",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15001,7 +15001,7 @@
           },
           "response": [
             {
-              "id": "384cc30d-82a6-4458-8a71-9a98e3a721dc",
+              "id": "37326aa9-71dc-4637-9854-c67d3dd1b5c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15065,7 +15065,7 @@
           }
         },
         {
-          "id": "7c3d3586-41d8-43be-af23-faa689851096",
+          "id": "8fec2d94-0496-490a-8998-31d82d1ec3dc",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15140,7 +15140,7 @@
           },
           "response": [
             {
-              "id": "b3d4a9f8-fed6-4da0-be96-f7bed9e61eba",
+              "id": "4d4aa328-c55a-4415-998f-195cfed6e6f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15237,7 +15237,7 @@
           }
         },
         {
-          "id": "488ecac0-163d-4a72-af2f-eade2617049c",
+          "id": "6db6b4ed-15f7-4c58-aa8a-a24ea0f6afdd",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15279,7 +15279,7 @@
           },
           "response": [
             {
-              "id": "591a2575-fd9b-49fa-b155-ed2f40b81395",
+              "id": "7253ead7-a5c4-4962-bc6e-d56bbf67665f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15343,7 +15343,7 @@
           }
         },
         {
-          "id": "ecae15e4-f17f-41bd-b67d-af227b59f875",
+          "id": "c208e1f0-9561-4d87-a86f-f525cb3f340c",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15386,7 +15386,7 @@
           },
           "response": [
             {
-              "id": "31cb5ee7-717d-40f9-b3d3-f4db322d7346",
+              "id": "2a640bd6-8d1f-4ccf-a02f-8a1c1c3085c2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15451,7 +15451,7 @@
           }
         },
         {
-          "id": "76a8ff0e-6bee-40dc-974e-dca4cd7a0f6e",
+          "id": "0688f8f9-5087-4e41-aa9d-92c28b1617da",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15494,7 +15494,7 @@
           },
           "response": [
             {
-              "id": "0693a96a-c7ba-45d7-9527-acf751e1731a",
+              "id": "7c61d533-c4f4-40c2-bece-aab42abba3c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15559,7 +15559,7 @@
           }
         },
         {
-          "id": "4b74b2ac-5f81-407a-b1a6-757b77849685",
+          "id": "aeafd00b-d5bf-4f25-b12d-f9441141f0c9",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15611,7 +15611,7 @@
           },
           "response": [
             {
-              "id": "e04fcc8e-7a05-452f-b4e8-092264d55f3c",
+              "id": "86243663-d61d-43f7-93ae-106860199020",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15685,7 +15685,7 @@
           }
         },
         {
-          "id": "2d33bd7c-84bd-4836-9b4d-054e658633ae",
+          "id": "eec14d01-1d79-47ea-9c2e-9a7ef9bd237d",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15727,7 +15727,7 @@
           },
           "response": [
             {
-              "id": "8711b254-7a4b-40da-bda5-59da37916c06",
+              "id": "20c8dd7b-ea2a-4d83-9f84-30c0898adc84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15791,7 +15791,7 @@
           }
         },
         {
-          "id": "61fcea32-83c0-476c-9e24-5b406dd88cd4",
+          "id": "6012b081-6d19-4b09-a431-cf68664f682b",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15844,7 +15844,7 @@
           },
           "response": [
             {
-              "id": "944a1990-08b7-4611-9419-178bccae9a5f",
+              "id": "aa8c118f-8ab8-4e36-905c-2133a2cc7f38",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15919,7 +15919,7 @@
           }
         },
         {
-          "id": "926ac078-b098-4a7a-8b0a-ada8f2041968",
+          "id": "6650f567-6860-4076-a4da-49aa77294028",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -15972,7 +15972,7 @@
           },
           "response": [
             {
-              "id": "f5c6e491-fa5e-4a27-ae48-30fb15408e5b",
+              "id": "4b0df04b-df87-474a-a09d-ed580009d109",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16047,7 +16047,7 @@
           }
         },
         {
-          "id": "403c7f11-ccd8-4e50-bff7-41d5204fafce",
+          "id": "0595580e-6ecf-40c3-99bd-7919611af275",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16091,7 +16091,7 @@
           },
           "response": [
             {
-              "id": "0b3c9676-5161-421f-898c-3df5cea8f75b",
+              "id": "5e9f7afe-efb2-4f2c-a622-08383c7d5cae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16146,7 +16146,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16157,7 +16157,7 @@
           }
         },
         {
-          "id": "c3c41ea1-e428-4b22-b2a4-b122bc57de12",
+          "id": "07a3a562-d9bc-442c-aa6a-1810b98b1ca7",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16201,7 +16201,7 @@
           },
           "response": [
             {
-              "id": "d0d58c7f-680c-4221-89ac-772c581313d1",
+              "id": "780895a9-089f-4f0b-a51d-f63825f074ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16256,7 +16256,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\",\n  \"key_2\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16273,7 +16273,7 @@
       "description": "",
       "item": [
         {
-          "id": "05b97e0a-8f6a-4cf7-a94f-68cafe24233e",
+          "id": "dad38095-49ff-4b0f-a5a3-9672b9229aef",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16315,7 +16315,7 @@
           },
           "response": [
             {
-              "id": "cdaf526e-98e9-4d5f-91be-372a3855fe88",
+              "id": "561c29a6-dcb4-4e0f-ad7d-e1338d904e09",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16364,7 +16364,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "24b978f8-9474-4a15-8be4-d02c4fafcc35",
+              "id": "5e33ad54-a157-430d-b51e-b367abd3fb6a",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16419,7 +16419,7 @@
           }
         },
         {
-          "id": "2128e763-7aab-444f-adf8-b8ee1204cc8e",
+          "id": "adf8a92e-cf33-473c-b01d-a7cedda30e23",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16465,7 +16465,7 @@
           },
           "response": [
             {
-              "id": "1d40ce63-2345-429e-8e4f-ec623c12d5d6",
+              "id": "130e0b8c-f140-4f4b-ac8b-f0bcefb3be7b",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16524,7 +16524,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "1b51df25-1723-44e7-8d37-d87b7775fbd4",
+              "id": "71b2c1b3-159f-4566-b63c-a8a4b863805d",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16589,7 +16589,7 @@
           }
         },
         {
-          "id": "e7a8d188-2b1d-4137-8e89-6d94bee62280",
+          "id": "125acf65-4f6d-44d1-adfb-42fa47d290a4",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16635,7 +16635,7 @@
           },
           "response": [
             {
-              "id": "24ef185b-ed13-4288-9212-929aa80c33c6",
+              "id": "9950344e-c957-4e23-90a7-d23ee9e322ab",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16694,7 +16694,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "aa0c8ed8-ad87-44ef-a1bf-ea3078427274",
+              "id": "51f9fee4-7371-4c9a-a213-4720cc587a5d",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16753,7 +16753,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "28197772-054d-4711-a8bc-370b2072af98",
+              "id": "9c215b6a-01f7-4ed1-95ef-e797beb4771b",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16812,7 +16812,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "98b50a90-4c19-4f62-bc34-8b03f859c20c",
+              "id": "4bf6c440-a6d3-4670-85a8-676682c75b8b",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16877,7 +16877,7 @@
           }
         },
         {
-          "id": "b1ab27fc-6430-44a6-9a47-dc68f72e1d6f",
+          "id": "ea386ebc-aa9e-4059-8bfa-1d9c85d4f5f3",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -16923,7 +16923,7 @@
           },
           "response": [
             {
-              "id": "476330fa-0c4e-4af6-9198-e0e63d0ea6d4",
+              "id": "dd1df357-cff1-4d57-8595-7b2c2c6f3655",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -16982,7 +16982,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "5d07db14-48ec-478e-9b16-fd724c061224",
+              "id": "8fb6ad21-b733-4a76-8dd4-95ea83d5aea4",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17047,7 +17047,7 @@
           }
         },
         {
-          "id": "85393c85-24a3-4f75-8237-4a5a4d69098a",
+          "id": "a8f8c53a-264e-4987-9d28-bdd515bde362",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17089,7 +17089,7 @@
           },
           "response": [
             {
-              "id": "96cf648c-d5ed-49c0-b00e-fa4d67992c66",
+              "id": "877ca07f-e026-4c93-8900-2f5944a6de78",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17150,7 +17150,7 @@
       "description": "",
       "item": [
         {
-          "id": "de7f1178-0989-4681-ba4d-afd0eae3ea16",
+          "id": "35123e46-3e09-4a9f-9735-b38fe7e29781",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17199,7 +17199,7 @@
           },
           "response": [
             {
-              "id": "26f07f31-5962-4592-ba76-dca8bd7bda29",
+              "id": "008a5636-ea58-43b1-a79b-a7580e49d6db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17259,7 +17259,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3332.173044992013,\n  \"key_1\": 5459\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17270,7 +17270,7 @@
           }
         },
         {
-          "id": "75b35e48-a694-4916-9d27-88acc23d3b4f",
+          "id": "aff9cde3-f069-47da-a54e-a2a7c03fc565",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17319,7 +17319,7 @@
           },
           "response": [
             {
-              "id": "f8eb5f78-8076-4187-aacd-69f41fc5044c",
+              "id": "3c0577cf-fca9-42ef-aaec-4ca45ff70dfd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17390,7 +17390,7 @@
           }
         },
         {
-          "id": "00c73b3e-bf5e-4bb1-a94f-dc3f0546ff4c",
+          "id": "d15db397-f2e9-439d-8d59-46668f67e08d",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17439,7 +17439,7 @@
           },
           "response": [
             {
-              "id": "b4bf55d1-d767-4765-8608-a8577797827c",
+              "id": "ad41fb4d-b968-458b-8c88-415557fb6669",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17510,7 +17510,7 @@
           }
         },
         {
-          "id": "6053d048-5daf-417e-af95-2f5fdcfd186c",
+          "id": "01c2534f-8fa9-453d-bcd7-43c39fda70e1",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17559,7 +17559,7 @@
           },
           "response": [
             {
-              "id": "d72c3970-1cc0-41e4-b136-5c82573a8374",
+              "id": "c166b718-e460-44a2-aed8-b55c0fe4b2e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17636,7 +17636,7 @@
       "description": "",
       "item": [
         {
-          "id": "ed5481d9-36c3-43ab-a7b3-f24bae25da1b",
+          "id": "fa89daf2-b36f-43ae-aa05-17a785f2e664",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17676,7 +17676,7 @@
           },
           "response": [
             {
-              "id": "48ef1be7-821b-40cf-ac30-923e31e938b3",
+              "id": "c2cf9205-a768-48f6-ae5b-e6eb713c9b5e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17738,7 +17738,7 @@
           }
         },
         {
-          "id": "0faf9c11-30f4-4896-8310-4a3303ae0852",
+          "id": "44546e48-dc9d-4a15-a97f-14d6229e58e8",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17768,7 +17768,7 @@
           },
           "response": [
             {
-              "id": "e69cb6a9-b318-4500-8843-79523500edb0",
+              "id": "1fa51aa5-8ab0-4514-9d3f-ca2ad1c7f13d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17809,7 +17809,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3332.173044992013,\n  \"key_1\": 5459\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17820,7 +17820,7 @@
           }
         },
         {
-          "id": "b9c4cef6-d2fa-4048-a752-f1a34f9382b6",
+          "id": "b860f253-e381-4eda-9eca-402fffce01ad",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17872,7 +17872,7 @@
           },
           "response": [
             {
-              "id": "72b99b1d-68f6-48de-9115-6021b4c7829c",
+              "id": "05072ac0-98f1-473a-a4c2-affa5bdb7d73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17952,7 +17952,7 @@
       "description": "",
       "item": [
         {
-          "id": "acb67479-8269-457a-b84a-d68f9316e6d0",
+          "id": "c04cd9bb-100b-498e-b9e5-9cf777a9d27b",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -17981,7 +17981,7 @@
           },
           "response": [
             {
-              "id": "83b6bba6-eb47-49d9-93dd-ce7169f93dd7",
+              "id": "1a2483ca-23f7-47ce-b580-65b6307e04c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18032,7 +18032,7 @@
           }
         },
         {
-          "id": "6702154e-6e0a-4ca0-af11-94a1467a0c50",
+          "id": "d8f7fc53-7e4a-417a-999c-14808c2f3477",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18073,7 +18073,7 @@
           },
           "response": [
             {
-              "id": "101b2211-4cdb-480c-84c1-74a749686634",
+              "id": "d95752eb-8fee-481e-9978-cb2abd5f8ff1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18142,7 +18142,7 @@
       "description": "",
       "item": [
         {
-          "id": "aeb1c328-f3c9-427b-a8c6-2a5ee8bf227b",
+          "id": "8bca8b17-6d78-4863-b86d-2449bca48154",
           "name": "health",
           "request": {
             "name": "health",
@@ -18171,7 +18171,7 @@
           },
           "response": [
             {
-              "id": "8d54b9ef-1813-4dd9-9053-590724a9c731",
+              "id": "94133fb5-a299-458e-8516-362a2e97142b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18211,7 +18211,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 3332.173044992013,\n  \"key_1\": 5459\n}",
+              "body": "{\n  \"key_0\": \"string\",\n  \"key_1\": false\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18228,7 +18228,7 @@
       "description": "",
       "item": [
         {
-          "id": "0cc6aca8-2136-4337-bd73-5353db1a882a",
+          "id": "2b278463-07b8-42bf-b73c-e7c2ee1f738a",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18280,7 +18280,7 @@
           },
           "response": [
             {
-              "id": "0224f8fc-61ad-4e00-bf04-2bdd87910605",
+              "id": "594cb8ab-7013-4c4d-89ae-47d7ebfae837",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18354,7 +18354,7 @@
           }
         },
         {
-          "id": "7dcffa70-2170-4726-a78d-bf5e3ff97ef7",
+          "id": "33a53e2d-ea36-4bb4-9f06-05265d94de33",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18395,7 +18395,7 @@
           },
           "response": [
             {
-              "id": "9666f1db-5841-4002-a205-53216508651b",
+              "id": "7818dff1-b709-48f1-b6db-a109b60f406e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18447,7 +18447,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
+              "body": "{\n  \"sensors\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"setpoints\": {\n    \"key_0\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    },\n    \"key_1\": {\n      \"count\": \"<long>\",\n      \"current\": \"<double>\",\n      \"min\": \"<double>\",\n      \"max\": \"<double>\",\n      \"avg\": \"<double>\"\n    }\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"totalMessages\": \"<long>\",\n  \"periodStart\": \"<dateTime>\",\n  \"periodEnd\": \"<dateTime>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18458,7 +18458,7 @@
           }
         },
         {
-          "id": "3d6b8939-9cb9-4e92-8427-4588b1e11e2b",
+          "id": "7783ace3-f9be-45f9-9863-60ba918cccf8",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18488,7 +18488,7 @@
           },
           "response": [
             {
-              "id": "85714385-7ee7-4b4f-95d4-132071c9c3a3",
+              "id": "b7211482-6782-4447-919f-ce53ab897f50",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18560,9 +18560,9 @@
     }
   ],
   "info": {
-    "_postman_id": "38ed7b63-6685-41eb-82aa-6c9e170c7e33",
+    "_postman_id": "54b1e8c0-5f00-4593-bf6c-41b3ab39247d",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 18:19 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-04 23:08 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/config/StompJwtAuthInterceptor.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/config/StompJwtAuthInterceptor.kt
@@ -8,31 +8,40 @@ import org.springframework.messaging.simp.stomp.StompCommand
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor
 import org.springframework.messaging.support.ChannelInterceptor
 import org.springframework.messaging.support.MessageHeaderAccessor
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.stereotype.Component
 
 /**
- * STOMP CONNECT interceptor that extracts a Bearer JWT from the native
- * `Authorization` header, validates it with [JwtService], and attaches the
- * authenticated user as the STOMP session [java.security.Principal].
+ * STOMP authentication interceptor.
  *
- * Once attached, [org.springframework.messaging.simp.SimpMessagingTemplate.convertAndSendToUser]
- * can route messages to a specific username via `/user/{username}/queue/...`,
- * which is required for the future server-side broadcast path.
+ * Hard-fails any STOMP CONNECT that does not carry a valid `Authorization:
+ * Bearer <jwt>` native header. On any of {missing header, malformed header,
+ * empty token, parse error, signature mismatch, expired, user not found,
+ * inactive user} this interceptor throws [AccessDeniedException] from
+ * [preSend]. Spring Messaging propagates the exception to the client as a
+ * STOMP ERROR frame and closes the session — no silent anonymous fallback.
  *
- * **Backwards-compatible by design**: if the CONNECT frame omits the header,
- * brings a malformed/expired token, or the user lookup fails, the interceptor
- * leaves the session principal unset. Spring then falls back to the
- * sessionId-based anonymous principal, preserving today's behaviour for
- * clients that do not yet send the JWT during STOMP handshake. The connection
- * is **never** rejected here — auth failures degrade gracefully into "no
- * targeted broadcasts for this session", which is exactly what we want for
- * a no-downtime rollout.
+ * Once the CONNECT is accepted, the authenticated principal is attached to
+ * the session via [StompHeaderAccessor.setUser] using the message's mutable
+ * accessor. This is required so that
+ * [org.springframework.messaging.simp.SimpMessagingTemplate.convertAndSendToUser]
+ * can target the session by principal name (the user's email, matching
+ * `User.email` and what
+ * [com.apptolast.invernaderos.core.security.CustomUserDetailsService] returns
+ * as `userDetails.username`).
  *
- * Errors during JWT parsing are absorbed and only logged at DEBUG; we do not
- * want a malformed token to surface as a STOMP CONNECT failure for paying
- * clients who will inevitably hit transient validation hiccups.
+ * SEND and SUBSCRIBE frames are also gated: if the session somehow reaches
+ * those commands without a bound principal we throw. Defense in depth
+ * against future Spring changes that might let an unauthenticated session
+ * past CONNECT.
+ *
+ * **Why** the previous "backwards-compatible anonymous fallback" was
+ * removed: it allowed clients without a Bearer to subscribe to
+ * `/user/queue/...` and trigger handlers that do not check the principal,
+ * exposing every active tenant's snapshot. See plan
+ * `bright-stirring-starfish.md`.
  */
 @Component
 class StompJwtAuthInterceptor(
@@ -43,63 +52,79 @@ class StompJwtAuthInterceptor(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     override fun preSend(message: Message<*>, channel: MessageChannel): Message<*> {
-        // IMPORTANT: use MessageHeaderAccessor.getAccessor (the mutable
-        // accessor Spring carries on the message) — NOT
-        // StompHeaderAccessor.wrap, which creates a read-only wrapper whose
-        // setUser(...) does not propagate to the message that downstream
-        // interceptors see. Symptom of using `wrap` here is exactly what
-        // the mobile reported: the interceptor logs success but the STOMP
-        // session is anonymous from SimpUserRegistry's point of view, and
-        // convertAndSendToUser silently drops the frame.
+        // Use the mutable accessor Spring carries on the message.
+        // StompHeaderAccessor.wrap returns a read-only wrapper whose
+        // setUser(...) does not propagate downstream; using `wrap` here
+        // is the bug that makes SimpUserRegistry see anonymous sessions
+        // even when this interceptor logs success.
         val accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java)
             ?: return message
-        if (accessor.command != StompCommand.CONNECT) return message
 
+        return when (accessor.command) {
+            StompCommand.CONNECT -> authenticateConnect(message, accessor)
+            StompCommand.SEND, StompCommand.SUBSCRIBE -> requireAuthenticated(message, accessor)
+            else -> message
+        }
+    }
+
+    private fun authenticateConnect(message: Message<*>, accessor: StompHeaderAccessor): Message<*> {
         val sessionId = accessor.sessionId
         val authHeader = accessor.getFirstNativeHeader("Authorization")
-        // INFO (was DEBUG) so we can diagnose auth flow from Dozzle without
-        // toggling levels. CONNECT runs once per STOMP session — at most a
-        // handful of lines per minute even with many clients reconnecting.
+
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            logger.info("STOMP CONNECT no-bearer sessionId={} — anonymous session, no targeted broadcasts", sessionId)
-            return message
+            logger.info("STOMP CONNECT rejected sessionId={} reason=no-bearer", sessionId)
+            throw AccessDeniedException("STOMP CONNECT requires Authorization: Bearer <jwt>")
         }
 
         val token = authHeader.substring("Bearer ".length).trim()
         if (token.isEmpty()) {
-            logger.info("STOMP CONNECT empty-bearer sessionId={} — anonymous session", sessionId)
-            return message
+            logger.info("STOMP CONNECT rejected sessionId={} reason=empty-bearer", sessionId)
+            throw AccessDeniedException("STOMP CONNECT bearer token is empty")
         }
 
-        try {
-            val username = jwtService.extractUsername(token)
-            val userDetails = userDetailsService.loadUserByUsername(username)
-            if (!jwtService.isTokenValid(token, userDetails)) {
-                logger.warn(
-                    "STOMP CONNECT invalid-token sessionId={} subject={} — anonymous session " +
-                        "(token expired or signature mismatch)",
-                    sessionId, username
-                )
-                return message
-            }
-            val auth = UsernamePasswordAuthenticationToken(
-                userDetails,
-                null,
-                userDetails.authorities
+        val username = try {
+            jwtService.extractUsername(token)
+        } catch (e: Exception) {
+            logger.warn("STOMP CONNECT rejected sessionId={} reason=parse-failed: {}", sessionId, e.message)
+            throw AccessDeniedException("STOMP CONNECT bearer token is malformed")
+        }
+
+        val userDetails = try {
+            userDetailsService.loadUserByUsername(username)
+        } catch (e: Exception) {
+            // Includes UsernameNotFoundException and "User is not active"
+            // (CustomUserDetailsService throws UsernameNotFoundException for both).
+            logger.warn(
+                "STOMP CONNECT rejected sessionId={} subject={} reason=user-load-failed: {}",
+                sessionId, username, e.message
             )
-            accessor.user = auth
-            logger.info(
-                "STOMP CONNECT authenticated sessionId={} principal={} (Principal.getName() will match this string)",
+            throw AccessDeniedException("STOMP CONNECT user not found or inactive")
+        }
+
+        if (!jwtService.isTokenValid(token, userDetails)) {
+            logger.warn(
+                "STOMP CONNECT rejected sessionId={} subject={} reason=invalid-or-expired",
                 sessionId, username
             )
-        } catch (e: Exception) {
-            // Defensive: malformed/expired token, unknown user, etc. Never
-            // reject the CONNECT — fall through to anonymous so polling
-            // clients keep working during the rollout.
+            throw AccessDeniedException("STOMP CONNECT bearer token is invalid or expired")
+        }
+
+        val auth = UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
+        accessor.user = auth
+        logger.info(
+            "STOMP CONNECT accepted sessionId={} principal={} authorities={}",
+            sessionId, username, userDetails.authorities.map { it.authority }
+        )
+        return message
+    }
+
+    private fun requireAuthenticated(message: Message<*>, accessor: StompHeaderAccessor): Message<*> {
+        if (accessor.user == null) {
             logger.warn(
-                "STOMP CONNECT parse-failed sessionId={} reason={} — anonymous session",
-                sessionId, e.message
+                "STOMP {} rejected sessionId={} reason=no-principal-bound",
+                accessor.command, accessor.sessionId
             )
+            throw AccessDeniedException("STOMP ${accessor.command} requires authenticated session")
         }
         return message
     }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketController.kt
@@ -1,64 +1,79 @@
 package com.apptolast.invernaderos.features.websocket
 
+import com.apptolast.invernaderos.features.user.UserService
+import com.apptolast.invernaderos.features.websocket.broadcast.WsDeliveryLogger
 import com.apptolast.invernaderos.features.websocket.dto.GreenhouseStatusResponse
 import org.slf4j.LoggerFactory
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.simp.annotation.SendToUser
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Controller
+import java.security.Principal
 
 /**
- * Controller WebSocket para servir datos de negocio enriquecidos.
+ * STOMP request-response controller for the greenhouse status snapshot.
  *
- * Flujo STOMP:
- * 1. Front conecta a ws://host/ws/greenhouse/status/client
- * 2. Front envia STOMP SEND a /app/status/request
- * 3. Backend consulta PostgreSQL (jerarquia) + TimescaleDB (valores actuales)
- * 4. Responde al usuario que hizo el request con la jerarquia completa enriquecida
+ * The session is guaranteed authenticated by [com.apptolast.invernaderos.config.StompJwtAuthInterceptor]
+ * (CONNECT without a valid JWT is rejected before this handler is reachable),
+ * but we re-validate the principal here defensively because:
+ *  - the controller may be invoked from tests that bypass the interceptor;
+ *  - any future Spring change that lets a frame past CONNECT without a
+ *    principal must not silently expose data.
+ *
+ * Tenant scoping:
+ *  - `ROLE_ADMIN`: returns all active tenants ([assembleFullStatus]),
+ *    consistent with the bypass in
+ *    [com.apptolast.invernaderos.features.shared.security.TenantOwnershipAspect]
+ *    (commit a15b528) for the REST surface.
+ *  - everyone else: returns only the snapshot of the user's own tenant
+ *    via [assembleStatusForTenant]. The tenant is resolved from the
+ *    authenticated `User.tenantId`, never from a client-supplied parameter.
  */
 @Controller
 class GreenhouseStatusWebSocketController(
-    private val assembler: GreenhouseStatusAssembler
+    private val assembler: GreenhouseStatusAssembler,
+    private val userService: UserService,
+    private val deliveryLogger: WsDeliveryLogger,
 ) {
     private val logger = LoggerFactory.getLogger(GreenhouseStatusWebSocketController::class.java)
 
-    /**
-     * Endpoint request-response: el front pide y recibe la jerarquia completa
-     * con los valores actuales del hardware embebidos.
-     *
-     * Destino de envio: /app/status/request
-     * Respuesta a: /user/queue/status/response (solo al usuario que pidio)
-     */
     @MessageMapping("/status/request")
     @SendToUser("/queue/status/response")
-    fun getFullStatus(): GreenhouseStatusResponse {
-        logger.info("WebSocket status request received")
+    fun getFullStatus(
+        principal: Principal?,
+        @Header("simpSessionId", required = false) sessionId: String?,
+    ): GreenhouseStatusResponse {
+        val auth = principal as? Authentication
+            ?: throw AccessDeniedException("WebSocket /status/request requires authenticated session")
 
-        val response = assembler.assembleFullStatus()
+        val email = auth.name
+        val isAdmin = auth.authorities.any { it.authority == "ROLE_ADMIN" }
 
-        // --- LOG DE VERIFICACIÓN PARA LOS 3 TIPOS ---
-        response.tenants.forEach { tenant ->
-            tenant.greenhouses.forEach { gh ->
-                gh.sectors.forEach { sector ->
-                    // 1. Logs de Dispositivos (Sensores/Actuadores)
-                    sector.devices.forEach { device ->
-                        logger.info("[DEVICE] :  clientName: ${device.clientName}")
-                    }
-
-                    // 2. Logs de Configuraciones (Settings)
-                    sector.settings.forEach { setting ->
-                        logger.info("[SETTING] : clientName: ${setting.clientName}")
-                    }
-
-                    // 3. Logs de Alertas
-                    sector.alerts.forEach { alert ->
-                        logger.info("[ALERT] : clientName: ${alert.clientName}")
-                    }
-                }
+        val response = if (isAdmin) {
+            logger.info("WS /status/request principal={} role=ADMIN scope=full sessionId={}", email, sessionId)
+            assembler.assembleFullStatus()
+        } else {
+            val user = userService.findByEmail(email)
+                ?: throw AccessDeniedException("Authenticated principal not found in users table: $email")
+            if (!user.isActive) {
+                throw AccessDeniedException("Authenticated principal is inactive: $email")
             }
+            logger.info(
+                "WS /status/request principal={} role=USER scope=tenant tenantId={} sessionId={}",
+                email, user.tenantId, sessionId,
+            )
+            assembler.assembleStatusForTenant(user.tenantId)
         }
 
-        logger.info("WebSocket status response: {} tenants", response.tenants.size)
-
+        deliveryLogger.logDelivery(
+            principal = email,
+            tenantIds = response.tenants.map { it.id },
+            source = "INITIAL_REQUEST",
+            snapshot = response,
+            sessionId = sessionId,
+        )
         return response
     }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsBroadcaster.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsBroadcaster.kt
@@ -45,6 +45,7 @@ class WsBroadcaster(
     private val simpUserRegistry: SimpUserRegistry,
     private val messagingTemplate: SimpMessagingTemplate,
     private val objectMapper: ObjectMapper,
+    private val deliveryLogger: WsDeliveryLogger,
     @Qualifier("redisTemplate") private val redisTemplate: RedisTemplate<String, Any>,
     @Qualifier("wsBroadcastChannel") private val redisChannel: String
 ) {
@@ -126,10 +127,21 @@ class WsBroadcaster(
         }
 
         var delivered = 0
+        val snapshotTenantIds = snapshot.tenants.map { it.id }
         targetUsers.forEach { username ->
+            val sessionId = simpUserRegistry.getUser(username)?.sessions?.firstOrNull()?.id
             try {
                 messagingTemplate.convertAndSendToUser(username, USER_QUEUE_DESTINATION, snapshot)
                 delivered++
+                // Per-recipient observability: who got what (sha256 + payload
+                // when invernaderos.websocket.log-payload is enabled).
+                deliveryLogger.logDelivery(
+                    principal = username,
+                    tenantIds = snapshotTenantIds,
+                    source = source,
+                    snapshot = snapshot,
+                    sessionId = sessionId,
+                )
             } catch (e: Exception) {
                 logger.warn("convertAndSendToUser failed user={} tenantId={}: {}",
                     username, tenantId, e.message)
@@ -232,10 +244,21 @@ class WsBroadcaster(
             val sampleConnected = connectedPrincipalNames.take(5)
             logger.info(
                 "WS broadcast NO MATCH tenantId={} activeEmailsCount={} connectedPrincipalsCount={} " +
-                    "sampleConnected={} — likely STOMP sessions un-authenticated " +
-                    "(check 'STOMP CONNECT no-bearer/invalid-token' lines for that sessionId)",
+                    "sampleConnected={} — no authenticated session of this tenant on this pod " +
+                    "(connected users live on a peer pod, are signed out, or belong to other tenants)",
                 tenantId, activeTenantEmails.size, connectedPrincipalNames.size, sampleConnected
             )
+        } else {
+            // Visibility on the cross-tenant filtering. `dropped` users are
+            // those connected to this pod but NOT recipients for this tenant
+            // (= tenant isolation working as intended).
+            val dropped = connectedPrincipalNames.size - intersection.size
+            if (dropped > 0) {
+                logger.debug(
+                    "WS broadcast tenant-isolated tenantId={} delivered={} droppedOtherTenantSessions={}",
+                    tenantId, intersection.size, dropped,
+                )
+            }
         }
 
         return intersection

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsDeliveryLogger.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsDeliveryLogger.kt
@@ -1,0 +1,120 @@
+package com.apptolast.invernaderos.features.websocket.broadcast
+
+import com.apptolast.invernaderos.features.websocket.dto.GreenhouseStatusResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.security.MessageDigest
+
+/**
+ * Per-recipient observability for the greenhouse-status WebSocket.
+ *
+ * Two log lines per delivery:
+ *
+ * 1. **Header** (always, INFO): structured one-liner with principal,
+ *    tenantId, source, payload size, sha256 hash, and item counts. Lets us
+ *    answer "what did user X see at time T?" without enabling payload dumps.
+ * 2. **Payload** (gated by `invernaderos.websocket.log-payload`, INFO with
+ *    marker `WS_PAYLOAD`): the full JSON snapshot, truncated to
+ *    `invernaderos.websocket.log-payload-max-bytes`. ON in dev, OFF in prod
+ *    by default to avoid GB of log volume.
+ *
+ * The sha256 lets us correlate against client-side logs (which already log
+ * received bytes) without exposing the JSON in prod.
+ */
+@Component
+class WsDeliveryLogger(
+    private val objectMapper: ObjectMapper,
+    @Value("\${invernaderos.websocket.log-payload:false}") private val logPayload: Boolean,
+    @Value("\${invernaderos.websocket.log-payload-max-bytes:16384}") private val maxBytes: Int,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Logs a delivery for a single recipient (broadcast or initial request).
+     *
+     * @param principal user email (matches [com.apptolast.invernaderos.features.user.User.email]).
+     * @param tenantIds tenants present in the snapshot — used to detect any
+     *   regression where a user receives data outside their own tenant.
+     * @param source human-readable origin tag (`SENSOR_FLUSH`, `INITIAL_REQUEST`, ...).
+     * @param sessionId optional STOMP session id for correlation with the
+     *   `STOMP CONNECT accepted ... sessionId=...` line.
+     */
+    fun logDelivery(
+        principal: String,
+        tenantIds: List<Long>,
+        source: String,
+        snapshot: GreenhouseStatusResponse,
+        sessionId: String? = null,
+    ) {
+        val bytes = serializeSafely(snapshot)
+        val sha = if (bytes != null) sha256Hex(bytes) else "n/a"
+        val size = bytes?.size ?: -1
+        val counts = countItems(snapshot)
+
+        logger.info(
+            "WS delivery principal={} sessionId={} source={} tenantIds={} payloadBytes={} " +
+                "payloadSha256={} greenhouses={} sectors={} devices={} settings={} alerts={}",
+            principal, sessionId ?: "?", source, tenantIds, size, sha,
+            counts.greenhouses, counts.sectors, counts.devices, counts.settings, counts.alerts,
+        )
+
+        if (logPayload && bytes != null) {
+            val (preview, truncated) = truncate(bytes, maxBytes)
+            logger.info(
+                "WS_PAYLOAD principal={} sessionId={} source={} sha256={} bytes={} truncatedBytes={} json={}",
+                principal, sessionId ?: "?", source, sha, size, truncated, preview,
+            )
+        }
+    }
+
+    private fun serializeSafely(snapshot: GreenhouseStatusResponse): ByteArray? = try {
+        objectMapper.writeValueAsBytes(snapshot)
+    } catch (e: Exception) {
+        logger.warn("WS delivery: failed to serialize snapshot for logging: {}", e.message)
+        null
+    }
+
+    internal fun sha256Hex(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Returns (preview, truncatedBytes). preview is UTF-8 decoded from the
+     * first [maxBytes] bytes; truncatedBytes is how many bytes were dropped.
+     */
+    internal fun truncate(bytes: ByteArray, maxBytes: Int): Pair<String, Int> {
+        if (bytes.size <= maxBytes) return String(bytes, Charsets.UTF_8) to 0
+        // Slice on byte boundary; UTF-8 multibyte chars at the cut may show
+        // as replacement chars — acceptable for log diagnostics.
+        val head = String(bytes.copyOf(maxBytes), Charsets.UTF_8)
+        return head to (bytes.size - maxBytes)
+    }
+
+    private data class Counts(
+        val greenhouses: Int,
+        val sectors: Int,
+        val devices: Int,
+        val settings: Int,
+        val alerts: Int,
+    )
+
+    private fun countItems(snapshot: GreenhouseStatusResponse): Counts {
+        var gh = 0; var sec = 0; var dev = 0; var set = 0; var alt = 0
+        snapshot.tenants.forEach { tenant ->
+            tenant.greenhouses.forEach { greenhouse ->
+                gh++
+                greenhouse.sectors.forEach { sector ->
+                    sec++
+                    dev += sector.devices.size
+                    set += sector.settings.size
+                    alt += sector.alerts.size
+                }
+            }
+        }
+        return Counts(gh, sec, dev, set, alt)
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -25,3 +25,11 @@ logging:
     org.springframework.security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer: ERROR
     org.springdoc.core.events.SpringDocAppInitializer: ERROR
     com.apptolast.invernaderos: DEBUG
+
+# WS payload dump activado en dev: cada delivery imprime el JSON entero
+# (truncado a 16 KB) en logs con marker WS_PAYLOAD. Útil para verificar
+# desde Dozzle qué viaja exactamente a cada cliente sin tener que pinchar
+# wireshark sobre el WS.
+invernaderos:
+  websocket:
+    log-payload: true

--- a/src/test/kotlin/com/apptolast/invernaderos/config/StompJwtAuthInterceptorTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/config/StompJwtAuthInterceptorTest.kt
@@ -1,0 +1,209 @@
+package com.apptolast.invernaderos.config
+
+import com.apptolast.invernaderos.core.security.JwtService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.messaging.Message
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+
+/**
+ * Unit tests for the strict (no-anonymous-fallback) STOMP CONNECT auth.
+ * Pins down the security contract: anything other than a CONNECT carrying a
+ * valid Bearer JWT must be rejected before reaching downstream handlers.
+ *
+ * Uses MockK on the collaborators ([JwtService], [UserDetailsService]) and a
+ * real Spring [Message] built via [MessageBuilder] so we exercise the same
+ * accessor wiring the framework uses at runtime.
+ */
+class StompJwtAuthInterceptorTest {
+
+    private lateinit var jwtService: JwtService
+    private lateinit var userDetailsService: UserDetailsService
+    private lateinit var interceptor: StompJwtAuthInterceptor
+
+    @BeforeEach
+    fun setUp() {
+        jwtService = mockk()
+        userDetailsService = mockk()
+        interceptor = StompJwtAuthInterceptor(jwtService, userDetailsService)
+    }
+
+    // ------------------------------------------------------------------
+    // CONNECT — rejection paths
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `CONNECT without Authorization header is rejected`() {
+        val message = connectMessage(authHeader = null)
+
+        assertThatThrownBy { interceptor.preSend(message, mockk(relaxed = true)) }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("Bearer")
+    }
+
+    @Test
+    fun `CONNECT with non-Bearer Authorization header is rejected`() {
+        val message = connectMessage(authHeader = "Basic dXNlcjpwYXNz")
+
+        assertThatThrownBy { interceptor.preSend(message, mockk(relaxed = true)) }
+            .isInstanceOf(AccessDeniedException::class.java)
+    }
+
+    @Test
+    fun `CONNECT with empty Bearer token is rejected`() {
+        val message = connectMessage(authHeader = "Bearer    ")
+
+        assertThatThrownBy { interceptor.preSend(message, mockk(relaxed = true)) }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("empty")
+    }
+
+    @Test
+    fun `CONNECT with malformed JWT is rejected`() {
+        every { jwtService.extractUsername("garbage") } throws RuntimeException("malformed")
+        val message = connectMessage(authHeader = "Bearer garbage")
+
+        assertThatThrownBy { interceptor.preSend(message, mockk(relaxed = true)) }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("malformed")
+    }
+
+    @Test
+    fun `CONNECT with valid JWT but unknown user is rejected`() {
+        every { jwtService.extractUsername("tok") } returns "ghost@example.com"
+        every { userDetailsService.loadUserByUsername("ghost@example.com") } throws
+            UsernameNotFoundException("not found")
+
+        val message = connectMessage(authHeader = "Bearer tok")
+
+        assertThatThrownBy { interceptor.preSend(message, mockk(relaxed = true)) }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("not found")
+    }
+
+    @Test
+    fun `CONNECT with expired or signature-mismatched JWT is rejected`() {
+        val userDetails = userDetails("alice@example.com", "ROLE_USER")
+        every { jwtService.extractUsername("tok") } returns "alice@example.com"
+        every { userDetailsService.loadUserByUsername("alice@example.com") } returns userDetails
+        every { jwtService.isTokenValid("tok", userDetails) } returns false
+
+        val message = connectMessage(authHeader = "Bearer tok")
+
+        assertThatThrownBy { interceptor.preSend(message, mockk(relaxed = true)) }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("invalid or expired")
+    }
+
+    // ------------------------------------------------------------------
+    // CONNECT — happy path
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `CONNECT with valid JWT binds principal and returns the message`() {
+        val userDetails = userDetails("alice@example.com", "ROLE_USER")
+        every { jwtService.extractUsername("tok") } returns "alice@example.com"
+        every { userDetailsService.loadUserByUsername("alice@example.com") } returns userDetails
+        every { jwtService.isTokenValid("tok", userDetails) } returns true
+
+        val message = connectMessage(authHeader = "Bearer tok")
+        val result = interceptor.preSend(message, mockk(relaxed = true))
+
+        val accessor = StompHeaderAccessor.wrap(result)
+        assertThat(accessor.user).isNotNull
+        assertThat(accessor.user!!.name).isEqualTo("alice@example.com")
+        verify(exactly = 1) { jwtService.isTokenValid("tok", userDetails) }
+    }
+
+    // ------------------------------------------------------------------
+    // SEND / SUBSCRIBE — defense in depth
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `SEND without bound principal is rejected`() {
+        val message = nonConnectMessage(StompCommand.SEND, principal = null)
+
+        assertThatThrownBy { interceptor.preSend(message, mockk(relaxed = true)) }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("SEND")
+    }
+
+    @Test
+    fun `SUBSCRIBE without bound principal is rejected`() {
+        val message = nonConnectMessage(StompCommand.SUBSCRIBE, principal = null)
+
+        assertThatThrownBy { interceptor.preSend(message, mockk(relaxed = true)) }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("SUBSCRIBE")
+    }
+
+    @Test
+    fun `SEND with bound principal passes through`() {
+        val authToken = org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+            "alice@example.com", null, listOf<GrantedAuthority>(SimpleGrantedAuthority("ROLE_USER"))
+        )
+        val message = nonConnectMessage(StompCommand.SEND, principal = authToken)
+
+        val result = interceptor.preSend(message, mockk(relaxed = true))
+
+        // Same message returned, principal preserved.
+        val accessor = StompHeaderAccessor.wrap(result)
+        assertThat(accessor.user).isSameAs(authToken)
+    }
+
+    @Test
+    fun `non-STOMP command messages pass through untouched`() {
+        // No StompHeaderAccessor on the message → return early without throwing.
+        val plain = MessageBuilder.withPayload("ignored").build()
+        val result = interceptor.preSend(plain, mockk(relaxed = true))
+        assertThat(result).isSameAs(plain)
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    private fun connectMessage(authHeader: String?): Message<*> {
+        val accessor = StompHeaderAccessor.create(StompCommand.CONNECT)
+        accessor.sessionId = "test-session-1"
+        // setLeaveMutable(true) keeps the accessor attached to the message
+        // headers so the interceptor's MessageHeaderAccessor.getAccessor(...)
+        // returns the same mutable instance it would receive at runtime.
+        // Without this, accessor.user = ... has no observable effect.
+        accessor.setLeaveMutable(true)
+        if (authHeader != null) accessor.setNativeHeader("Authorization", authHeader)
+        return MessageBuilder.createMessage("".toByteArray(), accessor.messageHeaders)
+    }
+
+    private fun nonConnectMessage(
+        command: StompCommand,
+        principal: java.security.Principal?,
+    ): Message<*> {
+        val accessor = StompHeaderAccessor.create(command)
+        accessor.sessionId = "test-session-2"
+        accessor.setLeaveMutable(true)
+        if (principal != null) accessor.user = principal
+        return MessageBuilder.createMessage("".toByteArray(), accessor.messageHeaders)
+    }
+
+    private fun userDetails(email: String, role: String): UserDetails {
+        return org.springframework.security.core.userdetails.User.builder()
+            .username(email)
+            .password("ignored")
+            .authorities(SimpleGrantedAuthority(role))
+            .build()
+    }
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketControllerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketControllerTest.kt
@@ -1,0 +1,175 @@
+package com.apptolast.invernaderos.features.websocket
+
+import com.apptolast.invernaderos.features.user.User
+import com.apptolast.invernaderos.features.user.UserService
+import com.apptolast.invernaderos.features.websocket.broadcast.WsDeliveryLogger
+import com.apptolast.invernaderos.features.websocket.dto.GreenhouseStatusResponse
+import com.apptolast.invernaderos.features.websocket.dto.TenantResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import java.time.Instant
+
+/**
+ * Pins down the tenant-scoping contract of the WS request-response handler:
+ *
+ *  - principal=null → AccessDeniedException (defense-in-depth even though
+ *    [com.apptolast.invernaderos.config.StompJwtAuthInterceptor] guarantees
+ *    one upstream).
+ *  - ROLE_USER → exactly one tenant in the response (the user's own).
+ *  - ROLE_ADMIN → all active tenants (consistent with TenantOwnershipAspect
+ *    bypass commit a15b528 on REST).
+ *  - inactive user / unknown email → AccessDeniedException.
+ */
+class GreenhouseStatusWebSocketControllerTest {
+
+    private lateinit var assembler: GreenhouseStatusAssembler
+    private lateinit var userService: UserService
+    private lateinit var deliveryLogger: WsDeliveryLogger
+    private lateinit var controller: GreenhouseStatusWebSocketController
+
+    @BeforeEach
+    fun setUp() {
+        assembler = mockk()
+        userService = mockk()
+        deliveryLogger = mockk(relaxed = true)
+        controller = GreenhouseStatusWebSocketController(assembler, userService, deliveryLogger)
+    }
+
+    @Test
+    fun `null principal is rejected with AccessDeniedException`() {
+        assertThatThrownBy { controller.getFullStatus(principal = null, sessionId = "s1") }
+            .isInstanceOf(AccessDeniedException::class.java)
+    }
+
+    @Test
+    fun `non-Authentication principal is rejected`() {
+        val plainPrincipal = java.security.Principal { "alice@example.com" }
+        assertThatThrownBy { controller.getFullStatus(principal = plainPrincipal, sessionId = "s1") }
+            .isInstanceOf(AccessDeniedException::class.java)
+    }
+
+    @Test
+    fun `ROLE_USER receives only their tenant snapshot`() {
+        val user = userRow(id = 7L, email = "alice@example.com", tenantId = 42L, isActive = true)
+        every { userService.findByEmail("alice@example.com") } returns user
+
+        val tenantSnapshot = singleTenantResponse(tenantId = 42L)
+        every { assembler.assembleStatusForTenant(42L) } returns tenantSnapshot
+
+        val response = controller.getFullStatus(
+            principal = userAuth("alice@example.com", "ROLE_USER"),
+            sessionId = "s1",
+        )
+
+        assertThat(response.tenants).hasSize(1)
+        assertThat(response.tenants[0].id).isEqualTo(42L)
+        verify(exactly = 1) { assembler.assembleStatusForTenant(42L) }
+        verify(exactly = 0) { assembler.assembleFullStatus() }
+        verify { deliveryLogger.logDelivery("alice@example.com", listOf(42L), "INITIAL_REQUEST", tenantSnapshot, "s1") }
+    }
+
+    @Test
+    fun `ROLE_USER with inactive user is rejected`() {
+        val user = userRow(id = 7L, email = "alice@example.com", tenantId = 42L, isActive = false)
+        every { userService.findByEmail("alice@example.com") } returns user
+
+        assertThatThrownBy {
+            controller.getFullStatus(
+                principal = userAuth("alice@example.com", "ROLE_USER"),
+                sessionId = "s1",
+            )
+        }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("inactive")
+        verify(exactly = 0) { assembler.assembleStatusForTenant(any()) }
+    }
+
+    @Test
+    fun `ROLE_USER with unknown email is rejected`() {
+        every { userService.findByEmail("ghost@example.com") } returns null
+
+        assertThatThrownBy {
+            controller.getFullStatus(
+                principal = userAuth("ghost@example.com", "ROLE_USER"),
+                sessionId = "s1",
+            )
+        }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("not found")
+    }
+
+    @Test
+    fun `ROLE_ADMIN receives full snapshot regardless of tenant`() {
+        val full = GreenhouseStatusResponse(
+            timestamp = Instant.parse("2026-05-04T22:15:00Z"),
+            tenants = listOf(
+                tenantResponse(1L),
+                tenantResponse(2L),
+                tenantResponse(3L),
+            ),
+        )
+        every { assembler.assembleFullStatus() } returns full
+
+        val response = controller.getFullStatus(
+            principal = userAuth("admin@example.com", "ROLE_ADMIN"),
+            sessionId = "s1",
+        )
+
+        assertThat(response.tenants).extracting<Long> { it.id }.containsExactly(1L, 2L, 3L)
+        verify(exactly = 1) { assembler.assembleFullStatus() }
+        verify(exactly = 0) { assembler.assembleStatusForTenant(any()) }
+        // Admin path must not require a UserRepository lookup.
+        verify(exactly = 0) { userService.findByEmail(any()) }
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    private fun userAuth(email: String, vararg authorities: String) =
+        UsernamePasswordAuthenticationToken(
+            email,
+            null,
+            authorities.map<String, GrantedAuthority> { SimpleGrantedAuthority(it) },
+        )
+
+    private fun userRow(id: Long, email: String, tenantId: Long, isActive: Boolean) =
+        User(
+            id = id,
+            code = "USR-${id.toString().padStart(5, '0')}",
+            tenantId = tenantId,
+            username = email.substringBefore("@"),
+            email = email,
+            passwordHash = "ignored",
+            role = "USER",
+            isActive = isActive,
+        )
+
+    private fun singleTenantResponse(tenantId: Long) = GreenhouseStatusResponse(
+        timestamp = Instant.parse("2026-05-04T22:15:00Z"),
+        tenants = listOf(tenantResponse(tenantId)),
+    )
+
+    private fun tenantResponse(id: Long) = TenantResponse(
+        id = id,
+        code = "TEN-${id.toString().padStart(5, '0')}",
+        name = "Tenant-$id",
+        email = "tenant$id@example.com",
+        province = null,
+        country = null,
+        phone = null,
+        location = null,
+        isActive = true,
+        users = emptyList(),
+        greenhouses = emptyList(),
+    )
+}

--- a/src/test/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsDeliveryLoggerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/websocket/broadcast/WsDeliveryLoggerTest.kt
@@ -1,0 +1,74 @@
+package com.apptolast.invernaderos.features.websocket.broadcast
+
+import com.apptolast.invernaderos.features.websocket.dto.GreenhouseStatusResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Pure tests for the delivery logger. We don't assert on the SLF4J output
+ * directly (would require attaching a test appender and is brittle); instead
+ * we test the deterministic helpers — sha256 hex and the truncation logic —
+ * which are the parts that affect log correctness, and exercise the public
+ * `logDelivery` to ensure it never throws on a normal snapshot.
+ */
+class WsDeliveryLoggerTest {
+
+    private val mapper = ObjectMapper().registerModule(JavaTimeModule())
+
+    @Test
+    fun `sha256 hex is deterministic and 64 chars long`() {
+        val logger = WsDeliveryLogger(mapper, logPayload = false, maxBytes = 1024)
+        val bytes = """{"hello":"world"}""".toByteArray()
+
+        val a = logger.sha256Hex(bytes)
+        val b = logger.sha256Hex(bytes)
+
+        assertThat(a).isEqualTo(b)
+        assertThat(a).hasSize(64)
+        assertThat(a).matches("^[0-9a-f]+$")
+    }
+
+    @Test
+    fun `sha256 differs for different payloads`() {
+        val logger = WsDeliveryLogger(mapper, logPayload = false, maxBytes = 1024)
+        val a = logger.sha256Hex("foo".toByteArray())
+        val b = logger.sha256Hex("bar".toByteArray())
+        assertThat(a).isNotEqualTo(b)
+    }
+
+    @Test
+    fun `truncate returns full string when bytes fit under max`() {
+        val logger = WsDeliveryLogger(mapper, logPayload = false, maxBytes = 1024)
+        val (preview, dropped) = logger.truncate("abc".toByteArray(), 1024)
+        assertThat(preview).isEqualTo("abc")
+        assertThat(dropped).isZero
+    }
+
+    @Test
+    fun `truncate slices at max and reports dropped byte count`() {
+        val logger = WsDeliveryLogger(mapper, logPayload = false, maxBytes = 4)
+        val (preview, dropped) = logger.truncate("abcdefghi".toByteArray(), 4)
+        assertThat(preview).isEqualTo("abcd")
+        assertThat(dropped).isEqualTo(5)
+    }
+
+    @Test
+    fun `logDelivery does not throw on minimal snapshot`() {
+        val logger = WsDeliveryLogger(mapper, logPayload = true, maxBytes = 8192)
+        val snapshot = GreenhouseStatusResponse(
+            timestamp = Instant.parse("2026-05-04T22:15:00Z"),
+            tenants = emptyList(),
+        )
+        // Sanity: no exception means the serialize-and-hash path is wired up.
+        logger.logDelivery(
+            principal = "alice@example.com",
+            tenantIds = emptyList(),
+            source = "INITIAL_REQUEST",
+            snapshot = snapshot,
+            sessionId = "s1",
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- **Hard-fail STOMP CONNECT** without a valid Bearer JWT (`StompJwtAuthInterceptor`). Anonymous fallback removed; ERROR frame on missing/empty/malformed/expired/unknown-user. SEND/SUBSCRIBE without principal also rejected as defense-in-depth.
- **Tenant-scoped `/app/status/request`** (`GreenhouseStatusWebSocketController`). Principal-driven: ROLE_USER receives only their tenant via `assembleStatusForTenant(user.tenantId)`; ROLE_ADMIN keeps full visibility consistent with `TenantOwnershipAspect` bypass (a15b528). Uses `UserService` to satisfy ArchUnit rule.
- **Per-recipient delivery logging** (`WsDeliveryLogger`). Every snapshot delivery (broadcast OR initial request) emits a structured INFO line with `principal`, `tenantId`, `sessionId`, `source`, `payloadBytes`, `payloadSha256` and item counts. Property-gated full-JSON dump (`invernaderos.websocket.log-payload`, ON in dev, OFF in prod by default) with `log-payload-max-bytes` truncation.
- **Tests**: 22 unit tests covering interceptor reject paths, controller scoping (admin/user/inactive/unknown), and logger determinism. All ArchUnit rules still green.

## Why
Production logs showed `RECV #1 tenants=3` reaching a client whose session the broadcaster reported as having no authenticated principal. Root cause: `StompJwtAuthInterceptor` was deliberately permissive (anonymous fallback) and `getFullStatus()` did not look at the principal. Result: any client (no token / expired token) could open a STOMP session, send `/app/status/request` and receive every active tenant's snapshot. This PR closes both gates and adds the per-recipient observability needed to verify isolation post-hoc.

## Test plan
- [ ] CI green on `develop` (verified: build + tests passed, image pushed).
- [ ] On `inverapi-dev.apptolast.com`: connect WS without Bearer → receive STOMP ERROR frame and disconnect.
- [ ] On `inverapi-dev.apptolast.com`: connect WS as ROLE_USER of tenant X → `RECV #1` carries only `tenants=[X]`.
- [ ] On `inverapi-dev.apptolast.com`: log shows `WS delivery principal=<email> tenantId=X payloadSha256=…` per delivery; with `log-payload=true`, full JSON dump under `WS_PAYLOAD` marker.
- [ ] On `inverapi-dev.apptolast.com`: connect as ROLE_ADMIN → initial snapshot has all tenants; broadcasts deliver only own tenant.
- [ ] Repeat the four checks on `inverapi.apptolast.com` after this merges (with `log-payload=false` so only sha256+counters appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)