### PR TITLE
feat(websocket): symmetric tenant-scope on /status/request + admin all-tenants opt-in

### DIFF
--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "40c362ed-105a-4223-a975-a4fb32736d8b",
+          "id": "f117c1ad-1f21-449e-b659-f77467f145e2",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "7078dc83-7707-4346-9426-fc3f981ecd8a",
+              "id": "0f3f3c41-848a-4777-a839-8a2261e48c8e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "5e854537-e08c-4152-a647-c0f00f40cf7a",
+          "id": "468cd179-db72-47f7-b438-1630e1d3613d",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "93b2b847-e6c9-4866-9e00-bfcd5804f467",
+              "id": "ddce5f9d-4545-424d-908d-87a6f1e824e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "d5144c9d-bdc9-4c5f-9a2d-7d872a390d82",
+          "id": "6e29cda6-8dcc-478b-83b7-4208b8f29ec1",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "384afac2-2225-41d1-af4e-0c61d698dffd",
+              "id": "38cad33a-2d24-4cf6-82bc-1273ca784111",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "9871ff0c-65f1-4b37-9857-fb5ac66b62b0",
+          "id": "cbd857a7-4ecd-4e6e-9234-53ba77034f55",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "434469f5-0236-4378-af04-cb1161704ead",
+              "id": "478936e4-169e-4da0-913f-e9d28c01994b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "ea7e9a1f-29c5-4868-b6cd-8e0ca9507635",
+          "id": "09dd3283-d502-420b-9a2e-a36ac4b47a87",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "6a498487-a7ac-4f1c-84a4-3538930855f6",
+              "id": "4b6f96dd-d864-4c5b-acac-68ca6d9cab5b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "9c8f42d5-9f59-47f6-9719-b3bcd1abc5a3",
+          "id": "493c4567-e42a-444a-a7f8-785f3ca24bdd",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "b5ec4509-8ba1-4cd0-9c54-f75aa403ce74",
+              "id": "46a7260d-6f13-4941-a2a4-4bddcfdf78ae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "bc8f0fec-64a3-4ee8-ba02-345fefb947a8",
+          "id": "ffed1734-9b96-450f-8db5-4c60c4ef1346",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "80e614f8-b9da-4c47-a1df-2a4d1f95163f",
+              "id": "8c13fe07-d3fb-4e92-9954-32e8eab6e19c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "05ff8e1f-1f11-4fc3-9e59-e2912b7ff6e5",
+          "id": "e635e7bb-757d-4476-8b1c-2e033600dc3d",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "12ceb80b-d579-48da-9551-8529e35aded9",
+              "id": "e61eb74d-6c9d-4d9c-90ec-cfe3a829ebcd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "045f0490-36eb-400b-b2a6-c2dbc01fb5ac",
+          "id": "8e8618b7-144d-480c-a241-80cb9118570e",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "572e08c4-86a3-4df3-81ea-c8759f7d85e3",
+              "id": "62074f73-a934-4ce7-897c-169514dc5241",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "4fe486b7-9087-4600-b7f0-642c5a6e534a",
+          "id": "8a835a37-11a8-467d-9587-6cc6d432b00e",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "979db381-906b-4f2e-a18b-bb9d633ca460",
+              "id": "7fc7dd6d-f56c-4b83-8bb8-978540e01a18",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "789aed8b-6da0-435d-bdf9-b87edcf853af",
+          "id": "4136cf4f-31e8-47d2-ad75-28ff14ccc228",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "40553a24-1c31-4034-836f-055fd9419d65",
+              "id": "bc7fd1b1-527e-4b9c-a111-65e594b633a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "03dcbbeb-179f-432e-b455-e3b21f302928",
+          "id": "51da411c-6a9d-4521-996d-d21d838e6c58",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "39091bb5-2b94-45a3-9fa5-b92e8f3ccacb",
+              "id": "9a8b78bb-e7b4-4cbc-9c3a-deb5f3c1d354",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "c3739f34-3d84-49c7-9f50-96067ea2510c",
+          "id": "9431c20a-c824-4f06-9c30-501b59801267",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "733dd840-337b-4414-a295-3342ba9934f6",
+              "id": "ebfc2c95-0fdd-4bc9-8b3f-e768b58599b0",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "6fcb1ed5-ed3c-4b65-adc7-c20d75a05f6b",
+          "id": "baaf3f7c-1d0b-457e-9140-d089e6a6f68b",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "219eeedb-c464-48ae-a8ba-e314fa65ac88",
+              "id": "13d7b47d-f864-4d23-8601-10e5abf03729",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1682,7 +1682,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "66a03b7a-7954-407d-9ebb-9cc1fb2faca3",
+          "id": "80ecb382-3b33-4c2f-b5fd-8a7e9c488486",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "07868a94-7cac-4012-ad14-4941d6cc71a4",
+              "id": "83a98582-c18e-4605-b141-ba2f4fb82fce",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "f82e058c-0e4f-440b-8c74-9e72840453b8",
+          "id": "30f5c1ed-a9fb-4b8f-bd49-049dde85c6d0",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "63defbe3-ed5c-4b87-a270-004c01b9e5d5",
+              "id": "855535be-744d-4f62-85f0-e6729841ffd6",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "862154f4-fa68-4bc4-ab55-c3478d5c28c7",
+          "id": "72ed90e6-2f4c-4fa6-94cc-a9beb46ac743",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "061f2e7e-929a-4aa1-9ae3-98b569ad1ecc",
+              "id": "0e1e0ffc-3d26-4d6e-9b60-7bff90193cdd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "4dadd3bd-43ba-450f-83cb-3d05a7f4f727",
+          "id": "985b9501-e5e6-44d6-bce6-f672457c343f",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "95a97754-55d3-41f3-a8d6-b233165c1e8e",
+              "id": "5f49887d-e237-48e9-a82e-24cf2c009bae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "0e12c08a-f2c5-45f5-9c03-c0780e310df2",
+          "id": "22e38be9-c22f-4e49-96d9-a0b15fa5797e",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "3b348ee4-7ebf-4dcb-8c15-0d2e8bf95c5f",
+              "id": "fb84f37f-e1ab-48c9-ab76-cdaa284e5001",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "7343914b-1f7b-4586-8646-46b14067ac0d",
+          "id": "908b73ee-e3a3-4773-8099-97d592e44df9",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "18ec09b9-81a6-433e-bb25-1a50921234c8",
+              "id": "276470c9-c5d2-42fd-ba77-6d514cda7136",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "27d1d0e8-e265-4424-8bbf-ced52121632c",
+          "id": "23f56c05-409d-48d9-b4da-0e2fe7297a42",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "40d52031-0b66-441c-8ef1-fe61053e577a",
+              "id": "adbacf55-a838-4344-99fe-91832b9bb2e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"IOS\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "22a6bc69-d6a2-44ab-88ee-4a6afbdae0c3",
+          "id": "77c53d6f-2836-4b3c-8dae-772e296a1b49",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "baeb0b7d-4e73-491a-ac42-c4fe02c27ec2",
+              "id": "294bea1d-b6b7-4596-bd51-9e2ff49539b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "c6699f77-3d3c-480a-ad1b-c968a7d356b5",
+          "id": "2da1ce94-6c9a-4430-a5fd-ca20a721c300",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "b1c86b72-cc65-4da7-9b49-a2092309a9ba",
+              "id": "9dd10baf-1340-4fb4-bb96-5995e00416e2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "9438c426-d5b2-4848-a0b6-3c9a82c34bd7",
+          "id": "b964941c-ba86-4211-8fd5-3d727f55297b",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "2c51c262-9844-4e7a-a659-7bba84ce4629",
+              "id": "38a12361-941e-442c-9a5f-326fed1cc603",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "b23e08d2-e5bc-4bdf-af0a-19b8bd8476be",
+          "id": "caeac1b4-d10b-4396-b13f-20b4e0301e49",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "47b0082a-b2e6-4d5c-991b-13da45ee75f7",
+              "id": "4b844412-34aa-46b9-8a8e-65a210a538df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "c62dcf9b-9efa-4b11-9f2d-b4f71bedadc1",
+          "id": "bbe4b7d7-952b-4c22-89d3-cf430c0d9b16",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "9c21a798-1b42-44cc-9103-3df8148b4ea9",
+              "id": "2c6cdb97-4f23-43be-b505-3ec25bb76e98",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "cea92e94-bb40-4e67-b0e5-aa43f66f9461",
+          "id": "ebd9812c-5742-4d2b-aee9-9e3c62f1400b",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "1253296d-989c-4c2f-a8fc-5cac4a0a89e0",
+              "id": "33643c65-c177-40a2-8329-8721c136344a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "12dad1c2-505a-4811-b6ee-d8b7159b25c0",
+          "id": "c1359b7f-658f-4d29-9a30-3a7a0508740c",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "d72c50b5-3278-4679-9e02-c2af8504ee52",
+              "id": "060ced33-ebb2-41a7-8494-d3267348ad14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "b5d05d0c-f576-439a-b9a6-5159ea9931e4",
+          "id": "e9fda131-4599-4d2c-ad88-f3a55f100bee",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "0397dbea-61a6-40db-91aa-d3357e074fbc",
+              "id": "f5eca7f9-ac5a-4d52-b1a1-6091968bc25f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": true\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": \"string\",\n        \"key_1\": 7334.678992979832\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": true,\n        \"key_1\": false\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 8253.09125270661\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "ee55f325-6355-42ff-899c-f12b31a61590",
+          "id": "6643d5ae-9340-453e-a407-ceb47854c34d",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "78670d3e-8b4f-4f26-bed2-357b20b07974",
+              "id": "e0de631d-d9ec-4f73-8438-9a8e45e7153e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "fb05d327-6f0f-4990-b8bd-dab119c1c91b",
+          "id": "d668352a-9f2a-411f-8600-ce3f524dcb41",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9940F8\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#226B8d\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "725ca281-7519-4909-a44c-e44a77a56a76",
+              "id": "f6377e0c-a5bb-499a-a918-cb833bc0b64d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#9940F8\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#226B8d\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "34bfd11e-a229-49eb-bbe2-e52dbf29593f",
+          "id": "8692a599-ca57-4ef2-afc7-2a105a508435",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "dc214116-fa29-422c-902c-8fad6be3ccb4",
+              "id": "63701b74-0b60-44f3-a88f-8cd2a8d5e1a9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "d62e6c05-b36f-4257-8f8e-b5dc2914ee20",
+          "id": "de64d5b6-7f95-4ef8-9123-06f4809e562a",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "4a17b403-8971-4ef4-9610-1cd1f51d0b60",
+              "id": "7f07f429-5ad3-40c5-9a70-a9987b1032b9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "7ae3a659-e99f-4b31-bc95-76e1f68685e2",
+          "id": "f91ea567-3cec-4a8e-b736-c94526cfc40d",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F159E2\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cEaeE8\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "dc8ffc2f-a513-4d57-a02e-b1f6fd15ab7e",
+              "id": "2c382c69-d04e-48bc-af1d-b715e495b7b9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F159E2\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cEaeE8\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "cfa80d82-0ffd-47d1-aaa3-e33a00898983",
+          "id": "0e9b3f31-10eb-45b0-8166-18b764e30df6",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "10a8e48c-2b66-4772-950d-51a236dbb617",
+              "id": "94511c5c-2af5-46e4-ac5d-59bf56b913b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "e7e8c8a3-1148-47cc-a28e-7a42ac3ceff5",
+          "id": "eac32ba3-1217-4162-a85f-13d03d073a82",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "f09f6466-37bd-4ca1-b2b3-b520c742c5d6",
+              "id": "68b5d027-23e8-4fdd-97d9-bb420f14c83c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "054340de-8a72-424e-93db-8a4bbe5ad2de",
+          "id": "e4466b20-2d1c-4be8-8178-8577a48ab3fd",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "ab01e29f-085b-4927-ab31-6dd1fa36433a",
+              "id": "ac81ed5c-60e8-46ff-8823-bf90e8c3307b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "1eb2fe21-9061-485a-9678-0c30d388ec3d",
+          "id": "d1bc60d4-cc23-4d94-9614-d87eeb0a53ec",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "e0a0e4c0-a3ae-4d8e-b89c-d1ea5145ef95",
+              "id": "ec8fe719-4985-43b4-96b6-899ff1e6bcee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "fc23d4f7-9fbe-410a-9144-d5d0f35776d5",
+          "id": "ec63aceb-5447-4b24-aed2-4c504b13edb3",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "94897777-9fb6-4ffd-b118-38f467db8ca2",
+              "id": "48db9221-c97b-48a4-b9e7-1b54e9e67d0a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "6ce427f9-a012-466d-a3b0-7d40f92d9abc",
+          "id": "ff4a00e2-d68c-4851-babc-2ffbb5413724",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "afb27e97-b3ee-48d4-94f6-d6d611b6fe90",
+              "id": "1cf09365-cf30-4dac-ba4b-b11eb287db80",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "8b7c00de-8822-46f1-bd48-09aae5a4948f",
+          "id": "720cb262-fd14-40c7-ad99-d1fbe4ec149e",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "ee195cd0-ea0c-4809-8019-f79a7fa73b35",
+              "id": "4b8b4768-fabc-464b-995b-f6e1e751460f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1515.3168425037245,\n  \"key_1\": 1013.3400203991183,\n  \"key_2\": 9698.902189626117\n}",
+              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "d526dccc-76ea-4bbf-a8b8-5e34305a0fe9",
+          "id": "72e0704f-9d94-42f2-8e4c-ac406e4c8b69",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "9e447135-1371-46c8-ac61-ec7c4f091a9a",
+              "id": "cc0c9c4a-0e28-4872-a8a2-14f8af55a28d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "9541ddc0-9863-450f-9043-94a7594279fd",
+          "id": "612c5f31-3613-4834-80d8-d87a3b207f96",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "8c402cd9-00a9-4584-9ec4-73c8b9efa783",
+              "id": "2e2b889e-98e4-40cd-b94b-16153ca7fd5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "a2a837e2-8211-41ec-bd31-afb1629cd94e",
+          "id": "44523778-7b0f-4a98-95ea-1cd8d64b89b7",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "87af0bc0-88c5-43f3-9f49-51b75a020c7e",
+              "id": "a7497869-05da-4f6e-af6d-a87c8a5ff72e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "a4ce2f2c-cadf-4b76-9b52-37e3f9a4b6b2",
+          "id": "2cb22ba3-7d64-474e-b443-0540b5352297",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "5b9d0c6c-664e-4ee8-9543-f8c5d1d789fd",
+              "id": "c5ae4260-5851-45e4-88f7-d615f2da86ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "7cfd1750-ef6b-4f47-a59f-e08e68269589",
+          "id": "940f1840-9918-438a-8a6b-831131866797",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "b935fab7-a0c9-44ae-95a7-66f16b1a2431",
+              "id": "3b290eca-c0ff-4b20-8e11-25b4cfb1d0c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "4997f4ca-69f8-4a7e-a1c2-7885ec8a910e",
+          "id": "5e4b7863-0b17-4ab3-a41b-9fb2bb1be499",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "f800b7ca-74a7-4ca1-8365-a905e60855bd",
+              "id": "f1f5ac81-e1f4-4ad5-a093-0d09ce3105c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "cb457638-6347-4ada-89f1-b66a5495dd11",
+          "id": "0b3f5f7a-b560-413e-85e5-afbcd38404f5",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "ae18dd3e-390f-478e-8ba9-ed4e9c24133b",
+              "id": "06567060-2a1b-4434-b65d-3458c45b3f88",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"TEXT\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "de00c2b1-e643-4712-9dc1-727ce369ec3c",
+          "id": "d1afe9f4-7b7d-44e6-9343-35fbeceeab34",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "3a1924cf-d33b-4058-b76a-0f9d1e298605",
+              "id": "8f7dcc94-07bd-4980-9098-6f43072f28f4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "b99b5cb0-ccf0-4b88-b526-c32cc33dafa2",
+          "id": "c049f307-aa64-4654-b5a9-ebf87f327dd3",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "2e743426-f285-45a8-a9c2-592a3655c3c0",
+              "id": "987a18d8-97d7-474e-8e10-9c183ffcb48c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "75c65751-9187-4c76-9556-0b02f5e419ed",
+          "id": "18bbf697-cd18-4f9e-b4a2-21c5a62c4da8",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "3fc5cb5a-f164-4e10-a1d3-3359e13a9cb7",
+              "id": "fd544c0a-40f3-46f4-9346-d08fd041921e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "b7b4f22b-61a2-47af-b84a-5f9f096693ec",
+          "id": "33149a39-c548-4d41-bb9f-37d91d986e8b",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "72fd8db4-a7f2-494e-aae6-6eda62676fa3",
+              "id": "7cc83f3e-587b-4c6d-976b-fd6fd3c300c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "1e0bd885-6007-4715-8ec3-7f200071edc9",
+          "id": "0e5e94b6-4dc3-48aa-a1b7-e1c45123ea18",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "6231a045-ab50-424c-9633-058aa4355e1b",
+              "id": "eee04500-53aa-41eb-8f86-399e6ad18491",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "57dd923c-3ec7-4d21-86c2-01bde31b3e91",
+          "id": "8b59cd04-1520-4038-9fdd-33ad6d225061",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "3507059a-e092-493c-8ccc-d01b88e45038",
+              "id": "589d10cf-c1cb-4c15-b555-f26f315440f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "2c9d0e4e-3c7c-4904-87e5-33682e4e89a7",
+          "id": "590610ea-f553-44ab-9bb2-8993765f73d4",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "e3562b75-c466-4289-ae18-fe83bc558f38",
+              "id": "70f3ebcb-f48a-4cb0-8770-726fb8749fbd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "ee31b965-0ac5-4904-8acf-016ed4df344b",
+          "id": "bde932d2-ec03-4b72-b41f-bbceff917fac",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "b37d7264-c083-46a2-a617-4ba8a56a4939",
+              "id": "f60ecd23-eac1-4d75-bdc7-4f9976846c03",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "e3728e40-0280-4074-bb0b-2e5297450125",
+          "id": "1a4430cc-e38b-4a35-a629-c3540301939b",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "d44f587b-bbdc-4415-9a47-21c90f0cbbd2",
+              "id": "41ee49cc-f4d7-4d35-b961-00a241bfdfa7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "e32faaad-df93-409e-8bbf-70c86bcf9df0",
+          "id": "3d89b737-c95f-4b34-bd12-8a80b5dc10b1",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "d46103ac-66d5-408f-b4cd-3874deb2264f",
+              "id": "4b6f9c1c-8425-45dc-872a-5b549396c61c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "e92ea63d-577e-4e2b-be25-3f1ee7fe2930",
+          "id": "3502fcd6-34ab-4c8d-93c8-144ca696b633",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "de8aea3f-1f91-481c-a005-df1f5da0690b",
+              "id": "a9886b9f-1afe-49ee-a0e2-16c6cde5fafb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "d66fe7f6-f4fd-48bb-8c14-3db38058b6b3",
+          "id": "610bd870-6cf8-4ef9-bc34-6f991dffb327",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "3a950142-bdba-43eb-91ff-b6b9d009866f",
+              "id": "744a87ce-99de-42ff-a94e-76f062c76375",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "e2b751a8-d4f9-49ab-8cae-2b57fead82b5",
+          "id": "5c2b3ec9-9fa1-48c8-87cb-567614ec0f2b",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "1e67a714-1a7b-43da-9d29-7d4eb94015f7",
+              "id": "bc38797d-4d92-4f20-a346-9083bf20b274",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "8804ba36-fba4-4660-b0b8-258133269407",
+          "id": "2ab96285-b8d4-4616-9f10-480903dd2b70",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "d7403215-a52e-47d4-97d2-c39ff90ca04d",
+              "id": "3e075958-c964-4bfe-9613-6d5f11eeca12",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "583c1a9c-a022-4427-8445-b0ae087fd25c",
+          "id": "de44494e-0d04-46c9-bda3-e5201cab4be6",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7553,7 +7553,7 @@
           },
           "response": [
             {
-              "id": "6dc840a0-f477-4f5e-86b5-b3063eb27788",
+              "id": "a5401434-dcf2-4989-9168-221518b1c6bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7629,7 +7629,7 @@
           }
         },
         {
-          "id": "4d9858d5-992a-4a68-90a8-361f4e40d923",
+          "id": "e89659ce-c8ed-4d5e-b55c-3b415757af11",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7683,7 +7683,7 @@
           },
           "response": [
             {
-              "id": "be52557d-084b-4997-93ca-34e8042386f0",
+              "id": "867ba9a1-2416-4085-a641-e2d6dceb5cb5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7765,7 +7765,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "14414ad8-d9de-46c5-bf0c-5525c0648c74",
+          "id": "5bd99d76-dcb6-4382-aa1d-082432f21b74",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7818,7 +7818,7 @@
           },
           "response": [
             {
-              "id": "71a4a3c2-b134-4cbd-bbb9-decf5766ffbd",
+              "id": "04c79914-b68c-4b2a-baec-668502e38dd1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
           }
         },
         {
-          "id": "6f224ce2-bf3f-428b-9c55-8e924772558b",
+          "id": "8493b85f-bbb2-404b-8203-0b60aeb8b77c",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -7959,7 +7959,7 @@
           },
           "response": [
             {
-              "id": "3035d556-7df6-46fa-8d3c-f15f3a18aec4",
+              "id": "4cba994f-f046-4e46-b26d-05332ac69569",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8047,7 +8047,7 @@
           }
         },
         {
-          "id": "3653125f-0efb-4402-9ce3-bbe8dcf28ecb",
+          "id": "cd3dbe38-0baf-4167-9bfd-c4912dc80695",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8094,7 +8094,7 @@
           },
           "response": [
             {
-              "id": "de012363-0b51-4478-9b3c-defb076ff7f6",
+              "id": "08e4ffde-7dc2-4a7c-9751-eced2286716a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8159,7 +8159,7 @@
           }
         },
         {
-          "id": "0d65d059-0af9-4181-bf5d-1b4aa65cc6c9",
+          "id": "cc5b0ce3-8234-41d5-88c8-18d7ec285a23",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8201,7 +8201,7 @@
           },
           "response": [
             {
-              "id": "b48c2d40-3ee9-4d6b-9d3d-d4979ac8bbec",
+              "id": "b405fb35-db03-4ff4-ac12-71ecba01d1b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8265,7 +8265,7 @@
           }
         },
         {
-          "id": "645673c4-b695-4503-ba9d-b0fc97be5d05",
+          "id": "9d219f21-8098-4967-a5ab-97c7d3886abc",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8320,7 +8320,7 @@
           },
           "response": [
             {
-              "id": "3c60af29-ab58-4546-9c76-96fff5befe3e",
+              "id": "7f5d32d3-a294-4a98-8697-ca464beadaa5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8403,7 +8403,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "d8fdec2c-02bc-473f-ab2a-95f7b72d1327",
+          "id": "6e379cf3-ef55-44f3-a0c1-dfb085ac6a4d",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8444,7 +8444,7 @@
           },
           "response": [
             {
-              "id": "fb2e2526-7451-4772-9e9c-73f8866d80a2",
+              "id": "bcf3d04a-3ea1-4b15-ab1f-421720f28af7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8507,7 +8507,7 @@
           }
         },
         {
-          "id": "432e0b5b-4e4d-4fd0-9693-e72afcb499ff",
+          "id": "2b37c359-dde0-4933-a0c3-e5b190b881b8",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8561,7 +8561,7 @@
           },
           "response": [
             {
-              "id": "41642dfb-fa40-488f-bffb-62b125b53d41",
+              "id": "c5d322d4-1461-4ce5-b598-a712965beb4a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "8bc3e5ed-c852-43f5-bfc9-48939667f9df",
+          "id": "97d6d8be-e510-4604-918d-baeec5cc9f5c",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8672,7 +8672,7 @@
           },
           "response": [
             {
-              "id": "17c5e18a-cd82-4b4e-8b31-b462bf778cdf",
+              "id": "f081f142-aa30-4645-8e11-f64399ad895a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8725,7 +8725,7 @@
           }
         },
         {
-          "id": "cdb21e30-887b-4b3a-9c6f-011be77314c9",
+          "id": "f335fea6-fddd-487f-95bf-677eae41d553",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "4c511cce-3915-442d-a062-3bd6b1cdb5fa",
+              "id": "1b5d25db-d830-4439-b944-a6fc72b8d638",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8861,7 +8861,7 @@
           }
         },
         {
-          "id": "5d1f2abf-7286-4dbc-98b3-802c14e359b5",
+          "id": "5bf23f4e-caa9-490e-a80f-76158223afef",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8903,7 +8903,7 @@
           },
           "response": [
             {
-              "id": "cf49f177-84a6-43b7-a261-bb3c267d8599",
+              "id": "ab66771b-7c4d-4d28-ae4f-41fe6dc84114",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8973,7 +8973,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "242e9b0a-510c-479d-a13b-6905e78f37f5",
+          "id": "64e10330-b1d7-47fd-a4dc-c109113851bd",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9026,7 +9026,7 @@
           },
           "response": [
             {
-              "id": "77ed3cad-97a0-4524-9c00-8d9f1d0369e3",
+              "id": "90fcfa8c-de53-4740-a0e7-19b96e22a6b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9101,7 +9101,7 @@
           }
         },
         {
-          "id": "0e0a9ea3-33bd-4545-9cb4-388bd481ca50",
+          "id": "a24f61a5-c79f-47c9-9731-82d3a49d7b6e",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9167,7 +9167,7 @@
           },
           "response": [
             {
-              "id": "b7ea628f-6fc1-4c18-b590-c7819871d7fa",
+              "id": "ab165a45-c9aa-4eac-b5be-ee7c60b25260",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9255,7 +9255,7 @@
           }
         },
         {
-          "id": "44e8d1a8-3cca-41d4-8746-26b4fb6442cf",
+          "id": "4b0dfc88-403c-4d3c-aa8f-84ffeb3bb20e",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9302,7 +9302,7 @@
           },
           "response": [
             {
-              "id": "c0677b61-973e-4b6c-948b-b5b8ed4fe492",
+              "id": "87fff7ad-44e8-44e1-97a7-c9935b139884",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9367,7 +9367,7 @@
           }
         },
         {
-          "id": "a0ccaba2-1352-4537-b2fb-9a998144e78b",
+          "id": "125f5e12-a0a8-4cd1-bbd6-ba0a00102ccc",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9409,7 +9409,7 @@
           },
           "response": [
             {
-              "id": "63fdebba-29fa-4b0e-b34b-97e24ec52f42",
+              "id": "7a1dea99-fac6-4c08-95fa-61b5d18e0aeb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9473,7 +9473,7 @@
           }
         },
         {
-          "id": "c49c8c97-cd9b-4a6c-80f4-bfd2ca49bce3",
+          "id": "2b72f641-fe73-4fdd-a38c-a84c390a16a9",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9528,7 +9528,7 @@
           },
           "response": [
             {
-              "id": "f91e211c-18bf-4a41-9405-ddc201fff01b",
+              "id": "14aeb131-76a8-4a64-9f14-39be6b7ab2e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9611,7 +9611,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "b0ec6fe7-3d79-480d-9309-737603563eb5",
+          "id": "e20669b9-b6a9-4881-ab7d-54225f597996",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9653,7 +9653,7 @@
           },
           "response": [
             {
-              "id": "4b451a6b-3007-4bc9-936c-cf5297172ace",
+              "id": "276f6d3a-c0bd-487c-8b3d-c53c07261b3e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9717,7 +9717,7 @@
           }
         },
         {
-          "id": "23421958-e474-4fb3-b402-98a2023c06e8",
+          "id": "9cc68fb3-1a56-4dca-97c9-0302cfebb934",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9772,7 +9772,7 @@
           },
           "response": [
             {
-              "id": "5d2cac46-684b-44ce-b2a8-d0160354c7f3",
+              "id": "e6573ddd-4a9c-4908-8b06-cfa54b128f02",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9849,7 +9849,7 @@
           }
         },
         {
-          "id": "7d99f7df-4046-4b66-9ee9-c23bc53b2f02",
+          "id": "8d1a6d9f-8b4c-4f4f-89bd-7aca87ae6f49",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9885,7 +9885,7 @@
           },
           "response": [
             {
-              "id": "a2a32e95-7b11-4564-affe-7a9881cd5b98",
+              "id": "dbfe273d-5cd1-4793-b6c2-6c8b580d0db1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9939,7 +9939,7 @@
           }
         },
         {
-          "id": "d616ffa5-d82b-4e4a-997f-f3119dbb0072",
+          "id": "05451a5f-f6c7-424d-a397-0a34acd0b4e2",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -9969,7 +9969,7 @@
           },
           "response": [
             {
-              "id": "58d1e2cb-f374-4923-89e3-52c09f66b24f",
+              "id": "fb4413f0-84fc-45d0-8b29-36c7466668cd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10021,7 +10021,7 @@
           }
         },
         {
-          "id": "fff44143-8325-48e8-97f8-6c46e29f5b63",
+          "id": "a4b89222-6838-4050-80b2-3c38b233dc94",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10064,7 +10064,7 @@
           },
           "response": [
             {
-              "id": "91bd75f6-0dad-454b-bda5-8d81d305138a",
+              "id": "5e355add-3950-4558-9a47-42c5ec5fad05",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10135,7 +10135,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "df35bda8-0d3f-4122-845f-759e309aea13",
+          "id": "7dbfeeab-15b4-4b84-87da-20d479e83dbc",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10177,7 +10177,7 @@
           },
           "response": [
             {
-              "id": "d17a78e0-acb5-406e-9e74-57c3cd695c0f",
+              "id": "3ce94655-593e-42e2-a7db-30a337dd1b73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10235,7 +10235,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "e0c3a868-b789-4f24-a686-4bf3b6660ee8",
+              "id": "4bd98608-daf9-495d-b1c8-626f7ca2e397",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10299,7 +10299,7 @@
           }
         },
         {
-          "id": "a7b126f1-6bf8-4824-b9d5-12b6d66d388a",
+          "id": "ba4573c7-19f3-45a2-8285-1bb84ca15c62",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10354,7 +10354,7 @@
           },
           "response": [
             {
-              "id": "c5415d1b-abd2-41d7-893c-11b51a8b1307",
+              "id": "a3ff555d-be93-427b-a8b1-d8310037caad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10425,7 +10425,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "be18c31c-e35a-410a-ba8c-0f4a1b789a7a",
+              "id": "4748effc-c832-414c-8d9e-54c2520bd1f6",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10496,7 +10496,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "a5129ab0-c12c-4014-9a59-77731bad630a",
+              "id": "09c73a2e-b904-4632-9cbc-3aa115f5f977",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10573,7 +10573,7 @@
           }
         },
         {
-          "id": "62994b03-8794-49bb-85bc-a3c8ffbc6273",
+          "id": "6405a847-45d6-4e71-8f51-004fdaf0964d",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10609,7 +10609,7 @@
           },
           "response": [
             {
-              "id": "aed4574a-13f8-4ec6-be28-ec7b619f17e2",
+              "id": "601ed8c1-e09c-4a4b-8213-938aefb43e01",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10657,7 +10657,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "87f5ce4d-2237-40e9-804b-62015c3b3fea",
+              "id": "d8fcc58e-8281-46d9-8333-28f4e9e16784",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10705,7 +10705,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "5b8484a0-88a2-439b-a1ac-9e512cde565d",
+              "id": "f3fd88d1-e65a-4927-b5b1-f8556ff97858",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10759,7 +10759,7 @@
           }
         },
         {
-          "id": "b288d6f9-18c9-491f-b9fe-5665944056a7",
+          "id": "b7f1c1fd-de64-4cb3-a51f-6da6f7369f63",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10789,7 +10789,7 @@
           },
           "response": [
             {
-              "id": "b84ca399-e194-4351-a18b-e0fcbf7ade4e",
+              "id": "711bf08c-03d3-413f-be69-136e5dbdf8fe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10841,7 +10841,7 @@
           }
         },
         {
-          "id": "13afca21-5b45-4495-ab53-a7b2d1aeb48b",
+          "id": "1dd36ee3-0b92-463b-be37-35fc0411c81c",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10884,7 +10884,7 @@
           },
           "response": [
             {
-              "id": "45e166fc-884f-49d2-84ca-e844650b3576",
+              "id": "172454fa-7984-4e6c-ae51-51d470c881e9",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10943,7 +10943,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d9892ba2-300b-43d1-9f6b-70cdff379e77",
+              "id": "4ed7528a-9452-4365-97bf-919781154852",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11014,7 +11014,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "97a74aa8-c359-4d9f-9d6c-2289a961b415",
+          "id": "eb942ed0-a77d-46a4-8763-e779bd349862",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11098,7 +11098,7 @@
           },
           "response": [
             {
-              "id": "218057cb-1684-4a5f-982d-6b6a7a184684",
+              "id": "4531429b-3630-4974-b42a-1561e50029e8",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11201,7 +11201,7 @@
           }
         },
         {
-          "id": "616716ee-b3d0-4011-a32f-8b086f9dc693",
+          "id": "ea5cc034-4cb6-4a79-9cd8-5f4b0ab8e750",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11267,7 +11267,7 @@
           },
           "response": [
             {
-              "id": "50249367-351f-4447-9ec1-2e76619891a3",
+              "id": "737b2bb6-799e-4611-ae72-d2a1e1818bd0",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11352,7 +11352,7 @@
           }
         },
         {
-          "id": "5352dbcf-273f-4d1f-a73a-667a7db2e302",
+          "id": "f2cc7ac1-db7a-4c10-babc-1953e5b8c9c4",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11436,7 +11436,7 @@
           },
           "response": [
             {
-              "id": "e3b9214d-c725-4690-a9c5-632e8ab195cd",
+              "id": "cc366c80-790d-462f-9cc4-0183920a05a0",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11539,7 +11539,7 @@
           }
         },
         {
-          "id": "82118a64-845e-4137-a4e2-bdb3213c31c0",
+          "id": "ded389d8-185e-4982-b344-0995175e4ac8",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11614,7 +11614,7 @@
           },
           "response": [
             {
-              "id": "1263d58f-534c-4517-a01b-c67730f79ac1",
+              "id": "631003ad-225f-4e79-bfec-59355b17507f",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11708,7 +11708,7 @@
           }
         },
         {
-          "id": "a2cf5e77-03cc-41d1-a422-4da40b9d1ec4",
+          "id": "69b35588-00cc-43d9-80f3-88479130ca3e",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11783,7 +11783,7 @@
           },
           "response": [
             {
-              "id": "26cabe03-a036-4997-a68a-85497a181bc8",
+              "id": "6e2a98e4-6544-4b91-afa1-9acf1a65030f",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11877,7 +11877,7 @@
           }
         },
         {
-          "id": "eb172aba-c4ac-49c3-a56e-7d7f2b6b50d6",
+          "id": "6f073f11-daec-4b51-b8e9-9cba83e69f25",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -11952,7 +11952,7 @@
           },
           "response": [
             {
-              "id": "d637001b-b3c7-425b-84ed-1a1d2e80d1d6",
+              "id": "02b1f686-2d9a-4f1d-8950-bfb5ada4f00f",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12052,7 +12052,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "10af6db3-2b35-40a1-9d29-e2087920e0b8",
+          "id": "15a4d71a-03dc-4b3a-9ecc-e0f178872251",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12118,7 +12118,7 @@
           },
           "response": [
             {
-              "id": "ff85ab1f-a678-4ccd-b846-b8fd77deb9e2",
+              "id": "2f39cba6-7245-414d-83f4-ae269addbb0a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12192,7 +12192,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1515.3168425037245,\n  \"key_1\": 1013.3400203991183,\n  \"key_2\": 9698.902189626117\n}",
+              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12209,7 +12209,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "fda44756-3a44-42a2-82f9-b1d950a5621c",
+          "id": "74bb667b-4b5b-4491-85d1-05e29a91db28",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12251,7 +12251,7 @@
           },
           "response": [
             {
-              "id": "99a0ea84-7ff3-4d19-a670-a41adf7ab0cd",
+              "id": "3864f3c9-97c5-4b13-800d-efb7821828a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12321,7 +12321,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "76ce561f-6866-4ef0-81c8-9a187825ee9b",
+          "id": "a794feff-ea7a-4050-be05-6efb56405aa4",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12360,7 +12360,7 @@
           },
           "response": [
             {
-              "id": "9e11e304-75b2-4dc2-b692-b51f35154c42",
+              "id": "a3049930-ca6e-4396-821c-e79ccbb1fb2c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12413,7 +12413,7 @@
           }
         },
         {
-          "id": "267506cd-d2ba-4ded-8ff4-b882228f9a85",
+          "id": "e672162a-1510-43f5-87ad-737142b6d312",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12445,7 +12445,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"xk-NR\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:53\",\n  \"quietHoursEnd\": \"16:17\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ys-YV\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"23:32\",\n  \"quietHoursEnd\": \"23:44\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12465,7 +12465,7 @@
           },
           "response": [
             {
-              "id": "6d31223f-8dd5-487e-96f4-aa54e7f3d59c",
+              "id": "6f4c79e7-cbc3-4119-803b-a4240befced9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12503,7 +12503,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"xk-NR\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"21:53\",\n  \"quietHoursEnd\": \"16:17\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ys-YV\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"23:32\",\n  \"quietHoursEnd\": \"23:44\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12537,7 +12537,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "c0fed75d-8d8a-4b6e-96dd-fd8841a44afe",
+          "id": "a6f1f839-aa2f-4bb9-9542-f806eab8d70d",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12579,7 +12579,7 @@
           },
           "response": [
             {
-              "id": "c7beab7a-034e-4ae0-9ec4-49acd05677d8",
+              "id": "aaf932a4-57d0-4c95-8543-d255ab123ed2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12643,7 +12643,7 @@
           }
         },
         {
-          "id": "94e79fac-d333-48bc-a67a-9d861cf9e631",
+          "id": "571fc024-b2b5-4d6b-8d40-1519c802c89c",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12686,7 +12686,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#E5bc2B\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#f6A14c\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12698,7 +12698,7 @@
           },
           "response": [
             {
-              "id": "7c50b4c4-557d-45b1-9d8e-1675d1c26fb1",
+              "id": "02498890-018e-4d01-accb-7c7df025b28e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12747,7 +12747,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#E5bc2B\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#f6A14c\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12775,7 +12775,7 @@
           }
         },
         {
-          "id": "9c6d7659-19ed-4e45-9509-29f814a2bdbc",
+          "id": "6d464ff9-143e-4d98-b5fc-a26a3f233b60",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12811,7 +12811,7 @@
           },
           "response": [
             {
-              "id": "db1accfa-1afa-456f-b273-a4eac8e4382c",
+              "id": "707b1036-233e-4f69-9a4e-96c9e738648f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12865,7 +12865,7 @@
           }
         },
         {
-          "id": "db982233-8cc2-493d-a336-2a30edde1fe2",
+          "id": "bee07dac-0028-449a-9ac2-9605fe510732",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12895,7 +12895,7 @@
           },
           "response": [
             {
-              "id": "95530923-c685-4c81-b934-8c150825a1c8",
+              "id": "e86af013-2730-4945-a0e1-8cce04db20bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12947,7 +12947,7 @@
           }
         },
         {
-          "id": "0aa487ff-3f13-426e-941e-546c3183128e",
+          "id": "c48a82e1-5697-452d-89e6-5975e7bc7ee8",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -12978,7 +12978,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#40Ef1C\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#533cdD\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12990,7 +12990,7 @@
           },
           "response": [
             {
-              "id": "8d83080f-fe6a-4ed3-8c0e-d5ea47bf9de0",
+              "id": "234a6821-6ea3-4bfc-9d93-b57ced50f400",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13027,7 +13027,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#40Ef1C\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#533cdD\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13055,7 +13055,7 @@
           }
         },
         {
-          "id": "4e061a8a-e2ef-4248-80ac-70d6d9348db3",
+          "id": "a48d4534-4784-42bd-a06f-df4cfab6785e",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13086,7 +13086,7 @@
           },
           "response": [
             {
-              "id": "c30f5e26-af76-4174-8148-097e5e1e9fdd",
+              "id": "61e7ed47-eab3-4a96-9043-607094895cf5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13145,7 +13145,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "fd89f9d9-a0f8-4150-89f5-69010d6fbea8",
+          "id": "57aaccd2-773e-410e-a52b-f60253ec9347",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "8737c1a2-ab03-46fa-9578-feec265d08d8",
+              "id": "8c0025b6-8c39-4b37-883f-1fa98914a08d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13273,7 +13273,7 @@
           }
         },
         {
-          "id": "5d824cf6-353a-442a-9894-c104bc37bc53",
+          "id": "01bea875-96a0-419c-9a86-596cab0a6eeb",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13339,7 +13339,7 @@
           },
           "response": [
             {
-              "id": "a4414195-4cad-4a0b-b5b1-4b98d9b446ab",
+              "id": "1c0f5f11-f311-4d73-b8d2-013e57e8e347",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13427,7 +13427,7 @@
           }
         },
         {
-          "id": "24b51740-575f-41b6-b62f-4ec2f00c9b42",
+          "id": "279c02f5-f250-4c77-9461-1857bf396576",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13474,7 +13474,7 @@
           },
           "response": [
             {
-              "id": "6f2ce72e-f955-4263-8098-e30374d5b4c9",
+              "id": "c05a93bd-5c7f-46c9-afa7-562ca1f7eed1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13539,7 +13539,7 @@
           }
         },
         {
-          "id": "7c2ebcd0-dcf8-423a-b055-251a4eb4b04a",
+          "id": "8527dda2-75fe-4231-8097-7d7a89143728",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13581,7 +13581,7 @@
           },
           "response": [
             {
-              "id": "f20fee7e-f73c-43e8-9d1d-b104572ae0c7",
+              "id": "d99bbbc2-affe-49da-bb07-e371672d560e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13645,7 +13645,7 @@
           }
         },
         {
-          "id": "295f332b-299e-46b1-a485-ded6a83edd00",
+          "id": "fec729cc-cf36-449d-be2f-a9ffb0b73693",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13700,7 +13700,7 @@
           },
           "response": [
             {
-              "id": "26189cd3-7de1-4fcb-9f08-e53042faaa67",
+              "id": "7a999800-3217-4d61-852b-7cad919d6e42",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13777,7 +13777,7 @@
           }
         },
         {
-          "id": "8ecb3a1c-3033-4d5a-bb34-8de51e6cdce4",
+          "id": "d0475a26-7750-48e1-9a6b-4bb5e0594905",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13831,7 +13831,7 @@
           },
           "response": [
             {
-              "id": "49fdeef1-e788-4b22-89a1-761a7fa4636d",
+              "id": "b4fa90d5-edec-4ee6-b8a0-664b837c8785",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13907,7 +13907,7 @@
           }
         },
         {
-          "id": "6f1a55eb-1d4c-4129-8f85-5ad9c2b65260",
+          "id": "16b276de-8f82-40c5-aa70-a01bb28558a4",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -13973,7 +13973,7 @@
           },
           "response": [
             {
-              "id": "11dc2cbe-d5e5-40a0-b37b-3e4d5abcd375",
+              "id": "14025e2d-7983-4a3f-812f-ed8cd8b940e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14061,7 +14061,7 @@
           }
         },
         {
-          "id": "8a1356b2-a22a-44d2-bc8a-bb7fbd49fbe3",
+          "id": "d93a3a97-8215-4255-a1fc-b804a590e4b7",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14139,7 +14139,7 @@
           },
           "response": [
             {
-              "id": "0743ee23-bdd9-462e-af32-d2b17d4967c0",
+              "id": "8bbd192a-da13-498e-9ef3-dc82e673d393",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14239,7 +14239,7 @@
           }
         },
         {
-          "id": "0d407a37-dd3b-4884-857a-fa598f5d207c",
+          "id": "8289a91d-c186-4624-9008-42896c24df5b",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14305,7 +14305,7 @@
           },
           "response": [
             {
-              "id": "97bcc835-4b4e-400c-b0e2-d3cff76e2882",
+              "id": "e0d3df73-19ff-46b5-8b52-bb5c14c14ce8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14393,7 +14393,7 @@
           }
         },
         {
-          "id": "6c644c30-67cf-47c6-86c6-658e31b274c0",
+          "id": "aaa3cb5a-1661-42dc-a1d3-44a6c843df1b",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14448,7 +14448,7 @@
           },
           "response": [
             {
-              "id": "5f37d6d6-cb7a-4a57-88de-d1cd164cf217",
+              "id": "31a14dd1-24af-4595-93ea-2391ac953548",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14531,7 +14531,7 @@
       "description": "",
       "item": [
         {
-          "id": "e796cce8-beb1-423f-a753-ba1933674707",
+          "id": "cfb1bf59-08a5-4776-b525-da418bc00eab",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14572,7 +14572,7 @@
           },
           "response": [
             {
-              "id": "b8865f81-8c02-43e8-b940-a1e51230d8bd",
+              "id": "b598bba0-e77f-4299-b3ce-6c704c0da0c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14635,7 +14635,7 @@
           }
         },
         {
-          "id": "f86b9ec4-8528-4f4f-b64e-d18ba8d26317",
+          "id": "658842c1-7d59-43e6-b739-9b34c119ab12",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14689,7 +14689,7 @@
           },
           "response": [
             {
-              "id": "05f81c1d-8b8a-4b59-ba9a-efc3556c14c1",
+              "id": "590dd83b-7725-40f9-9fa1-bf95946d0c41",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14765,7 +14765,7 @@
           }
         },
         {
-          "id": "07043534-3830-4247-959a-63ee1dd531b7",
+          "id": "079fedd2-ed1a-411d-bfff-c0de22fc43f8",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14800,7 +14800,7 @@
           },
           "response": [
             {
-              "id": "9eee2254-c9b9-4cfd-bb87-5d00a138c6c2",
+              "id": "05712bf0-41c5-463e-a989-2fac1ccbe531",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14853,7 +14853,7 @@
           }
         },
         {
-          "id": "a4bfb4b9-0a06-45a2-9ef5-f57557141fb4",
+          "id": "fb32e47b-0333-403a-9361-64c3e9fa2295",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14895,7 +14895,7 @@
           },
           "response": [
             {
-              "id": "3e2515dd-13b9-47a9-81ed-3ffb27f7dd9d",
+              "id": "fad611ae-15ba-49ff-bb8a-f7e6e3ce41e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14959,7 +14959,7 @@
           }
         },
         {
-          "id": "00700dd7-73c1-494a-996e-3e9679965fbf",
+          "id": "e99b6b65-ccc7-4e2a-b62a-20f12bc0c5a4",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15001,7 +15001,7 @@
           },
           "response": [
             {
-              "id": "945519e7-6aca-429d-8de6-d6dcd76412f6",
+              "id": "df9297b6-2094-476a-9437-3856cc54c17d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15065,7 +15065,7 @@
           }
         },
         {
-          "id": "5247acb8-a8a2-4ce9-b450-7b9dedee7290",
+          "id": "9ccfe2e5-ec5f-4d68-8c85-b52ef5b54bec",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15140,7 +15140,7 @@
           },
           "response": [
             {
-              "id": "542b42b7-25f5-4ed0-a160-3f01ef6a1f28",
+              "id": "eda22fd4-0d33-4ba1-93cf-9199df39b91f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15237,7 +15237,7 @@
           }
         },
         {
-          "id": "af907f0c-4588-4b71-a296-315adbabf917",
+          "id": "3a67dabb-e3ba-4989-af43-d858cc58fd11",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15279,7 +15279,7 @@
           },
           "response": [
             {
-              "id": "83112f35-5b19-4a41-8cc4-cedb1e11603f",
+              "id": "665948cb-b0fd-4cae-85fc-0f7fc875d7aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15343,7 +15343,7 @@
           }
         },
         {
-          "id": "6353d99d-cdb0-4494-8db2-42dc061cc918",
+          "id": "92521ea0-82f0-461a-9b0b-af621151c163",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15386,7 +15386,7 @@
           },
           "response": [
             {
-              "id": "d9a4eeaa-91b9-4c41-bbf7-e5657f55945c",
+              "id": "75e9fc17-d13c-4140-aa38-0d19d643af7d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15451,7 +15451,7 @@
           }
         },
         {
-          "id": "a41a7345-8281-48f6-b9fd-22a21f24d627",
+          "id": "384156ac-aa33-4f4c-9088-e59a3874d758",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15494,7 +15494,7 @@
           },
           "response": [
             {
-              "id": "cdf39ec6-2f0d-4c1b-b88d-da0cca05caa1",
+              "id": "037eba76-a839-42e2-bb2d-0888b519fbb0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15559,7 +15559,7 @@
           }
         },
         {
-          "id": "993ab6ed-c38b-46e0-9f74-0e74edda9f6f",
+          "id": "0e06cba2-e2e7-4164-90d8-9708cf09c151",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15611,7 +15611,7 @@
           },
           "response": [
             {
-              "id": "0ba2ecde-7e68-4adb-ad57-7d4701a42079",
+              "id": "b8697737-3705-47e6-b116-0ccbb3944ae6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15685,7 +15685,7 @@
           }
         },
         {
-          "id": "434e7925-1341-41d1-837f-22dc6706c06a",
+          "id": "cdd9579e-258b-4a9a-9fa9-e5c208b8e4b9",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15727,7 +15727,7 @@
           },
           "response": [
             {
-              "id": "4b0e0aa7-5f36-4e2d-bd1d-00a3aeca44f0",
+              "id": "49fff571-331f-4873-9eb2-326abf34ca39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15791,7 +15791,7 @@
           }
         },
         {
-          "id": "5b9d99de-15ef-41d4-9d22-ec74fff9ad23",
+          "id": "03afa486-1173-4de6-b6ac-b15147d38a5e",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15844,7 +15844,7 @@
           },
           "response": [
             {
-              "id": "7fb40e12-627d-4c78-bd82-93b3073c0dd3",
+              "id": "6885ebad-9fba-4554-93dc-b789c8d1da05",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15919,7 +15919,7 @@
           }
         },
         {
-          "id": "2af37d44-2ee0-48e4-9197-b6cc74c8c111",
+          "id": "d1d5edc2-4f46-49d3-9773-c0db0184b516",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -15972,7 +15972,7 @@
           },
           "response": [
             {
-              "id": "7e91d9b3-72b6-4199-ab2a-e176fd8cf171",
+              "id": "407c2237-58ee-42f4-a838-90b0644dfe64",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16047,7 +16047,7 @@
           }
         },
         {
-          "id": "307a9a57-d8d4-4037-93e5-151376db93cb",
+          "id": "c8389aba-dceb-48f6-ba7f-fee51177cd7e",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16091,7 +16091,7 @@
           },
           "response": [
             {
-              "id": "484adb78-b7d7-43e7-8d69-685c6ba101c8",
+              "id": "2e3e4b11-ea75-4e09-b757-a20bb51a813f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16146,7 +16146,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16157,7 +16157,7 @@
           }
         },
         {
-          "id": "21c390ee-f0c0-4895-a881-0e61cb915357",
+          "id": "61434140-ee86-4f82-81ce-a3f73e1dd5ba",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16201,7 +16201,7 @@
           },
           "response": [
             {
-              "id": "2c7feedc-63c4-4063-a226-d3d840db2cea",
+              "id": "746e8a74-fe26-4b30-8a1d-496590e165f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16256,7 +16256,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<long>\"\n}",
+              "body": "{\n  \"key_0\": \"<long>\",\n  \"key_1\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -16273,7 +16273,7 @@
       "description": "",
       "item": [
         {
-          "id": "8d5451c8-69fa-4524-811b-7375e5d8dbfd",
+          "id": "25109775-2fc1-41ab-99b5-628d1d2bbdd9",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16315,7 +16315,7 @@
           },
           "response": [
             {
-              "id": "57ebbb71-7c66-455c-a6dc-06c2a5fe2a50",
+              "id": "9c3f95bd-66f3-45a0-815b-caad45d3b143",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16364,7 +16364,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "3d43f506-1039-4550-9b27-3bd18996191c",
+              "id": "c62ffafc-c6f1-41dd-a336-fba91718d976",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16419,7 +16419,7 @@
           }
         },
         {
-          "id": "0f760ad6-cf1a-4b38-8a56-70e63fd9e162",
+          "id": "c1d13504-464d-4c0d-8366-02b2bddf022e",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16465,7 +16465,7 @@
           },
           "response": [
             {
-              "id": "6bf2b85f-afaa-4c3e-9c44-ba0a3428f09a",
+              "id": "8a80c9ee-8c53-4d39-b80d-79b9f72c8afb",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16524,7 +16524,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "556d2021-e0f0-4898-9b7b-03087cf5f698",
+              "id": "7b6d6bf1-1fc4-40e7-ba3d-c8e784bb2ef2",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16589,7 +16589,7 @@
           }
         },
         {
-          "id": "70ceaa49-5f7e-4126-814b-849ed412915d",
+          "id": "e808969d-fc48-46cf-aaf7-0b5b776269a0",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16635,7 +16635,7 @@
           },
           "response": [
             {
-              "id": "031bd5c9-af46-45c5-bc64-ce1ecec7eb9b",
+              "id": "59152e87-9d3e-406b-b83f-1beed9f1219e",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16694,7 +16694,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "b5c6881d-71ca-4610-b4bd-60b12b4809aa",
+              "id": "7d92c1ee-3d24-488e-993b-7ca54b66da78",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16753,7 +16753,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "5185d672-dffe-4ea6-9600-29d8c3151695",
+              "id": "77d4294e-96e8-45ef-b807-f17034cceabd",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16812,7 +16812,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "9af16411-2a88-48ce-9714-6ba747473f6d",
+              "id": "42ad5111-7c10-4dd5-8b7e-f87795ebbaa8",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16877,7 +16877,7 @@
           }
         },
         {
-          "id": "80985f60-e7fe-495e-9789-817f8236d4a2",
+          "id": "e8d2c4ae-e7cc-4776-8f30-8afc2e740a6f",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -16923,7 +16923,7 @@
           },
           "response": [
             {
-              "id": "9902100c-f85e-48f6-8c28-0351908c6396",
+              "id": "987aa1d2-0667-4982-962f-cc3aac68d603",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -16982,7 +16982,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c7be1e0e-a24f-4b94-b918-f05e80ee0ed7",
+              "id": "c2981f67-6b2a-479e-acaf-bb5d49c6c38a",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17047,7 +17047,7 @@
           }
         },
         {
-          "id": "fd87440f-66db-4353-a28d-6b678916da96",
+          "id": "63e173d9-5a97-4864-b563-e17c9980e7dd",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17089,7 +17089,7 @@
           },
           "response": [
             {
-              "id": "f2f51db6-fc5c-4b86-ac5c-572676b20103",
+              "id": "6685912a-7f67-4f3b-8f1e-abee893e7ed3",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17150,7 +17150,7 @@
       "description": "",
       "item": [
         {
-          "id": "a655ea81-2a07-428c-9b36-5028ed84a5b2",
+          "id": "7c747e0b-f552-4e47-83bd-06e3b45f1bb0",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17199,7 +17199,7 @@
           },
           "response": [
             {
-              "id": "214fcf4e-0464-4194-931f-8f9598607160",
+              "id": "3826c591-41f5-4aea-ac47-2d53386b9f04",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17259,7 +17259,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1515.3168425037245,\n  \"key_1\": 1013.3400203991183,\n  \"key_2\": 9698.902189626117\n}",
+              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17270,7 +17270,7 @@
           }
         },
         {
-          "id": "e1301425-a31b-45d0-80dd-352b8eb24463",
+          "id": "27c66b09-531a-4ad2-a937-2629bc48424c",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17319,7 +17319,7 @@
           },
           "response": [
             {
-              "id": "c68566f3-dee6-4dd1-ae23-bccfafa2855f",
+              "id": "2794caa4-3c0a-4065-8b3b-bbc2b866695f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17390,7 +17390,7 @@
           }
         },
         {
-          "id": "e38203a2-fcc5-4c2d-b4fa-f42d827f722e",
+          "id": "7c62c11e-8d00-4630-b7a6-44b1285cb19b",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17439,7 +17439,7 @@
           },
           "response": [
             {
-              "id": "0b091a92-9ab9-4391-aecb-76627dbbd434",
+              "id": "fe2c2c62-dac0-4d50-88d4-a32241977b4f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17510,7 +17510,7 @@
           }
         },
         {
-          "id": "d4f32a6a-582b-4b21-bfe5-85f336702820",
+          "id": "bd1b4dce-60c5-4c8c-bb76-da570f26bfdc",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17559,7 +17559,7 @@
           },
           "response": [
             {
-              "id": "22c3b099-afd6-493f-9e30-6050d5c72e1b",
+              "id": "283e668d-c246-432e-ae13-b1c07d72c2c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17636,7 +17636,7 @@
       "description": "",
       "item": [
         {
-          "id": "651196fb-3625-44c9-84a4-498f7930be28",
+          "id": "cabe28fb-074f-4fd4-8437-cc1ab774b2a6",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17676,7 +17676,7 @@
           },
           "response": [
             {
-              "id": "c61a0469-3e9a-47cd-89ee-72a57b24630a",
+              "id": "8f948781-76a1-4934-938e-528f08d83451",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17738,7 +17738,7 @@
           }
         },
         {
-          "id": "7b1cdcaf-ae36-433d-b686-66aee789bd71",
+          "id": "ce721c6d-d26e-4e20-9385-7e759cf8a899",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17768,7 +17768,7 @@
           },
           "response": [
             {
-              "id": "e0b7327f-4977-427a-a2aa-2f470dc7d4e3",
+              "id": "98458602-b28b-49f8-ab56-c2023f1d95a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17809,7 +17809,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1515.3168425037245,\n  \"key_1\": 1013.3400203991183,\n  \"key_2\": 9698.902189626117\n}",
+              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17820,7 +17820,7 @@
           }
         },
         {
-          "id": "ec348217-7af3-48be-b333-70cdd363f14a",
+          "id": "ab0ac81a-e3ef-40c2-b6c0-652ddeb3e82e",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17872,7 +17872,7 @@
           },
           "response": [
             {
-              "id": "54dbee61-059c-41b8-9aaa-34ea48456a82",
+              "id": "e9217323-29f6-47e9-a6da-915639f4eb54",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17952,7 +17952,7 @@
       "description": "",
       "item": [
         {
-          "id": "1b4a39eb-6d2e-4e7e-8941-0ac7137e9c77",
+          "id": "1a7280cc-772d-453b-bd38-84308cf2e899",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -17981,7 +17981,7 @@
           },
           "response": [
             {
-              "id": "f1b96ff8-9560-4692-9755-2e9907eb623f",
+              "id": "d14a1a2a-8136-4ca7-b0da-3b723eeb5635",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18032,7 +18032,7 @@
           }
         },
         {
-          "id": "af51e176-bd92-43f2-95d0-33f890705d9c",
+          "id": "443e6e99-294a-4fdc-ad65-c12930028d7d",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18073,7 +18073,7 @@
           },
           "response": [
             {
-              "id": "737f1277-db60-48be-9a66-f204a2fa7d8c",
+              "id": "148db9b5-9d04-43bb-9617-93b1968822e0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18142,7 +18142,7 @@
       "description": "",
       "item": [
         {
-          "id": "15c9a771-3e2f-44c0-98fb-71a2981febfa",
+          "id": "aa64191f-ad00-4431-98b5-569125d3effb",
           "name": "health",
           "request": {
             "name": "health",
@@ -18171,7 +18171,7 @@
           },
           "response": [
             {
-              "id": "31ed6805-1dba-4abc-ab43-03eca6225b32",
+              "id": "f1fcfcb6-0d8e-4051-89b4-de65f7894fce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18211,7 +18211,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 1515.3168425037245,\n  \"key_1\": 1013.3400203991183,\n  \"key_2\": 9698.902189626117\n}",
+              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18228,7 +18228,7 @@
       "description": "",
       "item": [
         {
-          "id": "5501bd9d-fa12-442b-8b31-7dcb6c877d2a",
+          "id": "2b1548cf-3850-4d65-be80-ac0d44dd1170",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18280,7 +18280,7 @@
           },
           "response": [
             {
-              "id": "60cab710-9f2c-41ed-83bf-aa90233b02fa",
+              "id": "7ae24fa0-ad98-40de-a7df-6697ade009e9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18354,7 +18354,7 @@
           }
         },
         {
-          "id": "52a0825c-8ad7-492f-9cb4-74a4bd508fd1",
+          "id": "ce48f215-f08b-41df-a51a-c7627dc3ae09",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18395,7 +18395,7 @@
           },
           "response": [
             {
-              "id": "aa1b91f4-adf7-4d7f-be0c-605391a00d01",
+              "id": "b1e37501-364c-4401-bcd4-e291da0074e9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18458,7 +18458,7 @@
           }
         },
         {
-          "id": "42041457-e38e-4025-9e63-0e480e2dba34",
+          "id": "fa1be684-73d8-4760-9a38-ec99599f57c0",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18488,7 +18488,7 @@
           },
           "response": [
             {
-              "id": "6a461b24-2e2a-470a-88f9-c2d8647a69f7",
+              "id": "c5612003-2745-49fc-80f4-46e54778b7f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18529,7 +18529,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\",\n  \"key_3\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18560,9 +18560,9 @@
     }
   ],
   "info": {
-    "_postman_id": "0447e158-1126-4431-b538-af1c77725b82",
+    "_postman_id": "f6dd4184-b389-4c07-a45f-02a25a5addbd",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-05 00:02 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-05 00:10 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/Invernaderos_API_Collection.postman_collection.json
+++ b/Invernaderos_API_Collection.postman_collection.json
@@ -5,7 +5,7 @@
       "description": "Endpoints para la gestión de sectores de un cliente",
       "item": [
         {
-          "id": "f117c1ad-1f21-449e-b659-f77467f145e2",
+          "id": "6137645b-44d8-4d9a-b7f8-e32413463161",
           "name": "Obtener un sector específico de un cliente",
           "request": {
             "name": "Obtener un sector específico de un cliente",
@@ -58,7 +58,7 @@
           },
           "response": [
             {
-              "id": "0f3f3c41-848a-4777-a839-8a2261e48c8e",
+              "id": "46b23daa-bc6c-4bf9-b244-7a560bffd578",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -133,7 +133,7 @@
           }
         },
         {
-          "id": "468cd179-db72-47f7-b438-1630e1d3613d",
+          "id": "262b8bc9-cb8b-49a6-afc7-eaeb264e8966",
           "name": "Actualizar un sector existente de un cliente",
           "request": {
             "name": "Actualizar un sector existente de un cliente",
@@ -199,7 +199,7 @@
           },
           "response": [
             {
-              "id": "ddce5f9d-4545-424d-908d-87a6f1e824e7",
+              "id": "3c44791f-062a-478b-9d4d-3004b14494a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -287,7 +287,7 @@
           }
         },
         {
-          "id": "6e29cda6-8dcc-478b-83b7-4208b8f29ec1",
+          "id": "4e888120-55d1-40d4-82c0-0da11b289bfc",
           "name": "Eliminar un sector de un cliente",
           "request": {
             "name": "Eliminar un sector de un cliente",
@@ -334,7 +334,7 @@
           },
           "response": [
             {
-              "id": "38cad33a-2d24-4cf6-82bc-1273ca784111",
+              "id": "c39ec7e8-3373-4aa1-8fb4-0966729e8b47",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -399,7 +399,7 @@
           }
         },
         {
-          "id": "cbd857a7-4ecd-4e6e-9234-53ba77034f55",
+          "id": "5e4e44ba-3b1f-44bb-b893-66ecc8183054",
           "name": "Obtener todos los sectores de un cliente",
           "request": {
             "name": "Obtener todos los sectores de un cliente",
@@ -441,7 +441,7 @@
           },
           "response": [
             {
-              "id": "478936e4-169e-4da0-913f-e9d28c01994b",
+              "id": "007a628f-5d45-404e-a1e9-3d99aa347d0e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -505,7 +505,7 @@
           }
         },
         {
-          "id": "09dd3283-d502-420b-9a2e-a36ac4b47a87",
+          "id": "bc20c4cf-df1e-45d6-80ea-4a202f9d9e91",
           "name": "Crear un nuevo sector para un cliente",
           "request": {
             "name": "Crear un nuevo sector para un cliente",
@@ -560,7 +560,7 @@
           },
           "response": [
             {
-              "id": "4b6f96dd-d864-4c5b-acac-68ca6d9cab5b",
+              "id": "77256cc6-bb3a-4fe8-84cc-9dc60dfcd377",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -643,7 +643,7 @@
       "description": "CRUD de unidades de medida",
       "item": [
         {
-          "id": "493c4567-e42a-444a-a7f8-785f3ca24bdd",
+          "id": "d22cc8d1-32fa-46c0-83f2-3d29dcf14540",
           "name": "Obtener una unidad por ID",
           "request": {
             "name": "Obtener una unidad por ID",
@@ -685,7 +685,7 @@
           },
           "response": [
             {
-              "id": "46a7260d-6f13-4941-a2a4-4bddcfdf78ae",
+              "id": "089cc7e3-b67b-4eaf-b0f0-adbd458e1497",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -749,7 +749,7 @@
           }
         },
         {
-          "id": "ffed1734-9b96-450f-8db5-4c60c4ef1346",
+          "id": "66462a29-0e14-4bd2-a8b9-5160c9f49d78",
           "name": "Actualizar unidad de medida",
           "request": {
             "name": "Actualizar unidad de medida",
@@ -804,7 +804,7 @@
           },
           "response": [
             {
-              "id": "8c13fe07-d3fb-4e92-9954-32e8eab6e19c",
+              "id": "381c7301-0e9a-4d91-b853-715e145f28bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -881,7 +881,7 @@
           }
         },
         {
-          "id": "e635e7bb-757d-4476-8b1c-2e033600dc3d",
+          "id": "e2e4e702-6865-4a05-9896-77e4e9f43ae3",
           "name": "Eliminar unidad de medida",
           "request": {
             "name": "Eliminar unidad de medida",
@@ -917,7 +917,7 @@
           },
           "response": [
             {
-              "id": "e61eb74d-6c9d-4d9c-90ec-cfe3a829ebcd",
+              "id": "34164bcc-bc94-4e76-b697-cc5a20e1b4af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -971,7 +971,7 @@
           }
         },
         {
-          "id": "8e8618b7-144d-480c-a241-80cb9118570e",
+          "id": "390daad8-b0f6-4235-9162-aa23202400f0",
           "name": "Obtener todas las unidades de medida",
           "request": {
             "name": "Obtener todas las unidades de medida",
@@ -1011,7 +1011,7 @@
           },
           "response": [
             {
-              "id": "62074f73-a934-4ce7-897c-169514dc5241",
+              "id": "22679099-337e-448b-a304-168cb19f5bd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "8a835a37-11a8-467d-9587-6cc6d432b00e",
+          "id": "a9511728-44c9-47f4-a78b-e25f8ab74d3e",
           "name": "Crear nueva unidad de medida",
           "request": {
             "name": "Crear nueva unidad de medida",
@@ -1116,7 +1116,7 @@
           },
           "response": [
             {
-              "id": "7fc7dd6d-f56c-4b83-8bb8-978540e01a18",
+              "id": "1b06fe11-e9f1-4d2f-a80c-664aed348058",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1181,7 +1181,7 @@
           }
         },
         {
-          "id": "4136cf4f-31e8-47d2-ad75-28ff14ccc228",
+          "id": "495b2737-3e2f-4707-8689-7630ff5eaf78",
           "name": "Desactivar unidad de medida",
           "request": {
             "name": "Desactivar unidad de medida",
@@ -1224,7 +1224,7 @@
           },
           "response": [
             {
-              "id": "bc7fd1b1-527e-4b9c-a111-65e594b633a6",
+              "id": "04400dc9-8764-4697-924b-79fcdc5ce23b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "id": "51da411c-6a9d-4521-996d-d21d838e6c58",
+          "id": "4e4717a2-67f3-414b-941e-9e9821082720",
           "name": "Activar unidad de medida",
           "request": {
             "name": "Activar unidad de medida",
@@ -1332,7 +1332,7 @@
           },
           "response": [
             {
-              "id": "9a8b78bb-e7b4-4cbc-9c3a-deb5f3c1d354",
+              "id": "6a6ba817-32a2-4dcd-806c-4cb0fa7a8bdb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1403,7 +1403,7 @@
       "description": "Audit log of alert state transitions and episode pairs",
       "item": [
         {
-          "id": "9431c20a-c824-4f06-9c30-501b59801267",
+          "id": "a3602171-b213-4fe4-871e-d61e77587d04",
           "name": "Get full transition timeline for a single alert",
           "request": {
             "name": "Get full transition timeline for a single alert",
@@ -1470,7 +1470,7 @@
           },
           "response": [
             {
-              "id": "ebfc2c95-0fdd-4bc9-8b3f-e768b58599b0",
+              "id": "96943181-4fcb-4cf1-98ae-486efa1033ed",
               "name": "Timeline returned (may be empty if alert not found or not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1545,7 +1545,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"USER\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
+              "body": "[\n  {\n    \"actor\": {\n      \"kind\": \"DEVICE\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  },\n  {\n    \"actor\": {\n      \"kind\": \"SYSTEM\",\n      \"userId\": \"<long>\",\n      \"username\": \"<string>\",\n      \"displayName\": \"<string>\",\n      \"ref\": \"<string>\"\n    },\n    \"alertCode\": \"<string>\",\n    \"alertId\": \"<long>\",\n    \"at\": \"<dateTime>\",\n    \"fromResolved\": \"<boolean>\",\n    \"occurrenceNumber\": \"<long>\",\n    \"sectorId\": \"<long>\",\n    \"source\": \"<string>\",\n    \"tenantId\": \"<long>\",\n    \"toResolved\": \"<boolean>\",\n    \"totalTransitionsSoFar\": \"<long>\",\n    \"transitionId\": \"<long>\",\n    \"rawValue\": \"<string>\",\n    \"alertMessage\": \"<string>\",\n    \"alertTypeId\": \"<integer>\",\n    \"alertTypeName\": \"<string>\",\n    \"severityId\": \"<integer>\",\n    \"severityName\": \"<string>\",\n    \"severityLevel\": \"<integer>\",\n    \"severityColor\": \"<string>\",\n    \"sectorCode\": \"<string>\",\n    \"greenhouseId\": \"<long>\",\n    \"greenhouseName\": \"<string>\",\n    \"previousTransitionAt\": \"<dateTime>\",\n    \"episodeStartedAt\": \"<dateTime>\",\n    \"episodeDurationSeconds\": \"<long>\"\n  }\n]",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -1556,7 +1556,7 @@
           }
         },
         {
-          "id": "baaf3f7c-1d0b-457e-9140-d089e6a6f68b",
+          "id": "800594e8-c622-4dcd-9696-28e2b02530f6",
           "name": "Count unresolved alerts for a specific sector",
           "request": {
             "name": "Count unresolved alerts for a specific sector",
@@ -1615,7 +1615,7 @@
           },
           "response": [
             {
-              "id": "13d7b47d-f864-4d23-8601-10e5abf03729",
+              "id": "25533181-ab86-460e-a26c-1ac57289f78e",
               "name": "Count of unresolved alerts (0 if sector not owned by tenant)",
               "originalRequest": {
                 "url": {
@@ -1693,7 +1693,7 @@
           }
         },
         {
-          "id": "80ecb382-3b33-4c2f-b5fd-8a7e9c488486",
+          "id": "5c5d568b-32e8-4984-84bd-2f3207da5d7e",
           "name": "Paginated tenant-wide feed of alert state transitions",
           "request": {
             "name": "Paginated tenant-wide feed of alert state transitions",
@@ -1910,7 +1910,7 @@
           },
           "response": [
             {
-              "id": "83a98582-c18e-4605-b141-ba2f4fb82fce",
+              "id": "9ae4ab08-5e97-4398-9eff-d2c302d7fae7",
               "name": "Paged list of transitions",
               "originalRequest": {
                 "url": {
@@ -2072,7 +2072,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    },\n    {\n      \"actor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"at\": \"<dateTime>\",\n      \"fromResolved\": \"<boolean>\",\n      \"occurrenceNumber\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"source\": \"<string>\",\n      \"tenantId\": \"<long>\",\n      \"toResolved\": \"<boolean>\",\n      \"totalTransitionsSoFar\": \"<long>\",\n      \"transitionId\": \"<long>\",\n      \"rawValue\": \"<string>\",\n      \"alertMessage\": \"<string>\",\n      \"alertTypeId\": \"<integer>\",\n      \"alertTypeName\": \"<string>\",\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"severityLevel\": \"<integer>\",\n      \"severityColor\": \"<string>\",\n      \"sectorCode\": \"<string>\",\n      \"greenhouseId\": \"<long>\",\n      \"greenhouseName\": \"<string>\",\n      \"previousTransitionAt\": \"<dateTime>\",\n      \"episodeStartedAt\": \"<dateTime>\",\n      \"episodeDurationSeconds\": \"<long>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2083,7 +2083,7 @@
           }
         },
         {
-          "id": "30f5c1ed-a9fb-4b8f-bd49-049dde85c6d0",
+          "id": "4588b4b6-b4d4-4a08-8ad1-0336794ed03e",
           "name": "Paginated list of alert episodes (open→close pairs)",
           "request": {
             "name": "Paginated list of alert episodes (open→close pairs)",
@@ -2229,7 +2229,7 @@
           },
           "response": [
             {
-              "id": "855535be-744d-4f62-85f0-e6729841ffd6",
+              "id": "3ecb5d1e-a15a-44b2-82f6-32a751082a86",
               "name": "Paged list of episodes",
               "originalRequest": {
                 "url": {
@@ -2356,7 +2356,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"USER\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
+              "body": "{\n  \"hasMore\": \"<boolean>\",\n  \"items\": [\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    },\n    {\n      \"alertCode\": \"<string>\",\n      \"alertId\": \"<long>\",\n      \"sectorId\": \"<long>\",\n      \"triggerActor\": {\n        \"kind\": \"DEVICE\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"triggerSource\": \"<string>\",\n      \"triggeredAt\": \"<dateTime>\",\n      \"resolvedAt\": \"<dateTime>\",\n      \"durationSeconds\": \"<long>\",\n      \"resolveSource\": \"<string>\",\n      \"resolveActor\": {\n        \"kind\": \"SYSTEM\",\n        \"userId\": \"<long>\",\n        \"username\": \"<string>\",\n        \"displayName\": \"<string>\",\n        \"ref\": \"<string>\"\n      },\n      \"severityId\": \"<integer>\",\n      \"severityName\": \"<string>\",\n      \"sectorCode\": \"<string>\"\n    }\n  ],\n  \"page\": \"<integer>\",\n  \"size\": \"<integer>\",\n  \"total\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2373,7 +2373,7 @@
       "description": "Endpoints para enviar comandos al PLC via MQTT",
       "item": [
         {
-          "id": "72ed90e6-2f4c-4fa6-94cc-a9beb46ac743",
+          "id": "4ec889e1-8e86-47e5-9801-b8378c77a70e",
           "name": "Enviar un comando al PLC via MQTT",
           "request": {
             "name": "Enviar un comando al PLC via MQTT",
@@ -2415,7 +2415,7 @@
           },
           "response": [
             {
-              "id": "0e1e0ffc-3d26-4d6e-9b60-7bff90193cdd",
+              "id": "a1d06802-e904-4968-837f-c5793c431006",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2479,7 +2479,7 @@
           }
         },
         {
-          "id": "985b9501-e5e6-44d6-bce6-f672457c343f",
+          "id": "7299a35c-3b3c-4ace-b38f-30b96aa4f33a",
           "name": "Historial de comandos por código",
           "request": {
             "name": "Historial de comandos por código",
@@ -2539,7 +2539,7 @@
           },
           "response": [
             {
-              "id": "5f49887d-e237-48e9-a82e-24cf2c009bae",
+              "id": "b564012a-e01c-43bd-a305-51a1583be463",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2627,7 +2627,7 @@
       "description": "Gestión del rate limiter de lecturas de sensores",
       "item": [
         {
-          "id": "22e38be9-c22f-4e49-96d9-a0b15fa5797e",
+          "id": "0a2102f3-fdaf-4168-b960-9dc5fe9dbb42",
           "name": "Resetear estadísticas",
           "request": {
             "name": "Resetear estadísticas",
@@ -2660,7 +2660,7 @@
           },
           "response": [
             {
-              "id": "fb84f37f-e1ab-48c9-ab76-cdaa284e5001",
+              "id": "4ad648df-6408-4723-87f5-b41c1dcabea0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2701,7 +2701,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -2712,7 +2712,7 @@
           }
         },
         {
-          "id": "908b73ee-e3a3-4773-8099-97d592e44df9",
+          "id": "3942226e-8303-484d-b4c4-61f225bd547e",
           "name": "Obtener estadísticas del rate limiter",
           "request": {
             "name": "Obtener estadísticas del rate limiter",
@@ -2745,7 +2745,7 @@
           },
           "response": [
             {
-              "id": "276470c9-c5d2-42fd-ba77-6d514cda7136",
+              "id": "9f105bf3-d727-45dd-a12a-b60f4e7017f5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2803,7 +2803,7 @@
       "description": "Registro de tokens FCM de dispositivos para notificaciones push",
       "item": [
         {
-          "id": "23f56c05-409d-48d9-b4da-0e2fe7297a42",
+          "id": "77cc7923-6898-4ac8-b5ac-af320275b7ab",
           "name": "Registrar (o refrescar) el token FCM de este dispositivo",
           "request": {
             "name": "Registrar (o refrescar) el token FCM de este dispositivo",
@@ -2829,7 +2829,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+              "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -2849,7 +2849,7 @@
           },
           "response": [
             {
-              "id": "adbacf55-a838-4344-99fe-91832b9bb2e1",
+              "id": "f51aa55f-d2b0-43cc-9b36-c1eb61340699",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2881,7 +2881,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"platform\": \"ANDROID\",\n  \"token\": \"<string>\"\n}",
+                  "raw": "{\n  \"platform\": \"WEB\",\n  \"token\": \"<string>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -2903,7 +2903,7 @@
           }
         },
         {
-          "id": "77c53d6f-2836-4b3c-8dae-772e296a1b49",
+          "id": "4a0ce929-6661-470e-abf5-42804a24e004",
           "name": "Desregistrar el token FCM (logout o invalidación)",
           "request": {
             "name": "Desregistrar el token FCM (logout o invalidación)",
@@ -2946,7 +2946,7 @@
           },
           "response": [
             {
-              "id": "294bea1d-b6b7-4596-bd51-9e2ff49539b8",
+              "id": "80da6d26-8471-44ba-81c1-59e34e4cbe19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3005,7 +3005,7 @@
       "description": "Endpoints para la gestión de dispositivos de un cliente",
       "item": [
         {
-          "id": "2da1ce94-6c9a-4430-a5fd-ca20a721c300",
+          "id": "9ef04b44-5990-4968-8407-654f6d2581a8",
           "name": "Obtener un dispositivo específico de un cliente",
           "request": {
             "name": "Obtener un dispositivo específico de un cliente",
@@ -3058,7 +3058,7 @@
           },
           "response": [
             {
-              "id": "9dd10baf-1340-4fb4-bb96-5995e00416e2",
+              "id": "476b36e6-913b-41ed-a710-9a9f5ae8ada3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3133,7 +3133,7 @@
           }
         },
         {
-          "id": "b964941c-ba86-4211-8fd5-3d727f55297b",
+          "id": "cb9fcbfd-d1ad-468a-8f81-3c45700221e0",
           "name": "Actualizar un dispositivo existente de un cliente",
           "request": {
             "name": "Actualizar un dispositivo existente de un cliente",
@@ -3199,7 +3199,7 @@
           },
           "response": [
             {
-              "id": "38a12361-941e-442c-9a5f-326fed1cc603",
+              "id": "43fe6fbd-0123-49a4-a19d-423711562398",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3287,7 +3287,7 @@
           }
         },
         {
-          "id": "caeac1b4-d10b-4396-b13f-20b4e0301e49",
+          "id": "382e97e1-dbef-40ad-b735-ecf8a79d52c9",
           "name": "Eliminar un dispositivo de un cliente",
           "request": {
             "name": "Eliminar un dispositivo de un cliente",
@@ -3334,7 +3334,7 @@
           },
           "response": [
             {
-              "id": "4b844412-34aa-46b9-8a8e-65a210a538df",
+              "id": "f64cf3e9-417c-40a0-ab9f-f4d88f8cfacf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3399,7 +3399,7 @@
           }
         },
         {
-          "id": "bbe4b7d7-952b-4c22-89d3-cf430c0d9b16",
+          "id": "a9b9ea2f-34c6-4834-be3f-d9f36e898ea9",
           "name": "Obtener todos los dispositivos de un cliente",
           "request": {
             "name": "Obtener todos los dispositivos de un cliente",
@@ -3441,7 +3441,7 @@
           },
           "response": [
             {
-              "id": "2c6cdb97-4f23-43be-b505-3ec25bb76e98",
+              "id": "86f4e3bd-c04c-46d5-9962-26b6cb203705",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3505,7 +3505,7 @@
           }
         },
         {
-          "id": "ebd9812c-5742-4d2b-aee9-9e3c62f1400b",
+          "id": "6f652863-1217-4346-9248-9a07f0006826",
           "name": "Crear un nuevo dispositivo para un cliente",
           "request": {
             "name": "Crear un nuevo dispositivo para un cliente",
@@ -3560,7 +3560,7 @@
           },
           "response": [
             {
-              "id": "33643c65-c177-40a2-8329-8721c136344a",
+              "id": "ec617e0d-5a50-4645-b495-d5c0e6388573",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3637,7 +3637,7 @@
           }
         },
         {
-          "id": "c1359b7f-658f-4d29-9a30-3a7a0508740c",
+          "id": "5f14855b-63f9-405f-af71-d0f31af1d83d",
           "name": "Obtener historial de comandos de un dispositivo",
           "request": {
             "name": "Obtener historial de comandos de un dispositivo",
@@ -3701,7 +3701,7 @@
           },
           "response": [
             {
-              "id": "060ced33-ebb2-41a7-8494-d3267348ad14",
+              "id": "93430e7e-d0ba-453c-9b6e-bdd70ee4cab7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3793,7 +3793,7 @@
       "description": "Paginated history of push notifications received",
       "item": [
         {
-          "id": "e9fda131-4599-4d2c-ad88-f3a55f100bee",
+          "id": "d5f34801-3a82-4325-a4eb-59e8ae831bd8",
           "name": "List push notifications received by the authenticated user (cursor-based pagination)",
           "request": {
             "name": "List push notifications received by the authenticated user (cursor-based pagination)",
@@ -3851,7 +3851,7 @@
           },
           "response": [
             {
-              "id": "f5eca7f9-ac5a-4d52-b1a1-6091968bc25f",
+              "id": "4ce5cd16-24d4-4f8c-9372-1e24e097848d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3912,7 +3912,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": true,\n        \"key_1\": false\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": 8253.09125270661\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
+              "body": "{\n  \"entries\": [\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    },\n    {\n      \"id\": \"<long>\",\n      \"notificationType\": \"<string>\",\n      \"payload\": {\n        \"key_0\": false,\n        \"key_1\": \"string\"\n      },\n      \"sentAt\": \"<dateTime>\",\n      \"status\": \"<string>\",\n      \"fcmMessageId\": \"<string>\",\n      \"error\": \"<string>\"\n    }\n  ],\n  \"nextCursor\": \"<long>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -3929,7 +3929,7 @@
       "description": "CRUD de niveles de severidad",
       "item": [
         {
-          "id": "6643d5ae-9340-453e-a407-ceb47854c34d",
+          "id": "b8ffdc03-3ca2-4129-8a74-15a0971e1032",
           "name": "Obtener un nivel de severidad por ID",
           "request": {
             "name": "Obtener un nivel de severidad por ID",
@@ -3971,7 +3971,7 @@
           },
           "response": [
             {
-              "id": "e0de631d-d9ec-4f73-8438-9a8e45e7153e",
+              "id": "23387b01-58d8-4259-b9f3-a44194ecb87b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4035,7 +4035,7 @@
           }
         },
         {
-          "id": "d668352a-9f2a-411f-8600-ce3f524dcb41",
+          "id": "9be2cc0c-b63e-452f-b9d2-e78a8c339029",
           "name": "Actualizar nivel de severidad",
           "request": {
             "name": "Actualizar nivel de severidad",
@@ -4078,7 +4078,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#226B8d\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#5853B3\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4090,7 +4090,7 @@
           },
           "response": [
             {
-              "id": "f6377e0c-a5bb-499a-a918-cb833bc0b64d",
+              "id": "cd494fe0-9caf-4efd-a0a3-c19f5e8f8b75",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4139,7 +4139,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#226B8d\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"level\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"color\": \"#5853B3\",\n  \"requiresAction\": \"<boolean>\",\n  \"notificationDelayMinutes\": \"<integer>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4167,7 +4167,7 @@
           }
         },
         {
-          "id": "8692a599-ca57-4ef2-afc7-2a105a508435",
+          "id": "6a4b6eb0-1ef6-4a68-a000-e53ac8b8b326",
           "name": "Eliminar nivel de severidad",
           "request": {
             "name": "Eliminar nivel de severidad",
@@ -4203,7 +4203,7 @@
           },
           "response": [
             {
-              "id": "63701b74-0b60-44f3-a88f-8cd2a8d5e1a9",
+              "id": "3961b363-360d-4d6d-bd43-fb4ede13b4dc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4257,7 +4257,7 @@
           }
         },
         {
-          "id": "de64d5b6-7f95-4ef8-9123-06f4809e562a",
+          "id": "4324a643-24f0-464a-be9d-0fccc5c721ca",
           "name": "Obtener todos los niveles de severidad",
           "request": {
             "name": "Obtener todos los niveles de severidad",
@@ -4287,7 +4287,7 @@
           },
           "response": [
             {
-              "id": "7f07f429-5ad3-40c5-9a70-a9987b1032b9",
+              "id": "8f5d14e0-30c7-45cf-9979-97bc9622b19a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4339,7 +4339,7 @@
           }
         },
         {
-          "id": "f91ea567-3cec-4a8e-b736-c94526cfc40d",
+          "id": "0ad3cf2e-bfb6-4218-85fe-d93e93055901",
           "name": "Crear nuevo nivel de severidad",
           "request": {
             "name": "Crear nuevo nivel de severidad",
@@ -4370,7 +4370,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cEaeE8\"\n}",
+              "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F3bC9b\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -4382,7 +4382,7 @@
           },
           "response": [
             {
-              "id": "2c382c69-d04e-48bc-af1d-b715e495b7b9",
+              "id": "22c572db-1af3-48aa-b4af-207ae8802228",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4419,7 +4419,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#cEaeE8\"\n}",
+                  "raw": "{\n  \"level\": \"<integer>\",\n  \"name\": \"<string>\",\n  \"notificationDelayMinutes\": \"<integer>\",\n  \"requiresAction\": \"<boolean>\",\n  \"description\": \"<string>\",\n  \"color\": \"#F3bC9b\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -4447,7 +4447,7 @@
           }
         },
         {
-          "id": "0e9b3f31-10eb-45b0-8166-18b764e30df6",
+          "id": "5f40a148-41d2-4805-89e0-202b292734bb",
           "name": "Obtener severidades que requieren acción",
           "request": {
             "name": "Obtener severidades que requieren acción",
@@ -4478,7 +4478,7 @@
           },
           "response": [
             {
-              "id": "94511c5c-2af5-46e4-ac5d-59bf56b913b7",
+              "id": "28ecb41f-1c2d-45c1-9b55-a1457ebcb19c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4537,7 +4537,7 @@
       "description": "Catalogo de tipos de datos para configuraciones",
       "item": [
         {
-          "id": "eac32ba3-1217-4162-a85f-13d03d073a82",
+          "id": "15e0665d-3c07-448b-b9ac-b7c96ff1c63e",
           "name": "Obtener un tipo de dato por ID",
           "request": {
             "name": "Obtener un tipo de dato por ID",
@@ -4579,7 +4579,7 @@
           },
           "response": [
             {
-              "id": "68b5d027-23e8-4fdd-97d9-bb420f14c83c",
+              "id": "cf897a05-a727-4c8d-831c-f5de762e6966",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4643,7 +4643,7 @@
           }
         },
         {
-          "id": "e4466b20-2d1c-4be8-8178-8577a48ab3fd",
+          "id": "e3eefa2e-d612-4b1e-afbb-f7c661eab354",
           "name": "Actualizar un tipo de dato existente",
           "request": {
             "name": "Actualizar un tipo de dato existente",
@@ -4698,7 +4698,7 @@
           },
           "response": [
             {
-              "id": "ac81ed5c-60e8-46ff-8823-bf90e8c3307b",
+              "id": "22b0a7d7-f68e-4470-b75f-73bdff870038",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4775,7 +4775,7 @@
           }
         },
         {
-          "id": "d1bc60d4-cc23-4d94-9614-d87eeb0a53ec",
+          "id": "c3ada7a5-f043-4c4f-a618-8b1cd9c08ff4",
           "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
           "request": {
             "name": "Eliminar un tipo de dato (no permite eliminar tipos basicos del sistema)",
@@ -4817,7 +4817,7 @@
           },
           "response": [
             {
-              "id": "ec8fe719-4985-43b4-96b6-899ff1e6bcee",
+              "id": "eb2eefea-e1b2-49f7-82f5-69e3b69eaac2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4881,7 +4881,7 @@
           }
         },
         {
-          "id": "ec63aceb-5447-4b24-aed2-4c504b13edb3",
+          "id": "d21b6797-c870-44e1-9604-979b411e623f",
           "name": "Obtener todos los tipos de datos ordenados por displayOrder",
           "request": {
             "name": "Obtener todos los tipos de datos ordenados por displayOrder",
@@ -4911,7 +4911,7 @@
           },
           "response": [
             {
-              "id": "48db9221-c97b-48a4-b9e7-1b54e9e67d0a",
+              "id": "7f258234-bf01-4587-a6ed-4f33ccdd665e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4963,7 +4963,7 @@
           }
         },
         {
-          "id": "ff4a00e2-d68c-4851-babc-2ffbb5413724",
+          "id": "2982ac0b-ee2f-426f-8bbe-ec6f710a3e7a",
           "name": "Crear un nuevo tipo de dato",
           "request": {
             "name": "Crear un nuevo tipo de dato",
@@ -5006,7 +5006,7 @@
           },
           "response": [
             {
-              "id": "1cf09365-cf30-4dac-ba4b-b11eb287db80",
+              "id": "3f96be1e-9a99-4742-ba9e-1d3c12af8400",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5071,7 +5071,7 @@
           }
         },
         {
-          "id": "720cb262-fd14-40c7-ad99-d1fbe4ec149e",
+          "id": "c64a137d-8d55-4839-9ffd-1ace8d19c2f9",
           "name": "Validar si un valor es valido para un tipo de dato",
           "request": {
             "name": "Validar si un valor es valido para un tipo de dato",
@@ -5124,7 +5124,7 @@
           },
           "response": [
             {
-              "id": "4b8b4768-fabc-464b-995b-f6e1e751460f",
+              "id": "531b37ab-7918-405d-8d8a-eca438ecc50d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5188,7 +5188,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": 6613,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -5199,7 +5199,7 @@
           }
         },
         {
-          "id": "72e0704f-9d94-42f2-8e4c-ac406e4c8b69",
+          "id": "f94583e4-fb4d-4db7-9e43-97130c5b21af",
           "name": "Obtener un tipo de dato por nombre",
           "request": {
             "name": "Obtener un tipo de dato por nombre",
@@ -5242,7 +5242,7 @@
           },
           "response": [
             {
-              "id": "cc0c9c4a-0e28-4872-a8a2-14f8af55a28d",
+              "id": "ce003203-15f1-44c8-8c5f-6283f262097f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5307,7 +5307,7 @@
           }
         },
         {
-          "id": "612c5f31-3613-4834-80d8-d87a3b207f96",
+          "id": "661b02d5-9abe-4ceb-b85b-464e573f49d5",
           "name": "Obtener solo los tipos de datos activos",
           "request": {
             "name": "Obtener solo los tipos de datos activos",
@@ -5338,7 +5338,7 @@
           },
           "response": [
             {
-              "id": "2e2b889e-98e4-40cd-b94b-16153ca7fd5f",
+              "id": "f15ddb46-35f8-4fd2-ad98-b130ba674d03",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5397,7 +5397,7 @@
       "description": "CRUD de tipos de dispositivos",
       "item": [
         {
-          "id": "44523778-7b0f-4a98-95ea-1cd8d64b89b7",
+          "id": "7360425b-765b-4402-846c-b607a92296f9",
           "name": "Obtener un tipo de dispositivo por ID",
           "request": {
             "name": "Obtener un tipo de dispositivo por ID",
@@ -5439,7 +5439,7 @@
           },
           "response": [
             {
-              "id": "a7497869-05da-4f6e-af6d-a87c8a5ff72e",
+              "id": "7fd4bebf-5ffc-494d-9f40-5a4e7c99924b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5503,7 +5503,7 @@
           }
         },
         {
-          "id": "2cb22ba3-7d64-474e-b443-0540b5352297",
+          "id": "21631602-b60d-4de4-bcb7-501d8d04ba58",
           "name": "Actualizar tipo de dispositivo",
           "request": {
             "name": "Actualizar tipo de dispositivo",
@@ -5546,7 +5546,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5558,7 +5558,7 @@
           },
           "response": [
             {
-              "id": "c5ae4260-5851-45e4-88f7-d615f2da86ea",
+              "id": "c4dac96b-3659-4878-992f-ae974c05815f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5607,7 +5607,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"BOOLEAN\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"categoryId\": \"<integer>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"DECIMAL\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"CONTINUOUS\",\n  \"isActive\": \"<boolean>\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5635,7 +5635,7 @@
           }
         },
         {
-          "id": "940f1840-9918-438a-8a6b-831131866797",
+          "id": "aa5c2b5f-89aa-4ab5-a636-99e17fb2ffe7",
           "name": "Eliminar tipo de dispositivo",
           "request": {
             "name": "Eliminar tipo de dispositivo",
@@ -5671,7 +5671,7 @@
           },
           "response": [
             {
-              "id": "3b290eca-c0ff-4b20-8e11-25b4cfb1d0c1",
+              "id": "7fee8793-0fc3-4786-8549-50d3ebe5eb2e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5725,7 +5725,7 @@
           }
         },
         {
-          "id": "5e4b7863-0b17-4ab3-a41b-9fb2bb1be499",
+          "id": "bc413324-a42c-46d1-b59c-a702605f4a52",
           "name": "Obtener tipos de dispositivos",
           "request": {
             "name": "Obtener tipos de dispositivos",
@@ -5774,7 +5774,7 @@
           },
           "response": [
             {
-              "id": "f1f5ac81-e1f4-4ad5-a093-0d09ce3105c7",
+              "id": "1797e112-4da0-4119-931e-becae769cd8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5845,7 +5845,7 @@
           }
         },
         {
-          "id": "0b3f5f7a-b560-413e-85e5-afbcd38404f5",
+          "id": "9c4aa6ba-e453-433c-b8bb-b24c497b76b9",
           "name": "Crear nuevo tipo de dispositivo",
           "request": {
             "name": "Crear nuevo tipo de dispositivo",
@@ -5876,7 +5876,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+              "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -5888,7 +5888,7 @@
           },
           "response": [
             {
-              "id": "06567060-2a1b-4434-b65d-3458c45b3f88",
+              "id": "8ea6b256-fbea-4fb1-8949-add9da33d76e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5925,7 +5925,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"JSON\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"MULTI_STATE\"\n}",
+                  "raw": "{\n  \"categoryId\": \"<integer>\",\n  \"isActive\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"defaultUnitId\": \"<integer>\",\n  \"dataType\": \"INTEGER\",\n  \"minExpectedValue\": \"<number>\",\n  \"maxExpectedValue\": \"<number>\",\n  \"controlType\": \"BINARY\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -5953,7 +5953,7 @@
           }
         },
         {
-          "id": "d1afe9f4-7b7d-44e6-9343-35fbeceeab34",
+          "id": "52b3f415-af2f-44fc-86e5-fa0b2c3d403c",
           "name": "Desactivar tipo de dispositivo",
           "request": {
             "name": "Desactivar tipo de dispositivo",
@@ -5996,7 +5996,7 @@
           },
           "response": [
             {
-              "id": "8f7dcc94-07bd-4980-9098-6f43072f28f4",
+              "id": "3048535c-bebd-4741-bf76-d0d44bed62b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "c049f307-aa64-4654-b5a9-ebf87f327dd3",
+          "id": "98aab1c6-dafa-47e1-85c3-75583ab4d404",
           "name": "Activar tipo de dispositivo",
           "request": {
             "name": "Activar tipo de dispositivo",
@@ -6104,7 +6104,7 @@
           },
           "response": [
             {
-              "id": "987a18d8-97d7-474e-8e10-9c183ffcb48c",
+              "id": "436f2c4b-1081-47a2-93d2-29d8543c958d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6169,7 +6169,7 @@
           }
         },
         {
-          "id": "18bbf697-cd18-4f9e-b4a2-21c5a62c4da8",
+          "id": "b7444399-8784-4b82-999e-f75b754ae1d4",
           "name": "Obtener tipos de sensores",
           "request": {
             "name": "Obtener tipos de sensores",
@@ -6200,7 +6200,7 @@
           },
           "response": [
             {
-              "id": "fd544c0a-40f3-46f4-9346-d08fd041921e",
+              "id": "80c1c8f2-a7ec-4efc-9ffa-c394493143ae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6253,7 +6253,7 @@
           }
         },
         {
-          "id": "33149a39-c548-4d41-bb9f-37d91d986e8b",
+          "id": "a58f4e3b-d4bb-406e-956d-ea19682106f0",
           "name": "Obtener tipos de actuadores",
           "request": {
             "name": "Obtener tipos de actuadores",
@@ -6284,7 +6284,7 @@
           },
           "response": [
             {
-              "id": "7cc83f3e-587b-4c6d-976b-fd6fd3c300c9",
+              "id": "077294a2-8dc4-49d0-9ba6-d7bc8fac64c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6343,7 +6343,7 @@
       "description": "CRUD de periodos",
       "item": [
         {
-          "id": "0e5e94b6-4dc3-48aa-a1b7-e1c45123ea18",
+          "id": "f158c7ec-bc7c-4a07-839e-ed2c81c5ce8f",
           "name": "Obtener un periodo por ID",
           "request": {
             "name": "Obtener un periodo por ID",
@@ -6385,7 +6385,7 @@
           },
           "response": [
             {
-              "id": "eee04500-53aa-41eb-8f86-399e6ad18491",
+              "id": "72e6ddca-2a23-4864-abb8-134658c5238a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6449,7 +6449,7 @@
           }
         },
         {
-          "id": "8b59cd04-1520-4038-9fdd-33ad6d225061",
+          "id": "7db27be1-2ac1-4cff-b228-c71cb02cc5ed",
           "name": "Actualizar periodo",
           "request": {
             "name": "Actualizar periodo",
@@ -6504,7 +6504,7 @@
           },
           "response": [
             {
-              "id": "589d10cf-c1cb-4c15-b555-f26f315440f6",
+              "id": "43b22a77-1038-429f-9456-c6aec1261b98",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6581,7 +6581,7 @@
           }
         },
         {
-          "id": "590610ea-f553-44ab-9bb2-8993765f73d4",
+          "id": "2c74ca36-9e95-4c6d-8895-72d4168d65ea",
           "name": "Eliminar periodo",
           "request": {
             "name": "Eliminar periodo",
@@ -6617,7 +6617,7 @@
           },
           "response": [
             {
-              "id": "70f3ebcb-f48a-4cb0-8770-726fb8749fbd",
+              "id": "87e4efa7-68df-43f1-8592-32e82454943d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6671,7 +6671,7 @@
           }
         },
         {
-          "id": "bde932d2-ec03-4b72-b41f-bbceff917fac",
+          "id": "7f5def02-c73e-4c4a-bae0-f218f0b39601",
           "name": "Obtener todos los periodos",
           "request": {
             "name": "Obtener todos los periodos",
@@ -6701,7 +6701,7 @@
           },
           "response": [
             {
-              "id": "f60ecd23-eac1-4d75-bdc7-4f9976846c03",
+              "id": "c3589cf5-6763-4d36-bcb4-c286406da6a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6753,7 +6753,7 @@
           }
         },
         {
-          "id": "1a4430cc-e38b-4a35-a629-c3540301939b",
+          "id": "8d5beb24-6c3c-4d89-9482-34704d724d36",
           "name": "Crear nuevo periodo",
           "request": {
             "name": "Crear nuevo periodo",
@@ -6796,7 +6796,7 @@
           },
           "response": [
             {
-              "id": "41ee49cc-f4d7-4d35-b961-00a241bfdfa7",
+              "id": "35c82427-4af1-4247-bd03-c767879beea0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6867,7 +6867,7 @@
       "description": "Endpoints para la gestion de alertas de un cliente",
       "item": [
         {
-          "id": "3d89b737-c95f-4b34-bd12-8a80b5dc10b1",
+          "id": "f121beca-203d-4916-8c62-d749bf09e017",
           "name": "Obtener una alerta especifica de un cliente",
           "request": {
             "name": "Obtener una alerta especifica de un cliente",
@@ -6920,7 +6920,7 @@
           },
           "response": [
             {
-              "id": "4b6f9c1c-8425-45dc-872a-5b549396c61c",
+              "id": "b1eff06c-fd21-45d9-b2ce-b434789600c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6995,7 +6995,7 @@
           }
         },
         {
-          "id": "3502fcd6-34ab-4c8d-93c8-144ca696b633",
+          "id": "7d749e43-704b-4b2e-a9bf-5a2b4268bfba",
           "name": "Actualizar una alerta existente de un cliente",
           "request": {
             "name": "Actualizar una alerta existente de un cliente",
@@ -7061,7 +7061,7 @@
           },
           "response": [
             {
-              "id": "a9886b9f-1afe-49ee-a0e2-16c6cde5fafb",
+              "id": "a2843903-c1f0-42cd-86c6-051e3137356d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7149,7 +7149,7 @@
           }
         },
         {
-          "id": "610bd870-6cf8-4ef9-bc34-6f991dffb327",
+          "id": "304efddb-0d22-4871-86e1-66b761ec36a9",
           "name": "Eliminar una alerta de un cliente",
           "request": {
             "name": "Eliminar una alerta de un cliente",
@@ -7196,7 +7196,7 @@
           },
           "response": [
             {
-              "id": "744a87ce-99de-42ff-a94e-76f062c76375",
+              "id": "c386683a-1d92-4b9d-b283-f81687a3aac3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7261,7 +7261,7 @@
           }
         },
         {
-          "id": "5c2b3ec9-9fa1-48c8-87cb-567614ec0f2b",
+          "id": "34533d0b-0a90-419a-b72c-1ad258c08fe3",
           "name": "Obtener todas las alertas de un cliente",
           "request": {
             "name": "Obtener todas las alertas de un cliente",
@@ -7303,7 +7303,7 @@
           },
           "response": [
             {
-              "id": "bc38797d-4d92-4f20-a346-9083bf20b274",
+              "id": "372af314-f50b-4393-b12c-b5f2e9ac83fb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7367,7 +7367,7 @@
           }
         },
         {
-          "id": "2ab96285-b8d4-4616-9f10-480903dd2b70",
+          "id": "e8768c6a-04c7-4d76-916d-ccc95d6ce12d",
           "name": "Crear una nueva alerta para un cliente",
           "request": {
             "name": "Crear una nueva alerta para un cliente",
@@ -7422,7 +7422,7 @@
           },
           "response": [
             {
-              "id": "3e075958-c964-4bfe-9613-6d5f11eeca12",
+              "id": "9dccca46-1bcb-4f34-a65a-8af896b61fa2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7499,7 +7499,7 @@
           }
         },
         {
-          "id": "de44494e-0d04-46c9-bda3-e5201cab4be6",
+          "id": "9f9a4139-13d7-4041-910b-7c5fe6965c5a",
           "name": "Resolver una alerta",
           "request": {
             "name": "Resolver una alerta",
@@ -7553,7 +7553,7 @@
           },
           "response": [
             {
-              "id": "a5401434-dcf2-4989-9168-221518b1c6bb",
+              "id": "f0059515-9580-4b90-af5b-fe204a8ca7a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7629,7 +7629,7 @@
           }
         },
         {
-          "id": "e89659ce-c8ed-4d5e-b55c-3b415757af11",
+          "id": "5c8bd4ed-6a15-46a8-b53e-f708a5b70edc",
           "name": "Reabrir una alerta resuelta",
           "request": {
             "name": "Reabrir una alerta resuelta",
@@ -7683,7 +7683,7 @@
           },
           "response": [
             {
-              "id": "867ba9a1-2416-4085-a641-e2d6dceb5cb5",
+              "id": "29e15a56-e43a-4c2f-999a-6dcf5adf7d18",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7765,7 +7765,7 @@
       "description": "Endpoints para la gestión de usuarios de un cliente",
       "item": [
         {
-          "id": "5bd99d76-dcb6-4382-aa1d-082432f21b74",
+          "id": "b6387a1a-8301-49a0-8ba1-57013519c069",
           "name": "Obtener un usuario específico de un cliente",
           "request": {
             "name": "Obtener un usuario específico de un cliente",
@@ -7818,7 +7818,7 @@
           },
           "response": [
             {
-              "id": "04c79914-b68c-4b2a-baec-668502e38dd1",
+              "id": "e181a00e-6ceb-47ec-9a21-28bc87b772f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
           }
         },
         {
-          "id": "8493b85f-bbb2-404b-8203-0b60aeb8b77c",
+          "id": "97ea51bc-7ff7-496d-80d2-3cb33a735210",
           "name": "Actualizar un usuario de un cliente",
           "request": {
             "name": "Actualizar un usuario de un cliente",
@@ -7959,7 +7959,7 @@
           },
           "response": [
             {
-              "id": "4cba994f-f046-4e46-b26d-05332ac69569",
+              "id": "00e93387-393e-4e7a-98bf-85c4bcb48e12",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8047,7 +8047,7 @@
           }
         },
         {
-          "id": "cd3dbe38-0baf-4167-9bfd-c4912dc80695",
+          "id": "e6304281-734f-42ed-acc3-29f2d56883be",
           "name": "Eliminar un usuario de un cliente",
           "request": {
             "name": "Eliminar un usuario de un cliente",
@@ -8094,7 +8094,7 @@
           },
           "response": [
             {
-              "id": "08e4ffde-7dc2-4a7c-9751-eced2286716a",
+              "id": "0376e2f8-4601-4d6f-83eb-d002a066156c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8159,7 +8159,7 @@
           }
         },
         {
-          "id": "cc5b0ce3-8234-41d5-88c8-18d7ec285a23",
+          "id": "b9a76f9e-0a6c-454a-815c-5fa351d7dd63",
           "name": "Obtener todos los usuarios de un cliente",
           "request": {
             "name": "Obtener todos los usuarios de un cliente",
@@ -8201,7 +8201,7 @@
           },
           "response": [
             {
-              "id": "b405fb35-db03-4ff4-ac12-71ecba01d1b2",
+              "id": "72aaca3e-3118-4f7c-96af-e6070810f92f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8265,7 +8265,7 @@
           }
         },
         {
-          "id": "9d219f21-8098-4967-a5ab-97c7d3886abc",
+          "id": "d313a80c-5711-418a-a254-a07b80e1d4cc",
           "name": "Crear un nuevo usuario para un cliente",
           "request": {
             "name": "Crear un nuevo usuario para un cliente",
@@ -8320,7 +8320,7 @@
           },
           "response": [
             {
-              "id": "7f5d32d3-a294-4a98-8697-ca464beadaa5",
+              "id": "cfdf2ca3-8a7e-4dc5-9e91-7209a1cff368",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8403,7 +8403,7 @@
       "description": "Endpoints para el CRUD de Tenants (Clientes)",
       "item": [
         {
-          "id": "6e379cf3-ef55-44f3-a0c1-dfb085ac6a4d",
+          "id": "0d1cb72b-6abc-46fa-9f6d-329829a1fd1f",
           "name": "Obtener un tenant por ID",
           "request": {
             "name": "Obtener un tenant por ID",
@@ -8444,7 +8444,7 @@
           },
           "response": [
             {
-              "id": "bcf3d04a-3ea1-4b15-ab1f-421720f28af7",
+              "id": "b4112d8d-e122-4510-8c9f-41fd72e50679",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8507,7 +8507,7 @@
           }
         },
         {
-          "id": "2b37c359-dde0-4933-a0c3-e5b190b881b8",
+          "id": "39de6cf7-4e0a-44eb-aacf-70202e58cf98",
           "name": "Actualizar un tenant existente",
           "request": {
             "name": "Actualizar un tenant existente",
@@ -8561,7 +8561,7 @@
           },
           "response": [
             {
-              "id": "c5d322d4-1461-4ce5-b598-a712965beb4a",
+              "id": "e83bd715-96fd-437b-9ffc-b4fdddcbce38",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8637,7 +8637,7 @@
           }
         },
         {
-          "id": "97d6d8be-e510-4604-918d-baeec5cc9f5c",
+          "id": "6842777a-687a-43c6-b5cb-ea109133e5d6",
           "name": "Eliminar un tenant",
           "request": {
             "name": "Eliminar un tenant",
@@ -8672,7 +8672,7 @@
           },
           "response": [
             {
-              "id": "f081f142-aa30-4645-8e11-f64399ad895a",
+              "id": "21e440c2-0484-4a76-a6bb-f983b9465f07",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8725,7 +8725,7 @@
           }
         },
         {
-          "id": "f335fea6-fddd-487f-95bf-677eae41d553",
+          "id": "deb8701b-4094-40b7-945f-5fd692037a0f",
           "name": "Obtener todos los tenants con filtros opcionales",
           "request": {
             "name": "Obtener todos los tenants con filtros opcionales",
@@ -8782,7 +8782,7 @@
           },
           "response": [
             {
-              "id": "1b5d25db-d830-4439-b944-a6fc72b8d638",
+              "id": "05f55665-279d-4562-9321-4cce9f77f27a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8861,7 +8861,7 @@
           }
         },
         {
-          "id": "5bf23f4e-caa9-490e-a80f-76158223afef",
+          "id": "5c7a65b9-1e0f-4f91-96b7-b78fed5c0536",
           "name": "Crear un nuevo tenant",
           "request": {
             "name": "Crear un nuevo tenant",
@@ -8903,7 +8903,7 @@
           },
           "response": [
             {
-              "id": "ab66771b-7c4d-4d28-ae4f-41fe6dc84114",
+              "id": "2e046419-9f22-40f4-887d-a7eed6ce613c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8973,7 +8973,7 @@
       "description": "Endpoints para la gestión de invernaderos de un cliente",
       "item": [
         {
-          "id": "64e10330-b1d7-47fd-a4dc-c109113851bd",
+          "id": "1bb3c97b-ea2d-432b-a33a-567ad6211800",
           "name": "Obtener un invernadero específico de un cliente",
           "request": {
             "name": "Obtener un invernadero específico de un cliente",
@@ -9026,7 +9026,7 @@
           },
           "response": [
             {
-              "id": "90fcfa8c-de53-4740-a0e7-19b96e22a6b2",
+              "id": "a2e72d94-7d98-461e-9419-a65840a9da07",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9101,7 +9101,7 @@
           }
         },
         {
-          "id": "a24f61a5-c79f-47c9-9731-82d3a49d7b6e",
+          "id": "f257447d-ceb4-4032-8e1e-ab011703dc98",
           "name": "Actualizar un invernadero existente de un cliente",
           "request": {
             "name": "Actualizar un invernadero existente de un cliente",
@@ -9167,7 +9167,7 @@
           },
           "response": [
             {
-              "id": "ab165a45-c9aa-4eac-b5be-ee7c60b25260",
+              "id": "fde728e5-7a6b-4a1f-ae4c-f641a23f59eb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9255,7 +9255,7 @@
           }
         },
         {
-          "id": "4b0dfc88-403c-4d3c-aa8f-84ffeb3bb20e",
+          "id": "3a383656-3592-4636-8b46-aad44a2495cf",
           "name": "Eliminar un invernadero de un cliente",
           "request": {
             "name": "Eliminar un invernadero de un cliente",
@@ -9302,7 +9302,7 @@
           },
           "response": [
             {
-              "id": "87fff7ad-44e8-44e1-97a7-c9935b139884",
+              "id": "c5045714-80cd-4354-b317-fcf98864e838",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9367,7 +9367,7 @@
           }
         },
         {
-          "id": "125f5e12-a0a8-4cd1-bbd6-ba0a00102ccc",
+          "id": "3a314336-d6a1-4410-98f2-3b48911485cb",
           "name": "Obtener todos los invernaderos de un cliente",
           "request": {
             "name": "Obtener todos los invernaderos de un cliente",
@@ -9409,7 +9409,7 @@
           },
           "response": [
             {
-              "id": "7a1dea99-fac6-4c08-95fa-61b5d18e0aeb",
+              "id": "2c95b828-9c91-4d56-a0a5-11d7f56c20f8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9473,7 +9473,7 @@
           }
         },
         {
-          "id": "2b72f641-fe73-4fdd-a38c-a84c390a16a9",
+          "id": "d66158f7-1275-455c-8b64-1b47d13e8560",
           "name": "Crear un nuevo invernadero para un cliente",
           "request": {
             "name": "Crear un nuevo invernadero para un cliente",
@@ -9528,7 +9528,7 @@
           },
           "response": [
             {
-              "id": "14aeb131-76a8-4a64-9f14-39be6b7ab2e8",
+              "id": "f1877716-6aa4-4859-bfda-0850d4a57ed5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9611,7 +9611,7 @@
       "description": "CRUD de tipos de alerta",
       "item": [
         {
-          "id": "e20669b9-b6a9-4881-ab7d-54225f597996",
+          "id": "8b4a0478-b9b1-4386-9b99-0cd51e825281",
           "name": "Obtener un tipo de alerta por ID",
           "request": {
             "name": "Obtener un tipo de alerta por ID",
@@ -9653,7 +9653,7 @@
           },
           "response": [
             {
-              "id": "276f6d3a-c0bd-487c-8b3d-c53c07261b3e",
+              "id": "6ff008c2-1d02-4423-b331-d78d676fe8ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9717,7 +9717,7 @@
           }
         },
         {
-          "id": "9cc68fb3-1a56-4dca-97c9-0302cfebb934",
+          "id": "28a9b939-80d9-44f0-9e7d-2230b7feb76c",
           "name": "Actualizar tipo de alerta",
           "request": {
             "name": "Actualizar tipo de alerta",
@@ -9772,7 +9772,7 @@
           },
           "response": [
             {
-              "id": "e6573ddd-4a9c-4908-8b06-cfa54b128f02",
+              "id": "0cd13862-81d7-44be-84e5-3725dd2586bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9849,7 +9849,7 @@
           }
         },
         {
-          "id": "8d1a6d9f-8b4c-4f4f-89bd-7aca87ae6f49",
+          "id": "c01a4cae-85b4-48d0-be24-0a80d910c74c",
           "name": "Eliminar tipo de alerta",
           "request": {
             "name": "Eliminar tipo de alerta",
@@ -9885,7 +9885,7 @@
           },
           "response": [
             {
-              "id": "dbfe273d-5cd1-4793-b6c2-6c8b580d0db1",
+              "id": "8213ddc5-c292-4769-bbf2-92ade39072a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9939,7 +9939,7 @@
           }
         },
         {
-          "id": "05451a5f-f6c7-424d-a397-0a34acd0b4e2",
+          "id": "25b702a7-3849-4568-bfdd-9913c5981b70",
           "name": "Obtener todos los tipos de alerta",
           "request": {
             "name": "Obtener todos los tipos de alerta",
@@ -9969,7 +9969,7 @@
           },
           "response": [
             {
-              "id": "fb4413f0-84fc-45d0-8b29-36c7466668cd",
+              "id": "26b9d86c-f192-4813-8a1e-20553f89425f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10021,7 +10021,7 @@
           }
         },
         {
-          "id": "a4b89222-6838-4050-80b2-3c38b233dc94",
+          "id": "2ceafc7a-82b0-4fc0-b411-2b96a4bf639e",
           "name": "Crear nuevo tipo de alerta",
           "request": {
             "name": "Crear nuevo tipo de alerta",
@@ -10064,7 +10064,7 @@
           },
           "response": [
             {
-              "id": "5e355add-3950-4558-9a47-42c5ec5fad05",
+              "id": "23d62b64-d209-4cc5-8656-c7d98ef59bcb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10135,7 +10135,7 @@
       "description": "CRUD de categorías de dispositivos",
       "item": [
         {
-          "id": "7dbfeeab-15b4-4b84-87da-20d479e83dbc",
+          "id": "03b66021-53ba-42d3-9bc6-2bd90b68e677",
           "name": "Obtener una categoría por ID",
           "request": {
             "name": "Obtener una categoría por ID",
@@ -10177,7 +10177,7 @@
           },
           "response": [
             {
-              "id": "3ce94655-593e-42e2-a7db-30a337dd1b73",
+              "id": "1a535ed5-dc04-48d9-bb27-ac538698393c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10235,7 +10235,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4bd98608-daf9-495d-b1c8-626f7ca2e397",
+              "id": "e4afde4b-fd3d-4950-8253-6b76a3c0009a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10299,7 +10299,7 @@
           }
         },
         {
-          "id": "ba4573c7-19f3-45a2-8285-1bb84ca15c62",
+          "id": "ea440331-a836-4c34-984c-5cfc023b21b2",
           "name": "Actualizar categoría de dispositivo",
           "request": {
             "name": "Actualizar categoría de dispositivo",
@@ -10354,7 +10354,7 @@
           },
           "response": [
             {
-              "id": "a3ff555d-be93-427b-a8b1-d8310037caad",
+              "id": "623d344b-534b-4233-aa42-0bdb2c2bdf49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10425,7 +10425,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4748effc-c832-414c-8d9e-54c2520bd1f6",
+              "id": "28cd9910-b61a-497c-b173-38d3574e5392",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -10496,7 +10496,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "09c73a2e-b904-4632-9cbc-3aa115f5f977",
+              "id": "90a922c2-b4b7-474e-94ff-991d3cb30212",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10573,7 +10573,7 @@
           }
         },
         {
-          "id": "6405a847-45d6-4e71-8f51-004fdaf0964d",
+          "id": "9c4db7e6-db3e-481d-8e5e-b4aa61d3cc8d",
           "name": "Eliminar categoría de dispositivo",
           "request": {
             "name": "Eliminar categoría de dispositivo",
@@ -10609,7 +10609,7 @@
           },
           "response": [
             {
-              "id": "601ed8c1-e09c-4a4b-8213-938aefb43e01",
+              "id": "d9cd4ef1-9f5d-4b73-8a20-bb284e6c8142",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -10657,7 +10657,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d8fcc58e-8281-46d9-8333-28f4e9e16784",
+              "id": "9dfae472-2470-4906-a127-92d70288acd8",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -10705,7 +10705,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "f3fd88d1-e65a-4927-b5b1-f8556ff97858",
+              "id": "8b0cb97d-3108-478e-a740-aacb12f3dbfc",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -10759,7 +10759,7 @@
           }
         },
         {
-          "id": "b7f1c1fd-de64-4cb3-a51f-6da6f7369f63",
+          "id": "864c521d-09d4-4a41-a009-c45afb6e2752",
           "name": "Obtener todas las categorías de dispositivos",
           "request": {
             "name": "Obtener todas las categorías de dispositivos",
@@ -10789,7 +10789,7 @@
           },
           "response": [
             {
-              "id": "711bf08c-03d3-413f-be69-136e5dbdf8fe",
+              "id": "012ca663-d1f1-46ac-bb41-6453837f8596",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10841,7 +10841,7 @@
           }
         },
         {
-          "id": "1dd36ee3-0b92-463b-be37-35fc0411c81c",
+          "id": "5d0178aa-dc43-4225-87ac-8849e72b1605",
           "name": "Crear nueva categoría de dispositivo",
           "request": {
             "name": "Crear nueva categoría de dispositivo",
@@ -10884,7 +10884,7 @@
           },
           "response": [
             {
-              "id": "172454fa-7984-4e6c-ae51-51d470c881e9",
+              "id": "43a49b4e-285b-4721-b2b9-ef1bf7a280e7",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -10943,7 +10943,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "4ed7528a-9452-4365-97bf-919781154852",
+              "id": "e7f2dd72-ba62-447c-b11a-84e8a6931c5f",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -11014,7 +11014,7 @@
       "description": "Derived statistics computed from the alert_state_changes audit log",
       "item": [
         {
-          "id": "eb942ed0-a77d-46a4-8763-e779bd349862",
+          "id": "7875d0c0-2b31-4977-80ce-4907b0cc4f95",
           "name": "Alert timeseries data",
           "request": {
             "name": "Alert timeseries data",
@@ -11098,7 +11098,7 @@
           },
           "response": [
             {
-              "id": "4531429b-3630-4974-b42a-1561e50029e8",
+              "id": "da1ea3d7-1a58-461a-9469-cd204518d84d",
               "name": "List of (bucketStart, key, opened, closed) data points, sorted by time ASC",
               "originalRequest": {
                 "url": {
@@ -11201,7 +11201,7 @@
           }
         },
         {
-          "id": "ea5cc034-4cb6-4a79-9cd8-5f4b0ab8e750",
+          "id": "044afb04-7e3b-485e-b3d8-e4f5beacd1de",
           "name": "Dashboard summary of alert statistics",
           "request": {
             "name": "Dashboard summary of alert statistics",
@@ -11267,7 +11267,7 @@
           },
           "response": [
             {
-              "id": "737b2bb6-799e-4611-ae72-d2a1e1818bd0",
+              "id": "151747a5-daa5-46f8-a3ee-0af687b8d3a8",
               "name": "Summary object",
               "originalRequest": {
                 "url": {
@@ -11352,7 +11352,7 @@
           }
         },
         {
-          "id": "f2cc7ac1-db7a-4c10-babc-1953e5b8c9c4",
+          "id": "b6819c25-e91d-4e38-b0f9-f0aea43d4c1d",
           "name": "Alert recurrence ranking",
           "request": {
             "name": "Alert recurrence ranking",
@@ -11436,7 +11436,7 @@
           },
           "response": [
             {
-              "id": "cc366c80-790d-462f-9cc4-0183920a05a0",
+              "id": "268e8d63-506c-4855-b5e1-7638200535b6",
               "name": "List of recurrence buckets, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11539,7 +11539,7 @@
           }
         },
         {
-          "id": "ded389d8-185e-4982-b344-0995175e4ac8",
+          "id": "b765fc6e-e423-48b7-812c-109a23c3406d",
           "name": "Mean time to resolve (MTTR) statistics",
           "request": {
             "name": "Mean time to resolve (MTTR) statistics",
@@ -11614,7 +11614,7 @@
           },
           "response": [
             {
-              "id": "631003ad-225f-4e79-bfec-59355b17507f",
+              "id": "f5498489-2be8-4ea6-be31-649b1b48d6b5",
               "name": "List of MTTR buckets, sorted by avg MTTR DESC",
               "originalRequest": {
                 "url": {
@@ -11708,7 +11708,7 @@
           }
         },
         {
-          "id": "69b35588-00cc-43d9-80f3-88479130ca3e",
+          "id": "a0f0a8dc-0203-4ed1-a99d-5af0be657293",
           "name": "Alert activity ranked by user actor",
           "request": {
             "name": "Alert activity ranked by user actor",
@@ -11783,7 +11783,7 @@
           },
           "response": [
             {
-              "id": "6e2a98e4-6544-4b91-afa1-9acf1a65030f",
+              "id": "9e72dc8e-5d98-4fb6-a8ef-ca592deab6bd",
               "name": "List of per-user activity counts, sorted by count DESC",
               "originalRequest": {
                 "url": {
@@ -11877,7 +11877,7 @@
           }
         },
         {
-          "id": "6f073f11-daec-4b51-b8e9-9cba83e69f25",
+          "id": "806cd7c3-8038-4282-afea-ecd19b4adb86",
           "name": "Total active time per group",
           "request": {
             "name": "Total active time per group",
@@ -11952,7 +11952,7 @@
           },
           "response": [
             {
-              "id": "02b1f686-2d9a-4f1d-8950-bfb5ada4f00f",
+              "id": "f78634d5-cd57-498d-812f-0fedf0bbfb9b",
               "name": "List of active-duration buckets, sorted by total DESC",
               "originalRequest": {
                 "url": {
@@ -12052,7 +12052,7 @@
       "description": "Endpoints para publicacion manual de mensajes MQTT",
       "item": [
         {
-          "id": "15a4d71a-03dc-4b3a-9ecc-e0f178872251",
+          "id": "2b424efb-d355-4895-9264-09168c14b095",
           "name": "Publicar JSON raw",
           "request": {
             "name": "Publicar JSON raw",
@@ -12118,7 +12118,7 @@
           },
           "response": [
             {
-              "id": "2f39cba6-7245-414d-83f4-ae269addbb0a",
+              "id": "e4828fff-033e-47fb-89c9-5c32dcdeb7e0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12192,7 +12192,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": 6613,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -12209,7 +12209,7 @@
       "description": "Endpoints para la gestión de sectores de un invernadero",
       "item": [
         {
-          "id": "74bb667b-4b5b-4491-85d1-05e29a91db28",
+          "id": "ba390b73-f3f3-4b28-9418-133850ab9c6e",
           "name": "Obtener todos los sectores de un invernadero",
           "request": {
             "name": "Obtener todos los sectores de un invernadero",
@@ -12251,7 +12251,7 @@
           },
           "response": [
             {
-              "id": "3864f3c9-97c5-4b13-800d-efb7821828a0",
+              "id": "d17f2fce-ca9d-44f5-86e7-7b0d749dfe9d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12321,7 +12321,7 @@
       "description": "Per-user notification preferences (categories, severity, quiet hours, locale)",
       "item": [
         {
-          "id": "a794feff-ea7a-4050-be05-6efb56405aa4",
+          "id": "618df38e-7332-4ebc-9931-b3cb0291d5f7",
           "name": "Get notification preferences for the authenticated user",
           "request": {
             "name": "Get notification preferences for the authenticated user",
@@ -12360,7 +12360,7 @@
           },
           "response": [
             {
-              "id": "a3049930-ca6e-4396-821c-e79ccbb1fb2c",
+              "id": "5a23ff10-62e2-4d10-a918-8d9671368f33",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12413,7 +12413,7 @@
           }
         },
         {
-          "id": "e672162a-1510-43f5-87ad-737142b6d312",
+          "id": "e6f993f5-308f-4c6d-b5b7-fdb94308924b",
           "name": "Update notification preferences for the authenticated user",
           "request": {
             "name": "Update notification preferences for the authenticated user",
@@ -12445,7 +12445,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ys-YV\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"23:32\",\n  \"quietHoursEnd\": \"23:44\"\n}",
+              "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ac-GE\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:11\",\n  \"quietHoursEnd\": \"21:41\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12465,7 +12465,7 @@
           },
           "response": [
             {
-              "id": "6f4c79e7-cbc3-4119-803b-a4240befced9",
+              "id": "f53a81dc-e474-40a7-bd20-b89038c08c21",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12503,7 +12503,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ys-YV\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"23:32\",\n  \"quietHoursEnd\": \"23:44\"\n}",
+                  "raw": "{\n  \"categoryAlerts\": \"<boolean>\",\n  \"categoryDevices\": \"<boolean>\",\n  \"categorySubscription\": \"<boolean>\",\n  \"locale\": \"ac-GE\",\n  \"minAlertSeverity\": \"<integer>\",\n  \"preferredChannel\": \"<string>\",\n  \"quietHoursTimezone\": \"<string>\",\n  \"quietHoursStart\": \"20:11\",\n  \"quietHoursEnd\": \"21:41\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12537,7 +12537,7 @@
       "description": "CRUD de estados de actuadores",
       "item": [
         {
-          "id": "a6f1f839-aa2f-4bb9-9542-f806eab8d70d",
+          "id": "03a91fc5-f442-4330-94dd-1bfb4e903470",
           "name": "Obtener un estado por ID",
           "request": {
             "name": "Obtener un estado por ID",
@@ -12579,7 +12579,7 @@
           },
           "response": [
             {
-              "id": "aaf932a4-57d0-4c95-8543-d255ab123ed2",
+              "id": "cfee6edd-4b6c-4ec0-aaa3-0a1a180ff442",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12643,7 +12643,7 @@
           }
         },
         {
-          "id": "571fc024-b2b5-4d6b-8d40-1519c802c89c",
+          "id": "e9cf0294-c4dc-494c-9553-f527949c597d",
           "name": "Actualizar estado de actuador",
           "request": {
             "name": "Actualizar estado de actuador",
@@ -12686,7 +12686,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#f6A14c\"\n}",
+              "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#6232Bb\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12698,7 +12698,7 @@
           },
           "response": [
             {
-              "id": "02498890-018e-4d01-accb-7c7df025b28e",
+              "id": "67d880c9-47ef-4389-83d3-4709b73646ea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12747,7 +12747,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#f6A14c\"\n}",
+                  "raw": "{\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"isOperational\": \"<boolean>\",\n  \"displayOrder\": \"<integer>\",\n  \"color\": \"#6232Bb\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -12775,7 +12775,7 @@
           }
         },
         {
-          "id": "6d464ff9-143e-4d98-b5fc-a26a3f233b60",
+          "id": "577f4f93-039e-4091-9a22-13149c495aa1",
           "name": "Eliminar estado de actuador",
           "request": {
             "name": "Eliminar estado de actuador",
@@ -12811,7 +12811,7 @@
           },
           "response": [
             {
-              "id": "707b1036-233e-4f69-9a4e-96c9e738648f",
+              "id": "f9fe74fe-5a64-45dc-8c8f-a9bcc4616f10",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12865,7 +12865,7 @@
           }
         },
         {
-          "id": "bee07dac-0028-449a-9ac2-9605fe510732",
+          "id": "56431951-e020-4b07-be1b-339f5ab58a87",
           "name": "Obtener todos los estados de actuadores",
           "request": {
             "name": "Obtener todos los estados de actuadores",
@@ -12895,7 +12895,7 @@
           },
           "response": [
             {
-              "id": "e86af013-2730-4945-a0e1-8cce04db20bf",
+              "id": "9502ded9-0b83-4ccc-b48f-5616c13c8ccc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12947,7 +12947,7 @@
           }
         },
         {
-          "id": "c48a82e1-5697-452d-89e6-5975e7bc7ee8",
+          "id": "2a942e17-492b-440a-a61f-027c34a44d9e",
           "name": "Crear nuevo estado de actuador",
           "request": {
             "name": "Crear nuevo estado de actuador",
@@ -12978,7 +12978,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#533cdD\"\n}",
+              "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#68dDbD\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -12990,7 +12990,7 @@
           },
           "response": [
             {
-              "id": "234a6821-6ea3-4bfc-9d93-b57ced50f400",
+              "id": "3ddcbebe-134a-4b7c-bf1e-24efcc06cbb9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13027,7 +13027,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#533cdD\"\n}",
+                  "raw": "{\n  \"displayOrder\": \"<integer>\",\n  \"isOperational\": \"<boolean>\",\n  \"name\": \"<string>\",\n  \"description\": \"<string>\",\n  \"color\": \"#68dDbD\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -13055,7 +13055,7 @@
           }
         },
         {
-          "id": "a48d4534-4784-42bd-a06f-df4cfab6785e",
+          "id": "3c76d5b7-bf0d-4759-bda2-794e1b742df0",
           "name": "Obtener estados operacionales",
           "request": {
             "name": "Obtener estados operacionales",
@@ -13086,7 +13086,7 @@
           },
           "response": [
             {
-              "id": "61e7ed47-eab3-4a96-9043-607094895cf5",
+              "id": "6ed79f44-23bd-4297-8f2c-fdb53fc17e26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13145,7 +13145,7 @@
       "description": "Endpoints para la gestion de configuraciones de parametros de un cliente",
       "item": [
         {
-          "id": "57aaccd2-773e-410e-a52b-f60253ec9347",
+          "id": "44c97e59-95eb-4d7b-b7a8-bd86e208d179",
           "name": "Obtener una configuracion especifica de un cliente",
           "request": {
             "name": "Obtener una configuracion especifica de un cliente",
@@ -13198,7 +13198,7 @@
           },
           "response": [
             {
-              "id": "8c0025b6-8c39-4b37-883f-1fa98914a08d",
+              "id": "70733395-a768-4591-92eb-30fab01f84df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13273,7 +13273,7 @@
           }
         },
         {
-          "id": "01bea875-96a0-419c-9a86-596cab0a6eeb",
+          "id": "1df8f2c2-ebc3-4b21-9b4d-9da4973a3382",
           "name": "Actualizar una configuracion existente de un cliente",
           "request": {
             "name": "Actualizar una configuracion existente de un cliente",
@@ -13339,7 +13339,7 @@
           },
           "response": [
             {
-              "id": "1c0f5f11-f311-4d73-b8d2-013e57e8e347",
+              "id": "83660b1c-44fa-4f95-82aa-ec4d22e4be0a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13427,7 +13427,7 @@
           }
         },
         {
-          "id": "279c02f5-f250-4c77-9461-1857bf396576",
+          "id": "2ecc9e8b-e3c0-400b-b77d-1a74781b3c7f",
           "name": "Eliminar una configuracion de un cliente",
           "request": {
             "name": "Eliminar una configuracion de un cliente",
@@ -13474,7 +13474,7 @@
           },
           "response": [
             {
-              "id": "c05a93bd-5c7f-46c9-afa7-562ca1f7eed1",
+              "id": "9ee226bf-e956-4b6e-9d95-94a41f448124",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13539,7 +13539,7 @@
           }
         },
         {
-          "id": "8527dda2-75fe-4231-8097-7d7a89143728",
+          "id": "95296bbb-0127-4592-8b01-23e9fcdfb914",
           "name": "Obtener todas las configuraciones de un cliente",
           "request": {
             "name": "Obtener todas las configuraciones de un cliente",
@@ -13581,7 +13581,7 @@
           },
           "response": [
             {
-              "id": "d99bbbc2-affe-49da-bb07-e371672d560e",
+              "id": "eca1186a-93e6-4ae0-b91a-2ec85b4e2609",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13645,7 +13645,7 @@
           }
         },
         {
-          "id": "fec729cc-cf36-449d-be2f-a9ffb0b73693",
+          "id": "7507bd5e-6218-4675-8749-975f7ccbe734",
           "name": "Crear una nueva configuracion para un cliente",
           "request": {
             "name": "Crear una nueva configuracion para un cliente",
@@ -13700,7 +13700,7 @@
           },
           "response": [
             {
-              "id": "7a999800-3217-4d61-852b-7cad919d6e42",
+              "id": "8079f821-80fe-498c-a12c-ebe2e7e76b25",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13777,7 +13777,7 @@
           }
         },
         {
-          "id": "d0475a26-7750-48e1-9a6b-4bb5e0594905",
+          "id": "585bdcd6-8920-48da-b0b9-284c4a931831",
           "name": "Obtener todas las configuraciones de un sector",
           "request": {
             "name": "Obtener todas las configuraciones de un sector",
@@ -13831,7 +13831,7 @@
           },
           "response": [
             {
-              "id": "b4fa90d5-edec-4ee6-b8a0-664b837c8785",
+              "id": "5e18f65f-50ee-4262-9aca-f0b6e647f71b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13907,7 +13907,7 @@
           }
         },
         {
-          "id": "16b276de-8f82-40c5-aa70-a01bb28558a4",
+          "id": "68e98bd1-6588-4487-b79b-98d2404f3757",
           "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por tipo de parametro",
@@ -13973,7 +13973,7 @@
           },
           "response": [
             {
-              "id": "14025e2d-7983-4a3f-812f-ed8cd8b940e8",
+              "id": "00f8a4c5-83dd-4362-9d50-ff722b4bfa8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14061,7 +14061,7 @@
           }
         },
         {
-          "id": "d93a3a97-8215-4255-a1fc-b804a590e4b7",
+          "id": "80851177-01a7-4526-ab5f-e4c08ca7a3a7",
           "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
           "request": {
             "name": "Obtener una configuracion especifica por sector, parametro y estado de actuador",
@@ -14139,7 +14139,7 @@
           },
           "response": [
             {
-              "id": "8bbd192a-da13-498e-9ef3-dc82e673d393",
+              "id": "413ef59f-91e3-4a30-b4b1-e93bba320a03",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14239,7 +14239,7 @@
           }
         },
         {
-          "id": "8289a91d-c186-4624-9008-42896c24df5b",
+          "id": "d61d25ab-fb32-4df3-959f-8d4ecbc25bec",
           "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
           "request": {
             "name": "Obtener las configuraciones de un sector filtradas por estado de actuador",
@@ -14305,7 +14305,7 @@
           },
           "response": [
             {
-              "id": "e0d3df73-19ff-46b5-8b52-bb5c14c14ce8",
+              "id": "e573c2ef-a925-425d-8812-913b05d40d89",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14393,7 +14393,7 @@
           }
         },
         {
-          "id": "aaa3cb5a-1661-42dc-a1d3-44a6c843df1b",
+          "id": "0d5ebf42-a7a8-4e60-b2ce-bc1d31ba5175",
           "name": "Obtener las configuraciones activas de un sector",
           "request": {
             "name": "Obtener las configuraciones activas de un sector",
@@ -14448,7 +14448,7 @@
           },
           "response": [
             {
-              "id": "31a14dd1-24af-4595-93ea-2391ac953548",
+              "id": "e4da3f09-59ff-483d-809b-d9e7c27fa17a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14531,7 +14531,7 @@
       "description": "",
       "item": [
         {
-          "id": "cfb1bf59-08a5-4776-b525-da418bc00eab",
+          "id": "3bbd1dd8-c024-48a9-a10b-f798d0747a4c",
           "name": "get Alert By Id",
           "request": {
             "name": "get Alert By Id",
@@ -14572,7 +14572,7 @@
           },
           "response": [
             {
-              "id": "b598bba0-e77f-4299-b3ce-6c704c0da0c7",
+              "id": "cfebb0ca-799a-4108-9c90-1216913db43e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14635,7 +14635,7 @@
           }
         },
         {
-          "id": "658842c1-7d59-43e6-b739-9b34c119ab12",
+          "id": "5a6eab26-a9d4-405c-b578-2f1115d3be1a",
           "name": "update Alert",
           "request": {
             "name": "update Alert",
@@ -14689,7 +14689,7 @@
           },
           "response": [
             {
-              "id": "590dd83b-7725-40f9-9fa1-bf95946d0c41",
+              "id": "f1f1bc64-f878-4fd2-91ed-eb087391218d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14765,7 +14765,7 @@
           }
         },
         {
-          "id": "079fedd2-ed1a-411d-bfff-c0de22fc43f8",
+          "id": "2c646b97-b8af-474f-8539-49d21848b44f",
           "name": "delete Alert",
           "request": {
             "name": "delete Alert",
@@ -14800,7 +14800,7 @@
           },
           "response": [
             {
-              "id": "05712bf0-41c5-463e-a989-2fac1ccbe531",
+              "id": "2306cb22-1bbc-4d39-ae9c-5125d1f853d2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14853,7 +14853,7 @@
           }
         },
         {
-          "id": "fb32e47b-0333-403a-9361-64c3e9fa2295",
+          "id": "f144b41c-20fe-41e9-8512-da68dd2465f2",
           "name": "resolve Alert",
           "request": {
             "name": "resolve Alert",
@@ -14895,7 +14895,7 @@
           },
           "response": [
             {
-              "id": "fad611ae-15ba-49ff-bb8a-f7e6e3ce41e6",
+              "id": "19b15f6f-8a20-41c6-b380-06b5e396f7f8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14959,7 +14959,7 @@
           }
         },
         {
-          "id": "e99b6b65-ccc7-4e2a-b62a-20f12bc0c5a4",
+          "id": "ab88b973-0720-4575-91e4-8064ada4468e",
           "name": "reopen Alert",
           "request": {
             "name": "reopen Alert",
@@ -15001,7 +15001,7 @@
           },
           "response": [
             {
-              "id": "df9297b6-2094-476a-9437-3856cc54c17d",
+              "id": "f8815b34-f1fe-4426-b6fe-dc1d72fe7377",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15065,7 +15065,7 @@
           }
         },
         {
-          "id": "9ccfe2e5-ec5f-4d68-8c85-b52ef5b54bec",
+          "id": "2ece3e15-0936-4d31-95d2-176900e7e73a",
           "name": "get Alerts",
           "request": {
             "name": "get Alerts",
@@ -15140,7 +15140,7 @@
           },
           "response": [
             {
-              "id": "eda22fd4-0d33-4ba1-93cf-9199df39b91f",
+              "id": "3ec9743f-8b17-4976-b45a-78b958660db9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15237,7 +15237,7 @@
           }
         },
         {
-          "id": "3a67dabb-e3ba-4989-af43-d858cc58fd11",
+          "id": "48e45c69-6067-437f-89ea-b37816bdf902",
           "name": "create Alert",
           "request": {
             "name": "create Alert",
@@ -15279,7 +15279,7 @@
           },
           "response": [
             {
-              "id": "665948cb-b0fd-4cae-85fc-0f7fc875d7aa",
+              "id": "a1e9f2b8-773b-47de-84fa-734b64baedcc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15343,7 +15343,7 @@
           }
         },
         {
-          "id": "92521ea0-82f0-461a-9b0b-af621151c163",
+          "id": "6a413f96-6184-44c0-8549-919a68b9aa14",
           "name": "get Unresolved By Tenant",
           "request": {
             "name": "get Unresolved By Tenant",
@@ -15386,7 +15386,7 @@
           },
           "response": [
             {
-              "id": "75e9fc17-d13c-4140-aa38-0d19d643af7d",
+              "id": "f0d1e485-4b89-4362-bc14-169e9dc42b22",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15451,7 +15451,7 @@
           }
         },
         {
-          "id": "384156ac-aa33-4f4c-9088-e59a3874d758",
+          "id": "a5e7c7e5-b100-4251-9a9f-637414f16f9b",
           "name": "get Unresolved By Sector",
           "request": {
             "name": "get Unresolved By Sector",
@@ -15494,7 +15494,7 @@
           },
           "response": [
             {
-              "id": "037eba76-a839-42e2-bb2d-0888b519fbb0",
+              "id": "3a2a90e8-c138-47fa-8b37-e5013807bac8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15559,7 +15559,7 @@
           }
         },
         {
-          "id": "0e06cba2-e2e7-4164-90d8-9708cf09c151",
+          "id": "7e6d7e1e-7002-4754-a867-bcc9f80a6ed8",
           "name": "get Alerts By Tenant",
           "request": {
             "name": "get Alerts By Tenant",
@@ -15611,7 +15611,7 @@
           },
           "response": [
             {
-              "id": "b8697737-3705-47e6-b116-0ccbb3944ae6",
+              "id": "0ae3cc85-82b8-4011-9114-5a31731e75e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15685,7 +15685,7 @@
           }
         },
         {
-          "id": "cdd9579e-258b-4a9a-9fa9-e5c208b8e4b9",
+          "id": "da6879d5-4cc7-403d-92a8-f16cb1eeea95",
           "name": "get Alerts By Sector",
           "request": {
             "name": "get Alerts By Sector",
@@ -15727,7 +15727,7 @@
           },
           "response": [
             {
-              "id": "49fff571-331f-4873-9eb2-326abf34ca39",
+              "id": "177d3d32-1921-4703-84df-953ec32c877e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15791,7 +15791,7 @@
           }
         },
         {
-          "id": "03afa486-1173-4de6-b6ac-b15147d38a5e",
+          "id": "290eb241-b101-4388-a0d7-84f897e747dc",
           "name": "get Recent By Tenant",
           "request": {
             "name": "get Recent By Tenant",
@@ -15844,7 +15844,7 @@
           },
           "response": [
             {
-              "id": "6885ebad-9fba-4554-93dc-b789c8d1da05",
+              "id": "d61faaea-2266-438e-8740-97ffece6b43f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15919,7 +15919,7 @@
           }
         },
         {
-          "id": "d1d5edc2-4f46-49d3-9773-c0db0184b516",
+          "id": "2c51039b-4c3f-4f7e-9185-0898262ac2b7",
           "name": "get History By Tenant",
           "request": {
             "name": "get History By Tenant",
@@ -15972,7 +15972,7 @@
           },
           "response": [
             {
-              "id": "407c2237-58ee-42f4-a838-90b0644dfe64",
+              "id": "d3c3ce62-04a2-4b53-9b00-997bc23b62cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16047,7 +16047,7 @@
           }
         },
         {
-          "id": "c8389aba-dceb-48f6-ba7f-fee51177cd7e",
+          "id": "4bc22bd1-4c91-4a08-a647-05dcfee165bb",
           "name": "count Unresolved By Tenant",
           "request": {
             "name": "count Unresolved By Tenant",
@@ -16091,7 +16091,7 @@
           },
           "response": [
             {
-              "id": "2e3e4b11-ea75-4e09-b757-a20bb51a813f",
+              "id": "7b7e3b0a-0c24-4a0e-8ff1-d8c45363ff76",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16157,7 +16157,7 @@
           }
         },
         {
-          "id": "61434140-ee86-4f82-81ce-a3f73e1dd5ba",
+          "id": "db19a791-a4df-4a56-8b8b-325d1f0738a2",
           "name": "count Critical By Tenant",
           "request": {
             "name": "count Critical By Tenant",
@@ -16201,7 +16201,7 @@
           },
           "response": [
             {
-              "id": "746e8a74-fe26-4b30-8a1d-496590e165f3",
+              "id": "ce6d3f60-0bf4-4efd-8c27-d7c43ac0f66f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16273,7 +16273,7 @@
       "description": "",
       "item": [
         {
-          "id": "25109775-2fc1-41ab-99b5-628d1d2bbdd9",
+          "id": "42def08d-6fbc-4b81-b9e7-9b8adc28ecf9",
           "name": "Reset password",
           "request": {
             "name": "Reset password",
@@ -16315,7 +16315,7 @@
           },
           "response": [
             {
-              "id": "9c3f95bd-66f3-45a0-815b-caad45d3b143",
+              "id": "8cfa799c-241e-4b0c-9ca5-244bb684ab28",
               "name": "Password successfully reset",
               "originalRequest": {
                 "url": {
@@ -16364,7 +16364,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c62ffafc-c6f1-41dd-a336-fba91718d976",
+              "id": "d1318be8-5207-49e5-afc0-0ddbaa60a185",
               "name": "Invalid or expired token",
               "originalRequest": {
                 "url": {
@@ -16419,7 +16419,7 @@
           }
         },
         {
-          "id": "c1d13504-464d-4c0d-8366-02b2bddf022e",
+          "id": "da7116ef-d1d8-4771-936e-96ce53daaad7",
           "name": "Register new tenant",
           "request": {
             "name": "Register new tenant",
@@ -16465,7 +16465,7 @@
           },
           "response": [
             {
-              "id": "8a80c9ee-8c53-4d39-b80d-79b9f72c8afb",
+              "id": "22a18f70-87f1-42a0-add9-32a2f1ada4f0",
               "name": "Successfully registered",
               "originalRequest": {
                 "url": {
@@ -16524,7 +16524,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "7b6d6bf1-1fc4-40e7-ba3d-c8e784bb2ef2",
+              "id": "0812aeae-6ced-4a07-a6e9-064f58515099",
               "name": "Invalid input data",
               "originalRequest": {
                 "url": {
@@ -16589,7 +16589,7 @@
           }
         },
         {
-          "id": "e808969d-fc48-46cf-aaf7-0b5b776269a0",
+          "id": "b4815e32-0da7-4dcd-aeca-c7644607a4a4",
           "name": "Rotate refresh token",
           "request": {
             "name": "Rotate refresh token",
@@ -16635,7 +16635,7 @@
           },
           "response": [
             {
-              "id": "59152e87-9d3e-406b-b83f-1beed9f1219e",
+              "id": "545edfe4-0013-42aa-9227-b1c642b69ac9",
               "name": "New token pair issued",
               "originalRequest": {
                 "url": {
@@ -16694,7 +16694,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "7d92c1ee-3d24-488e-993b-7ca54b66da78",
+              "id": "bad8acab-441b-4233-94e6-9ecc5beff2f5",
               "name": "Malformed body",
               "originalRequest": {
                 "url": {
@@ -16753,7 +16753,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "77d4294e-96e8-45ef-b807-f17034cceabd",
+              "id": "8684ee75-16ea-46b9-8ee6-d6a4d890aa37",
               "name": "Refresh token invalid, expired, revoked or reused",
               "originalRequest": {
                 "url": {
@@ -16812,7 +16812,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "42ad5111-7c10-4dd5-8b7e-f87795ebbaa8",
+              "id": "28b42309-7c72-46f9-8376-64a8a4bfcb65",
               "name": "Refresh token feature is disabled",
               "originalRequest": {
                 "url": {
@@ -16877,7 +16877,7 @@
           }
         },
         {
-          "id": "e8d2c4ae-e7cc-4776-8f30-8afc2e740a6f",
+          "id": "933ee3ca-e0ab-4aca-8d6c-01d01f0e0cc2",
           "name": "Authenticate user",
           "request": {
             "name": "Authenticate user",
@@ -16923,7 +16923,7 @@
           },
           "response": [
             {
-              "id": "987aa1d2-0667-4982-962f-cc3aac68d603",
+              "id": "53bb25f2-77a7-4d49-ba8d-13e165aa090a",
               "name": "Successfully authenticated",
               "originalRequest": {
                 "url": {
@@ -16982,7 +16982,7 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "c2981f67-6b2a-479e-acaf-bb5d49c6c38a",
+              "id": "d161fdc6-3fdd-40ab-8663-dea437a91fcc",
               "name": "Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -17047,7 +17047,7 @@
           }
         },
         {
-          "id": "63e173d9-5a97-4864-b563-e17c9980e7dd",
+          "id": "82ce8b0d-15bd-497d-b2f9-0fc674ced7cf",
           "name": "Request password reset",
           "request": {
             "name": "Request password reset",
@@ -17089,7 +17089,7 @@
           },
           "response": [
             {
-              "id": "6685912a-7f67-4f3b-8f1e-abee893e7ed3",
+              "id": "2732fb18-aaf3-4a54-aa7e-a29e62ec2876",
               "name": "Email sent if user exists",
               "originalRequest": {
                 "url": {
@@ -17150,7 +17150,7 @@
       "description": "",
       "item": [
         {
-          "id": "7c747e0b-f552-4e47-83bd-06e3b45f1bb0",
+          "id": "03b3b462-14bd-48dc-b1fc-445241f6663e",
           "name": "get Statistics Summary",
           "request": {
             "name": "get Statistics Summary",
@@ -17199,7 +17199,7 @@
           },
           "response": [
             {
-              "id": "3826c591-41f5-4aea-ac47-2d53386b9f04",
+              "id": "25a9f109-303c-415f-af3b-75d52e487bf5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17259,7 +17259,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": 6613,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17270,7 +17270,7 @@
           }
         },
         {
-          "id": "27c66b09-531a-4ad2-a937-2629bc48424c",
+          "id": "701783c4-2976-4e82-884f-8278aa6ea557",
           "name": "get Hourly Statistics",
           "request": {
             "name": "get Hourly Statistics",
@@ -17319,7 +17319,7 @@
           },
           "response": [
             {
-              "id": "2794caa4-3c0a-4065-8b3b-bbc2b866695f",
+              "id": "b4f39afa-8b0c-4406-ad79-4f2f593ef54f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17390,7 +17390,7 @@
           }
         },
         {
-          "id": "7c62c11e-8d00-4630-b7a6-44b1285cb19b",
+          "id": "5e7a7004-56a4-4325-a9f5-fd621b1854b2",
           "name": "get Historical Data",
           "request": {
             "name": "get Historical Data",
@@ -17439,7 +17439,7 @@
           },
           "response": [
             {
-              "id": "fe2c2c62-dac0-4d50-88d4-a32241977b4f",
+              "id": "8dbeebd9-9e5d-4a70-8b1a-09013fc1fb6d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17510,7 +17510,7 @@
           }
         },
         {
-          "id": "bd1b4dce-60c5-4c8c-bb76-da570f26bfdc",
+          "id": "800cc46f-8fc3-40a7-8639-943c3e8f1077",
           "name": "get Daily Statistics",
           "request": {
             "name": "get Daily Statistics",
@@ -17559,7 +17559,7 @@
           },
           "response": [
             {
-              "id": "283e668d-c246-432e-ae13-b1c07d72c2c4",
+              "id": "7aea3aa9-84f5-4e98-bd60-576ee4eed6c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17636,7 +17636,7 @@
       "description": "",
       "item": [
         {
-          "id": "cabe28fb-074f-4fd4-8437-cc1ab774b2a6",
+          "id": "c44a3a75-02ec-4e0a-92d1-0a76715305b8",
           "name": "Get latest sensor readings",
           "request": {
             "name": "Get latest sensor readings",
@@ -17676,7 +17676,7 @@
           },
           "response": [
             {
-              "id": "8f948781-76a1-4934-938e-528f08d83451",
+              "id": "4c2ae4de-e4bd-4515-9fc0-8d8bf7a1bfa9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17738,7 +17738,7 @@
           }
         },
         {
-          "id": "ce721c6d-d26e-4e20-9385-7e759cf8a899",
+          "id": "9122be1b-e394-4199-9e7e-4c0398116916",
           "name": "Get current values for all codes",
           "request": {
             "name": "Get current values for all codes",
@@ -17768,7 +17768,7 @@
           },
           "response": [
             {
-              "id": "98458602-b28b-49f8-ab56-c2023f1d95a3",
+              "id": "a2f13158-0144-42eb-9c9b-4a98a1b60a4d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17809,7 +17809,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": 6613,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -17820,7 +17820,7 @@
           }
         },
         {
-          "id": "ab0ac81a-e3ef-40c2-b6c0-652ddeb3e82e",
+          "id": "78f0e06c-aa19-4ee3-8660-8c7ee53c64bb",
           "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
           "request": {
             "name": "Get readings by code (e.g., SET-00036, DEV-00031)",
@@ -17872,7 +17872,7 @@
           },
           "response": [
             {
-              "id": "e9217323-29f6-47e9-a6da-915639f4eb54",
+              "id": "406ce71b-3120-4867-afc4-7aefaca56502",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17952,7 +17952,7 @@
       "description": "",
       "item": [
         {
-          "id": "1a7280cc-772d-453b-bd38-84308cf2e899",
+          "id": "83473da8-e9c3-4313-8d26-32704aa3d926",
           "name": "get All Users 1",
           "request": {
             "name": "get All Users 1",
@@ -17981,7 +17981,7 @@
           },
           "response": [
             {
-              "id": "d14a1a2a-8136-4ca7-b0da-3b723eeb5635",
+              "id": "5267b50a-42d9-43d2-aacc-746f94879135",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18032,7 +18032,7 @@
           }
         },
         {
-          "id": "443e6e99-294a-4fdc-ad65-c12930028d7d",
+          "id": "0e5ef73e-ef28-431a-aea4-b41995b2e2cb",
           "name": "get Mqtt User",
           "request": {
             "name": "get Mqtt User",
@@ -18073,7 +18073,7 @@
           },
           "response": [
             {
-              "id": "148db9b5-9d04-43bb-9617-93b1968822e0",
+              "id": "0499348d-4af1-4245-87b9-fc4afd66911e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18142,7 +18142,7 @@
       "description": "",
       "item": [
         {
-          "id": "aa64191f-ad00-4431-98b5-569125d3effb",
+          "id": "49334e4b-f07a-4d2f-9b2f-b047cd186e2a",
           "name": "health",
           "request": {
             "name": "health",
@@ -18171,7 +18171,7 @@
           },
           "response": [
             {
-              "id": "f1fcfcb6-0d8e-4051-89b4-de65f7894fce",
+              "id": "5dd8a8bb-fd08-499b-82b9-4c35be6e3f8a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18211,7 +18211,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": 150,\n  \"key_1\": true\n}",
+              "body": "{\n  \"key_0\": 6613,\n  \"key_1\": \"string\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18228,7 +18228,7 @@
       "description": "",
       "item": [
         {
-          "id": "2b1548cf-3850-4d65-be80-ac0d44dd1170",
+          "id": "64185f87-4c7f-4dd2-8a68-2034f6e4c72d",
           "name": "get Sensor Statistics",
           "request": {
             "name": "get Sensor Statistics",
@@ -18280,7 +18280,7 @@
           },
           "response": [
             {
-              "id": "7ae24fa0-ad98-40de-a7df-6697ade009e9",
+              "id": "3ada6eae-b8e8-49fb-ae79-a6bdb5391841",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18354,7 +18354,7 @@
           }
         },
         {
-          "id": "ce48f215-f08b-41df-a51a-c7627dc3ae09",
+          "id": "ab4b2287-544d-44d0-88db-d29809b6cc46",
           "name": "get Summary Statistics",
           "request": {
             "name": "get Summary Statistics",
@@ -18395,7 +18395,7 @@
           },
           "response": [
             {
-              "id": "b1e37501-364c-4401-bcd4-e291da0074e9",
+              "id": "a5645da2-757b-4cd2-90d4-a9e498e2cc04",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18458,7 +18458,7 @@
           }
         },
         {
-          "id": "fa1be684-73d8-4760-9a38-ec99599f57c0",
+          "id": "d14552e7-e293-4257-af67-d16101fc80ce",
           "name": "health 1",
           "request": {
             "name": "health 1",
@@ -18488,7 +18488,7 @@
           },
           "response": [
             {
-              "id": "c5612003-2745-49fc-80f4-46e54778b7f2",
+              "id": "20b1cc61-7b21-4fc4-a934-acaa26cd685c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18529,7 +18529,7 @@
                   "value": "*/*"
                 }
               ],
-              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\"\n}",
+              "body": "{\n  \"key_0\": \"<string>\",\n  \"key_1\": \"<string>\",\n  \"key_2\": \"<string>\"\n}",
               "cookie": [],
               "_postman_previewlanguage": "text"
             }
@@ -18560,9 +18560,9 @@
     }
   ],
   "info": {
-    "_postman_id": "f6dd4184-b389-4c07-a45f-02a25a5addbd",
+    "_postman_id": "e1f56b9d-cc59-45c1-9781-182b7519265f",
     "name": "Invernaderos API - Auto-generated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-05 00:10 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
+    "description": "Colección generada automáticamente desde OpenAPI spec.\n\nFecha: 2026-05-05 01:01 UTC\nRama: develop\nEntorno: dev\n\nGenerado por GitHub Actions workflow."
   }
 }

--- a/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketController.kt
+++ b/src/main/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketController.kt
@@ -22,27 +22,38 @@ import org.springframework.stereotype.Controller
  * `true`, and Kotlin nullable types (`Principal?`) make `isOptional()`
  * return `true`. The JVM signature still expects a plain `Principal`, so
  * the reflective invocation explodes with `IllegalStateException: argument
- * type mismatch`. We hit exactly that crash on the dev rollout — see
- * `GreenhouseStatusWebSocketControllerSpringInvocationTest` which
- * exercises Spring's real handler machinery to keep the regression
- * pinned. Reading the principal and sessionId from the `Message`
- * sidesteps the resolver entirely.
+ * type mismatch` — exactly the crash that hit dev on the first rollout.
+ * `GreenhouseStatusWebSocketControllerSpringInvocationTest` exercises
+ * Spring's real handler machinery so a regression here fails tests
+ * instead of crashing real clients.
+ *
+ * **Tenant scoping (symmetric with broadcasts).** Both endpoints below
+ * route data based on the authenticated principal — they never trust a
+ * client-supplied `tenantId`:
+ *
+ *  - [getFullStatus] (`/app/status/request`): tenant-scoped by default
+ *    for every role, including `ROLE_ADMIN`. The handler resolves the
+ *    user's tenant from `User.tenantId` (the row in `metadata.users`,
+ *    NOT NULL by schema). An admin that wants the cross-tenant view
+ *    opts in by sending the STOMP native header `X-Status-Scope: all`,
+ *    which routes to [assembleFullStatus]. A non-admin sending
+ *    `scope=all` is rejected with [AccessDeniedException]. Default-safe.
+ *  - [getAllTenantsStatus] (`/app/status/request/all-tenants`):
+ *    explicitly admin-only. Same effect as `scope=all` on the default
+ *    endpoint. Convenient for tools that prefer a separate destination
+ *    over a header negotiation.
  *
  * The session is guaranteed authenticated by
  * [com.apptolast.invernaderos.config.StompJwtAuthInterceptor] (CONNECT
- * without a valid JWT is rejected before this handler is reachable), but
- * we re-validate defensively here because (a) tests can bypass the
+ * without a valid JWT is rejected before this handler is reachable),
+ * but we re-validate defensively here because (a) tests can bypass the
  * interceptor and (b) any future Spring change that lets a frame past
  * CONNECT without a principal must not silently expose data.
  *
- * Tenant scoping:
- *  - `ROLE_ADMIN`: returns all active tenants ([assembleFullStatus]),
- *    consistent with the bypass in
- *    [com.apptolast.invernaderos.features.shared.security.TenantOwnershipAspect]
- *    (commit a15b528) for the REST surface.
- *  - everyone else: returns only the snapshot of the user's own tenant
- *    via [assembleStatusForTenant]. The tenant is resolved from the
- *    authenticated `User.tenantId`, never from a client-supplied parameter.
+ * Result: clients no longer see the asymmetric "first message has all
+ * tenants, subsequent broadcasts have one" pattern that motivated this
+ * refactor — the initial request and the broadcast pipeline are now
+ * symmetric for default callers.
  */
 @Controller
 class GreenhouseStatusWebSocketController(
@@ -56,36 +67,85 @@ class GreenhouseStatusWebSocketController(
     @SendToUser("/queue/status/response")
     fun getFullStatus(message: Message<*>): GreenhouseStatusResponse {
         val accessor = SimpMessageHeaderAccessor.wrap(message)
-        val sessionId = accessor.sessionId
-        val auth = accessor.user as? Authentication
-            ?: throw AccessDeniedException("WebSocket /status/request requires authenticated session")
-
+        val auth = requireAuthenticated(accessor, "/status/request")
         val email = auth.name
-        val isAdmin = auth.authorities.any { it.authority == "ROLE_ADMIN" }
+        val isAdmin = auth.authorities.any { it.authority == ROLE_ADMIN }
+        val scope = accessor.getFirstNativeHeader(STATUS_SCOPE_HEADER)?.lowercase()
 
-        val response = if (isAdmin) {
-            logger.info("WS /status/request principal={} role=ADMIN scope=full sessionId={}", email, sessionId)
-            assembler.assembleFullStatus()
-        } else {
-            val user = userService.findByEmail(email)
-                ?: throw AccessDeniedException("Authenticated principal not found in users table: $email")
-            if (!user.isActive) {
-                throw AccessDeniedException("Authenticated principal is inactive: $email")
+        return if (scope == STATUS_SCOPE_ALL) {
+            if (!isAdmin) {
+                throw AccessDeniedException("$STATUS_SCOPE_HEADER=$STATUS_SCOPE_ALL requires ROLE_ADMIN")
             }
-            logger.info(
-                "WS /status/request principal={} role=USER scope=tenant tenantId={} sessionId={}",
-                email, user.tenantId, sessionId,
-            )
-            assembler.assembleStatusForTenant(user.tenantId)
+            respondAllTenants(email, accessor.sessionId)
+        } else {
+            respondTenantScoped(email, isAdmin, accessor.sessionId)
         }
+    }
 
+    @MessageMapping("/status/request/all-tenants")
+    @SendToUser("/queue/status/response")
+    fun getAllTenantsStatus(message: Message<*>): GreenhouseStatusResponse {
+        val accessor = SimpMessageHeaderAccessor.wrap(message)
+        val auth = requireAuthenticated(accessor, "/status/request/all-tenants")
+        if (auth.authorities.none { it.authority == ROLE_ADMIN }) {
+            throw AccessDeniedException("/status/request/all-tenants requires ROLE_ADMIN")
+        }
+        return respondAllTenants(auth.name, accessor.sessionId)
+    }
+
+    private fun requireAuthenticated(accessor: SimpMessageHeaderAccessor, destination: String): Authentication {
+        return accessor.user as? Authentication
+            ?: throw AccessDeniedException("WebSocket $destination requires authenticated session")
+    }
+
+    private fun respondTenantScoped(email: String, isAdmin: Boolean, sessionId: String?): GreenhouseStatusResponse {
+        val user = userService.findByEmail(email)
+            ?: throw AccessDeniedException("Authenticated principal not found in users table: $email")
+        if (!user.isActive) {
+            throw AccessDeniedException("Authenticated principal is inactive: $email")
+        }
+        val role = if (isAdmin) "ADMIN" else "USER"
+        logger.info(
+            "WS /status/request principal={} role={} scope=tenant tenantId={} sessionId={}",
+            email, role, user.tenantId, sessionId,
+        )
+        val response = assembler.assembleStatusForTenant(user.tenantId)
         deliveryLogger.logDelivery(
             principal = email,
             tenantIds = response.tenants.map { it.id },
-            source = "INITIAL_REQUEST",
+            source = SOURCE_INITIAL_REQUEST,
             snapshot = response,
             sessionId = sessionId,
         )
         return response
+    }
+
+    private fun respondAllTenants(email: String, sessionId: String?): GreenhouseStatusResponse {
+        logger.info(
+            "WS /status/request principal={} role=ADMIN scope=all sessionId={}",
+            email, sessionId,
+        )
+        val response = assembler.assembleFullStatus()
+        deliveryLogger.logDelivery(
+            principal = email,
+            tenantIds = response.tenants.map { it.id },
+            source = SOURCE_INITIAL_REQUEST_ALL,
+            snapshot = response,
+            sessionId = sessionId,
+        )
+        return response
+    }
+
+    companion object {
+        /** STOMP native header name for opt-in cross-tenant scope. Value compared case-insensitively. */
+        const val STATUS_SCOPE_HEADER = "X-Status-Scope"
+        const val STATUS_SCOPE_ALL = "all"
+        const val ROLE_ADMIN = "ROLE_ADMIN"
+
+        /** Source tag for the per-recipient `WsDeliveryLogger` line on the default tenant-scoped initial request. */
+        const val SOURCE_INITIAL_REQUEST = "INITIAL_REQUEST"
+
+        /** Source tag for the cross-tenant initial request (admin opt-in or `/all-tenants` destination). */
+        const val SOURCE_INITIAL_REQUEST_ALL = "INITIAL_REQUEST_ALL"
     }
 }

--- a/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketControllerSpringInvocationTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketControllerSpringInvocationTest.kt
@@ -2,6 +2,7 @@ package com.apptolast.invernaderos.features.websocket
 
 import com.apptolast.invernaderos.features.user.User
 import com.apptolast.invernaderos.features.user.UserService
+import com.apptolast.invernaderos.features.websocket.GreenhouseStatusWebSocketController.Companion.STATUS_SCOPE_HEADER
 import com.apptolast.invernaderos.features.websocket.broadcast.WsDeliveryLogger
 import com.apptolast.invernaderos.features.websocket.dto.GreenhouseStatusResponse
 import com.apptolast.invernaderos.features.websocket.dto.TenantResponse
@@ -10,10 +11,11 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.core.convert.support.DefaultConversionService
+import org.springframework.messaging.Message
+import org.springframework.messaging.converter.StringMessageConverter
 import org.springframework.messaging.handler.annotation.support.HeaderMethodArgumentResolver
 import org.springframework.messaging.handler.annotation.support.HeadersMethodArgumentResolver
 import org.springframework.messaging.handler.annotation.support.MessageMethodArgumentResolver
-import org.springframework.messaging.converter.StringMessageConverter
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod
 import org.springframework.messaging.simp.annotation.support.PrincipalMethodArgumentResolver
@@ -26,89 +28,140 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import java.time.Instant
 
 /**
- * Regression guard for the dev-rollout crash where Spring's
- * `PrincipalMethodArgumentResolver` wrapped a Kotlin nullable `Principal?`
- * parameter in `Optional<Principal>`, leaving the JVM signature
- * incompatible at reflective invocation time.
+ * Regression guards for the Spring messaging argument-resolver chain.
  *
  * The previous controller-level unit test used MockK and called the
  * Kotlin function directly — it never went through Spring's
- * argument-resolver chain, so it could not detect the wrapping. This
- * test wires the same resolver chain that
+ * argument-resolver chain, so it could not detect a Kotlin-vs-Spring
+ * incompatibility (e.g. `Optional<Principal>` wrapping when the
+ * parameter is declared `Principal?`). This test wires the same
+ * resolver lineup that
  * [org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler]
- * uses at runtime, so any future controller change that re-introduces a
- * resolver-incompatible parameter (Kotlin `Principal?`, `Optional<X>`
- * mismatched with the JVM signature, etc.) fails this test instead of
- * crashing real clients in dev/prod.
+ * uses at runtime, so any future controller change that re-introduces
+ * a resolver-incompatible parameter (Kotlin `Principal?`,
+ * `Optional<X>` mismatched with the JVM signature, etc.) fails this
+ * test instead of crashing real clients.
  *
- * Specifically: this test will fail with `IllegalStateException: argument
- * type mismatch` exactly like the dev pod did, instead of silently
- * passing.
+ * Both `@MessageMapping` methods are covered, plus the admin opt-in
+ * with `X-Status-Scope: all` to make sure the native-header path
+ * also survives Spring's resolution chain.
  */
 class GreenhouseStatusWebSocketControllerSpringInvocationTest {
 
     @Test
-    fun `controller is invokable by Spring messaging argument resolvers (regression for Optional Principal wrap)`() {
-        val assembler = mockk<GreenhouseStatusAssembler>()
-        val userService = mockk<UserService>()
-        val deliveryLogger = mockk<WsDeliveryLogger>(relaxed = true)
-        val controller = GreenhouseStatusWebSocketController(assembler, userService, deliveryLogger)
-
-        // Same resolver lineup SimpAnnotationMethodMessageHandler uses at
-        // runtime (excluding payload/destination resolvers — irrelevant
-        // here because the controller takes `Message<*>`).
-        val conversionService = DefaultConversionService()
-        val messageConverter = StringMessageConverter()
-        val resolvers = HandlerMethodArgumentResolverComposite().apply {
-            addResolver(HeaderMethodArgumentResolver(conversionService, null))
-            addResolver(HeadersMethodArgumentResolver())
-            addResolver(PrincipalMethodArgumentResolver())
-            addResolver(MessageMethodArgumentResolver(messageConverter))
+    fun `getFullStatus is invokable via Spring resolver chain (default tenant scope)`() {
+        val (controller, _) = newController { assembler, userService ->
+            val user = User(
+                id = 7L, code = "USR-00007", tenantId = 42L, username = "alice",
+                email = "alice@example.com", passwordHash = "ignored", role = "USER", isActive = true,
+            )
+            every { userService.findByEmail("alice@example.com") } returns user
+            every { assembler.assembleStatusForTenant(42L) } returns singleTenantResponse(42L)
         }
-
-        val handler = InvocableHandlerMethod(
-            controller,
-            GreenhouseStatusWebSocketController::class.java
-                .getMethod("getFullStatus", org.springframework.messaging.Message::class.java),
-        ).apply { setMessageMethodArgumentResolvers(resolvers) }
-
-        val tenantSnapshot = GreenhouseStatusResponse(
-            timestamp = Instant.parse("2026-05-04T22:15:00Z"),
-            tenants = listOf(tenantResponse(42L)),
+        val message = sendMessage(
+            destination = "/app/status/request",
+            principal = principal("alice@example.com", "ROLE_USER"),
         )
-        val user = User(
-            id = 7L,
-            code = "USR-00007",
-            tenantId = 42L,
-            username = "alice",
-            email = "alice@example.com",
-            passwordHash = "ignored",
-            role = "USER",
-            isActive = true,
-        )
-        every { userService.findByEmail("alice@example.com") } returns user
-        every { assembler.assembleStatusForTenant(42L) } returns tenantSnapshot
 
-        val auth = UsernamePasswordAuthenticationToken(
-            "alice@example.com",
-            null,
-            listOf<GrantedAuthority>(SimpleGrantedAuthority("ROLE_USER")),
-        )
-        val accessor = StompHeaderAccessor.create(StompCommand.SEND)
-        accessor.destination = "/app/status/request"
-        accessor.sessionId = "test-session-via-spring"
-        accessor.user = auth
-        val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
-
-        // This is the key invocation — it goes through Spring's resolver
-        // chain just like the production handler dispatch. If the
-        // controller signature regresses to a Kotlin nullable Principal
-        // (or any other resolver-incompatible shape) this throws.
-        val result = handler.invoke(message) as GreenhouseStatusResponse
+        val result = invoke(controller, "getFullStatus", message) as GreenhouseStatusResponse
 
         assertThat(result.tenants).hasSize(1)
         assertThat(result.tenants[0].id).isEqualTo(42L)
     }
+
+    @Test
+    fun `getFullStatus admin with X-Status-Scope all returns full snapshot`() {
+        val (controller, _) = newController { assembler, _ ->
+            every { assembler.assembleFullStatus() } returns fullStatus(1L, 2L, 3L)
+        }
+        val message = sendMessage(
+            destination = "/app/status/request",
+            principal = principal("admin@example.com", "ROLE_ADMIN"),
+            nativeHeaders = mapOf(STATUS_SCOPE_HEADER to "all"),
+        )
+
+        val result = invoke(controller, "getFullStatus", message) as GreenhouseStatusResponse
+
+        assertThat(result.tenants).extracting<Long> { it.id }.containsExactly(1L, 2L, 3L)
+    }
+
+    @Test
+    fun `getAllTenantsStatus admin returns full snapshot via Spring resolver chain`() {
+        val (controller, _) = newController { assembler, _ ->
+            every { assembler.assembleFullStatus() } returns fullStatus(10L, 20L)
+        }
+        val message = sendMessage(
+            destination = "/app/status/request/all-tenants",
+            principal = principal("admin@example.com", "ROLE_ADMIN"),
+        )
+
+        val result = invoke(controller, "getAllTenantsStatus", message) as GreenhouseStatusResponse
+
+        assertThat(result.tenants).extracting<Long> { it.id }.containsExactly(10L, 20L)
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    private fun newController(
+        stub: (assembler: GreenhouseStatusAssembler, userService: UserService) -> Unit,
+    ): Pair<GreenhouseStatusWebSocketController, WsDeliveryLogger> {
+        val assembler = mockk<GreenhouseStatusAssembler>()
+        val userService = mockk<UserService>()
+        val deliveryLogger = mockk<WsDeliveryLogger>(relaxed = true)
+        stub(assembler, userService)
+        return GreenhouseStatusWebSocketController(assembler, userService, deliveryLogger) to deliveryLogger
+    }
+
+    private fun invoke(
+        controller: GreenhouseStatusWebSocketController,
+        methodName: String,
+        message: Message<*>,
+    ): Any? {
+        val resolvers = HandlerMethodArgumentResolverComposite().apply {
+            addResolver(HeaderMethodArgumentResolver(DefaultConversionService(), null))
+            addResolver(HeadersMethodArgumentResolver())
+            addResolver(PrincipalMethodArgumentResolver())
+            addResolver(MessageMethodArgumentResolver(StringMessageConverter()))
+        }
+        val method = GreenhouseStatusWebSocketController::class.java
+            .getMethod(methodName, Message::class.java)
+        val handler = InvocableHandlerMethod(controller, method).apply {
+            setMessageMethodArgumentResolvers(resolvers)
+        }
+        return handler.invoke(message)
+    }
+
+    private fun sendMessage(
+        destination: String,
+        principal: java.security.Principal,
+        nativeHeaders: Map<String, String> = emptyMap(),
+    ): Message<ByteArray> {
+        val accessor = StompHeaderAccessor.create(StompCommand.SEND)
+        accessor.destination = destination
+        accessor.sessionId = "test-session-via-spring"
+        accessor.user = principal
+        nativeHeaders.forEach { (k, v) -> accessor.setNativeHeader(k, v) }
+        return MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+    }
+
+    private fun principal(email: String, vararg authorities: String) =
+        UsernamePasswordAuthenticationToken(
+            email,
+            null,
+            authorities.map<String, GrantedAuthority> { SimpleGrantedAuthority(it) },
+        )
+
+    private fun singleTenantResponse(tenantId: Long) = GreenhouseStatusResponse(
+        timestamp = Instant.parse("2026-05-05T00:00:00Z"),
+        tenants = listOf(tenantResponse(tenantId)),
+    )
+
+    private fun fullStatus(vararg tenantIds: Long) = GreenhouseStatusResponse(
+        timestamp = Instant.parse("2026-05-05T00:00:00Z"),
+        tenants = tenantIds.map { tenantResponse(it) },
+    )
 
     private fun tenantResponse(id: Long) = TenantResponse(
         id = id,

--- a/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketControllerTest.kt
+++ b/src/test/kotlin/com/apptolast/invernaderos/features/websocket/GreenhouseStatusWebSocketControllerTest.kt
@@ -2,6 +2,9 @@ package com.apptolast.invernaderos.features.websocket
 
 import com.apptolast.invernaderos.features.user.User
 import com.apptolast.invernaderos.features.user.UserService
+import com.apptolast.invernaderos.features.websocket.GreenhouseStatusWebSocketController.Companion.SOURCE_INITIAL_REQUEST
+import com.apptolast.invernaderos.features.websocket.GreenhouseStatusWebSocketController.Companion.SOURCE_INITIAL_REQUEST_ALL
+import com.apptolast.invernaderos.features.websocket.GreenhouseStatusWebSocketController.Companion.STATUS_SCOPE_HEADER
 import com.apptolast.invernaderos.features.websocket.broadcast.WsDeliveryLogger
 import com.apptolast.invernaderos.features.websocket.dto.GreenhouseStatusResponse
 import com.apptolast.invernaderos.features.websocket.dto.TenantResponse
@@ -24,22 +27,26 @@ import java.security.Principal
 import java.time.Instant
 
 /**
- * Pins down the tenant-scoping contract of the WS request-response handler:
+ * Pins down the symmetric tenant-scoping contract of the WS handlers:
  *
- *  - principal=null on the message → AccessDeniedException (defense-in-depth
- *    even though [com.apptolast.invernaderos.config.StompJwtAuthInterceptor]
- *    guarantees one upstream).
- *  - ROLE_USER → exactly one tenant in the response (the user's own).
- *  - ROLE_ADMIN → all active tenants (consistent with TenantOwnershipAspect
- *    bypass commit a15b528 on REST).
- *  - inactive user / unknown email → AccessDeniedException.
+ *  - Default `/status/request` → tenant-scoped for every role.
+ *    `ROLE_ADMIN` no longer receives the cross-tenant snapshot by
+ *    default — that's the user-visible behaviour change in this
+ *    refactor.
+ *  - `/status/request` with native header `X-Status-Scope: all` →
+ *    cross-tenant snapshot, but ONLY when the caller is `ROLE_ADMIN`.
+ *    Non-admins sending the header are rejected with
+ *    [AccessDeniedException].
+ *  - `/status/request/all-tenants` → admin-only equivalent of the
+ *    header opt-in, useful for tooling that prefers a dedicated
+ *    destination.
+ *  - All previous defensive cases still hold (null/non-Authentication
+ *    principal → 403, inactive user → 403, unknown email → 403).
  *
- * These tests **call the controller directly** with a hand-built
- * [Message]. They do NOT exercise Spring's argument resolver chain — see
+ * These tests call the controller directly — they do NOT exercise
+ * Spring's argument-resolver chain. See
  * [GreenhouseStatusWebSocketControllerSpringInvocationTest] for the
- * counterpart that does (and which catches the
- * `Optional<Principal>` wrapping bug Spring's resolver introduces for
- * Kotlin nullable parameters).
+ * counterpart that does.
  */
 class GreenhouseStatusWebSocketControllerTest {
 
@@ -55,6 +62,8 @@ class GreenhouseStatusWebSocketControllerTest {
         deliveryLogger = mockk(relaxed = true)
         controller = GreenhouseStatusWebSocketController(assembler, userService, deliveryLogger)
     }
+
+    // -------------------- Default endpoint, tenant scope --------------------
 
     @Test
     fun `null principal on message is rejected with AccessDeniedException`() {
@@ -73,7 +82,6 @@ class GreenhouseStatusWebSocketControllerTest {
     fun `ROLE_USER receives only their tenant snapshot`() {
         val user = userRow(id = 7L, email = "alice@example.com", tenantId = 42L, isActive = true)
         every { userService.findByEmail("alice@example.com") } returns user
-
         val tenantSnapshot = singleTenantResponse(tenantId = 42L)
         every { assembler.assembleStatusForTenant(42L) } returns tenantSnapshot
 
@@ -85,7 +93,24 @@ class GreenhouseStatusWebSocketControllerTest {
         assertThat(response.tenants[0].id).isEqualTo(42L)
         verify(exactly = 1) { assembler.assembleStatusForTenant(42L) }
         verify(exactly = 0) { assembler.assembleFullStatus() }
-        verify { deliveryLogger.logDelivery("alice@example.com", listOf(42L), "INITIAL_REQUEST", tenantSnapshot, "s1") }
+        verify { deliveryLogger.logDelivery("alice@example.com", listOf(42L), SOURCE_INITIAL_REQUEST, tenantSnapshot, "s1") }
+    }
+
+    @Test
+    fun `ROLE_ADMIN without scope header is now tenant-scoped (regression vs PR 156)`() {
+        val adminUser = userRow(id = 1L, email = "admin@example.com", tenantId = 99L, isActive = true)
+        every { userService.findByEmail("admin@example.com") } returns adminUser
+        val tenantSnapshot = singleTenantResponse(tenantId = 99L)
+        every { assembler.assembleStatusForTenant(99L) } returns tenantSnapshot
+
+        val response = controller.getFullStatus(
+            message(principal = userAuth("admin@example.com", "ROLE_ADMIN")),
+        )
+
+        assertThat(response.tenants).hasSize(1)
+        assertThat(response.tenants[0].id).isEqualTo(99L)
+        verify(exactly = 1) { assembler.assembleStatusForTenant(99L) }
+        verify(exactly = 0) { assembler.assembleFullStatus() }
     }
 
     @Test
@@ -112,34 +137,118 @@ class GreenhouseStatusWebSocketControllerTest {
             .hasMessageContaining("not found")
     }
 
+    // -------------------- Default endpoint, scope=all opt-in ----------------
+
     @Test
-    fun `ROLE_ADMIN receives full snapshot regardless of tenant`() {
-        val full = GreenhouseStatusResponse(
-            timestamp = Instant.parse("2026-05-04T22:15:00Z"),
-            tenants = listOf(tenantResponse(1L), tenantResponse(2L), tenantResponse(3L)),
-        )
+    fun `ROLE_ADMIN with scope all returns full snapshot`() {
+        val full = fullStatus(1L, 2L, 3L)
         every { assembler.assembleFullStatus() } returns full
 
         val response = controller.getFullStatus(
-            message(principal = userAuth("admin@example.com", "ROLE_ADMIN")),
+            message(
+                principal = userAuth("admin@example.com", "ROLE_ADMIN"),
+                scopeHeaderValue = "all",
+            ),
         )
 
         assertThat(response.tenants).extracting<Long> { it.id }.containsExactly(1L, 2L, 3L)
         verify(exactly = 1) { assembler.assembleFullStatus() }
         verify(exactly = 0) { assembler.assembleStatusForTenant(any()) }
-        // Admin path must not require a UserService lookup.
         verify(exactly = 0) { userService.findByEmail(any()) }
+        verify { deliveryLogger.logDelivery("admin@example.com", listOf(1L, 2L, 3L), SOURCE_INITIAL_REQUEST_ALL, full, any()) }
+    }
+
+    @Test
+    fun `scope all is case-insensitive`() {
+        val full = fullStatus(1L, 2L)
+        every { assembler.assembleFullStatus() } returns full
+
+        val response = controller.getFullStatus(
+            message(principal = userAuth("admin@example.com", "ROLE_ADMIN"), scopeHeaderValue = "ALL"),
+        )
+
+        assertThat(response.tenants).hasSize(2)
+        verify(exactly = 1) { assembler.assembleFullStatus() }
+    }
+
+    @Test
+    fun `ROLE_USER with scope all is rejected`() {
+        assertThatThrownBy {
+            controller.getFullStatus(
+                message(
+                    principal = userAuth("alice@example.com", "ROLE_USER"),
+                    scopeHeaderValue = "all",
+                ),
+            )
+        }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("ROLE_ADMIN")
+        verify(exactly = 0) { assembler.assembleFullStatus() }
+        verify(exactly = 0) { assembler.assembleStatusForTenant(any()) }
+    }
+
+    @Test
+    fun `unrecognised scope value falls back to tenant scope`() {
+        val user = userRow(id = 1L, email = "admin@example.com", tenantId = 99L, isActive = true)
+        every { userService.findByEmail("admin@example.com") } returns user
+        val tenantSnapshot = singleTenantResponse(99L)
+        every { assembler.assembleStatusForTenant(99L) } returns tenantSnapshot
+
+        controller.getFullStatus(
+            message(principal = userAuth("admin@example.com", "ROLE_ADMIN"), scopeHeaderValue = "bogus"),
+        )
+
+        verify(exactly = 1) { assembler.assembleStatusForTenant(99L) }
+        verify(exactly = 0) { assembler.assembleFullStatus() }
+    }
+
+    // -------------------- /all-tenants endpoint ------------------------------
+
+    @Test
+    fun `getAllTenantsStatus with ROLE_ADMIN returns full snapshot`() {
+        val full = fullStatus(1L, 2L, 3L)
+        every { assembler.assembleFullStatus() } returns full
+
+        val response = controller.getAllTenantsStatus(
+            message(principal = userAuth("admin@example.com", "ROLE_ADMIN"), sessionId = "s2"),
+        )
+
+        assertThat(response.tenants).extracting<Long> { it.id }.containsExactly(1L, 2L, 3L)
+        verify(exactly = 1) { assembler.assembleFullStatus() }
+        verify(exactly = 0) { userService.findByEmail(any()) }
+        verify { deliveryLogger.logDelivery("admin@example.com", listOf(1L, 2L, 3L), SOURCE_INITIAL_REQUEST_ALL, full, "s2") }
+    }
+
+    @Test
+    fun `getAllTenantsStatus with ROLE_USER is rejected`() {
+        assertThatThrownBy {
+            controller.getAllTenantsStatus(message(principal = userAuth("alice@example.com", "ROLE_USER")))
+        }
+            .isInstanceOf(AccessDeniedException::class.java)
+            .hasMessageContaining("ROLE_ADMIN")
+        verify(exactly = 0) { assembler.assembleFullStatus() }
+    }
+
+    @Test
+    fun `getAllTenantsStatus without principal is rejected`() {
+        assertThatThrownBy { controller.getAllTenantsStatus(message(principal = null)) }
+            .isInstanceOf(AccessDeniedException::class.java)
     }
 
     // ------------------------------------------------------------------
     // helpers
     // ------------------------------------------------------------------
 
-    private fun message(principal: Principal?, sessionId: String? = "test-session-1"): Message<ByteArray> {
+    private fun message(
+        principal: Principal?,
+        sessionId: String? = "test-session-1",
+        scopeHeaderValue: String? = null,
+    ): Message<ByteArray> {
         val accessor = StompHeaderAccessor.create(StompCommand.SEND)
         accessor.destination = "/app/status/request"
         accessor.sessionId = sessionId
         if (principal != null) accessor.user = principal
+        if (scopeHeaderValue != null) accessor.setNativeHeader(STATUS_SCOPE_HEADER, scopeHeaderValue)
         return MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
     }
 
@@ -165,6 +274,11 @@ class GreenhouseStatusWebSocketControllerTest {
     private fun singleTenantResponse(tenantId: Long) = GreenhouseStatusResponse(
         timestamp = Instant.parse("2026-05-04T22:15:00Z"),
         tenants = listOf(tenantResponse(tenantId)),
+    )
+
+    private fun fullStatus(vararg tenantIds: Long) = GreenhouseStatusResponse(
+        timestamp = Instant.parse("2026-05-04T22:15:00Z"),
+        tenants = tenantIds.map { tenantResponse(it) },
     )
 
     private fun tenantResponse(id: Long) = TenantResponse(


### PR DESCRIPTION
## Summary
Eliminate the asymmetry the previous hardening (#155/#156) left between the initial request (admin → all tenants) and broadcasts (admin → own tenant). Mobile clients observed the user-visible jitter "first RECV tenants=3 alerts=5, subsequent RECV tenants=1 alerts=1" and the alert list briefly showed cross-tenant data before reconciling.

- `/app/status/request` is now tenant-scoped for every role, including ROLE_ADMIN. Tenant resolved from `User.tenantId` (NOT NULL by schema), never from a client-supplied parameter.
- Admin opt-in via STOMP native header `X-Status-Scope: all` (case-insensitive). Non-admins are rejected with `AccessDeniedException`.
- New `@MessageMapping("/status/request/all-tenants")` provides an explicit destination equivalent of the header opt-in, restricted to `ROLE_ADMIN`.
- Per-recipient delivery log distinguishes the two paths via `source`: `INITIAL_REQUEST` vs `INITIAL_REQUEST_ALL`.

## Verification
Dev rolled out on commit `bfe8ba7` at 01:02 UTC.

```
STOMP CONNECT accepted sessionId=c68ac236-... principal=adminfronts@adminfronts.com authorities=[ROLE_ADMIN]
WS /status/request principal=adminfronts@adminfronts.com role=ADMIN scope=tenant tenantId=814997898604790412 sessionId=c68ac236-...
WS delivery principal=adminfronts@adminfronts.com source=INITIAL_REQUEST tenantIds=[814997898604790412] payloadBytes=60514 ... greenhouses=4 sectors=19 devices=47 settings=71 alerts=1
```

Before the fix: `tenants=3, alerts=5, payloadBytes=66197`. After: `tenants=1, alerts=1, payloadBytes=60514`. Symmetric with subsequent broadcasts.

`grep -E "ERROR|WARN|Exception|Unhandled"` in dev logs since the rollout → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)